### PR TITLE
fixes a bug where insets on shadow decorators no longer need to be...

### DIFF
--- a/framework/source/class/qx/ui/core/Widget.js
+++ b/framework/source/class/qx/ui/core/Widget.js
@@ -2510,13 +2510,6 @@ qx.Class.define("qx.ui.core.Widget",
           var shadowWidth = bounds.width + insets.left + insets.right;
           var shadowHeight = bounds.height + insets.top + insets.bottom;
 
-          // remove the old insets if given
-          if (old) {
-            var oldInsets = pool.getDecoratorElement(old).getInsets();
-            shadowWidth = shadowWidth - oldInsets.left - oldInsets.right;
-            shadowHeight = shadowHeight - oldInsets.top - oldInsets.bottom;
-          }
-
           elem.resize(shadowWidth, shadowHeight);
         }
 


### PR DESCRIPTION
...reversed when replacing the shadow because insets are now negative. 
This shows up if an appearance changes the decorator based on state and
those decorators have different insets.

Please see bug report http://bugs.qooxdoo.org/show_bug.cgi?id=6927
