### PR TITLE
Fixes bug #5995 where drag and drop "drop" event is not always fired

### DIFF
--- a/framework/source/class/qx/event/handler/DragDrop.js
+++ b/framework/source/class/qx/event/handler/DragDrop.js
@@ -617,6 +617,14 @@ qx.Class.define("qx.event.handler.DragDrop",
             this.__manager.addListener(this.__root, "keyup", this._onKeyUp, this, true);
             this.__manager.addListener(this.__root, "keypress", this._onKeyPress, this, true);
 
+            // Initialise the current droppable
+            var dropable = this.__findDroppable(e.getTarget());
+            if (dropable && dropable != this.__dropTarget)
+            {
+              this.__validDrop = this.__fireEvent("dragover", dropable, this.__dragTarget, true, e);
+              this.__dropTarget = dropable;
+            }
+            
             // Reevaluate current action
             var keys = this.__keys;
             keys.Control = e.isCtrlPressed();


### PR DESCRIPTION
qx.event.handler.DragDrop will only send the drop event if the mouse moves off the widget being dragged (or over another, overlapping widget).  This is inconsistent because the "drop" event _is_ fired if you move off the widget and then return to the same place, but isn't fired if you move within the widget even though the dragstart and drag end are at the same X/Y position.  The bug effectively prevents the user from dragging a widget a minor distance without having to waggle the mouse back and forth first.

Relates to http://bugzilla.qooxdoo.org/show_bug.cgi?id=5995
