### PR TITLE
fixed rgbToRgbString method that returned "rgb(0,0,0,0)" instead of "rgb...

### DIFF
--- a/framework/source/class/qx/test/util/ColorUtil.js
+++ b/framework/source/class/qx/test/util/ColorUtil.js
@@ -25,6 +25,14 @@ qx.Class.define("qx.test.util.ColorUtil",
   members :
   {
 
+    testRgbToRgbString : function()
+    {
+      this.assertEquals("rgba(255,0,0,1)", qx.util.ColorUtil.rgbToRgbString([255, 0, 0, 1]));
+      this.assertEquals("rgba(255,0,0,0.5)", qx.util.ColorUtil.rgbToRgbString([255, 0, 0, 0.5]));
+      this.assertEquals("rgba(255,0,0,0)", qx.util.ColorUtil.rgbToRgbString([255, 0, 0, 0]));
+      this.assertEquals("rgb(255,0,0)", qx.util.ColorUtil.rgbToRgbString([255, 0, 0]));
+    },
+
     testCssStringToRgb : function()
     {
       this.assertEquals("255,0,0", qx.util.ColorUtil.cssStringToRgb("rgba(255,0,0,1)"));

--- a/framework/source/class/qx/util/ColorUtil.js
+++ b/framework/source/class/qx/util/ColorUtil.js
@@ -269,7 +269,7 @@ qx.Bootstrap.define("qx.util.ColorUtil",
      * @return {String} an RGB string
      */
     rgbToRgbString : function(rgb) {
-      return "rgb" + (rgb[3] ? "a" : "") +  "(" + rgb.join(",") + ")";
+      return "rgb" + (rgb[3] !== undefined ? "a" : "") +  "(" + rgb.join(",") + ")";
     },
 
 


### PR DESCRIPTION
...a(0,0,0,0)" if alpha value was equal to 0
