### PR TITLE
Update DragDrop.js

### DIFF
--- a/framework/source/class/qx/event/handler/DragDrop.js
+++ b/framework/source/class/qx/event/handler/DragDrop.js
@@ -282,12 +282,31 @@ qx.Class.define("qx.event.handler.DragDrop",
       return this.__sessionActive;
     },
 
+    /**
+     * Exposes the validDrop flag for specialized drag & drop operations
+     * (setter)
+     */
+    setValidDrop(value)
+    {
+       this.__validDrop = !!value;
+    },
+
+    /**
+     * Exposes the validDrop flag for specialized drag & drop operations
+     * (getter)
+     */
+    isValidDrop(value)
+    {
+       this.__validDrop = !!value;
+    },
 
     /*
     ---------------------------------------------------------------------------
       INTERNAL UTILS
     ---------------------------------------------------------------------------
     */
+    
+
 
     /**
      * Rebuilds the internal data storage used during a drag&drop session


### PR DESCRIPTION
Adding getter and setter for private validDrop flag. this is neccessary to enable external drag session management (for example, when the drop permission is dynamically computed).
