### PR TITLE
qx.ui.table.Table: handle contextmenu event via _onTapPane event handler to get selection of the pointed row again back.

### DIFF
--- a/framework/source/class/qx/ui/table/pane/Scroller.js
+++ b/framework/source/class/qx/ui/table/pane/Scroller.js
@@ -87,6 +87,7 @@ qx.Class.define("qx.ui.table.pane.Scroller",
     this._paneClipper.addListener("pointermove", this._onPointermovePane, this);
     this._paneClipper.addListener("pointerdown", this._onPointerdownPane, this);
     this._paneClipper.addListener("tap", this._onTapPane, this);
+    this._paneClipper.addListener("contextmenu", this._onTapPane, this);
     this._paneClipper.addListener("contextmenu", this._onContextMenu, this);
     if (qx.core.Environment.get("device.type") === "desktop") {
       this._paneClipper.addListener("dblclick", this._onDbltapPane, this);


### PR DESCRIPTION
See bug http://bugzilla.qooxdoo.org/show_bug.cgi?id=8920
Compensates changes made to solve http://bugzilla.qooxdoo.org/show_bug.cgi?id=8873
