### PR TITLE
Fixes bug where qx.data.Array.splice fires wrong/inaccurate change event

### DIFF
--- a/framework/source/class/qx/data/Array.js
+++ b/framework/source/class/qx/data/Array.js
@@ -344,29 +344,71 @@ qx.Class.define("qx.data.Array",
       if (this.__array.length != oldLength) {
         this.__updateLength();
       }
-      // fire an event for the change
-      var removed = amount > 0;
-      var added = arguments.length > 2;
+      
       var items = null;
-      if (removed || added) {
-        if (this.__array.length > oldLength) {
-          var type = "add";
-          items = qx.lang.Array.fromArguments(arguments, 2);
-        } else if (this.__array.length < oldLength) {
-          var type = "remove";
-          items = returnArray;
-        } else {
-          var type = "order";
+      var reordered = true;
+      if (amount > 0) {
+        items = [];
+        // Detect actual changes, otherwise we notify that items have been removed when they
+        //  they are still in the array
+        for (var i = 0; i < returnArray.length; i++)
+          if (this.__array.indexOf(returnArray[i]) < 0)
+            items.push(returnArray[i]);
+        if (items.length > 0) {
+          reordered = false;
+          this.fireDataEvent("change",
+            {
+              start: startIndex,
+              end: this.length - 1,
+              type: "remove",
+              items: items
+            }, null
+          );
         }
-        this.fireDataEvent("change",
-          {
-            start: startIndex,
-            end: this.length - 1,
-            type: type,
-            items: items
-          }, null
-        );
       }
+      if (arguments.length > 2) {
+        var added = qx.lang.Array.fromArguments(arguments, 2);
+        items = [];
+        // Detect actual changes, otherwise we notify that items have been added when they
+        //  they are no longer in the array
+        for (var i = 0; i < added.length; i++)
+          if (returnArray.indexOf(added[i]) < 0)
+            items.push(added[i]);
+        if (items.length > 0) {
+          reordered = false;
+          this.fireDataEvent("change",
+            {
+              start: startIndex,
+              end: this.length - 1,
+              type: "add",
+              items: items
+            }, null
+          );
+        }
+      }
+      
+      // only fire a change event if neither an add or remove was fired
+      if (amount > 0 && arguments.length > 2 && reordered) {
+        // check that the array really was reordered
+        if (returnArray.length == added.length) {
+          reordered = false;
+          for (var i = 0; !reordered && i < returnArray.length; i++) {
+            if (returnArray[i] != added[i])
+            reordered = true;
+          }
+        }
+        if (reordered) {
+          this.fireDataEvent("change",
+            {
+              start: startIndex,
+              end: this.length - 1,
+              type: "order",
+              items: null
+            }, null
+          );
+        }
+      }
+      
 
       // remove the listeners first [BUG #7132]
       for (var i = 0; i < returnArray.length; i++) {

--- a/framework/source/class/qx/test/data/DataArray.js
+++ b/framework/source/class/qx/test/data/DataArray.js
@@ -549,6 +549,66 @@ qx.Class.define("qx.test.data.DataArray",
         self.assertEquals(1, e.getData().items.length, "Wrong amount of items in the event.");
       }, "Change event not fired!");
       a.dispose();
+      
+      // test for add to only list new elements
+      a = new qx.data.Array(1, 2, 3);
+      var addFired = false, removeFired = false, orderedFired = false;
+      this.assertEventFired(a, "change", function () {
+        a.splice(1, 1, 0, 2).dispose();
+      }, function(e) {
+    	if (e.getData().type == "add") {
+          self.assertEquals(1, e.getData().start, "Wrong start index in the event.");
+          self.assertEquals(3, e.getData().end, "Wrong end index in the event.");
+          self.assertArrayEquals([0], e.getData().items, "Wrong items in the event.");
+          addFired = true;
+    	} else if (e.getData().type == "remove") {
+          removeFired = true;
+    	} else if (e.getData().type == "order") {
+    	  orderedFired = true;
+    	}
+      }, "Change event not fired!");
+      this.assertTrue(addFired && !removeFired && !orderedFired, "splice does not send correct change events");
+      a.dispose();
+      
+      // test for remove to only list deleted elements
+      a = new qx.data.Array(1, 2, 3);
+      var addFired = false, removeFired = false, orderedFired = false;
+      this.assertEventFired(a, "change", function () {
+        a.splice(1, 2, 3).dispose();
+      }, function(e) {
+      	if (e.getData().type == "add") {
+            addFired = true;
+      	} else if (e.getData().type == "remove") {
+            self.assertEquals(1, e.getData().start, "Wrong start index in the event.");
+            self.assertEquals(1, e.getData().end, "Wrong end index in the event.");
+            self.assertArrayEquals([2], e.getData().items, "Wrong items in the event.");
+            removeFired = true;
+      	} else if (e.getData().type == "order") {
+    	  orderedFired = true;
+    	}
+      }, "Change event not fired!");
+      this.assertTrue(!addFired && removeFired && !orderedFired, "splice does not send correct change events");
+      a.dispose();
+      
+      // test for reordering
+      a = new qx.data.Array(1, 2, 3);
+      var addFired = false, removeFired = false, orderedFired = false;
+      this.assertEventFired(a, "change", function () {
+        a.splice(0, 3, 3, 2, 1).dispose();
+      }, function(e) {
+      	if (e.getData().type == "add") {
+            addFired = true;
+      	} else if (e.getData().type == "remove") {
+            self.assertEquals(1, e.getData().start, "Wrong start index in the event.");
+            self.assertEquals(1, e.getData().end, "Wrong end index in the event.");
+            self.assertArrayEquals([2], e.getData().items, "Wrong items in the event.");
+            removeFired = true;
+      	} else if (e.getData().type == "order") {
+    	  orderedFired = true;
+    	}
+      }, "Change event not fired!");
+      this.assertTrue(!addFired && !removeFired && orderedFired, "splice does not send correct change events");
+      a.dispose();      
     },
 
     testSetItemEvent: function() {


### PR DESCRIPTION
This pull request was previously released as pull request #19 but was marked as already fixed - it's not (I think I screwed up my original commit); the problem can be seen here [1] and is logged here [2].

This branch and pull request fixes the problem, including unit tests

[1] http://tinyurl.com/d826eyj 
[2] http://bugzilla.qooxdoo.org/show_bug.cgi?id=6207
