### PR TITLE
[BUG #8581] resetHiddenRows now reset correct rows data

### DIFF
--- a/framework/source/class/qx/ui/table/model/Filtered.js
+++ b/framework/source/class/qx/ui/table/model/Filtered.js
@@ -32,7 +32,6 @@ qx.Class.define("qx.ui.table.model.Filtered",
 
     this.numericAllowed = new Array("==", "!=", ">", "<", ">=", "<=");
     this.betweenAllowed = new Array("between", "!between");
-    this.__applyingFilters = false;
     this.Filters = new Array();
 
   },
@@ -41,7 +40,6 @@ qx.Class.define("qx.ui.table.model.Filtered",
   members :
   {
     __fullArr : null,
-    __applyingFilters : null,
 
 
     /**
@@ -348,10 +346,7 @@ qx.Class.define("qx.ui.table.model.Filtered",
       var rowArr = this.getData();
 
       dispatchEvent = (dispatchEvent != null ? dispatchEvent : true);
-      if (!this.__applyingFilters) {
-        this.__fullArr = rowArr.slice(0);
-        this.__applyingFilters = true;
-      }
+      this.__fullArr = rowArr.slice(0);
 
       if (numOfRows == null || numOfRows < 1) {
         numOfRows = 1;


### PR DESCRIPTION
Hi,

In qx.ui.table.model.Filtered, resetHiddenRows() does not reset correct data the second time if data has changed between first and second call. See the bug report to understand better : http://bugs.qooxdoo.org/show_bug.cgi?id=8591
this.__fullArr need to be always updated in hideRows() method because data may have changed since last . So the condition line 351 should not exists
