### PR TITLE
[BUG #7267] - Problem in qx.ui.mobile.form.List when changeBubble event ...

### DIFF
--- a/framework/source/class/qx/ui/mobile/list/List.js
+++ b/framework/source/class/qx/ui/mobile/list/List.js
@@ -276,9 +276,9 @@ qx.Class.define("qx.ui.mobile.list.List",
     {
       if(evt) {
         var data = evt.getData();
-        if(data.name && data.old.length == data.value.length) {
+        var isArray = (qx.lang.Type.isArray(data.old) && qx.lang.Type.isArray(data.value));
+        if(!isArray || (isArray && data.old.length == data.value.length)) {
           var rows = this._extractRowsToRender(data.name);
-          
           for (var i=0; i < rows.length; i++) {
             this.__renderRow(rows[i]);
           }


### PR DESCRIPTION
Bug fix for http://bugzilla.qooxdoo.org/show_bug.cgi?id=7267

qx.ui.mobile.list.List does not react correctly on a change of a property of a
model contained on the array.
On a string property, change is only applied if old string length is same than
new string length

Playground test : http://goo.gl/FYW2a 

Comment on commit introducing the bug :
https://github.com/qooxdoo/qooxdoo/commit/a5e7fa14ce9c5491ac905fdb4009fbc4d88fa10b#commitcomment-2703010
