### PR TITLE
Enhance error output on theme errors in appearance and decoration queue

### DIFF
--- a/framework/source/class/qx/theme/manager/Decoration.js
+++ b/framework/source/class/qx/theme/manager/Decoration.js
@@ -91,18 +91,17 @@ qx.Class.define("qx.theme.manager.Decoration",
     addCssClass : function(value) {
       var sheet = qx.ui.style.Stylesheet.getInstance();
 
-      var instance;
-      if (qx.lang.Type.isString(value)) {
-        instance = this.resolve(value);
-      } else {
-        instance = value;
-      }
+      var instance = value;
 
       value = this.getCssClassName(value);
       var selector = "." + value;
 
       if (sheet.hasRule(selector)) {
         return value;
+      }
+
+      if (qx.lang.Type.isString(instance)) {
+        instance = this.resolve(instance);
       }
 
       // create and add a CSS rule

--- a/framework/source/class/qx/theme/manager/Decoration.js
+++ b/framework/source/class/qx/theme/manager/Decoration.js
@@ -103,6 +103,9 @@ qx.Class.define("qx.theme.manager.Decoration",
       if (qx.lang.Type.isString(instance)) {
         instance = this.resolve(instance);
       }
+      if(!instance) {
+        throw new Error(' unable to resolve CSS class for decorator "' + value + '"');
+      }
 
       // create and add a CSS rule
       var css = "";

--- a/framework/source/class/qx/ui/core/queue/Appearance.js
+++ b/framework/source/class/qx/ui/core/queue/Appearance.js
@@ -91,7 +91,12 @@ qx.Class.define("qx.ui.core.queue.Appearance",
 
         // Only apply to currently visible widgets
         if (Visibility.isVisible(obj)) {
-          obj.syncAppearance();
+          try {
+            obj.syncAppearance();
+          }
+          catch(e) {
+            qx.log.Logger.error(qx.ui.core.queue.Appearance, "Error in the 'Appearance' queue: obj.classname: " + obj.classname + ", " + e, e);
+          }
         } else {
           obj.$$stateChanges = true;
         }


### PR DESCRIPTION
Enhance error output on theme errors in appearance and decoration queue.
Small optimization: If the decorator already has a rule in the stylesheet there is no need to call this.resolve() here.
Check if resolving the decorator was successfull and throw an exception with a meaningfull error message if not.
