### PR TITLE
Minor handling of wrong usage of Decorator

### DIFF
--- a/framework/source/class/qx/theme/manager/Decoration.js
+++ b/framework/source/class/qx/theme/manager/Decoration.js
@@ -133,8 +133,14 @@ qx.Class.define("qx.theme.manager.Decoration",
       if (clazz instanceof Array) {
         var names = clazz.concat([]);
         for (var i=0; i < names.length; i++) {
+          // only mixins are allowed in array
+          if (qx.core.Environment.get("qx.debug")) {
+            if (names[i].$$type !== "Mixin") {
+              throw new Error("Invalid declaration of decorator " + value + " has been found. Only mixins can be enclosed in [] brackets. Found " + names[i] + " in declaration.");
+            }
+          }        
           names[i] = names[i].basename.replace(".", "");
-        }
+        };
         var name = "qx.ui.decoration.dynamic." + names.join("_");
         if (!qx.Class.getByName(name)) {
           qx.Class.define(name, {


### PR DESCRIPTION
Little fix for http://bugzilla.qooxdoo.org/show_bug.cgi?id=7247 to show more verbose error message on wrong usage of Decorator.

``` javascript
"table" : {
  decorator : [qx.ui.decoration.Single]
}
```

Originally this breaks the code with not very helpful error message. I have added this message instead while qx.debug is enabled:

_Invalid declaration of decorator table has been found. Only mixins can be enclosed in [] brackets. Found [Class qx.ui.decoration.Single]._
