### PR TITLE
Disable native capturing for IE 9 in master for v 4.1

### DIFF
--- a/framework/source/class/qx/event/dispatch/MouseCapture.js
+++ b/framework/source/class/qx/event/dispatch/MouseCapture.js
@@ -167,14 +167,16 @@ qx.Class.define("qx.event.dispatch.MouseCapture",
       }
 
       // turn on native mouse capturing if the browser supports it
-      if (this.hasNativeCapture) {
-        this.nativeSetCapture(element, containerCapture);
-        var self = this;
-        qx.bom.Event.addNativeListener(element, "losecapture", function()
-        {
-          qx.bom.Event.removeNativeListener(element, "losecapture", arguments.callee);
-          self.releaseCapture();
-        });
+      if (qx.core.Environment.get("browser.documentmode") !== 9) {
+        if (this.hasNativeCapture) {
+          this.nativeSetCapture(element, containerCapture);
+          var self = this;
+          qx.bom.Event.addNativeListener(element, "losecapture", function()
+          {
+            qx.bom.Event.removeNativeListener(element, "losecapture", arguments.callee);
+           self.releaseCapture();
+          });
+        }
       }
 
       this.__containerCapture = containerCapture;


### PR DESCRIPTION
The native capturing was disabled with change https://github.com/qooxdoo/qooxdoo/commit/ba0e027215d48115dea86a2ab973921ed50d5c43
but is missing in current qooxdoo/master

See http://bugzilla.qooxdoo.org/show_bug.cgi?id=8587
