### PR TITLE
possible fix for setRows function

### DIFF
--- a/framework/source/class/qx/ui/table/model/Simple.js
+++ b/framework/source/class/qx/ui/table/model/Simple.js
@@ -646,7 +646,7 @@ qx.Class.define("qx.ui.table.model.Simple",
       }
 
       // Prepare the rowArr so it can be used for apply
-      rowArr.splice(0, 0, startIndex, rowArr.length);
+      rowArr.splice(0, 0, startIndex, Math.max(this.__rowArr.length, rowArr.length));
 
       // Replace rows
       Array.prototype.splice.apply(this.__rowArr, rowArr);


### PR DESCRIPTION
Currently setRows function works improperly when we set less rows than table already has.
This commit suggests a possible solution for that bug.
