### PR TITLE
qx.event.Manager - add registerHandler

### DIFF
--- a/framework/source/class/qx/event/Idle.js
+++ b/framework/source/class/qx/event/Idle.js
@@ -17,7 +17,6 @@
 
 ************************************************************************ */
 
-
 /**
  * A generic singleton that fires an "interval" event all 100 miliseconds. It
  * can be used whenever one needs to run code periodically. The main purpose of
@@ -32,12 +31,6 @@ qx.Class.define("qx.event.Idle",
   construct : function()
   {
     this.base(arguments);
-
-    var timer = new qx.event.Timer(this.getTimeoutInterval());
-    timer.addListener("interval", this._onInterval, this);
-    timer.start();
-
-    this.__timer = timer;
   },
 
 
@@ -83,7 +76,8 @@ qx.Class.define("qx.event.Idle",
 
     // property apply
     _applyTimeoutInterval : function(value) {
-      this.__timer.setInterval(value);
+    	if (this.__timer)
+    		this.__timer.setInterval(value);
     },
 
     /**
@@ -91,6 +85,65 @@ qx.Class.define("qx.event.Idle",
      */
     _onInterval : function() {
       this.fireEvent("interval");
+    },
+    
+    /**
+     * Starts the timer but only if there are listeners for the "interval" event
+     */
+    __startTimer: function() {
+    	if (!this.__timer && this.hasListener("interval")) {
+    	    var timer = new qx.event.Timer(this.getTimeoutInterval());
+    	    timer.addListener("interval", this._onInterval, this);
+    	    timer.start();
+
+    	    this.__timer = timer;
+    	}
+    },
+    
+    /**
+     * Stops the timer but only if there are no listeners for the interval event 
+     */
+    __stopTimer: function() {
+    	if (this.__timer && !this.hasListener("interval")) {
+    		this.__timer.stop();
+    		this.__timer = null;
+    	}
+    },
+    
+    /*
+     * @Override
+     */
+    addListener: function(type, listener, self, capture) {
+    	var result = this.base(arguments, type, listener, self, capture);
+    	this.__startTimer();
+    	return result;
+    },
+    
+    /*
+     * @Override
+     */
+    addListenerOnce: function(type, listener, self, capture) {
+    	var result = this.base(arguments, type, listener, self, capture);
+    	this.__startTimer();
+    	return result;
+    },
+    
+    /*
+     * @Override
+     */
+    removeListener: function(type, listener, self, capture) {
+    	var result = this.base(arguments, type, listener, self, capture);
+    	this.__stopTimer();
+    	return result;
+    },
+    
+    /*
+     * @Override
+     */
+    removeListenerById: function(id) {
+    	var result = this.base(arguments, id);
+    	this.__stopTimer();
+    	return result;
     }
 
   },

--- a/framework/source/class/qx/event/Manager.js
+++ b/framework/source/class/qx/event/Manager.js
@@ -167,6 +167,21 @@ qx.Class.define("qx.event.Manager",
 
 
     /**
+     * Registers an instance of a handler for this manager (window); if there is already
+     * an instance of a handler for a given class an error is thrown.  This method allows
+     * applications to override the default handling for window, but must be called early
+     * in the application lifecycle
+     * @param handler {IEventHandler} the new handler
+     * @param clazz {Class} the Qooxdoo class which would normally handle events
+     */
+    registerHandler : function(handler, clazz) {
+    	if (this.__handlers[clazz.classname])
+    		throw new Error("Cannot register handler for " + clazz.classname + " because it is alredy registered");
+    	this.__handlers[clazz.classname] = handler;
+    },
+
+
+    /**
      * Returns an instance of the given dispatcher class for this manager(window).
      *
      * @param clazz {Class} Any class which implements {@link qx.event.IEventHandler}


### PR DESCRIPTION
Event handlers are developed as individual modules and registered with qx.event.Manager but because qx.event.Manager calls the constructor of each event handler they cannot be replaced with any implementation other than the default.

This is an unfortunate restriction which prevents event handlers from being customised, something which is essential when dealing with multiple document instances (eg drag and drop between iframe and the main document), or when subtle extensions are required in the application.

This change adds a registerHandler method that allows the app to provide it's own handlers; the change will not impact existing code.
