### PR TITLE
[BUG #9105] Fix text selection after moving a Window

### DIFF
--- a/framework/source/class/qx/ui/core/MMovable.js
+++ b/framework/source/class/qx/ui/core/MMovable.js
@@ -285,7 +285,7 @@ qx.Mixin.define("qx.ui.core.MMovable",
      */
     _onMovePointerUp : function(e)
     {
-      if (this.hasListener("roll", this._onMoveRoll, this)) {
+      if (this.hasListener("roll")) {
         this.removeListener("roll", this._onMoveRoll, this);
       }
 


### PR DESCRIPTION
I am not sure my proposal is correct. Nevertheless I encountered a problem when moving the object of qx.ui.window.Window class. After move action a user is not able to select the text within form text widgets (I mean select by mouse). In my case the "roll" event handling was not removed.
