### PR TITLE
Allow decorator properties to be repeated for multiple values for certain CSS properties

### DIFF
--- a/framework/source/class/qx/lang/Array.js
+++ b/framework/source/class/qx/lang/Array.js
@@ -453,7 +453,7 @@ qx.Bootstrap.define("qx.lang.Array",
     /**
      * Extends an array up to the given length by repeating the elements already present.
      * @param arr {Array} Incoming array. Has to contain at least one element.
-     * @param arr {Integer} Desired length. Must be greater than or equal to the the length of arr.
+     * @param to {Integer} Desired length. Must be greater than or equal to the the length of arr.
      */
     prolong : function(arr, to)
     {

--- a/framework/source/class/qx/lang/Array.js
+++ b/framework/source/class/qx/lang/Array.js
@@ -450,6 +450,18 @@ qx.Bootstrap.define("qx.lang.Array",
       return result === undefined ? null : result;
     },
 
+    /**
+     * Extends an array up to the given length by repeating the elements already present.
+     * @param arr {Array} Incoming array. Has to contain at least one element.
+     * @param arr {Integer} Desired length. Must be greater than or equal to the the length of arr.
+     */
+    prolong : function(arr, to)
+    {
+      var initial = arr.length;
+      while(arr.length < to) {
+        arr.push(arr[arr.length%initial]);
+      }
+    },
 
     /**
      * Recreates an array which is free of all duplicate elements from the original.
@@ -461,7 +473,7 @@ qx.Bootstrap.define("qx.lang.Array",
      * @param arr {Array} Incoming array
      * @return {Array} Returns a copy with no duplicates or the original array if no duplicates were found
      */
-    unique: function(arr)
+    unique : function(arr)
     {
       var ret=[], doneStrings={}, doneNumbers={}, doneObjects={};
       var value, count=0;

--- a/framework/source/class/qx/ui/decoration/Decorator.js
+++ b/framework/source/class/qx/ui/decoration/Decorator.js
@@ -112,6 +112,13 @@ qx.Class.define("qx.ui.decoration.Decorator", {
         }
       }
 
+      for(var name in styles)
+      {
+        if(qx.lang.Type.isArray(styles[name])) {
+          styles[name] = styles[name].join(', ');
+        }
+      }
+
       this.__initialized = true;
       return styles;
     },

--- a/framework/source/class/qx/ui/decoration/MBackgroundImage.js
+++ b/framework/source/class/qx/ui/decoration/MBackgroundImage.js
@@ -78,6 +78,16 @@ qx.Mixin.define("qx.ui.decoration.MBackgroundImage",
       group : ["backgroundPositionY", "backgroundPositionX"]
     },
 
+
+    /**
+     * Property group to define the background position
+     */
+    backgroundOrigin :
+    {
+      nullable : true,
+      apply : "_applyBackgroundImage"
+    },
+
     /**
      * Whether to order gradients before Image-URL-based background declarations if both qx.ui.decoration.MBackgroundImage and qx.ui.decoration.MLinearBackgroundGradient decorations are used.
      */
@@ -106,12 +116,15 @@ qx.Mixin.define("qx.ui.decoration.MBackgroundImage",
       if(!qx.lang.Type.isArray(tops)) tops = [tops];
       var lefts = this.getBackgroundPositionX();
       if(!qx.lang.Type.isArray(lefts)) lefts = [lefts];
+      var origins = this.getBackgroundOrigin();
+      if(!qx.lang.Type.isArray(origins)) origins = [origins];
 
       var items = Math.max(images.length, repeats.length, tops.length, lefts.length);
       qx.lang.Array.prolong(images, items);
       qx.lang.Array.prolong(repeats, items);
       qx.lang.Array.prolong(tops, items);
       qx.lang.Array.prolong(lefts, items);
+      qx.lang.Array.prolong(origins, items);
 
       if("background" in styles) {
         if(!Array.isArray(styles['background'])) {
@@ -126,6 +139,7 @@ qx.Mixin.define("qx.ui.decoration.MBackgroundImage",
         var repeat = repeats[i];
         var top = tops[i] || 0;
         var left = lefts[i] || 0;
+        var origin = origins[i] || '';
         if (top == null) {
           top = 0;
         }
@@ -145,14 +159,15 @@ qx.Mixin.define("qx.ui.decoration.MBackgroundImage",
         var attrs = {
           image: 'url(' + source + ')',
           position: left + " " + top,
-          repeat: 'repeat'
+          repeat: 'repeat',
+          origin: origin
         };
         if (repeat === "scale") {
           attrs.size = "100% 100%";
         } else {
           attrs.repeat = repeat;
         }
-        var imageMarkup = [attrs.image, attrs.position + ('size' in attrs ? ' / ' + attrs.size : ''), attrs.repeat];
+        var imageMarkup = [attrs.image, attrs.position + ('size' in attrs ? ' / ' + attrs.size : ''), attrs.repeat, attrs.origin];
         
         styles["background"][this.getOrderGradientsFront() ? 'push' : 'unshift'](imageMarkup.join(' '));
 

--- a/framework/source/class/qx/ui/decoration/MBackgroundImage.js
+++ b/framework/source/class/qx/ui/decoration/MBackgroundImage.js
@@ -27,7 +27,6 @@ qx.Mixin.define("qx.ui.decoration.MBackgroundImage",
     /** The URL of the background image */
     backgroundImage :
     {
-      check : "String",
       nullable : true,
       apply : "_applyBackgroundImage"
     },
@@ -36,7 +35,6 @@ qx.Mixin.define("qx.ui.decoration.MBackgroundImage",
     /** How the background image should be repeated */
     backgroundRepeat :
     {
-      check : ["repeat", "repeat-x", "repeat-y", "no-repeat", "scale"],
       init : "repeat",
       apply : "_applyBackgroundImage"
     },
@@ -78,6 +76,15 @@ qx.Mixin.define("qx.ui.decoration.MBackgroundImage",
     backgroundPosition :
     {
       group : ["backgroundPositionY", "backgroundPositionX"]
+    },
+
+    /**
+     * Whether to order gradients before Image-URL-based background declarations if both qx.ui.decoration.MBackgroundImage and qx.ui.decoration.MLinearBackgroundGradient decorations are used.
+     */
+    orderGradientsFront :
+    {
+      check: 'Boolean',
+      init: false
     }
   },
 
@@ -90,48 +97,74 @@ qx.Mixin.define("qx.ui.decoration.MBackgroundImage",
      */
     _styleBackgroundImage : function(styles)
     {
-      var image = this.getBackgroundImage();
-      if(!image) {
-        return;
-      }
+      var images = this.getBackgroundImage();
+      if(!images) { return; }
+      if(!qx.lang.Type.isArray(images)) images = [images];
+      var repeats = this.getBackgroundRepeat();
+      if(!qx.lang.Type.isArray(repeats)) repeats = [repeats];
+      var tops = this.getBackgroundPositionY();
+      if(!qx.lang.Type.isArray(tops)) tops = [tops];
+      var lefts = this.getBackgroundPositionX();
+      if(!qx.lang.Type.isArray(lefts)) lefts = [lefts];
 
-      var id = qx.util.AliasManager.getInstance().resolve(image);
-      var source = qx.util.ResourceManager.getInstance().toUri(id);
-      if (styles["background-image"]) {
-        styles["background-image"] +=  ', url(' + source + ')';
+      var items = Math.max(images.length, repeats.length, tops.length, lefts.length);
+      qx.lang.Array.prolong(images, items);
+      qx.lang.Array.prolong(repeats, items);
+      qx.lang.Array.prolong(tops, items);
+      qx.lang.Array.prolong(lefts, items);
+
+      if("background" in styles) {
+        if(!Array.isArray(styles['background'])) {
+          styles['background'] = [styles['background']];
+        }
       } else {
-        styles["background-image"] = 'url(' + source + ')';
+        styles['background'] = [];
       }
 
-      var repeat = this.getBackgroundRepeat();
-      if (repeat === "scale") {
-        styles["background-size"] = "100% 100%";
-      }
-      else {
-        styles["background-repeat"] = repeat;
-      }
+      for(var i=0;i<items;i++) {
+        var image = images[i];
+        var repeat = repeats[i];
+        var top = tops[i] || 0;
+        var left = lefts[i] || 0;
+        if (top == null) {
+          top = 0;
+        }
+        if (left == null) {
+          left = 0;
+        }
+        if (!isNaN(top)) {
+          top += "px";
+        }
+        if (!isNaN(left)) {
+          left += "px";
+        }
+        
+        var id = qx.util.AliasManager.getInstance().resolve(image);
+        var source = qx.util.ResourceManager.getInstance().toUri(id);
+        
+        var attrs = {
+          image: 'url(' + source + ')',
+          position: left + " " + top,
+          repeat: 'repeat'
+        };
+        if (repeat === "scale") {
+          attrs.size = "100% 100%";
+        } else {
+          attrs.repeat = repeat;
+        }
+        var imageMarkup = [attrs.image, attrs.position + ('size' in attrs ? ' / ' + attrs.size : ''), attrs.repeat];
+        
+        styles["background"][this.getOrderGradientsFront() ? 'push' : 'unshift'](imageMarkup.join(' '));
 
-      var top = this.getBackgroundPositionY() || 0;
-      var left = this.getBackgroundPositionX() || 0;
-
-      if (!isNaN(top)) {
-        top += "px";
-      }
-
-      if (!isNaN(left)) {
-        left += "px";
-      }
-
-      styles["background-position"] = left + " " + top;
-
-      if (qx.core.Environment.get("qx.debug") &&
-        source &&  qx.lang.String.endsWith(source, ".png") &&
-        (repeat == "scale" || repeat == "no-repeat") &&
-        qx.core.Environment.get("engine.name") == "mshtml" &&
-        qx.core.Environment.get("browser.documentmode") < 9)
-      {
-        this.warn("Background PNGs with repeat == 'scale' or repeat == 'no-repeat'" +
-          " are not supported in this client! The image's resource id is '" + id + "'");
+        if (qx.core.Environment.get("qx.debug") &&
+          source &&  qx.lang.String.endsWith(source, ".png") &&
+          (repeat == "scale" || repeat == "no-repeat") &&
+          qx.core.Environment.get("engine.name") == "mshtml" &&
+          qx.core.Environment.get("browser.documentmode") < 9)
+        {
+          this.warn("Background PNGs with repeat == 'scale' or repeat == 'no-repeat'" +
+            " are not supported in this client! The image's resource id is '" + id + "'");
+        }
       }
     },
 

--- a/framework/source/class/qx/ui/decoration/MBoxShadow.js
+++ b/framework/source/class/qx/ui/decoration/MBoxShadow.js
@@ -35,7 +35,6 @@ qx.Mixin.define("qx.ui.decoration.MBoxShadow",
     shadowHorizontalLength :
     {
       nullable : true,
-      check : "Integer",
       apply : "_applyBoxShadow"
     },
 
@@ -43,7 +42,6 @@ qx.Mixin.define("qx.ui.decoration.MBoxShadow",
     shadowVerticalLength :
     {
       nullable : true,
-      check : "Integer",
       apply : "_applyBoxShadow"
     },
 
@@ -51,7 +49,6 @@ qx.Mixin.define("qx.ui.decoration.MBoxShadow",
     shadowBlurRadius :
     {
       nullable : true,
-      check : "Integer",
       apply : "_applyBoxShadow"
     },
 
@@ -59,7 +56,6 @@ qx.Mixin.define("qx.ui.decoration.MBoxShadow",
     shadowSpreadRadius :
     {
       nullable : true,
-      check : "Integer",
       apply : "_applyBoxShadow"
     },
 
@@ -67,7 +63,6 @@ qx.Mixin.define("qx.ui.decoration.MBoxShadow",
     shadowColor :
     {
       nullable : true,
-      check : "Color",
       apply : "_applyBoxShadow"
     },
 
@@ -75,7 +70,6 @@ qx.Mixin.define("qx.ui.decoration.MBoxShadow",
     inset :
     {
       init : false,
-      check : "Boolean",
       apply : "_applyBoxShadow"
     },
 
@@ -106,31 +100,57 @@ qx.Mixin.define("qx.ui.decoration.MBoxShadow",
         return;
       }
 
-      if (qx.core.Environment.get("qx.theme"))
-      {
-        var Color = qx.theme.manager.Color.getInstance();
-        var color = Color.resolve(this.getShadowColor());
-      }
-      else
-      {
-        var color = this.getShadowColor();
+      propName = qx.bom.Style.getCssName(propName);
+
+      var vLengths = this.getShadowVerticalLength() || [0];
+      if(!qx.lang.Type.isArray(vLengths)) vLengths = [vLengths];
+      var hLengths = this.getShadowHorizontalLength() || [0];
+      if(!qx.lang.Type.isArray(hLengths)) hLengths = [hLengths];
+      var blurs = this.getShadowBlurRadius() || [0];
+      if(!qx.lang.Type.isArray(blurs)) blurs = [blurs];
+      var spreads = this.getShadowSpreadRadius() || [0];
+      if(!qx.lang.Type.isArray(spreads)) spreads = [spreads];
+      var colors = this.getShadowColor() || ['black'];
+      if(!qx.lang.Type.isArray(colors)) colors = [colors];
+      var insets = this.getInset();
+      if(!qx.lang.Type.isArray(insets)) insets = [!!insets];
+
+      var items = Math.max(vLengths.length, hLengths.length, blurs.length, spreads.length, colors.length, insets.length);
+      qx.lang.Array.prolong(vLengths, items);
+      qx.lang.Array.prolong(hLengths, items);
+      qx.lang.Array.prolong(blurs, items);
+      qx.lang.Array.prolong(spreads, items);
+      qx.lang.Array.prolong(colors, items);
+      qx.lang.Array.prolong(insets, items);
+
+      var Color = null;
+      if(qx.core.Environment.get("qx.theme")) {
+        Color = qx.theme.manager.Color.getInstance();
       }
 
-      if (color != null)
+      for(var i=0;i<items;i++)
       {
-        var vLength = this.getShadowVerticalLength() || 0;
-        var hLength = this.getShadowHorizontalLength() || 0;
-        var blur = this.getShadowBlurRadius() || 0;
-        var spread = this.getShadowSpreadRadius() || 0;
-        var inset = this.getInset() ? "inset " : "";
-        var value = inset + hLength + "px " + vLength + "px " + blur + "px " + spread + "px " + color;
+        var vLength = vLengths[i];
+        var hLength = hLengths[i];
+        var blur = blurs[i];
+        var spread = spreads[i];
+        var color = colors[i];
+        var inset = insets[i];
 
-        // apply or append the box shadow styles
-        propName = qx.bom.Style.getCssName(propName);
-        if (!styles[propName]) {
-          styles[propName] = value;
-        } else {
-          styles[propName] += "," + value;
+        if(Color) {
+          color = Color.resolve(color);
+        }
+
+        if(color != null)
+        {
+          var value = (inset ? 'inset ' : '') + hLength + "px " + vLength + "px " + blur + "px " + spread + "px " + color;
+
+          // apply or append the box shadow styles
+          if (!styles[propName]) {
+            styles[propName] = value;
+          } else {
+            styles[propName] += "," + value;
+          }
         }
       }
     },

--- a/framework/source/class/qx/ui/decoration/MLinearBackgroundGradient.js
+++ b/framework/source/class/qx/ui/decoration/MLinearBackgroundGradient.js
@@ -279,52 +279,6 @@ qx.Mixin.define("qx.ui.decoration.MLinearBackgroundGradient",
       return {start: startColor, end: endColor};
     },
 
-
-    /**
-     * Helper for IE which applies the filter used for the gradient to a separate
-     * DIV element which will be put into the decorator. This is necessary in case
-     * the decorator has rounded corners.
-     * @return {String} The HTML for the inner gradient DIV.
-     */
-    _getContent : function() {
-      // IE filter syntax
-      // http://msdn.microsoft.com/en-us/library/ms532997(v=vs.85).aspx
-      // It needs to be wrapped in a separate div bug #6318
-      if (qx.core.Environment.get("css.gradient.filter") &&
-        !qx.core.Environment.get("css.gradient.linear")) {
-
-        var colors = this.__getColors();
-        var type = this.getOrientation() == "horizontal" ? 1 : 0;
-
-        // convert all hex3 to hex6
-        var startColor = qx.util.ColorUtil.hex3StringToHex6String(colors.start);
-        var endColor = qx.util.ColorUtil.hex3StringToHex6String(colors.end);
-
-        // get rid of the starting '#'
-        startColor = startColor.substring(1, startColor.length);
-        endColor = endColor.substring(1, endColor.length);
-
-        // filter gradients block the box shadow implementation ->
-        // we need to set them explicitly [BUG #6761]
-        var shadow = "";
-        if (this.classname.indexOf("MBoxShadow") != -1) {
-          var styles = {};
-          this._styleBoxShadow(styles);
-          shadow = "<div style='width: 100%; height: 100%; position: absolute;" +
-            qx.bom.element.Style.compile(styles) +
-            "'></div>";
-        }
-
-        return "<div style=\"position: absolute; width: 100%; height: 100%; " +
-          "filter:progid:DXImageTransform.Microsoft.Gradient" +
-          "(GradientType=" + type + ", " +
-          "StartColorStr='#FF" + startColor + "', " +
-          "EndColorStr='#FF" + endColor + "';)\">" + shadow + "</div>";
-      }
-      return "";
-    },
-
-
     // property apply
     _applyLinearBackgroundGradient : function()
     {

--- a/framework/source/class/qx/ui/decoration/MLinearBackgroundGradient.js
+++ b/framework/source/class/qx/ui/decoration/MLinearBackgroundGradient.js
@@ -47,7 +47,6 @@ qx.Mixin.define("qx.ui.decoration.MLinearBackgroundGradient",
      */
     startColor :
     {
-      check : "Color",
       nullable : true,
       apply : "_applyLinearBackgroundGradient"
     },
@@ -58,7 +57,6 @@ qx.Mixin.define("qx.ui.decoration.MLinearBackgroundGradient",
      */
     endColor :
     {
-      check : "Color",
       nullable : true,
       apply : "_applyLinearBackgroundGradient"
     },
@@ -66,7 +64,6 @@ qx.Mixin.define("qx.ui.decoration.MLinearBackgroundGradient",
     /** The orientation of the gradient. */
     orientation :
     {
-      check : ["horizontal", "vertical"],
       init : "vertical",
       apply : "_applyLinearBackgroundGradient"
     },
@@ -74,7 +71,6 @@ qx.Mixin.define("qx.ui.decoration.MLinearBackgroundGradient",
     /** Position in percent where to start the color. */
     startColorPosition :
     {
-      check : "Number",
       init : 0,
       apply : "_applyLinearBackgroundGradient"
     },
@@ -82,7 +78,6 @@ qx.Mixin.define("qx.ui.decoration.MLinearBackgroundGradient",
     /** Position in percent where to start the color. */
     endColorPosition :
     {
-      check : "Number",
       init : 100,
       apply : "_applyLinearBackgroundGradient"
     },
@@ -90,7 +85,6 @@ qx.Mixin.define("qx.ui.decoration.MLinearBackgroundGradient",
     /** Defines if the given positions are in % or px.*/
     colorPositionUnit :
     {
-      check : ["px", "%"],
       init : "%",
       apply : "_applyLinearBackgroundGradient"
     },
@@ -114,8 +108,7 @@ qx.Mixin.define("qx.ui.decoration.MLinearBackgroundGradient",
 
   members :
   {
-    __canvas : null,
-
+    __colorResolver: null,
 
     /**
      * Takes a styles map and adds the linear background styles in place to the
@@ -125,158 +118,194 @@ qx.Mixin.define("qx.ui.decoration.MLinearBackgroundGradient",
      * @param styles {Map} A map to add the styles.
      */
     _styleLinearBackgroundGradient : function(styles) {
-      var colors = this.__getColors();
-      var startColor = colors.start;
-      var endColor = colors.end;
-      var value;
+      var backgroundStyle = [];
 
-      if (!startColor || !endColor) {
-        return;
-      }
+      var startColors = this.getStartColor();
+      if(!startColors) { return; }
+      if(!qx.lang.Type.isArray(startColors)) startColors = [startColors];
+      var endColors = this.getEndColor();
+      if(!endColors) { return; }
+      if(!qx.lang.Type.isArray(endColors)) endColors = [endColors];
+      var units = this.getColorPositionUnit();
+      if(!qx.lang.Type.isArray(units)) units = [units];
+      var orientations = this.getOrientation();
+      if(!qx.lang.Type.isArray(orientations)) orientations = [orientations];
+      var startColorPositions = this.getStartColorPosition();
+      if(!qx.lang.Type.isArray(startColorPositions)) startColorPositions = [startColorPositions];
+      var endColorPositions = this.getEndColorPosition();
+      if(!qx.lang.Type.isArray(endColorPositions)) endColorPositions = [endColorPositions];
 
-      var unit = this.getColorPositionUnit();
+      var items = Math.max(startColors.length, endColors.length, units.length, orientations.length);
+      qx.lang.Array.prolong(startColors, items);
+      qx.lang.Array.prolong(endColors, items);
+      qx.lang.Array.prolong(units, items);
+      qx.lang.Array.prolong(orientations, items);
+      qx.lang.Array.prolong(startColorPositions, items);
+      qx.lang.Array.prolong(endColorPositions, items);
+            
+      var styleImpl = this.__styleLinearBackgroundGradientAccordingToSpec;
 
-      // new implementation for webkit is available since chrome 10 --> version
       if (qx.core.Environment.get("css.gradient.legacywebkit")) {
-        // webkit uses px values if non are given
-        unit = unit === "px" ? "" : unit;
-
-        if (this.getOrientation() == "horizontal") {
-          var startPos = this.getStartColorPosition() + unit +" 0" + unit;
-          var endPos = this.getEndColorPosition() + unit + " 0" + unit;
-        } else {
-          var startPos = "0" + unit + " " + this.getStartColorPosition() + unit;
-          var endPos = "0" + unit +" " + this.getEndColorPosition() + unit;
-        }
-
-        var color =
-          "from(" + startColor +
-          "),to(" + endColor + ")";
-
-        value = "-webkit-gradient(linear," + startPos + "," + endPos + "," + color + ")";
-        styles["background"] = value;
-
-      // IE9 canvas solution
+        styleImpl = this.__styleLinearBackgroundGradientForLegacyWebkit;
       } else if (qx.core.Environment.get("css.gradient.filter") &&
         !qx.core.Environment.get("css.gradient.linear") && qx.core.Environment.get("css.borderradius")) {
-
-          if (!this.__canvas) {
-            this.__canvas = document.createElement("canvas");
-          }
-
-          var isVertical = this.getOrientation() == "vertical";
-
-          var colors = this.__getColors();
-          var height = isVertical ? 200 : 1;
-          var width = isVertical ? 1 : 200;
-
-          this.__canvas.width = width;
-          this.__canvas.height = height;
-          var ctx = this.__canvas.getContext('2d');
-
-          if (isVertical) {
-            var lingrad = ctx.createLinearGradient(0, 0, 0, height);
-          } else {
-            var lingrad = ctx.createLinearGradient(0, 0, width, 0);
-          }
-
-          lingrad.addColorStop(this.getStartColorPosition() / 100, colors.start);
-          lingrad.addColorStop(this.getEndColorPosition() / 100, colors.end);
-
-          ctx.fillStyle = lingrad;
-          ctx.fillRect(0, 0, width, height);
-
-          var value = "url(" + this.__canvas.toDataURL() + ")";
-          styles["background-image"] = value;
-          styles["background-size"] = "100% 100%";
-
-      // old IE filter fallback
+        styleImpl = this.__styleLinearBackgroundGradientWithMSFilter;
       } else if (qx.core.Environment.get("css.gradient.filter") &&
-        !qx.core.Environment.get("css.gradient.linear"))
-      {
-        var colors = this.__getColors();
-        var type = this.getOrientation() == "horizontal" ? 1 : 0;
-
-        var startColor = colors.start;
-        var endColor = colors.end;
-
-        // convert rgb, hex3 and named colors to hex6
-        if (!qx.util.ColorUtil.isHex6String(startColor)) {
-          startColor = qx.util.ColorUtil.stringToRgb(startColor);
-          startColor = qx.util.ColorUtil.rgbToHexString(startColor);
-        }
-        if (!qx.util.ColorUtil.isHex6String(endColor)) {
-          endColor = qx.util.ColorUtil.stringToRgb(endColor);
-          endColor = qx.util.ColorUtil.rgbToHexString(endColor);
-        }
-
-        // get rid of the starting '#'
-        startColor = startColor.substring(1, startColor.length);
-        endColor = endColor.substring(1, endColor.length);
-
-        value = "progid:DXImageTransform.Microsoft.Gradient" +
-          "(GradientType=" + type + ", " +
-          "StartColorStr='#FF" + startColor + "', " +
-          "EndColorStr='#FF" + endColor + "';)";
-        if (styles["filter"]) {
-          styles["filter"] += ", " + value;
-        } else {
-          styles["filter"] = value;
-        }
-
-        // Elements with transparent backgrounds will not receive receive mouse
-        // events if a Gradient filter is set.
-        if (!styles["background-color"] ||
-            styles["background-color"] == "transparent")
-        {
-          // We don't support alpha transparency for the gradient color stops
-          // so it doesn't matter which color we set here.
-          styles["background-color"] = "white";
-        }
-
-      // spec like syntax
-      } else {
-        // WebKit, Opera and Gecko interpret 0deg as "to right"
-        var deg = this.getOrientation() == "horizontal" ? 0 : 270;
-
-        var start = startColor + " " + this.getStartColorPosition() + unit;
-        var end = endColor + " " + this.getEndColorPosition() + unit;
-
-        var prefixedName = qx.core.Environment.get("css.gradient.linear");
-        // Browsers supporting the unprefixed implementation interpret 0deg as
-        // "to top" as defined by the spec [BUG #6513]
-        if (prefixedName === "linear-gradient") {
-          deg = this.getOrientation() == "horizontal" ? deg + 90 : deg - 90;
-        }
-
-        value = prefixedName + "(" + deg + "deg, " + start + "," + end + ")";
-        if (styles["background-image"]) {
-          styles["background-image"] += ", " + value;
-        }
-        else {
-          styles["background-image"] = value;
+        !qx.core.Environment.get("css.gradient.linear")) {
+        styleImpl = this.__styleLinearBackgroundGradientWithMSFilter;
+      }
+      
+      for(var i=0;i<items;i++) {
+        var startColor = this.__getColor(startColors[i]);
+        var endColor = this.__getColor(endColors[i]);
+        var unit = units[i];
+        var orientation = orientations[i];
+        var startColorPosition = startColorPositions[i];
+        var endColorPosition = endColorPositions[i];
+        
+        if(!styleImpl(startColor, endColor, unit, orientation, startColorPosition, endColorPosition, styles, backgroundStyle)) {
+          break;
         }
       }
+      
+      if("background" in styles) {
+        if(!qx.lang.Type.isArray(styles['background'])) {
+          styles['background'] = [styles['background']];
+        }
+      } else {
+        styles['background'] = [];
+      }
+      var orderGradientsFront = 'getOrderGradientsFront' in this ? this.getOrderGradientsFront() : false;
+      var operation = orderGradientsFront ? Array.prototype.unshift : Array.prototype.push;
+      operation.apply(styles['background'], backgroundStyle);
+    },
+    
+    // new implementation for webkit is available since chrome 10 --> version
+    __styleLinearBackgroundGradientForLegacyWebkit: function me(startColor, endColor, unit, orientation, startColorPosition, endColorPosition, styles, backgroundStyle) {
+      // webkit uses px values if non are given
+      unit = unit === "px" ? "" : unit;
+
+      if (orientation == "horizontal") {
+        var startPos = startColorPosition + unit +" 0" + unit;
+        var endPos = endColorPosition + unit + " 0" + unit;
+      } else {
+        var startPos = "0" + unit + " " + startColorPosition + unit;
+        var endPos = "0" + unit +" " + endColorPosition + unit;
+      }
+
+      var color =
+        "from(" + startColor +
+        "),to(" + endColor + ")";
+
+      backgroundStyle.push("-webkit-gradient(linear," + startPos + "," + endPos + "," + color + ")");
+      return true;
     },
 
+    // IE9 canvas solution
+    __styleLinearBackgroundGradientWithCanvas: function me(startColor, endColor, unit, orientation, startColorPosition, endColorPosition, styles, backgroundStyle) {
+      if (!me.__canvas) {
+        me.__canvas = document.createElement("canvas");
+      }
 
+      var isVertical = orientation == "vertical";
+
+      var height = isVertical ? 200 : 1;
+      var width = isVertical ? 1 : 200;
+
+      me.__canvas.width = width;
+      me.__canvas.height = height;
+      var ctx = me.__canvas.getContext('2d');
+
+      if (isVertical) {
+        var lingrad = ctx.createLinearGradient(0, 0, 0, height);
+      } else {
+        var lingrad = ctx.createLinearGradient(0, 0, width, 0);
+      }
+
+      lingrad.addColorStop(startColorPosition / 100, startColor);
+      lingrad.addColorStop(endColorPosition / 100, endColor);
+
+      //Clear the rect before drawing to allow for semitransparent colors
+      ctx.clearRect(0, 0, width, height);
+      ctx.fillStyle = lingrad;
+      ctx.fillRect(0, 0, width, height);
+
+      backgroundStyle.push("url(" + me.__canvas.toDataURL() + ") 100% 100%");
+      return true;
+    },
+    
+      // old IE filter fallback
+    __styleLinearBackgroundGradientWithMSFilter: function(startColor, endColor, unit, orientation, startColorPosition, endColorPosition, styles, backgroundStyle) {
+      var type = orientation == "horizontal" ? 1 : 0;
+
+      // convert rgb, hex3 and named colors to hex6
+      if (!qx.util.ColorUtil.isHex6String(startColor)) {
+        startColor = qx.util.ColorUtil.stringToRgb(startColor);
+        startColor = qx.util.ColorUtil.rgbToHexString(startColor);
+      }
+      if (!qx.util.ColorUtil.isHex6String(endColor)) {
+        endColor = qx.util.ColorUtil.stringToRgb(endColor);
+        endColor = qx.util.ColorUtil.rgbToHexString(endColor);
+      }
+
+      // get rid of the starting '#'
+      startColor = startColor.substring(1, startColor.length);
+      endColor = endColor.substring(1, endColor.length);
+
+      var value = "progid:DXImageTransform.Microsoft.Gradient" +
+        "(GradientType=" + type + ", " +
+        "StartColorStr='#FF" + startColor + "', " +
+        "EndColorStr='#FF" + endColor + "';)";
+      if (styles["filter"]) {
+        styles["filter"] += ", " + value;
+      } else {
+        styles["filter"] = value;
+      }
+
+      // Elements with transparent backgrounds will not receive receive mouse
+      // events if a Gradient filter is set.
+      if (!styles["background-color"] ||
+          styles["background-color"] == "transparent")
+      {
+        // We don't support alpha transparency for the gradient color stops
+        // so it doesn't matter which color we set here.
+        styles["background-color"] = "white";
+      }
+      return false;
+    },
+    
+    // spec-compliant syntax
+    __styleLinearBackgroundGradientAccordingToSpec: function(startColor, endColor, unit, orientation, startColorPosition, endColorPosition, styles, backgroundStyle) {
+      // WebKit, Opera and Gecko interpret 0deg as "to right"
+      var deg = orientation == "horizontal" ? 0 : 270;
+
+      var start = startColor + " " + startColorPosition + unit;
+      var end = endColor + " " + endColorPosition + unit;
+
+      var prefixedName = qx.core.Environment.get("css.gradient.linear");
+      // Browsers supporting the unprefixed implementation interpret 0deg as
+      // "to top" as defined by the spec [BUG #6513]
+      if (prefixedName === "linear-gradient") {
+        deg = orientation == "horizontal" ? deg + 90 : deg - 90;
+      }
+
+      backgroundStyle.push(prefixedName + "(" + deg + "deg, " + start + "," + end + ")");
+      return true;
+    },
+    
     /**
-     * Helper to get start and end color.
-     * @return {Map} A map containing start and end color.
+     * Helper to get a resolved color from a name
+     * @return {String} The resolved color
      */
-    __getColors : function() {
-      if (qx.core.Environment.get("qx.theme"))
-      {
-        var Color = qx.theme.manager.Color.getInstance();
-        var startColor = Color.resolve(this.getStartColor());
-        var endColor = Color.resolve(this.getEndColor());
+    __getColor : function(color) {
+      if(this.colorResolver === null) {
+        if(qx.core.Environment.get("qx.theme")) {
+          this.colorResolver = qx.theme.manager.Color.getInstance();
+        } else {
+          this.colorResolver = false;
+        }
       }
-      else
-      {
-        var startColor = this.getStartColor();
-        var endColor = this.getEndColor();
-      }
-      return {start: startColor, end: endColor};
+      return this.colorResolver ? this.colorResolver.resolve(color) : color;
     },
 
     // property apply

--- a/framework/source/class/qx/ui/decoration/MLinearBackgroundGradient.js
+++ b/framework/source/class/qx/ui/decoration/MLinearBackgroundGradient.js
@@ -180,7 +180,22 @@ qx.Mixin.define("qx.ui.decoration.MLinearBackgroundGradient",
       operation.apply(styles['background'], backgroundStyle);
     },
     
-    // new implementation for webkit is available since chrome 10 --> version
+    /**
+     * Compute CSS rules to style the background with gradients.
+     * This can be called multiple times and SHOULD layer the gradients on top of each other and on top of existing backgrounds.
+     * Legacy implementation for old WebKit browsers (Chrome < 10).
+     * 
+     * @param startColor {Color} The color to start the gradient with
+     * @param endColor {Color} The color to end the gradient with
+     * @param unit {Color} The unit in which startColorPosition and endColorPosition are measured
+     * @param orientation {String} Either 'horizontal' or 'vertical'
+     * @param startColorPosition {Number} The position of the gradient’s starting point, measured in `unit` units along the `orientation` axis from top or left
+     * @param endColorPosition {Number} The position of the gradient’s ending point, measured in `unit` units along the `orientation` axis from top or left
+     * @param styles {Map} The complete styles currently poised to be applied by decorators. Should not be written to in this method (use `backgroundStyle` for that)
+     * @param backgroundStyle {Map} This method should push new background styles onto this array.
+     *
+     * @return {Boolean} Whether this implementation supports multiple gradients atop each other (true).
+     */
     __styleLinearBackgroundGradientForLegacyWebkit: function me(startColor, endColor, unit, orientation, startColorPosition, endColorPosition, styles, backgroundStyle) {
       // webkit uses px values if non are given
       unit = unit === "px" ? "" : unit;
@@ -201,7 +216,22 @@ qx.Mixin.define("qx.ui.decoration.MLinearBackgroundGradient",
       return true;
     },
 
-    // IE9 canvas solution
+    /**
+     * Compute CSS rules to style the background with gradients.
+     * This can be called multiple times and SHOULD layer the gradients on top of each other and on top of existing backgrounds.
+     * IE9 canvas solution.
+     * 
+     * @param startColor {Color} The color to start the gradient with
+     * @param endColor {Color} The color to end the gradient with
+     * @param unit {Color} The unit in which startColorPosition and endColorPosition are measured
+     * @param orientation {String} Either 'horizontal' or 'vertical'
+     * @param startColorPosition {Number} The position of the gradient’s starting point, measured in `unit` units along the `orientation` axis from top or left
+     * @param endColorPosition {Number} The position of the gradient’s ending point, measured in `unit` units along the `orientation` axis from top or left
+     * @param styles {Map} The complete styles currently poised to be applied by decorators. Should not be written to in this method (use `backgroundStyle` for that)
+     * @param backgroundStyle {Map} This method should push new background styles onto this array.
+     *
+     * @return {Boolean} Whether this implementation supports multiple gradients atop each other (true).
+     */
     __styleLinearBackgroundGradientWithCanvas: function me(startColor, endColor, unit, orientation, startColorPosition, endColorPosition, styles, backgroundStyle) {
       if (!me.__canvas) {
         me.__canvas = document.createElement("canvas");
@@ -234,7 +264,22 @@ qx.Mixin.define("qx.ui.decoration.MLinearBackgroundGradient",
       return true;
     },
     
-      // old IE filter fallback
+    /**
+     * Compute CSS rules to style the background with gradients.
+     * This can be called multiple times and SHOULD layer the gradients on top of each other and on top of existing backgrounds.
+     * Old IE filter fallback.
+     * 
+     * @param startColor {Color} The color to start the gradient with
+     * @param endColor {Color} The color to end the gradient with
+     * @param unit {Color} The unit in which startColorPosition and endColorPosition are measured
+     * @param orientation {String} Either 'horizontal' or 'vertical'
+     * @param startColorPosition {Number} The position of the gradient’s starting point, measured in `unit` units along the `orientation` axis from top or left
+     * @param endColorPosition {Number} The position of the gradient’s ending point, measured in `unit` units along the `orientation` axis from top or left
+     * @param styles {Map} The complete styles currently poised to be applied by decorators. Should not be written to in this method (use `backgroundStyle` for that). Note: this particular implementation will do that because it needs to change the `filter` property.
+     * @param backgroundStyle {Map} This method should push new background styles onto this array.
+     *
+     * @return {Boolean} Whether this implementation supports multiple gradients atop each other (false).
+     */
     __styleLinearBackgroundGradientWithMSFilter: function(startColor, endColor, unit, orientation, startColorPosition, endColorPosition, styles, backgroundStyle) {
       var type = orientation == "horizontal" ? 1 : 0;
 
@@ -274,7 +319,22 @@ qx.Mixin.define("qx.ui.decoration.MLinearBackgroundGradient",
       return false;
     },
     
-    // spec-compliant syntax
+    /**
+     * Compute CSS rules to style the background with gradients.
+     * This can be called multiple times and SHOULD layer the gradients on top of each other and on top of existing backgrounds.
+     * Default implementation (uses spec-compliant syntax).
+     * 
+     * @param startColor {Color} The color to start the gradient with
+     * @param endColor {Color} The color to end the gradient with
+     * @param unit {Color} The unit in which startColorPosition and endColorPosition are measured
+     * @param orientation {String} Either 'horizontal' or 'vertical'
+     * @param startColorPosition {Number} The position of the gradient’s starting point, measured in `unit` units along the `orientation` axis from top or left
+     * @param endColorPosition {Number} The position of the gradient’s ending point, measured in `unit` units along the `orientation` axis from top or left
+     * @param styles {Map} The complete styles currently poised to be applied by decorators. Should not be written to in this method (use `backgroundStyle` for that)
+     * @param backgroundStyle {Map} This method should push new background styles onto this array.
+     *
+     * @return {Boolean} Whether this implementation supports multiple gradients atop each other (true).
+     */
     __styleLinearBackgroundGradientAccordingToSpec: function(startColor, endColor, unit, orientation, startColorPosition, endColorPosition, styles, backgroundStyle) {
       // WebKit, Opera and Gecko interpret 0deg as "to right"
       var deg = orientation == "horizontal" ? 0 : 270;
@@ -295,6 +355,7 @@ qx.Mixin.define("qx.ui.decoration.MLinearBackgroundGradient",
     
     /**
      * Helper to get a resolved color from a name
+     * @param color {String} The name to resolve
      * @return {String} The resolved color
      */
     __getColor : function(color) {

--- a/framework/source/class/qx/ui/decoration/MLinearBackgroundGradient.js
+++ b/framework/source/class/qx/ui/decoration/MLinearBackgroundGradient.js
@@ -298,14 +298,14 @@ qx.Mixin.define("qx.ui.decoration.MLinearBackgroundGradient",
      * @return {String} The resolved color
      */
     __getColor : function(color) {
-      if(this.colorResolver === null) {
+      if(this.__colorResolver === null) {
         if(qx.core.Environment.get("qx.theme")) {
-          this.colorResolver = qx.theme.manager.Color.getInstance();
+          this.__colorResolver = qx.theme.manager.Color.getInstance();
         } else {
-          this.colorResolver = false;
+          this.__colorResolver = false;
         }
       }
-      return this.colorResolver ? this.colorResolver.resolve(color) : color;
+      return this.__colorResolver ? this.__colorResolver.resolve(color) : color;
     },
 
     // property apply


### PR DESCRIPTION
As I have I’ve previously [mentioned](http://qooxdoo.678.n2.nabble.com/Qooxdoo-3-0-decorator-questions-td7584521.html), I’ve patched MLinearBackgroundGradient and MLinearBackgroundGradient to allow for multiple background images and MBoxShadow to allow for multiple shadow definitions.

I’ve run the framework test suite of qx.test.ui namespace with the changes with no failures (but some test runs did have 133 failures but I did not get consistent results) though I’ve not added any new test cases for the new features.
