### PR TITLE
Allow removing an item from the storage via the Offline class

### DIFF
--- a/framework/source/class/qx/data/store/Offline.js
+++ b/framework/source/class/qx/data/store/Offline.js
@@ -93,6 +93,8 @@ qx.Class.define("qx.data.store.Offline",
           "changeBubble", this.__storeModel, this
         );
         this.__storeModel();
+      } else {
+        this._storage.removeItem(this._key);
       }
     },
 


### PR DESCRIPTION
It would be nice if one can delete an item from the storage that is managed using an instance of the Offline class. Currently nothing happens if calling resetModel or setModel(null).

This patch deletes the item from the storage if the model ist set to null.
