### PR TITLE
Added group, groupCollapsed, and groupEnd logging

### DIFF
--- a/framework/source/class/qx/core/MLogging.js
+++ b/framework/source/class/qx/core/MLogging.js
@@ -77,6 +77,49 @@ qx.Mixin.define("qx.core.MLogging",
 
 
     /**
+     * Starts a logging group with an optional title. All output that
+     * occurs between calling this method and calling <code>groupEnd</code>
+     * appears in the same visual group. This logging group is initially
+     * expanded.
+     *
+     * @param varargs {var} The item(s) to log. Any number of arguments is
+     * supported. If an argument is not a string, the object dump will be
+     * logged.
+     */
+    group : function(varargs) {
+      this.__logMessage("group", arguments);
+    },
+
+
+    /**
+     * Starts a logging group with an optional title. All output that
+     * occurs between calling this method and calling <code>groupEnd</code>
+     * appears in the same visual group. This logging group is initially
+     * collapsed.
+     *
+     * @param varargs {var} The item(s) to log. Any number of arguments is
+     * supported. If an argument is not a string, the object dump will be
+     * logged.
+     */
+    groupCollapsed : function(varargs) {
+      this.__logMessage("groupCollapsed", arguments);
+    },
+
+
+    /**
+     * Closes the most recently created logging group created with
+     * <code>group</code> or <code>groupCollapsed</code>.
+     *
+     * @param varargs {var} The item(s) to log. Any number of arguments is
+     * supported. If an argument is not a string, the object dump will be
+     * logged.
+     */
+    groupEnd : function() {
+      this.__logMessage("groupEnd", []);
+    },
+
+
+    /**
      * Prints the current stack trace
      *
      */

--- a/framework/source/class/qx/log/Logger.js
+++ b/framework/source/class/qx/log/Logger.js
@@ -51,6 +51,9 @@ qx.Class.define("qx.log.Logger",
      * @param value {String} One of "debug", "info", "warn" or "error".
      */
     setLevel : function(value) {
+      if (value[0] == "_") {
+        return;
+      }
       this.__level = value;
     },
 
@@ -219,6 +222,42 @@ qx.Class.define("qx.log.Logger",
       var trace = qx.dev.StackTrace.getStackTrace();
       qx.log.Logger.__log("info",
       [(typeof object !== "undefined" ? [object].concat(trace) : trace).join("\n")]);
+    },
+
+    /**
+     * Sending a message at level "group" to the logger.
+     *
+     * @param object {Object} Contextual object (either instance or static class)
+     * @param message {var} Any number of arguments supported. An argument may
+     *   have any JavaScript data type. All data is serialized immediately and
+     *   does not keep references to other objects.
+     */
+    group : function(object, message) {
+      qx.log.Logger.__log("_group", arguments);
+    },
+
+    /**
+     * Sending a message at level "groupCollapsed" to the logger.
+     *
+     * @param object {Object} Contextual object (either instance or static class)
+     * @param message {var} Any number of arguments supported. An argument may
+     *   have any JavaScript data type. All data is serialized immediately and
+     *   does not keep references to other objects.
+     */
+    groupCollapsed : function(object, message) {
+      qx.log.Logger.__log("_groupCollapsed", arguments);
+    },
+
+    /**
+     * Sending a message at level "groupEnd" to the logger.
+     *
+     * @param object {Object} Contextual object (either instance or static class)
+     * @param message {var} Any number of arguments supported. An argument may
+     *   have any JavaScript data type. All data is serialized immediately and
+     *   does not keep references to other objects.
+     */
+    groupEnd : function(object, message) {
+      qx.log.Logger.__log("_groupEnd", arguments);
     },
 
 
@@ -408,7 +447,8 @@ qx.Class.define("qx.log.Logger",
     /**
      * Internal logging main routine.
      *
-     * @param level {String} One of "debug", "info", "warn" or "error"
+     * @param level {String} One of "debug", "info", "warn" or "error",
+     *   "_group", "_groupCollapsed", "_groupEnd"
      * @param args {Array} List of other arguments, where the first is
      *   taken as the context object.
      */
@@ -416,7 +456,7 @@ qx.Class.define("qx.log.Logger",
     {
       // Filter according to level
       var levels = this.__levels;
-      if (levels[level] < levels[this.__level]) {
+      if (level[0] != "_" && levels[level] < levels[this.__level]) {
         return;
       }
 

--- a/framework/source/class/qx/log/appender/Native.js
+++ b/framework/source/class/qx/log/appender/Native.js
@@ -52,8 +52,12 @@ qx.Class.define("qx.log.appender.Native",
     process : function(entry)
     {
       if (qx.core.Environment.get("html.console")) {
+        var level = entry.level;
+        if (level[0] == '_') {
+          level = level.substring(1);
+        }
         // Firefox 4's Web Console doesn't support "debug"
-        var level = console[entry.level] ? entry.level : "log";
+        var level = console[level] ? level : "log";
         if (console[level]) {
           var args = qx.log.appender.Util.toText(entry);
           console[level](args);


### PR DESCRIPTION
See:
https://developers.google.com/chrome-developer-tools/docs/console-api#consolegroupobject_object

These features are helpful for organizing console log output. While much of the new native console logging API seems to be intent on making the console yet another markup-space, the native grouping mechanisms are actually quite nice for logging organization.

This adds .group, .groupCollapsed, and .groupEnd to compliment the existing console logging functions (info, debug,warn,error).

The only appender I modified to add support to was the native one, so consider the HTML console/other consoles entirely untested. It's possible my implementation of the "_" prefix on loglevels negating the debuglevel checks is not ideal, and a better way exists. This is basically the smallest amount of work that can be done to cause a measurable benefit so that others could consider picking up where I left off.
