### PR TITLE
[BUG #7838] qx.util.format.NumberFormat#parse fails to parse decimals <1 without leading zero

### DIFF
--- a/framework/source/class/qx/test/util/NumberFormat.js
+++ b/framework/source/class/qx/test/util/NumberFormat.js
@@ -73,9 +73,16 @@ qx.Class.define("qx.test.util.NumberFormat",
 
       var goodNumbers = {
         "1000" : 1000,
+        "-0,02" : -0.02,
+        "0,02" : 0.02,
+        ",02" : 0.02,
+        "-,02" : -0.02,
+        "+,02" : 0.02,
+        "-1.111.111,2" : -1111111.2,
         "-1.000.000" : -1000000,
         "+1.000,12" : 1000.12
-      }
+      };
+
       for (var number in goodNumbers) {
         this.assertEquals(nf.parse(number), goodNumbers[number]);
       }

--- a/framework/source/class/qx/util/format/NumberFormat.js
+++ b/framework/source/class/qx/util/format/NumberFormat.js
@@ -247,7 +247,7 @@ qx.Class.define("qx.util.format.NumberFormat",
         "^" +
         qx.lang.String.escapeRegexpChars(this.getPrefix()) +
         '([-+]){0,1}'+
-        '([0-9]{1,3}(?:'+ groupSepEsc + '{0,1}[0-9]{3}){0,})' +
+        '([0-9]{1,3}(?:'+ groupSepEsc + '{0,1}[0-9]{3}){0,}){0,1}' +
         '(' + decimalSepEsc + '\\d+){0,1}' +
         qx.lang.String.escapeRegexpChars(this.getPostfix()) +
         "$"
@@ -260,7 +260,7 @@ qx.Class.define("qx.util.format.NumberFormat",
       }
 
       var negative = (hit[1] == "-");
-      var integerStr = hit[2];
+      var integerStr = hit[2] || "0";
       var fractionStr = hit[3];
 
       // Remove the thousand groupings


### PR DESCRIPTION
second regex group (integer part) can be caught 1 or 0 times,
in case of zero integerStr is set to "0"
