### PR TITLE
Make generator.py more flexible for automatic builds

### DIFF
--- a/tool/data/generator/generate.tmpl.py
+++ b/tool/data/generator/generate.tmpl.py
@@ -26,21 +26,34 @@
 import sys, os, re, subprocess
 
 CMD_PYTHON = sys.executable
-QOOXDOO_PATH = '${REL_QOOXDOO_PATH}'
+##
+# Set QOOXDOO_PATH initally to None
+##
+
+QOOXDOO_PATH=None
+
+##
+# Check if the environment has QOOXDOO_PATH variable ser
+##
+
+if os.environ.has_key("QOOXDOO_PATH"):
+    QOOXDOO_PATH=os.environ["QOOXDOO_PATH"]
 
 def getQxPath():
     path = QOOXDOO_PATH
-    # try updating from config file
-    if os.path.exists('config.json'):
-        # "using QOOXDOO_PATH from config.json"
-        qpathr=re.compile(r'"QOOXDOO_PATH"\s*:\s*"([^"]*)"\s*,?')
-        conffile = open('config.json')
-        aconffile = conffile.readlines()
-        for line in aconffile:
-            mo = qpathr.search(line)
-            if mo:
-                path = mo.group(1)
-                break # assume first occurrence is ok
+    # Only try updating the QOOXDOO_PATH from config.json when path is None
+    if path is None:
+        # try updating from config file
+        if os.path.exists('config.json'):
+            # "using QOOXDOO_PATH from config.json"
+            qpathr=re.compile(r'"QOOXDOO_PATH"\s*:\s*"([^"]*)"\s*,?')
+            conffile = open('config.json')
+            aconffile = conffile.readlines()
+            for line in aconffile:
+                mo = qpathr.search(line)
+                if mo:
+                    path = mo.group(1)
+                    break # assume first occurrence is ok
     path = os.path.normpath(os.path.join(os.path.dirname(os.path.abspath(sys.argv[0])), path))
 
     return path


### PR DESCRIPTION
Dear Colleagues,

during my work on DC² (http://launchpad.net/dc2) I was in need of a qooxdoo package to build the DC² qooxdoo frontend from source inside a debian sbuild chroot.

This was not trivial, because I think the generator.py is a bit simple.
It checks automatically the config.json file, and even with the -m QOOXDOO_PATH:... switch it takes only the data from config.json.

I adjusted the generate.tmpl.py template to honour an environment variable QOOXDOO_PATH first.
So you can have a shell construct like this:

QOOXDOO_PATH=/whenever/whereever/whatever/ ./generate.py -m QOOXDOO_PATH:/whenever/whereever/whatever

so generate.py can find the real generator script first.

If you are ok, just pull from my repo.

Kind regards,

Stephan Adig

modified:   generate.tmpl.py
