### PR TITLE
[BUG #8311] DateFormat fails to parse 2-digit numbers with the single "w" in a mask

### DIFF
--- a/framework/source/class/qx/test/util/DateFormat.js
+++ b/framework/source/class/qx/test/util/DateFormat.js
@@ -125,6 +125,58 @@ qx.Class.define("qx.test.util.DateFormat",
       dateFmt.dispose();
     },
 
+    testWeeksInDateParsing : function()
+    {
+      var dateFormat,
+          testDate,
+          parsedDate;
+
+      dateFormat = new qx.util.format.DateFormat("EEEE d MMMM yyyy ww");
+
+      testDate = (new Date(2014, 0, 1)).getTime();
+      parsedDate = dateFormat.parse("Wednesday 1 January 2014 01");
+      this.assertIdentical(testDate, parsedDate.getTime(), "ww - 01, should have been parsed");
+
+      try {
+        parsedDate = dateFormat.parse("Wednesday 1 January 2014 1");
+      } catch(e) {
+        parsedDate = new Date();
+      }
+
+      this.assertNotIdentical(testDate, parsedDate.getTime(), "ww - 1, should not have been parsed");
+
+      try {
+        parsedDate = dateFormat.parse("Wednesday 1 January 2014 ");
+      } catch(e) {
+        parsedDate = new Date();
+      }
+
+      this.assertNotIdentical(testDate, parsedDate.getTime(), "ww - '', should not have been parsed");
+
+      testDate = (new Date(2014, 4, 6)).getTime();
+      parsedDate = dateFormat.parse("Tuesday 6 May 2014 19");
+      this.assertIdentical(testDate, parsedDate.getTime(), "ww - 19, should have been parsed");
+
+      dateFormat = new qx.util.format.DateFormat("EEEE d MMMM yyyy w");
+      parsedDate = dateFormat.parse("Tuesday 6 May 2014 19");
+      this.assertIdentical(testDate, parsedDate.getTime(), "w - 19, should have been parsed");
+
+      testDate = (new Date(2014, 0, 1)).getTime();
+      parsedDate = dateFormat.parse("Wednesday 1 January 2014 01");
+      this.assertIdentical(testDate, parsedDate.getTime(), "w - 01, should have been parsed");
+
+      parsedDate = dateFormat.parse("Wednesday 1 January 2014 1");
+      this.assertIdentical(testDate, parsedDate.getTime(), "w - 1, should have been parsed");
+
+      try {
+        parsedDate = dateFormat.parse("Wednesday 1 January 2014 ");
+      } catch(e) {
+        parsedDate = new Date();
+      }
+
+      this.assertNotIdentical(testDate, parsedDate.getTime(), "w - '', should not have been parsed");
+    },
+
     testTimeZone : function()
     {
       var date = new qx.test.util.DateMock({timezoneOffset: -60, time: 1316000836451});

--- a/framework/source/class/qx/util/format/DateFormat.js
+++ b/framework/source/class/qx/util/format/DateFormat.js
@@ -1634,14 +1634,14 @@ qx.Class.define("qx.util.format.DateFormat",
       rules.push(
       {
         pattern : "w",
-        regex   : "(\\d?)",
+        regex   : "(\\d\\d?)",
         field   : "weekOfYear"
       });
 
       rules.push(
       {
         pattern : "ww",
-        regex   : "(\\d\\d?)",
+        regex   : "(\\d\\d)",
         field   : "weekOfYear"
       });
 


### PR DESCRIPTION
http://bugzilla.qooxdoo.org/show_bug.cgi?id=8311

"Tuesday 6 May 2014 19" fails to be parsed against "EEEE d MMMM yyyy w"
IMO that is incorrect as number of w's should indicate the minimum amount of
digits representing week number, so that both "Tuesday 6 May 2014 19" and
"Wednesday 1 January 2014 1" should be parsed
In fact that is how "d" works.

Actually, following this logic both "ww" and "dd" should not allow 1-digit
values the way they do now
