### PR TITLE
fixed bug where qx.ui.layout.Flow.connectToWidget() does not handle null

### DIFF
--- a/framework/source/class/qx/ui/layout/Flow.js
+++ b/framework/source/class/qx/ui/layout/Flow.js
@@ -224,7 +224,8 @@ qx.Class.define("qx.ui.layout.Flow",
       // only one line of items which is leading to the wrong height. This
       // wrong height does e.g. surpress scrolling since the scroll pane does
       // not know about the correct needed height.
-      widget.setAllowShrinkY(false);
+      if (widget)
+    	widget.setAllowShrinkY(false);
     },
 
 


### PR DESCRIPTION
qx.ui.layout.Flow.connectToWidget() does not handle cases where widget can be null (eg when the widget's layout is changed from Flow to something else).

Please see http://bugs.qooxdoo.org/show_bug.cgi?id=6818
