### PR TITLE
Lose the need to pass args to base() and self()

### DIFF
--- a/framework/source/class/qx/core/Object.js
+++ b/framework/source/class/qx/core/Object.js
@@ -117,26 +117,33 @@ qx.Class.define("qx.core.Object",
     /**
      * Call the same method of the super class.
      *
-     * @param args {arguments} the arguments variable of the calling method
+     * @param args {arguments} the arguments variable of the calling method. Optional. Deprecated.
      * @param varargs {var} variable number of arguments passed to the overwritten function
      * @return {var} the return value of the method of the base class.
      */
-    base : function(args, varargs)
+    base : function base(varags)
     {
+      var caller = base.caller;
+      var args = [].slice.call(arguments);
+      if (args[0] && qx.Bootstrap.isFunction(args[0].callee) && qx.Bootstrap.isFunction(args[0].callee.base))
+      {
+        caller = args.shift().callee;
+      }
+      var baseMethod = caller.base;
       if (qx.core.Environment.get("qx.debug"))
       {
-        if (!qx.Bootstrap.isFunction(args.callee.base)) {
+        if (!qx.Bootstrap.isFunction(baseMethod)) {
           throw new Error(
             "Cannot call super class. Method is not derived: " +
-            args.callee.displayName
+            caller.displayName
           );
         }
       }
 
-      if (arguments.length === 1) {
-        return args.callee.base.call(this);
+      if (args.length === 0) {
+        return baseMethod.call(this);
       } else {
-        return args.callee.base.apply(this, Array.prototype.slice.call(arguments, 1));
+        return baseMethod.apply(this, args);
       }
     },
 
@@ -144,11 +151,10 @@ qx.Class.define("qx.core.Object",
     /**
      * Returns the static class (to access static members of this class)
      *
-     * @param args {arguments} the arguments variable of the calling method
      * @return {var} the return value of the method of the base class.
      */
-    self : function(args) {
-      return args.callee.self;
+    self : function self() {
+      return self.caller.self;
     },
 
 

--- a/framework/source/class/qx/test/Class.js
+++ b/framework/source/class/qx/test/Class.js
@@ -76,6 +76,110 @@ qx.Class.define("qx.test.Class",
             return "stop";
           },
 
+          makeWhroom : function(whroomer) {
+            return whroomer() + " whroom";
+          },
+          
+          makeSomething : function(something) {
+            return something[0].toUpperCase()+something.slice(1);
+          },
+
+          getName : function() {
+            return this._name;
+          }
+        }
+      });
+
+      var car = new qx.Car("Audi");
+      this.assertEquals("start", car.startEngine());
+      this.assertEquals("stop", car.stopEngine());
+      this.assertEquals("Audi", car.getName());
+
+      qx.Class.define("qx.Bmw",
+      {
+        extend : qx.Car,
+
+        construct : function(name, prize) {
+          this.base(arguments, name);
+        },
+
+        members :
+        {
+          startEngine : function()
+          {
+            var ret = this.base();
+            return "brrr " + ret;
+          },
+
+          stopEngine : function stopEngine()
+          {
+            var ret = stopEngine.base.call();
+            return "brrr " + ret;
+          },
+
+          makeWhroom : function(whroomer) {
+            return this.base(whroomer || function() { return 'brrr'; });
+          },
+          
+          makeSomething : function(something) {
+            return "brrr " + this.base(something);
+          },
+
+          getWheels : function() {
+            return this.self().WHEELS;
+          },
+
+          getMaxSpeed : function()
+          {
+            // call base in non overridden method
+            this.base(arguments);
+          }
+        },
+
+        statics : { WHEELS : 4 }
+      });
+
+      var bmw = new qx.Bmw("bmw", 44000);
+      this.assertEquals("bmw", bmw.getName());
+      this.assertEquals("brrr start", bmw.startEngine());
+      this.assertEquals("brrr stop", bmw.stopEngine());
+      this.assertEquals("brrr whroom", bmw.makeWhroom());
+      this.assertEquals("brrrrr whroom", bmw.makeWhroom(function() { return 'brrrrr'; }));
+      this.assertEquals("brrr Something", bmw.makeSomething('something'));
+      this.assertEquals(4, bmw.getWheels());
+
+      if (this.isDebugOn())
+      {
+        this.assertException(function() {
+          bmw.getMaxSpeed();
+        }, Error);
+      }
+    },
+    
+    testSuperClassCallWithArguments : function()
+    {
+      qx.Class.define("qx.Car",
+      {
+        extend : qx.core.Object,
+
+        construct : function(name) {
+          this._name = name;
+        },
+
+        members :
+        {
+          startEngine : function() {
+            return "start";
+          },
+
+          stopEngine : function() {
+            return "stop";
+          },
+          
+          makeWhroom : function(whroomer) {
+            return whroomer() + " whroom";
+          },
+
           getName : function() {
             return this._name;
           }
@@ -108,6 +212,15 @@ qx.Class.define("qx.test.Class",
             var ret = arguments.callee.base.call();
             return "brrr " + ret;
           },
+          
+          fakeStopEngine : function() {
+            var ret = this.base({callee: this.startEngine});
+            return "brrr " + ret;
+          },
+
+          makeWhroom : function(whroomer) {
+            return this.base(arguments, whroomer || function() { return 'brrr'; });
+          },
 
           getWheels : function() {
             return this.self(arguments).WHEELS;
@@ -127,6 +240,9 @@ qx.Class.define("qx.test.Class",
       this.assertEquals("bmw", bmw.getName());
       this.assertEquals("brrr start", bmw.startEngine());
       this.assertEquals("brrr stop", bmw.stopEngine());
+      this.assertEquals("brrr start", bmw.fakeStopEngine());
+      this.assertEquals("brrr whroom", bmw.makeWhroom());
+      this.assertEquals("brrrrr whroom", bmw.makeWhroom(function() { return 'brrrrr'; }));
       this.assertEquals(4, bmw.getWheels());
 
       if (this.isDebugOn())
@@ -136,8 +252,7 @@ qx.Class.define("qx.test.Class",
         }, Error);
       }
     },
-
-
+    
     testAbstract : function()
     {
       qx.Class.define("qx.AbstractCar",


### PR DESCRIPTION
It bothers me to explicitly pass the `arguments` variable of the calling function to `base()` and `self()`; we don’t need the arguments of the caller to get the caller.

We can use Function.prototype.caller (as functionName.caller or arguments.callee.caller) internally instead. It is non-standard but works everywhere. There might be some confusion with arguments.caller, which is deprecated and does not work everywhere.

This change is completely backwards-compatible.

Unit tests attached.
