### PR TITLE
[BUG #8555] qx.util.Validate.email accepts any extension with more than 2 characters

### DIFF
--- a/framework/source/class/qx/test/util/Validate.js
+++ b/framework/source/class/qx/test/util/Validate.js
@@ -54,6 +54,9 @@ qx.Class.define("qx.test.util.Validate",
       this.assertException(function() {
         qx.util.Validate.email("Custom Error Message")("not an email");
       }, qx.core.ValidationError, "Custom Error Message");
+
+      //Valid since new domain extensions
+      qx.util.Validate.email()("foo@bar.qooxdoo");
     },
 
     testString : function()

--- a/framework/source/class/qx/util/Validate.js
+++ b/framework/source/class/qx/util/Validate.js
@@ -129,7 +129,7 @@ qx.Class.define("qx.util.Validate",
       errorMessage = errorMessage ||
         qx.locale.Manager.tr("'%1' is not an email address.", (value || ""));
 
-      var reg = /^([A-Za-z0-9_\-\.])+\@([A-Za-z0-9_\-\.])+\.([A-Za-z]{2,4})$/;
+      var reg = /^([A-Za-z0-9_\-\.])+\@([A-Za-z0-9_\-\.])+\.([A-Za-z]{2,})$/;
       if (reg.test(value) === false) {
         throw new qx.core.ValidationError("Validation Error",errorMessage);
       }


### PR DESCRIPTION
Hi,
I opened a bug here http://bugs.qooxdoo.org/show_bug.cgi?id=8555
Email extensions with more than 4 characters is now accepted
