### PR TITLE
Added null check to Spinner.js which fixes the following bug:

### DIFF
--- a/framework/source/class/qx/ui/form/Spinner.js
+++ b/framework/source/class/qx/ui/form/Spinner.js
@@ -499,8 +499,10 @@ qx.Class.define("qx.ui.form.Spinner",
       var textfield = this.getChildControl("textfield");
       textfield.setFilter(this._getFilterRegExp());
 
-      this.getNumberFormat().addListener("changeNumberFormat",
-        this._onChangeNumberFormat, this);
+      if (this.getNumberFormat() !== null) {
+        this.getNumberFormat().addListener("changeNumberFormat",
+          this._onChangeNumberFormat, this);
+      }
 
       this._applyValue(this.__lastValidValue, undefined);
     },


### PR DESCRIPTION
The property numberFormat of qx.ui.form.Spinner is nullable. If you do something like

spinner.setNumberFormat(new qx.util.format.NumberFormat());
spinner.setNumberFormat(null);

it will produce an error in the shape of:

/framework/source/class/qx/ui/form/Spinner.js:502 Uncaught TypeError: Cannot read property 'addListener' of null

because it tries

this.getNumberFormat().addListener(...);

although this.getNumberFormat() is null.

Fixed it with an "if (this.getNumberFormat() !== null)".
