### PR TITLE
Fix 0.7-beta1 migration script import path

### DIFF
--- a/qooxdoo/tool/data/migration/0.7-beta1/patch.py
+++ b/qooxdoo/tool/data/migration/0.7-beta1/patch.py
@@ -5,7 +5,7 @@ import os
 import logging
 
 # reconfigure path to import modules from modules subfolder
-sys.path.insert(0, os.path.join(os.path.dirname(os.path.abspath(sys.argv[0])), "../../modules"))
+sys.path.insert(0, os.path.join(os.path.dirname(os.path.abspath(sys.argv[0])), "../pylib/ecmascript/frontend"))
 
 import tree, compiler, comment
 


### PR DESCRIPTION
I needed this change to get the migration to run. Seems like these files have moved along the way.
