### PR TITLE
[BUG #8667] Spinner use NumberFormat locale instead of app locale

### DIFF
--- a/framework/source/class/qx/test/ui/form/Spinner.js
+++ b/framework/source/class/qx/test/ui/form/Spinner.js
@@ -1,0 +1,45 @@
+/* ************************************************************************
+
+   qooxdoo - the new era of web development
+
+   http://qooxdoo.org
+
+   Copyright:
+     2004-2014 1&1 Internet AG, Germany, http://www.1und1.de
+
+   License:
+     LGPL: http://www.gnu.org/licenses/lgpl.html
+     EPL: http://www.eclipse.org/org/documents/epl-v10.php
+     See the LICENSE file in the project's top-level directory for details.
+
+   Authors:
+     * William Oprandi (woprandi)
+
+************************************************************************ */
+qx.Class.define("qx.test.ui.form.Spinner",
+{
+  extend : qx.dev.unit.TestCase,
+
+  members :
+  {
+    /**
+     * Test if spinner use NumberFormat locale
+     */
+    testCorrectLocaleUsed : function()
+    {
+      var spinner = new qx.ui.form.Spinner();
+
+      // "us" locale has dot as decimal separator
+      var nf = new qx.util.format.NumberFormat("us");
+      spinner.setNumberFormat(nf);
+
+      spinner.setValue(1.23);
+      this.assertEquals(spinner.getChildControl("textfield").getValue(), "1.23");
+
+      // "fr" locale has comma as decimal separator
+      spinner.getNumberFormat().setLocale("fr");
+      spinner.setValue(2.34);
+      this.assertEquals(spinner.getChildControl("textfield").getValue(), "2,34");
+    }
+  }
+});

--- a/framework/source/class/qx/ui/form/Spinner.js
+++ b/framework/source/class/qx/ui/form/Spinner.js
@@ -292,12 +292,16 @@ qx.Class.define("qx.ui.form.Spinner",
      */
     _getFilterRegExp : function()
     {
-      var decimalSeparator = qx.locale.Number.getDecimalSeparator(
-        qx.locale.Manager.getInstance().getLocale()
-      );
-      var groupSeparator = qx.locale.Number.getGroupSeparator(
-        qx.locale.Manager.getInstance().getLocale()
-      );
+      var decimalSeparator, groupSeparator, locale;
+
+      if (this.getNumberFormat() !== null) {
+        locale = this.getNumberFormat().getLocale();
+      } else {
+        locale = qx.locale.Manager.getInstance().getLocale();
+      }
+
+      decimalSeparator = qx.locale.Number.getDecimalSeparator(locale);
+      groupSeparator = qx.locale.Number.getGroupSeparator(locale);
 
       var prefix = "";
       var postfix = "";

--- a/framework/source/class/qx/util/format/NumberFormat.js
+++ b/framework/source/class/qx/util/format/NumberFormat.js
@@ -39,17 +39,7 @@ qx.Class.define("qx.util.format.NumberFormat",
   construct : function(locale)
   {
     this.base(arguments);
-    if (arguments.length > 0) {
-      if (arguments.length === 1) {
-        if (qx.lang.Type.isString(locale)) {
-          this.__locale = locale;
-        } else {
-          throw new Error("Wrong argument type. String is expected.");
-        }
-      } else {
-        throw new Error("Wrong number of arguments.");
-      }
-    }
+    this.setLocale(locale);
   },
 
 
@@ -128,6 +118,14 @@ qx.Class.define("qx.util.format.NumberFormat",
       check : "String",
       init : "",
       event : "changeNumberFormat"
+    },
+
+    /** Locale used */
+    locale :
+    {
+      check : "String",
+      init : null,
+      event : "changeLocale"
     }
   },
 
@@ -142,8 +140,6 @@ qx.Class.define("qx.util.format.NumberFormat",
 
   members :
   {
-
-    __locale : null,
 
     /**
      * Formats a number.
@@ -217,7 +213,7 @@ qx.Class.define("qx.util.format.NumberFormat",
         var groupPos;
 
         for (groupPos=origIntegerStr.length; groupPos>3; groupPos-=3) {
-          integerStr = "" + qx.locale.Number.getGroupSeparator(this.__locale) + origIntegerStr.substring(groupPos - 3, groupPos) + integerStr;
+          integerStr = "" + qx.locale.Number.getGroupSeparator(this.getLocale()) + origIntegerStr.substring(groupPos - 3, groupPos) + integerStr;
         }
 
         integerStr = origIntegerStr.substring(0, groupPos) + integerStr;
@@ -232,7 +228,7 @@ qx.Class.define("qx.util.format.NumberFormat",
       var str = prefix + (negative ? "-" : "") + integerStr;
 
       if (fractionStr.length > 0) {
-        str += "" + qx.locale.Number.getDecimalSeparator(this.__locale) + fractionStr;
+        str += "" + qx.locale.Number.getDecimalSeparator(this.getLocale()) + fractionStr;
       }
 
       str += postfix;
@@ -251,8 +247,8 @@ qx.Class.define("qx.util.format.NumberFormat",
     parse : function(str)
     {
       // use the escaped separators for regexp
-      var groupSepEsc = qx.lang.String.escapeRegexpChars(qx.locale.Number.getGroupSeparator(this.__locale) + "");
-      var decimalSepEsc = qx.lang.String.escapeRegexpChars(qx.locale.Number.getDecimalSeparator(this.__locale) + "");
+      var groupSepEsc = qx.lang.String.escapeRegexpChars(qx.locale.Number.getGroupSeparator(this.getLocale()) + "");
+      var decimalSepEsc = qx.lang.String.escapeRegexpChars(qx.locale.Number.getDecimalSeparator(this.getLocale()) + "");
 
       var regex = new RegExp(
         "^" +


### PR DESCRIPTION
Hi,

This pull request corresponds to this bug  : http://bugzilla.qooxdoo.org/show_bug.cgi?id=8667
NumberFormat class now use locale property instead of just a private attribute. It allows spinner to use this locale instead of the app locale.
