### PR TITLE
validation tooltip extensions

### DIFF
--- a/framework/source/class/qx/ui/form/validation/Manager.js
+++ b/framework/source/class/qx/ui/form/validation/Manager.js
@@ -499,6 +499,24 @@ qx.Class.define("qx.ui.form.validation.Manager",
 
 
     /**
+     * Selects invalid form items
+     *
+     * @return {Array} invalid form items
+     */
+    getInvalidFormItems : function() {
+      var res = [];
+      for (var i = 0; i < this.__formItems.length; i++) {
+        var formItem = this.__formItems[i].item;
+        if (!formItem.getValid()) {
+          res.push(formItem);
+        }
+      }
+
+      return res;
+    },
+
+
+    /**
      * Resets the validator.
      */
     reset: function() {

--- a/framework/source/class/qx/ui/tooltip/Manager.js
+++ b/framework/source/class/qx/ui/tooltip/Manager.js
@@ -280,6 +280,16 @@ qx.Class.define("qx.ui.tooltip.Manager",
     __onMouseOverRoot : function(e)
     {
       var target = qx.ui.core.Widget.getWidgetByElement(e.getTarget());
+      this.showToolTip(target);
+    },
+
+
+    /**
+     * Explicitly show tooltip for particular form item.
+     *
+     * @param target {Object || null} widget to show tooltip for
+     */
+    showToolTip : function(target) {
       if (!target){
         return;
       }

--- a/framework/source/class/qx/ui/tooltip/Manager.js
+++ b/framework/source/class/qx/ui/tooltip/Manager.js
@@ -130,16 +130,20 @@ qx.Class.define("qx.ui.tooltip.Manager",
      * Get the shared tooltip, which is used to display the
      * {@link qx.ui.core.Widget#toolTipText} and
      * {@link qx.ui.core.Widget#toolTipIcon} properties of widgets.
+     * You can use this public shared instance to e.g. customize the
+     * look and feel of the validation tooltips like
+     * <code>getSharedErrorTooltip().getChildControl("atom").getChildControl("label").set({rich: true, wrap: true, width: 80})</code>
      *
      * @return {qx.ui.tooltip.ToolTip} The shared tooltip
      */
-    __getSharedErrorTooltip : function()
+    getSharedErrorTooltip : function()
     {
       if (!this.__sharedErrorToolTip)
       {
         this.__sharedErrorToolTip = new qx.ui.tooltip.ToolTip().set({
           appearance: "tooltip-error"
         });
+        this.__sharedErrorToolTip.setLabel(""); // trigger label widget creation
         this.__sharedErrorToolTip.syncAppearance();
       }
       return this.__sharedErrorToolTip;
@@ -319,7 +323,7 @@ qx.Class.define("qx.ui.tooltip.Manager",
 
       if (invalidMessage)
       {
-        tooltip = this.__getSharedErrorTooltip().set({
+        tooltip = this.getSharedErrorTooltip().set({
           label: invalidMessage
         });
       }


### PR DESCRIPTION
Hi,

I extended qooxdoo tooltip and validation machinery to be able to implement our current project requirements:
- Make tooltip wrappable 
- Show first validation tooltip immediately

Please review my changes and integrate if possible.

I could have pushed to the master myself but appreciate somebody else's review.

Regards,

Vladimir
