### PR TITLE
Give IMarshalerDelegate.getModelClass access to data.

### DIFF
--- a/framework/source/class/qx/data/marshal/IMarshalerDelegate.js
+++ b/framework/source/class/qx/data/marshal/IMarshalerDelegate.js
@@ -73,11 +73,12 @@ qx.Interface.define("qx.data.marshal.IMarshalerDelegate",
      *
      * @param properties {String} A sorted order of propertynames
      *   separated by ".
+     * @param object {Map} The object for which an class is needed.
      * @return {Class|null} Returns the class containing the properties
      *   corresponding to the given hash of the properties. If <code>null</code>
      *   will be returned, the marshaler will create a class.
      */
-    getModelClass : function(properties) {},
+    getModelClass : function(properties, object) {},
 
 
     /**

--- a/framework/source/class/qx/data/marshal/Json.js
+++ b/framework/source/class/qx/data/marshal/Json.js
@@ -155,7 +155,7 @@ qx.Class.define("qx.data.marshal.Json",
       if (
         this.__delegate
         && this.__delegate.getModelClass
-        && this.__delegate.getModelClass(hash) != null
+        && this.__delegate.getModelClass(hash, data) != null
       ) {
         return;
       }
@@ -270,13 +270,14 @@ qx.Class.define("qx.data.marshal.Json",
      *
      * @param hash {String} The hash of the data for which an instance should
      *   be created.
+     * @param data {Map} The data for which an instance should be created.
      * @return {qx.core.Object} An instance of the corresponding class.
      */
-    __createInstance: function(hash) {
+    __createInstance: function(hash, data) {
       var delegateClass;
       // get the class from the delegate
       if (this.__delegate && this.__delegate.getModelClass) {
-        delegateClass = this.__delegate.getModelClass(hash);
+        delegateClass = this.__delegate.getModelClass(hash, data);
       }
       if (delegateClass != null) {
         return (new delegateClass());
@@ -354,7 +355,7 @@ qx.Class.define("qx.data.marshal.Json",
       } else if (isObject) {
         // create an instance for the object
         var hash = this.__jsonToHash(data);
-        var model = this.__createInstance(hash);
+        var model = this.__createInstance(hash, data);
 
         // go threw all element in the data
         for (var key in data) {


### PR DESCRIPTION
I don't know what the official reasoning here is, but I found the properties string that getModelClass() would receive quite useless. Note only does this require parsing/regex to properly check for the presence of any property, but you also cannot differentiate based on the maps values, which might well be the most interesting use case.

This passes the original data object along as well, as a second argument, so it's backwards compatible.
