### PR TITLE
[BUG #8776] Fix NumberFormat parse with prefix or postfix

### DIFF
--- a/framework/source/class/qx/test/util/NumberFormat.js
+++ b/framework/source/class/qx/test/util/NumberFormat.js
@@ -189,7 +189,24 @@ qx.Class.define("qx.test.util.NumberFormat",
       nf.setPostfix(" Percent");
       this.assertEquals(5, nf.parse(numberStr),
         "parsing failed after number format change");
-    }
+    },
 
+    testParseWithPrefixOrPostfix : function()
+    {
+      var spinner = new qx.ui.form.Spinner();
+      var prefix = "$ ";
+      var postfix = " €";
+      var nf = new qx.util.format.NumberFormat("fr").set({
+        maximumFractionDigits: 2,
+        minimumFractionDigits : 2,
+        prefix : prefix,
+        postfix : postfix
+      });
+
+      spinner.setNumberFormat(nf);
+      spinner.getChildControl("textfield").setValue("1,23");
+
+      this.assertEquals(spinner.getChildControl("textfield").getValue(), prefix + "1,23" + postfix);
+    }
   }
 });

--- a/framework/source/class/qx/util/format/NumberFormat.js
+++ b/framework/source/class/qx/util/format/NumberFormat.js
@@ -255,13 +255,13 @@ qx.Class.define("qx.util.format.NumberFormat",
       var decimalSepEsc = qx.lang.String.escapeRegexpChars(qx.locale.Number.getDecimalSeparator(this.__locale) + "");
 
       var regex = new RegExp(
-        "^" +
+        "^(" +
         qx.lang.String.escapeRegexpChars(this.getPrefix()) +
-        '([-+]){0,1}'+
+        ')?([-+]){0,1}'+
         '([0-9]{1,3}(?:'+ groupSepEsc + '{0,1}[0-9]{3}){0,}){0,1}' +
-        '(' + decimalSepEsc + '\\d+){0,1}' +
+        '(' + decimalSepEsc + '\\d+){0,1}(' +
         qx.lang.String.escapeRegexpChars(this.getPostfix()) +
-        "$"
+        ")?$"
       );
 
       var hit = regex.exec(str);
@@ -270,9 +270,11 @@ qx.Class.define("qx.util.format.NumberFormat",
         throw new Error("Number string '" + str + "' does not match the number format");
       }
 
-      var negative = (hit[1] == "-");
-      var integerStr = hit[2] || "0";
-      var fractionStr = hit[3];
+      // hit[1] = potential prefix
+      var negative = (hit[2] == "-");
+      var integerStr = hit[3] || "0";
+      var fractionStr = hit[4];
+      // hit[5] = potential postfix
 
       // Remove the thousand groupings
       integerStr = integerStr.replace(new RegExp(groupSepEsc, "g"), "");


### PR DESCRIPTION
Hi,

This PR corresponds to this bugzilla entry : http://bugzilla.qooxdoo.org/show_bug.cgi?id=8776
If NumberFormat locale defined has comma as decimal separator, and
postfix/prefix set, parse return wrong value (check playground example in bugzilla)
