### PR TITLE
Bug #8687: Fix "swipe outside the screen" on Surface tablet

### DIFF
--- a/framework/source/class/qx/event/type/Pointer.js
+++ b/framework/source/class/qx/event/type/Pointer.js
@@ -62,7 +62,7 @@ qx.Class.define("qx.event.type.Pointer",
     getDocumentLeft : function() {
       var x = this.base(arguments);
       // iOS 6 does not copy pageX over to the fake pointer event
-      if (x == 0 && this.getPointerType() == "touch") {
+      if (x == 0 && this.getPointerType() == "touch" && this._native._original !== undefined) {
         x = Math.round(this._native._original.changedTouches[0].pageX) || 0;
       }
       return x;
@@ -73,7 +73,7 @@ qx.Class.define("qx.event.type.Pointer",
     getDocumentTop : function() {
       var y = this.base(arguments);
       // iOS 6 does not copy pageY over to the fake pointer event
-      if (y == 0 && this.getPointerType() == "touch") {
+      if (y == 0 && this.getPointerType() == "touch" && this._native._original !== undefined) {
         y = Math.round(this._native._original.changedTouches[0].pageY) || 0;
       }
       return y;


### PR DESCRIPTION
If you swipe from the inside to the outside of the screen on a Microsoft Surface tablet, qooxdoo throws an exception. Checking for this._native._original before fixes it.
