### PR TITLE
TabView middle mouse button reactions

### DIFF
--- a/framework/source/class/qx/ui/tabview/TabButton.js
+++ b/framework/source/class/qx/ui/tabview/TabButton.js
@@ -236,6 +236,16 @@ qx.Class.define("qx.ui.tabview.TabButton",
       } else {
         this._excludeChildControl("close-button");
       }
+      
+      // Close tab by middle mouse button click
+      this.addListener("click",
+      function(e)
+      {
+        if (e.isMiddlePressed() & this.getShowCloseButton()){
+         this.fireDataEvent("close", this);
+        }
+      },
+      this);
     },
 
     // property apply

--- a/framework/source/class/qx/ui/tabview/TabView.js
+++ b/framework/source/class/qx/ui/tabview/TabView.js
@@ -71,6 +71,21 @@ qx.Class.define("qx.ui.tabview.TabView",
     } else {
       this.initBarPosition();
     }
+    
+    // Bar mousewheel listener
+    this.getChildControl("bar").addListener("mousewheel", function (e) {
+      if (e.getWheelDelta() < 0) {
+          this.previous();
+      } else {
+          this.next();
+      };
+
+      // stop the propagation
+      // prevent any other widget from receiving this event
+      // e.g. place a tabview widget inside a scroll container widget
+      e.stopPropagation();
+      e.preventDefault();
+    }, this);
   },
 
 
@@ -157,6 +172,23 @@ qx.Class.define("qx.ui.tabview.TabView",
       }
 
       return control || this.base(arguments, id);
+    },
+    
+    // Select next tab
+    next: function () {
+     var size = this.getSelectables().length;
+     var idx = this.getSelectables().indexOf(this.getSelection()[0]);
+     if (idx < size - 1) {
+       this.setSelection([this.getSelectables()[idx + 1]]);
+     };
+    },
+
+    // Select previous tab
+    previous: function () {
+      var idx = this.getSelectables().indexOf(this.getSelection()[0]);
+      if (idx > 0) {
+        this.setSelection([this.getSelectables()[idx - 1]]);
+      };
     },
 
     /**


### PR DESCRIPTION
TabView tabs now are switched by mouse wheel rotation.
TabView tabs, having close button could be closed by middle mouse button click.
I am not sure second feature needs separation from the close button, so I'm edited _applyShowCloseButton function and waiting for your opinions now.

P.S.: first variant of the commit text was wrong, so I'm changed it.
