### PR TITLE
[BUG #6697] Fix private members initialization

### DIFF
--- a/framework/source/class/qx/ui/table/rowrenderer/Default.js
+++ b/framework/source/class/qx/ui/table/rowrenderer/Default.js
@@ -40,10 +40,9 @@ qx.Class.define("qx.ui.table.rowrenderer.Default",
   {
     this.base(arguments);
 
-    this.__fontStyleString = "";
-    this.__fontStyleString = {};
-
     this._colors = {};
+    this.__fontStyle = {};
+    this.__fontStyleString = "";
 
     // link to font theme
     this._renderFont(qx.theme.manager.Font.getInstance().resolve("default"));
@@ -116,8 +115,8 @@ qx.Class.define("qx.ui.table.rowrenderer.Default",
       }
       else
       {
-        this.__fontStyleString = "";
         this.__fontStyle = qx.bom.Font.getDefaultStyles();
+        this.__fontStyleString = "";
       }
     },
 


### PR DESCRIPTION
```
Bug fix:
  Fix __fontStyle not being initialized
    (and __fontStyleString being initialized twice with different values).
General:
  Private members usage within the class sorted
    (for consistency with declaration/destruction and logical order).
```
