### PR TITLE
Disable native capturing for IE 9 document mode on Windows Vista

### DIFF
--- a/framework/source/class/qx/event/dispatch/MouseCapture.js
+++ b/framework/source/class/qx/event/dispatch/MouseCapture.js
@@ -215,7 +215,7 @@ qx.Class.define("qx.event.dispatch.MouseCapture",
 
     /** Whether the browser should use native mouse capturing */
     hasNativeCapture : (qx.core.Environment.get("engine.name") == "mshtml" &&
-    (qx.core.Environment.get("os.version") !== "7" ||
+    ((qx.core.Environment.get("os.version") !== "7" && qx.core.Environment.get("os.version") !== "vista") ||
     qx.core.Environment.get("browser.documentmode") < 9)),
 
 


### PR DESCRIPTION
Disable native capturing not only on Windows 7 but also for Windows Vista for IE in document mode 9.

See http://bugzilla.qooxdoo.org/show_bug.cgi?id=8587
