### PR TITLE
Fix for bug 8683

### DIFF
--- a/framework/source/class/qx/ui/core/Widget.js
+++ b/framework/source/class/qx/ui/core/Widget.js
@@ -1342,7 +1342,7 @@ qx.Class.define("qx.ui.core.Widget",
       // Compute height
       var layout = this._getLayout();
       if (layout && layout.hasHeightForWidth()) {
-        var contentHeight =  layout.getHeightForWidth(width);
+        var contentHeight =  layout.getHeightForWidth(contentWidth);
       } else {
         contentHeight = this._getContentHeightForWidth(contentWidth);
       }


### PR DESCRIPTION
Corrected width in Widget._getHeightForWidth when layout.hasHeightForWidth is true. See http://bugzilla.qooxdoo.org/show_bug.cgi?id=8683
