### PR TITLE
[BUG #9135] '+' is allowed in an email address

### DIFF
--- a/framework/source/class/qx/test/util/Validate.js
+++ b/framework/source/class/qx/test/util/Validate.js
@@ -57,6 +57,9 @@ qx.Class.define("qx.test.util.Validate",
 
       //Valid since new domain extensions
       qx.util.Validate.email()("foo@bar.qooxdoo");
+
+      //'+' allowed (gmail aliases)
+      qx.util.Validate.email()("foobar+alias@qooxdoo.org");
     },
 
     testString : function()

--- a/framework/source/class/qx/util/Validate.js
+++ b/framework/source/class/qx/util/Validate.js
@@ -129,7 +129,7 @@ qx.Class.define("qx.util.Validate",
       errorMessage = errorMessage ||
         qx.locale.Manager.tr("'%1' is not an email address.", (value || ""));
 
-      var reg = /^([A-Za-z0-9_\-\.])+\@([A-Za-z0-9_\-\.])+\.([A-Za-z]{2,})$/;
+      var reg = /^([A-Za-z0-9_\-\.\+])+\@([A-Za-z0-9_\-\.])+\.([A-Za-z]{2,})$/;
       if (reg.test(value) === false) {
         throw new qx.core.ValidationError("Validation Error",errorMessage);
       }


### PR DESCRIPTION
This PR for the bug : http://bugs.qooxdoo.org/show_bug.cgi?id=9135
