### PR TITLE
[#7338] NumberFormat constructor should accept the only argument (String)

### DIFF
--- a/framework/source/class/qx/test/util/NumberFormat.js
+++ b/framework/source/class/qx/test/util/NumberFormat.js
@@ -41,6 +41,41 @@ qx.Class.define("qx.test.util.NumberFormat",
       this.__nf.dispose();
     },
 
+    testNumberFormatConstructor: function() {
+      var wrongArgs = [null, undefined, NaN, Infinity, 1, {}, [], true],
+          correctArgs = ["de_DE"],
+          nf, i, len;
+
+      try {
+        nf = new qx.util.format.NumberFormat();
+      } catch (e) {
+        this.fail("Failed on an empty arguments list");
+      }
+
+      try {
+        nf = new qx.util.format.NumberFormat("de_DE", true);
+        this.fail("Did not fail on wrong arguments number");
+      } catch (e) {
+
+      }
+
+      for (i = 0, len= wrongArgs.length; i < len; i += 1) {
+        try {
+          nf = new qx.util.format.NumberFormat(wrongArgs[i]);
+          this.fail("A wrong argument did not raise an error: " + wrongArgs[i]);
+        } catch (e) {
+
+        }
+      }
+
+      for (i = 0, len= correctArgs.length; i < len; i += 1) {
+        try {
+          nf = new qx.util.format.NumberFormat(correctArgs[i]);
+        } catch (e) {
+          this.fail("A correct argument did raise an error: " + correctArgs[i]);
+        }
+      }
+    },
 
     testNumberFormat : function()
     {

--- a/framework/source/class/qx/util/format/NumberFormat.js
+++ b/framework/source/class/qx/util/format/NumberFormat.js
@@ -34,11 +34,22 @@ qx.Class.define("qx.util.format.NumberFormat",
 
   /**
    * @param locale {String} optional locale to be used
+   * @throws {Error} If the number of arguments !== 1 and the argument is not a string.
    */
   construct : function(locale)
   {
     this.base(arguments);
-    this.__locale = locale;
+    if (arguments.length > 0) {
+      if (arguments.length === 1) {
+        if (qx.lang.Type.isString(locale)) {
+          this.__locale = locale;
+        } else {
+          throw new Error("Wrong argument type. String is expected.");
+        }
+      } else {
+        throw new Error("Wrong number of arguments.");
+      }
+    }
   },
 
 


### PR DESCRIPTION
NumberFormat constructor should accept the only argument (String)
http://bugzilla.qooxdoo.org/show_bug.cgi?id=7338
