### PR TITLE
[BUG #9056] Call directly _applyValue() if value is the same than before

### DIFF
--- a/framework/source/class/qx/test/ui/form/Spinner.js
+++ b/framework/source/class/qx/test/ui/form/Spinner.js
@@ -33,6 +33,43 @@ qx.Class.define("qx.test.ui.form.Spinner", {
 
       spinner.setValue(1.23);
       this.assertEquals("1,23", spinner.getChildControl("textfield").getValue());
+    },
+
+    /**
+     * Test if postfix is always set after textfield of the spinner has been edited
+     */
+    testPostfixIsAlwaysSet : function() {
+      var spinner = new qx.ui.form.Spinner();
+      spinner.set({
+        maximum: 120,
+        minimum: 1
+      });
+      var numberFormat = new qx.util.format.NumberFormat();
+      numberFormat.setPostfix("min");
+      spinner.setNumberFormat(numberFormat);
+      var tf = spinner.getChildControl("textfield");
+
+      // Basic tests
+      tf.setValue("113");
+      this.assertEquals("113min", tf.getValue());
+      tf.setValue("121");
+      this.assertEquals("120min", tf.getValue());
+
+      // Check if postfix is added even if the spinner value won't change (value set to maximum)
+      tf.setValue("122");
+      this.assertEquals("120min", tf.getValue());
+
+      // Same for here (value set to minimum)
+      tf.setValue("-67");
+      this.assertEquals("1min", tf.getValue());
+      tf.setValue("-99");
+      this.assertEquals("1min", tf.getValue());
+
+      // And same here with a valid number
+      tf.setValue("50");
+      this.assertEquals("50min", tf.getValue());
+      tf.setValue("50");
+      this.assertEquals("50min", tf.getValue());
     }
   }
 });

--- a/framework/source/class/qx/ui/form/Spinner.js
+++ b/framework/source/class/qx/ui/form/Spinner.js
@@ -429,8 +429,7 @@ qx.Class.define("qx.ui.form.Spinner",
     /**
      * Apply routine for the value property.
      *
-     * It checks the min and max values, disables / enables the
-     * buttons and handles the wrap around.
+     * It disables / enables the buttons and handles the wrap around.
      *
      * @param value {Number} The new value of the spinner
      * @param old {Number} The former value of the spinner
@@ -696,17 +695,19 @@ qx.Class.define("qx.ui.form.Spinner",
       // if the result is a number
       if (!isNaN(value))
       {
-        // Fix range
+        // Fix value if invalid
         if (value > this.getMaximum()) {
-          textField.setValue(this.getMaximum() + "");
-          return;
+          value = this.getMaximum();
         } else if (value < this.getMinimum()) {
-          textField.setValue(this.getMinimum() + "");
-          return;
+          value = this.getMinimum();
         }
 
-        // set the value in the spinner
-        this.setValue(value);
+        // If value is the same than before, call direcly _applyValue()
+        if (value === this.__lastValidValue) {
+          this._applyValue(this.__lastValidValue);
+        } else {
+          this.setValue(value);
+        }
       }
       else
       {


### PR DESCRIPTION
Hi,
This is a fix for the bug reported here : http://bugs.qooxdoo.org/show_bug.cgi?id=9056
I added a new unit test to the spinner.
