### PR TITLE
qx.ui.mobile.core.Blocker does not unregister events on hide

### DIFF
--- a/qooxdoo/framework/source/class/qx/ui/mobile/core/Blocker.js
+++ b/qooxdoo/framework/source/class/qx/ui/mobile/core/Blocker.js
@@ -85,6 +85,7 @@ qx.Class.define("qx.ui.mobile.core.Blocker",
       if (this.__count <= 0)
       {
         this.__count = 0;
+        this.__unregisterEventListener();
         this.exclude();
       }
     },

--- a/qooxdoo/framework/source/class/qx/ui/mobile/page/NavigationPage.js
+++ b/qooxdoo/framework/source/class/qx/ui/mobile/page/NavigationPage.js
@@ -185,7 +185,7 @@ qx.Class.define("qx.ui.mobile.page.NavigationPage",
      */
     _getNavigationBar : function()
     {
-      return this.__navigationBar();
+      return this.__navigationBar;
     },
 
 


### PR DESCRIPTION
Hello,

the Blocker class of the mobile widget set does not unregister its events on hiding. This prevents any form fields to be clicked after a blocker was used on the same page.

Thanks!
