### PR TITLE
Modified qx.Class.define

### DIFF
--- a/framework/source/class/qx/Class.js
+++ b/framework/source/class/qx/Class.js
@@ -227,7 +227,7 @@ qx.Bootstrap.define("qx.Class",
         }
       }
       // If config has a 'extend' key but it's null or undefined
-      else if (config.hasOwnProperty('extend'))
+      else if (config.hasOwnProperty('extend') && qx.core.Environment.get("qx.debug"))
       {
          throw new Error('"extend" parameter is null or undefined');
       }

--- a/framework/source/class/qx/Class.js
+++ b/framework/source/class/qx/Class.js
@@ -226,6 +226,11 @@ qx.Bootstrap.define("qx.Class",
           }
         }
       }
+      // If config has a 'extend' key but it's null or undefined
+      else if (config.hasOwnProperty('extend'))
+      {
+         throw new Error('"extend" parameter is null or undefined');
+      }
 
       // Process environment
       if (config.environment)


### PR DESCRIPTION
Modified qx.Class.define to throw new error if "extend" parameter is passed but it's undefined.
