### PR TITLE
qx.io.remote.Request api

### DIFF
--- a/framework/source/class/qx/io/remote/Request.js
+++ b/framework/source/class/qx/io/remote/Request.js
@@ -174,7 +174,7 @@ qx.Class.define("qx.io.remote.Request",
 
 
     /**
-     * Determines what type of request to issue (GET or POST).
+     * Determines what type of request to issue (GET, POST, PUT, HEAD, DELETE).
      */
     method :
     {


### PR DESCRIPTION
In qx.io.remote.Request api 
Missing method name in the description of method property
