### PR TITLE
Re: Performance profiling in Firefox and the effect of qx.event.Idle

### DIFF
--- a/framework/source/class/qx/event/Idle.js
+++ b/framework/source/class/qx/event/Idle.js
@@ -17,7 +17,6 @@
 
 ************************************************************************ */
 
-
 /**
  * A generic singleton that fires an "interval" event all 100 miliseconds. It
  * can be used whenever one needs to run code periodically. The main purpose of
@@ -32,12 +31,6 @@ qx.Class.define("qx.event.Idle",
   construct : function()
   {
     this.base(arguments);
-
-    var timer = new qx.event.Timer(this.getTimeoutInterval());
-    timer.addListener("interval", this._onInterval, this);
-    timer.start();
-
-    this.__timer = timer;
   },
 
 
@@ -83,7 +76,8 @@ qx.Class.define("qx.event.Idle",
 
     // property apply
     _applyTimeoutInterval : function(value) {
-      this.__timer.setInterval(value);
+    	if (this.__timer)
+    		this.__timer.setInterval(value);
     },
 
     /**
@@ -91,6 +85,65 @@ qx.Class.define("qx.event.Idle",
      */
     _onInterval : function() {
       this.fireEvent("interval");
+    },
+    
+    /**
+     * Starts the timer but only if there are listeners for the "interval" event
+     */
+    __startTimer: function() {
+    	if (!this.__timer && this.hasListener("interval")) {
+    	    var timer = new qx.event.Timer(this.getTimeoutInterval());
+    	    timer.addListener("interval", this._onInterval, this);
+    	    timer.start();
+
+    	    this.__timer = timer;
+    	}
+    },
+    
+    /**
+     * Stops the timer but only if there are no listeners for the interval event 
+     */
+    __stopTimer: function() {
+    	if (this.__timer && !this.hasListener("interval")) {
+    		this.__timer.stop();
+    		this.__timer = null;
+    	}
+    },
+    
+    /*
+     * @Override
+     */
+    addListener: function(type, listener, self, capture) {
+    	var result = this.base(arguments, type, listener, self, capture);
+    	this.__startTimer();
+    	return result;
+    },
+    
+    /*
+     * @Override
+     */
+    addListenerOnce: function(type, listener, self, capture) {
+    	var result = this.base(arguments, type, listener, self, capture);
+    	this.__startTimer();
+    	return result;
+    },
+    
+    /*
+     * @Override
+     */
+    removeListener: function(type, listener, self, capture) {
+    	var result = this.base(arguments, type, listener, self, capture);
+    	this.__stopTimer();
+    	return result;
+    },
+    
+    /*
+     * @Override
+     */
+    removeListenerById: function(id) {
+    	var result = this.base(arguments, id);
+    	this.__stopTimer();
+    	return result;
     }
 
   },
@@ -111,3 +164,4 @@ qx.Class.define("qx.event.Idle",
   }
 
 });
+

--- a/framework/source/class/qx/event/Idle.js
+++ b/framework/source/class/qx/event/Idle.js
@@ -17,6 +17,7 @@
 
 ************************************************************************ */
 
+
 /**
  * A generic singleton that fires an "interval" event all 100 miliseconds. It
  * can be used whenever one needs to run code periodically. The main purpose of
@@ -31,6 +32,12 @@ qx.Class.define("qx.event.Idle",
   construct : function()
   {
     this.base(arguments);
+
+    var timer = new qx.event.Timer(this.getTimeoutInterval());
+    timer.addListener("interval", this._onInterval, this);
+    timer.start();
+
+    this.__timer = timer;
   },
 
 
@@ -76,8 +83,7 @@ qx.Class.define("qx.event.Idle",
 
     // property apply
     _applyTimeoutInterval : function(value) {
-    	if (this.__timer)
-    		this.__timer.setInterval(value);
+      this.__timer.setInterval(value);
     },
 
     /**
@@ -85,65 +91,6 @@ qx.Class.define("qx.event.Idle",
      */
     _onInterval : function() {
       this.fireEvent("interval");
-    },
-    
-    /**
-     * Starts the timer but only if there are listeners for the "interval" event
-     */
-    __startTimer: function() {
-    	if (!this.__timer && this.hasListener("interval")) {
-    	    var timer = new qx.event.Timer(this.getTimeoutInterval());
-    	    timer.addListener("interval", this._onInterval, this);
-    	    timer.start();
-
-    	    this.__timer = timer;
-    	}
-    },
-    
-    /**
-     * Stops the timer but only if there are no listeners for the interval event 
-     */
-    __stopTimer: function() {
-    	if (this.__timer && !this.hasListener("interval")) {
-    		this.__timer.stop();
-    		this.__timer = null;
-    	}
-    },
-    
-    /*
-     * @Override
-     */
-    addListener: function(type, listener, self, capture) {
-    	var result = this.base(arguments, type, listener, self, capture);
-    	this.__startTimer();
-    	return result;
-    },
-    
-    /*
-     * @Override
-     */
-    addListenerOnce: function(type, listener, self, capture) {
-    	var result = this.base(arguments, type, listener, self, capture);
-    	this.__startTimer();
-    	return result;
-    },
-    
-    /*
-     * @Override
-     */
-    removeListener: function(type, listener, self, capture) {
-    	var result = this.base(arguments, type, listener, self, capture);
-    	this.__stopTimer();
-    	return result;
-    },
-    
-    /*
-     * @Override
-     */
-    removeListenerById: function(id) {
-    	var result = this.base(arguments, id);
-    	this.__stopTimer();
-    	return result;
     }
 
   },
@@ -164,4 +111,3 @@ qx.Class.define("qx.event.Idle",
   }
 
 });
-

--- a/framework/source/class/qx/event/Manager.js
+++ b/framework/source/class/qx/event/Manager.js
@@ -164,6 +164,21 @@ qx.Class.define("qx.event.Manager",
 
       return this.__handlers[clazz.classname] = new clazz(this);
     },
+    
+    
+    /**
+     * Registers an instance of a handler for this manager (window); if there is already
+     * an instance of a handler for a given class an error is thrown.  This method allows
+     * applications to override the default handling for window, but must be called early
+     * in the application lifecycle
+     * @param handler {IEventHandler} the new handler
+     * @param clazz {Class} the Qooxdoo class which would normally handle events
+     */
+    registerHandler : function(handler, clazz) {
+    	if (this.__handlers[clazz.classname])
+    		throw new Error("Cannot register handler for " + clazz.classname + " because it is alredy registered");
+    	this.__handlers[clazz.classname] = handler;
+    },
 
 
     /**


### PR DESCRIPTION
Changed qx.event.Idle to only create a Timer while there are listeners for the interval event, removes Timer after last listener released
