### PR TITLE
[Bug #8564] "," not accepted as shortcut

### DIFF
--- a/framework/source/class/qx/event/util/Keyboard.js
+++ b/framework/source/class/qx/event/util/Keyboard.js
@@ -247,6 +247,7 @@ qx.Bootstrap.define("qx.event.util.Keyboard", {
         case "-":
         case "*":
         case "/":
+        case ",":
           return true;
 
         default:


### PR DESCRIPTION
qx.ui.core.Command doesn't accept "," as shortcut for the numpad DEL key
