### PR TITLE
[Bug 8854] Ignore receiving of commands when the widget is disabled

### DIFF
--- a/framework/source/class/qx/ui/core/MExecutable.js
+++ b/framework/source/class/qx/ui/core/MExecutable.js
@@ -120,12 +120,14 @@ qx.Mixin.define("qx.ui.core.MExecutable",
      * @param e {qx.event.type.Event} The execute event of the command.
      */
     __onCommandExecute : function(e) {
-      if (this.__semaphore) {
-        this.__semaphore = false;
-        return;
+      if (this.isEnabled()) {
+        if (this.__semaphore) {
+          this.__semaphore = false;
+          return;
+        }
+        this.__semaphore = true;
+        this.execute();
       }
-      this.__semaphore = true;
-      this.execute();
     },
 
 


### PR DESCRIPTION
From my point of view disabled widgets should ignore command "execute" events. A button for example is disabled and not clickable - and should not be executeable with a keyboard shortcut, too.
