### PR TITLE
qx.Interface.classImplements and qx.Interface.objectImplements to reduce number of exceptions

### DIFF
--- a/framework/source/class/qx/Class.js
+++ b/framework/source/class/qx/Class.js
@@ -656,19 +656,13 @@ qx.Bootstrap.define("qx.Class",
         return true;
       }
 
-      try
-      {
-        qx.Interface.assertObject(obj, iface);
-        return true;
+      if (qx.Interface.objectImplements(obj, iface)) {
+    	  return true;
       }
-      catch(ex) {}
 
-      try
-      {
-        qx.Interface.assert(clazz, iface, false);
-        return true;
+      if (qx.Interface.classImplements(clazz, iface)) {
+    	  return true;
       }
-      catch(ex) {}
 
       return false;
     },

--- a/framework/source/class/qx/Interface.js
+++ b/framework/source/class/qx/Interface.js
@@ -400,7 +400,154 @@ qx.Bootstrap.define("qx.Interface",
         }
       }
     },
+    
+    
+    /**
+     * Asserts that the given object implements all the methods defined in the
+     * interface. This method throws an exception if the object does not
+     * implement the interface.
+     *
+     *  @param object {qx.core.Object} Object to check interface for
+     *  @param iface {Interface} The interface to verify
+     */
+    objectImplements : function(object, iface)
+    {
+      var clazz = object.constructor;
+      if (!this.__hasMembers(object, clazz, iface) ||
+		!this.__hasProperties(clazz, iface) ||
+		!this.__hasEvents(clazz, iface)) 
+      {
+    	return false;
+      }
 
+      // Validate extends, recursive
+      var extend = iface.$$extends;
+      if (extend)
+      {
+        for (var i=0, l=extend.length; i<l; i++) {
+          if (!this.objectImplements(object, extend[i])) 
+          {
+        	return false;  
+          }
+        }
+      }
+      
+      return true;
+    },
+    
+    
+    /**
+     * Tests whether an interface is implemented by a class, without throwing an 
+     * exception when it doesnt
+     * @param clazz {Class} class to check interface for
+     * @param iface {Interface} the interface to verify
+     * @return {Boolean} true if interface is implemented
+     */
+    classImplements : function(clazz, iface) {
+      if (!this.__hasMembers(clazz.prototype, clazz, iface) ||
+    	  !this.__hasProperties(clazz, iface) ||
+          !this.__hasEvents(clazz, iface)) 
+      {
+      	return false;
+      }
+
+      // Validate extends, recursive
+      var extend = iface.$$extends;
+      if (extend)
+      {
+        for (var i=0, l=extend.length; i<l; i++) 
+        {
+          if (!this.has(clazz, extend[i])) {
+          	return false;
+          }
+        }
+      }
+        
+      return true;
+    },
+
+    /**
+     * Assert properties
+     *
+     * @param clazz {Class} class to check interface for
+     * @param iface {Interface} the interface to verify
+     */
+    __hasProperties : function(clazz, iface)
+    {
+      if (iface.$$properties)
+      {
+        for (var key in iface.$$properties)
+        {
+          if (!qx.util.OOUtil.getPropertyDefinition(clazz, key)) {
+            return false;
+          }
+        }
+      }
+      return true;
+    },
+
+
+    /**
+     * Assert events
+     *
+     * @param clazz {Class} class to check interface for
+     * @param iface {Interface} the interface to verify
+     */
+    __hasEvents : function(clazz, iface)
+    {
+      if (iface.$$events)
+      {
+        for (var key in iface.$$events)
+        {
+          if (!qx.util.OOUtil.supportsEvent(clazz, key)) {
+            return false;
+          }
+        }
+      }
+      return true;
+    },
+
+
+    /**
+     * Assert members
+     *
+     * @param object {qx.core.Object} The object, which contains the methods
+     * @param clazz {Class} class of the object
+     * @param iface {Interface} the interface to verify
+     */
+    __hasMembers : function(object, clazz, iface)
+    {
+      // Validate members
+      var members = iface.$$members;
+      if (members)
+      {
+        for (var key in members)
+        {
+          if (qx.Bootstrap.isFunction(members[key]))
+          {
+            var isPropertyMethod = this.__isPropertyMethod(clazz, key);
+            var hasMemberFunction = isPropertyMethod || qx.Bootstrap.isFunction(object[key]);
+
+            if (!hasMemberFunction)
+            {
+              return false;
+            }
+          }
+          else
+          {
+            // Other members are not checked more detailed because of
+            // JavaScript's loose type handling
+            if (typeof object[key] === undefined)
+            {
+              if (typeof object[key] !== "function") {
+                  return false;
+              }
+            }
+          }
+        }
+      }
+      return true;
+    },
 
 
 

--- a/framework/source/class/qx/test/Interface.js
+++ b/framework/source/class/qx/test/Interface.js
@@ -68,6 +68,85 @@ qx.Class.define("qx.test.Interface",
       });
 
       var audi = new qx.test.i.Audi("audi");
+      
+      this.assertTrue(qx.Interface.classImplements(qx.test.i.Audi, qx.test.i.ICar));
+      
+      // Everything implemented
+      qx.Class.define("qx.test.i.Bmw1",
+        {
+          extend : Object,
+          construct : function() {},
+
+          members :
+          {
+            startEngine : function() {
+              return "start";
+            }
+          },
+
+          statics :
+          {
+            honk : function() {
+              return "honk";
+            }
+          },
+
+          properties : { color : { } }
+        });
+      this.assertTrue(qx.Interface.classImplements(qx.test.i.Bmw1, qx.test.i.ICar));
+      
+      // Missing members
+      qx.Class.define("qx.test.i.Bmw2",
+        {
+          extend : Object,
+          construct : function() {},
+          statics :
+          {
+            honk : function() {
+              return "honk";
+            }
+          },
+
+          properties : { color : { } }
+        });
+      this.assertFalse(qx.Interface.classImplements(qx.test.i.Bmw2, qx.test.i.ICar));
+
+      // Missing statics (ie it does implement all necessary)
+      qx.Class.define("qx.test.i.Bmw3",
+        {
+          extend : Object,
+          construct : function() {},
+          members :
+          {
+            startEngine : function() {
+              return "start";
+            }
+          },
+
+          properties : { color : { } }
+        });
+      this.assertTrue(qx.Interface.classImplements(qx.test.i.Bmw3, qx.test.i.ICar));
+
+      // Missing properties
+      qx.Class.define("qx.test.i.Bmw4",
+        {
+          extend : Object,
+          construct : function() {},
+          members :
+          {
+            startEngine : function() {
+              return "start";
+            }
+          },
+
+          statics :
+          {
+            honk : function() {
+              return "honk";
+            }
+          }
+        });
+      this.assertFalse(qx.Interface.classImplements(qx.test.i.Bmw4, qx.test.i.ICar));
 
       if (this.isDebugOn())
       {


### PR DESCRIPTION
Adds qx.Interface.classImplements and qx.Interface.objectImplements to detect interfaces without throwing exceptions (ie they correspond to
qx.Interface.assert/assertObject), and a mod to
qx.Class.implementsInterface to use the new methods.  This patch can
greatly reduce the number of first-chance exceptions thrown by the
framework and is especially useful when debugging code which uses the
binding mechanism.

Please see bug http://bugzilla.qooxdoo.org/show_bug.cgi?id=7330
