### PR TITLE
add overflow: hidden property to Label

### DIFF
--- a/framework/source/class/qx/html/Label.js
+++ b/framework/source/class/qx/html/Label.js
@@ -67,7 +67,7 @@ qx.Class.define("qx.html.Label",
     {
       var rich = this.__rich;
       var el = qx.bom.Label.create(this._content, rich);
-
+      el.style.overflow = 'hidden';
       return el;
     },
 


### PR DESCRIPTION
By default the qx.ui.core.Widget sets the overflow style. but since qx.ui.basic.Label overrides _createDomElement and does not set the hidden property. This patch sets it in qx.html.Label ... not sure if that is good, maybe it should be set in qx.ui.basic.Label

In any event, this fixes http://bugs.qooxdoo.org/show_bug.cgi?id=7506
