### PR TITLE
Fixes bug 8023: generates an exception upon no data in RPC result

### DIFF
--- a/framework/source/class/qx/io/remote/Rpc.js
+++ b/framework/source/class/qx/io/remote/Rpc.js
@@ -191,7 +191,8 @@ qx.Class.define("qx.io.remote.Rpc",
     localError :
     {
       timeout : 1,
-      abort   : 2
+      abort   : 2,
+      nodata  : 3
     },
 
 
@@ -686,6 +687,17 @@ qx.Class.define("qx.io.remote.Rpc",
       req.addListener("completed", function(evt)
       {
         response = evt.getContent();
+
+        // server may have reset, giving us no data on our requests
+        if (response === null)
+        {
+          ex = makeException(qx.io.remote.Rpc.origin.local,
+                             qx.io.remote.Rpc.localError.nodata,
+                             "No data in response to " + whichMethod);
+          id = this.getSequenceNumber();
+          handleRequestFinished("failed", eventTarget);
+          return;
+        }
 
         // Parse. Skip when response is already an object
         // because the script transport was used.


### PR DESCRIPTION
This patch generates an exception if no data is received in an RPC result, rather than allowing the code to crash trying to access a non-existent member of the (null) object.
