### PR TITLE
prevent failure when error string is shorter than 300 characters

### DIFF
--- a/tool/bin/generator.py
+++ b/tool/bin/generator.py
@@ -263,7 +263,8 @@ if __name__ == '__main__':
                 #print >> sys.stderr, e
                 print >> sys.stderr, type(e), ":",
                 for el in e.args:
-                    print >> sys.stderr, str(el)[:300]
+                    maxlen = min(len(el), 300)
+                    print >> sys.stderr, str(el)[:maxlen]
             else:
                 print >> sys.stderr, "\nTerminating on unprintable exception; please re-run with -s."
             sys.exit(1)


### PR DESCRIPTION
If one of the lines in the error string is less than 300 characters then the current Qooxdoo codebase will fail because there is an attempt to create a string slice that is longer than the string.

This pull request addresses that issue by printing 300 characters if they are available and otherwise only printing what is available.
