### PR TITLE
Jobs that use PYTHON_CMD fails when there are spaces in python path

### DIFF
--- a/tool/pylib/generator/config/Defaults.py
+++ b/tool/pylib/generator/config/Defaults.py
@@ -69,7 +69,7 @@ class Defaults(object):
         # overriding the config file and the FOO macro.
         u"GENERATOR_OPTS"  : getGenOpts(),
         u"HOME"            : getUserHome("."),
-        u"PYTHON_CMD"      : "'" + sys.executable + "'",
+        u"PYTHON_CMD"      : '"' + sys.executable + '"',
         u"TMPDIR"          : tempfile.gettempdir(),
         u"QOOXDOO_VERSION" : getQooxdooVersion(),
         u"QOOXDOO_REVISION": getQooxdooRevision(),

--- a/tool/pylib/generator/config/Defaults.py
+++ b/tool/pylib/generator/config/Defaults.py
@@ -69,10 +69,9 @@ class Defaults(object):
         # overriding the config file and the FOO macro.
         u"GENERATOR_OPTS"  : getGenOpts(),
         u"HOME"            : getUserHome("."),
-        u"PYTHON_CMD"      : sys.executable,
+        u"PYTHON_CMD"      : "'" + sys.executable + "'",
         u"TMPDIR"          : tempfile.gettempdir(),
         u"QOOXDOO_VERSION" : getQooxdooVersion(),
         u"QOOXDOO_REVISION": getQooxdooRevision(),
         u"USERNAME"        : os.getenv("USERNAME"),
     }
-


### PR DESCRIPTION
Commands like minify-css for mobile apps fails when you have python installed in the path containing spaces, like Program Files on Windows.

Note: Tested only on windows, but I dont see reason it should break linux builds as well, there is nothing wrong with having path wrapped in double quotes.

Here is error message:

```
----------------------------------------------------------------------------
    Executing: minify-css
----------------------------------------------------------------------------
>>> Executing shell command "C:\Program Files\Python27\python.exe C:\Users\Michal\Workspace\mobileapp-poc\qooxdoo-sdk/tool/bin/mkdir.py ./build/resource/mobileapp/css"...
'C:\Program' is not recognized as an internal or external command,  program or batch file.
<type 'exceptions.RuntimeError'> : Shell command returned error code: 1
```
