### PR TITLE
Fixed bug in qx.ui.mobile.page.NavigationPage

### DIFF
--- a/qooxdoo/framework/source/class/qx/ui/mobile/page/NavigationPage.js
+++ b/qooxdoo/framework/source/class/qx/ui/mobile/page/NavigationPage.js
@@ -185,7 +185,7 @@ qx.Class.define("qx.ui.mobile.page.NavigationPage",
      */
     _getNavigationBar : function()
     {
-      return this.__navigationBar();
+      return this.__navigationBar;
     },
 
 


### PR DESCRIPTION
property __navigationBar is not a function (in getter function)
