### PR TITLE
[BUG #9149] Improve SVG handling in IE

### DIFF
--- a/framework/source/class/qx/io/ImageLoader.js
+++ b/framework/source/class/qx/io/ImageLoader.js
@@ -218,7 +218,7 @@ qx.Bootstrap.define("qx.io.ImageLoader",
         }
 
         // Create image element
-        var el = new Image();
+        var el = document.createElement('img');
 
         // Create common callback routine
         var boundCallback = qx.lang.Function.listener(this.__onload, this, el, source);
@@ -297,6 +297,15 @@ qx.Bootstrap.define("qx.io.ImageLoader",
       // Shorthand
       var entry = this.__data[source];
 
+      // [BUG #9149]: When loading a SVG IE11 won't have
+      // the width/height of the element set, unless 
+      // it is inserted into the DOM.
+      if(qx.bom.client.Engine.getName() == "mshtml" &&
+          parseFloat(qx.bom.client.Engine.getVersion()) === 11)
+      {
+        document.body.appendChild(element);
+      }
+
       var isImageAvailable = function (imgElem) {
         return (imgElem && imgElem.height !== 0);
       };
@@ -306,8 +315,8 @@ qx.Bootstrap.define("qx.io.ImageLoader",
       if (event.type === "load" && isImageAvailable(element)) {
         // Store dimensions
         entry.loaded = true;
-        entry.width = this.__getWidth(element);
-        entry.height = this.__getHeight(element);
+        entry.width = element.width;
+        entry.height = element.height;
 
         // try to determine the image format
         var result = this.__knownImageTypesRegExp.exec(source);
@@ -317,6 +326,12 @@ qx.Bootstrap.define("qx.io.ImageLoader",
       }
       else {
         entry.failed = true;
+      }
+
+      if(qx.bom.client.Engine.getName() == "mshtml" &&
+          parseFloat(qx.bom.client.Engine.getVersion()) === 11)
+      {
+        document.body.removeChild(element);
       }
 
       // Cleanup listeners
@@ -336,31 +351,6 @@ qx.Bootstrap.define("qx.io.ImageLoader",
       }
     },
 
-
-    /**
-     * Returns the natural width of the given image element.
-     *
-     * @param element {Element} DOM element which represents the image
-     * @return {Integer} Image width
-     */
-    __getWidth : function(element)
-    {
-      return qx.core.Environment.get("html.image.naturaldimensions") ?
-        element.naturalWidth : element.width;
-    },
-
-
-    /**
-     * Returns the natural height of the given image element.
-     *
-     * @param element {Element} DOM element which represents the image
-     * @return {Integer} Image height
-     */
-    __getHeight : function(element)
-    {
-      return qx.core.Environment.get("html.image.naturaldimensions") ?
-        element.naturalHeight : element.height;
-    },
 
     /**
      * Dispose stored images.

--- a/framework/source/class/qx/test/io/ImageLoader.js
+++ b/framework/source/class/qx/test/io/ImageLoader.js
@@ -34,6 +34,9 @@ qx.Class.define("qx.test.io.ImageLoader",
     {
       this.__imageUri = qx.util.ResourceManager.getInstance().toUri("qx/test/colorstrip.gif");
       this.__wrongImageUri = this.__imageUri.replace(/color/, "foocolor");
+
+      this.__vectorImageUri = qx.util.ResourceManager.getInstance().toUri("qx/test/bluebar.svg");
+      this.__wrongVectorImageUri = this.__vectorImageUri.replace(/blue/, "fooblue");
     },
 
     tearDown : function()
@@ -46,6 +49,24 @@ qx.Class.define("qx.test.io.ImageLoader",
     {
       this.__imageSource = null;
       qx.io.ImageLoader.load(this.__imageUri, function(source, entry) {
+        this.__imageSource = source;
+      }, this);
+
+      qx.event.Timer.once(function(e) {
+        var self = this;
+        this.resume(function() {
+          this.assertTrue(qx.io.ImageLoader.isLoaded(this.__imageSource));
+        }, self);
+      }, this, 500);
+
+
+      this.wait();
+    },
+
+    testLoadVectorImageSuccess : function()
+    {
+      this.__imageSource = null;
+      qx.io.ImageLoader.load(this.__vectorImageUri, function(source, entry) {
         this.__imageSource = source;
       }, this);
 
@@ -77,10 +98,44 @@ qx.Class.define("qx.test.io.ImageLoader",
       this.wait();
     },
 
+    testLoadVectorImageFailure : function()
+    {
+      this.__imageSource = null;
+      qx.io.ImageLoader.load(this.__wrongVectorImageUri, function(source, entry) {
+        this.__imageSource = source;
+      }, this);
+
+      qx.event.Timer.once(function(e) {
+        var self = this;
+        this.resume(function() {
+          this.assertTrue(qx.io.ImageLoader.isFailed(this.__imageSource));
+        }, self);
+      }, this, 500);
+
+      this.wait();
+    },
+
     testImageWidth : function()
     {
       this.__imageSource = null;
       qx.io.ImageLoader.load(this.__imageUri, function(source, entry) {
+        this.__imageSource = source;
+      }, this);
+
+      qx.event.Timer.once(function(e) {
+        var self = this;
+        this.resume(function() {
+          this.assertEquals(192, qx.io.ImageLoader.getWidth(this.__imageSource));
+        }, self);
+      }, this, 500);
+
+      this.wait();
+    },
+
+    testVectorImageWidth : function()
+    {
+      this.__imageSource = null;
+      qx.io.ImageLoader.load(this.__vectorImageUri, function(source, entry) {
         this.__imageSource = source;
       }, this);
 
@@ -111,10 +166,46 @@ qx.Class.define("qx.test.io.ImageLoader",
       this.wait();
     },
 
+    testVectorImageHeight : function()
+    {
+      this.__imageSource = null;
+      qx.io.ImageLoader.load(this.__vectorImageUri, function(source, entry) {
+        this.__imageSource = source;
+      }, this);
+
+      qx.event.Timer.once(function(e) {
+        var self = this;
+        this.resume(function() {
+          this.assertEquals(10, qx.io.ImageLoader.getHeight(this.__imageSource));
+        }, self);
+      }, this, 500);
+
+      this.wait();
+    },
+
     testImageSize : function()
     {
       this.__imageSource = null;
       qx.io.ImageLoader.load(this.__imageUri, function(source, entry) {
+        this.__imageSource = source;
+      }, this);
+
+      qx.event.Timer.once(function(e) {
+        var self = this;
+        this.resume(function() {
+          var size = qx.io.ImageLoader.getSize(this.__imageSource);
+          this.assertEquals(192, size.width);
+          this.assertEquals(10, size.height);
+        }, self);
+      }, this, 500);
+
+      this.wait();
+    },
+
+    testVectorImageSize : function()
+    {
+      this.__imageSource = null;
+      qx.io.ImageLoader.load(this.__vectorImageUri, function(source, entry) {
         this.__imageSource = source;
       }, this);
 

--- a/framework/source/resource/qx/test/bluebar.svg
+++ b/framework/source/resource/qx/test/bluebar.svg
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg xmlns="http://www.w3.org/2000/svg" version="1.1" viewBox="0 0 192 10" height="10" width="192">
+    <rect y="0" x="0" height="10" width="192" style="opacity:1;fill:#0000ff;stroke:none;;fill-opacity:1" />
+</svg>


### PR DESCRIPTION
PR for: http://bugzilla.qooxdoo.org/show_bug.cgi?id=9149

I had to replace `new Image()` with `document.createElement('img')`.
Using the former, the element wouldn't have the width/height set even
after appending it to the DOM.
The rest is explained in the bug ticket.

Let me know if there is something missing or if improvements are
necessary.
