### PR TITLE
Improve performance profiling by modifying qx.event.Idle

### DIFF
--- a/framework/source/class/qx/event/Idle.js
+++ b/framework/source/class/qx/event/Idle.js
@@ -17,7 +17,6 @@
 
 ************************************************************************ */
 
-
 /**
  * A generic singleton that fires an "interval" event all 100 miliseconds. It
  * can be used whenever one needs to run code periodically. The main purpose of
@@ -32,12 +31,6 @@ qx.Class.define("qx.event.Idle",
   construct : function()
   {
     this.base(arguments);
-
-    var timer = new qx.event.Timer(this.getTimeoutInterval());
-    timer.addListener("interval", this._onInterval, this);
-    timer.start();
-
-    this.__timer = timer;
   },
 
 
@@ -83,7 +76,8 @@ qx.Class.define("qx.event.Idle",
 
     // property apply
     _applyTimeoutInterval : function(value) {
-      this.__timer.setInterval(value);
+    	if (this.__timer)
+    		this.__timer.setInterval(value);
     },
 
     /**
@@ -91,6 +85,65 @@ qx.Class.define("qx.event.Idle",
      */
     _onInterval : function() {
       this.fireEvent("interval");
+    },
+    
+    /**
+     * Starts the timer but only if there are listeners for the "interval" event
+     */
+    __startTimer: function() {
+    	if (!this.__timer && this.hasListener("interval")) {
+    	    var timer = new qx.event.Timer(this.getTimeoutInterval());
+    	    timer.addListener("interval", this._onInterval, this);
+    	    timer.start();
+
+    	    this.__timer = timer;
+    	}
+    },
+    
+    /**
+     * Stops the timer but only if there are no listeners for the interval event 
+     */
+    __stopTimer: function() {
+    	if (this.__timer && !this.hasListener("interval")) {
+    		this.__timer.stop();
+    		this.__timer = null;
+    	}
+    },
+    
+    /*
+     * @Override
+     */
+    addListener: function(type, listener, self, capture) {
+    	var result = this.base(arguments, type, listener, self, capture);
+    	this.__startTimer();
+    	return result;
+    },
+    
+    /*
+     * @Override
+     */
+    addListenerOnce: function(type, listener, self, capture) {
+    	var result = this.base(arguments, type, listener, self, capture);
+    	this.__startTimer();
+    	return result;
+    },
+    
+    /*
+     * @Override
+     */
+    removeListener: function(type, listener, self, capture) {
+    	var result = this.base(arguments, type, listener, self, capture);
+    	this.__stopTimer();
+    	return result;
+    },
+    
+    /*
+     * @Override
+     */
+    removeListenerById: function(id) {
+    	var result = this.base(arguments, id);
+    	this.__stopTimer();
+    	return result;
     }
 
   },


### PR DESCRIPTION
Changed to only create a Timer while there are listeners for the interval event and removes Timer after last listener released.  This can reduce the number of profiled function calls from 9,000 in 10 seconds to zero when Idle is not required, massively simplifying the profile process.

Relates to http://bugs.qooxdoo.org/show_bug.cgi?id=6115
