### PR TITLE
Error on closing qx.ui.core.Blocker when previous active widget is not focusable

### DIFF
--- a/framework/source/class/qx/ui/core/Blocker.js
+++ b/framework/source/class/qx/ui/core/Blocker.js
@@ -278,7 +278,7 @@ qx.Class.define("qx.ui.core.Blocker",
       if (focusElementsLength > 0)       {
         widget = this.__focusElements.pop();
 
-        if (widget && !widget.isDisposed()) {
+        if (widget && !widget.isDisposed() && widget.isFocusable()) {
           widget.focus();
         }
       }


### PR DESCRIPTION
Under certain circumstances console in Chrome 38 and 39 throws an error if a qx.ui.window.Window instance is closed.

The window manager seems to try to re focus the backuped widget which had the focus before the window opened. On window close the re focusing fails with the following error message in the console, leaving the blocker active (no mouse/keyboard action possible after this):

310779 qx.ui.core.queue.Widget: Error in the 'Widget' queue:Error: Widget is not focusable! Error: Widget is not focusable!
qx.ui.core.Widget:3341:15,qx.ui.core.Blocker:282:18,qx.ui.core.Blocker:449:12,qx.ui.core.Blocker:440:12,qx.ui.core.MBlocker:122:24,qx.ui.window.Manager:90:22,qx.ui.core.queue.Widget:130:13,qx.ui.core.queue.Manager:110:41,qx.ui.core.queue.Manager:223:9,qx.ui.core.queue.Manager:98:12Native.js:59 qx.Bootstrap.define.statics.process

The pull request fixes this by checking if the re focused widget is focusable at all via method isFocusable.

See bugzilla bug http://bugzilla.qooxdoo.org/show_bug.cgi?id=8668
