### PR TITLE
[Bug #7522] Added support for different group item sizes

### DIFF
--- a/framework/source/class/qx/ui/list/List.js
+++ b/framework/source/class/qx/ui/list/List.js
@@ -145,6 +145,17 @@ qx.Class.define("qx.ui.list.List",
     },
 
 
+    /** Group item height */
+    groupItemHeight :
+    {
+      check : "Integer",
+      init : null,
+      nullable : true,
+      apply : "_applyGroupRowHeight",
+      themeable : true
+    },
+
+
     /**
      * The path to the property which holds the information that should be
      * displayed as a label. This is only needed if objects are stored in the
@@ -508,6 +519,10 @@ qx.Class.define("qx.ui.list.List",
       this.getPane().getRowConfig().setDefaultItemSize(value);
     },
 
+    // apply method
+    _applyGroupRowHeight : function(value, old) {
+      this.__updateGroupRowHeight();
+    },
 
     // apply method
     _applyLabelPath : function(value, old) {
@@ -598,6 +613,26 @@ qx.Class.define("qx.ui.list.List",
 
 
     /**
+     * Helper method to update row heights.
+     */
+    __updateGroupRowHeight : function()
+    {
+      var rc = this.getPane().getRowConfig();
+      var gh = this.getGroupItemHeight();
+      rc.resetItemSizes();
+
+      if (gh) {
+        for (var i = 0,l = this.__lookupTable.length; i < l; ++i)
+        {
+          if (this.__lookupTable[i] == -1) {
+            rc.setItemSize(i, gh);
+          }
+        }
+      }
+    },
+
+
+    /**
      * Internal method for building the lookup table.
      */
     __buildUpLookupTable : function()
@@ -619,6 +654,7 @@ qx.Class.define("qx.ui.list.List",
       }
 
       this._updateSelection();
+      this.__updateGroupRowHeight();
       this.__updateRowCount();
     },
 


### PR DESCRIPTION
In some usecases ordinary list items are relative huge (i.e. when containing a
specific icon, etc.) and the group header only consists of a headline that
groups a couple of list items.

Currently it is not possible to set the group height to a different value from
defaultItemSize - although the infrastructure that is used supports different
heights for layer items.

Sadly there's no way to easily inherit from qx.ui.list.List because the parts
that need access are private.

Please find a patch that adds a few lines of code to support a
"groupItemHeight" property and adjusts the row config item sizes if it's
specified.

See: http://bugzilla.qooxdoo.org/show_bug.cgi?id=7522
