### PR TITLE
Bug 8097 - DateFormat.parse throws an error on a year "00" (yy)

### DIFF
--- a/framework/source/class/qx/test/util/DateFormat.js
+++ b/framework/source/class/qx/test/util/DateFormat.js
@@ -26,6 +26,7 @@ qx.Class.define("qx.test.util.DateFormat",
 
   // result contain an object with what should be expected, the result to test the date against
   __dates : [
+    {'date' : new Date(2000, 2, 14), 'result' : {}},
     {'date' : new Date(2006, 2, 14), 'result' : {}},
     {'date' : new Date(2007, 3, 14), 'result' : {}},
     {'date' : new Date(2009, 10, 30), 'result' : {}},

--- a/framework/source/class/qx/util/format/DateFormat.js
+++ b/framework/source/class/qx/util/format/DateFormat.js
@@ -1155,7 +1155,7 @@ qx.Class.define("qx.util.format.DateFormat",
       {
         value = parseInt(value, 10);
 
-        if(value > 0)
+        if(value >= 0)
         {
           if (value < DateFormat.ASSUME_YEAR_2000_THRESHOLD) {
             value += 2000;
@@ -1171,7 +1171,7 @@ qx.Class.define("qx.util.format.DateFormat",
       {
         value = parseInt(value, 10);
 
-        if(value > 0)
+        if(value >= 0)
         {
           if (value < DateFormat.ASSUME_YEAR_2000_THRESHOLD) {
             value += 2000;


### PR DESCRIPTION
the "parse" method of DateFormat throws an Error, because dateValues.year !=
date.getFullYear(), when a year is "00" (yy) as it is parsed to 0 in the
yearManipulator function and when 0 is passed to a Date() constructor year is
1900, so dateValues.year is 0 and date.getFullYear() is 1900
