### PR TITLE
[BUG #7715] Allow decorator properties to be repeated for multiple values for certain CSS properties

### DIFF
--- a/framework/source/class/qx/ui/decoration/Decorator.js
+++ b/framework/source/class/qx/ui/decoration/Decorator.js
@@ -111,6 +111,13 @@ qx.Class.define("qx.ui.decoration.Decorator", {
           this[name](styles);
         }
       }
+      for(var name in styles)
+      {
+        if(qx.lang.Type.isArray(styles[name])) {
+          styles[name] = styles[name].join(', ');
+        }
+      }
+
 
       this.__initialized = true;
       return styles;

--- a/framework/source/class/qx/ui/decoration/Decorator.js
+++ b/framework/source/class/qx/ui/decoration/Decorator.js
@@ -159,6 +159,19 @@ qx.Class.define("qx.ui.decoration.Decorator", {
     // overridden
     _isInitialized: function() {
       return this.__initialized;
+    },
+
+
+    /**
+    * Extends an array up to the given length by repeating the elements already present.
+    * @param arr {Array} Incoming array. Has to contain at least one element.
+    * @param to {Integer} Desired length. Must be greater than or equal to the the length of arr.
+    */
+    _prolongArray: function(array, to) {
+      var initial = array.length;
+      while(array.length < to) {
+        array.push(array[array.length%initial]);
+      }
     }
   }
 });

--- a/framework/source/class/qx/ui/decoration/Decorator.js
+++ b/framework/source/class/qx/ui/decoration/Decorator.js
@@ -161,13 +161,40 @@ qx.Class.define("qx.ui.decoration.Decorator", {
       return this.__initialized;
     },
 
+    /**
+    * Ensures that every propertyValue specified in propertyNames is an array.
+    * The value arrays are prolonged to match in length.
+    * @param arr {Array} Array containing the propertyNames.
+    * @returns {Array} Array containing the prolonged value arrays.
+    */
+    _getProlongedPropertyValueArrays: function(propertyNames) {
+      // transform non-array values to an array containing that value
+      var propertyValues = propertyNames.map(function(propName) {
+        var value = this.get(propName);
+        if(!qx.lang.Type.isArray(value)) {
+          value = [value];
+        }
+        return value;
+      }, this);
+
+      // Because it's possible to set multiple values for a property there's 
+      // a chance that not all properties have the same amount of values set.
+      // Prolong the value arrays by repeating existing values until all
+      // arrays match in length.
+      var items = Math.max.apply(Math, propertyValues.map(function(prop) { return prop.length; }));
+      for(var i = 0; i < propertyValues.length; i++) {
+        this.__prolongArray(propertyValues[i], items);
+      }
+
+      return propertyValues;
+    },
 
     /**
     * Extends an array up to the given length by repeating the elements already present.
     * @param arr {Array} Incoming array. Has to contain at least one element.
     * @param to {Integer} Desired length. Must be greater than or equal to the the length of arr.
     */
-    _prolongArray: function(array, to) {
+    __prolongArray: function(array, to) {
       var initial = array.length;
       while(array.length < to) {
         array.push(array[array.length%initial]);

--- a/framework/source/class/qx/ui/decoration/Decorator.js
+++ b/framework/source/class/qx/ui/decoration/Decorator.js
@@ -163,11 +163,11 @@ qx.Class.define("qx.ui.decoration.Decorator", {
 
     /**
     * Ensures that every propertyValue specified in propertyNames is an array.
-    * The value arrays are prolonged to match in length.
+    * The value arrays are extended and repeated to match in length.
     * @param arr {Array} Array containing the propertyNames.
-    * @returns {Array} Array containing the prolonged value arrays.
+    * @returns {Array} Array containing the extended value arrays.
     */
-    _getProlongedPropertyValueArrays: function(propertyNames) {
+    _getExtendedPropertyValueArrays: function(propertyNames) {
       // transform non-array values to an array containing that value
       var propertyValues = propertyNames.map(function(propName) {
         var value = this.get(propName);
@@ -178,12 +178,12 @@ qx.Class.define("qx.ui.decoration.Decorator", {
       }, this);
 
       // Because it's possible to set multiple values for a property there's 
-      // a chance that not all properties have the same amount of values set.
-      // Prolong the value arrays by repeating existing values until all
+      // a chance that not all properties have the same number of values set.
+      // Extend the value arrays by repeating existing values until all
       // arrays match in length.
       var items = Math.max.apply(Math, propertyValues.map(function(prop) { return prop.length; }));
       for(var i = 0; i < propertyValues.length; i++) {
-        this.__prolongArray(propertyValues[i], items);
+        this.__extendArray(propertyValues[i], items);
       }
 
       return propertyValues;
@@ -194,7 +194,7 @@ qx.Class.define("qx.ui.decoration.Decorator", {
     * @param arr {Array} Incoming array. Has to contain at least one element.
     * @param to {Integer} Desired length. Must be greater than or equal to the the length of arr.
     */
-    __prolongArray: function(array, to) {
+    __extendArray: function(array, to) {
       var initial = array.length;
       while(array.length < to) {
         array.push(array[array.length%initial]);

--- a/framework/source/class/qx/ui/decoration/MBackgroundImage.js
+++ b/framework/source/class/qx/ui/decoration/MBackgroundImage.js
@@ -110,29 +110,9 @@ qx.Mixin.define("qx.ui.decoration.MBackgroundImage",
      */
     _styleBackgroundImage : function(styles)
     {
-      // transform non-array values to an array containing that value
-      var images = this.getBackgroundImage();
-      if(!images) { return; }
-      if(!qx.lang.Type.isArray(images)) images = [images];
-      var repeats = this.getBackgroundRepeat();
-      if(!qx.lang.Type.isArray(repeats)) repeats = [repeats];
-      var tops = this.getBackgroundPositionY();
-      if(!qx.lang.Type.isArray(tops)) tops = [tops];
-      var lefts = this.getBackgroundPositionX();
-      if(!qx.lang.Type.isArray(lefts)) lefts = [lefts];
-      var origins = this.getBackgroundOrigin();
-      if(!qx.lang.Type.isArray(origins)) origins = [origins];
-
-      // Because it's possible to set multiple values for a property there's 
-      // a chance that not all properties have the same amount of values set.
-      // Prolong the value arrays by repeating existing values until all
-      // arrays match in length.
-      var items = Math.max(images.length, repeats.length, tops.length, lefts.length);
-      this._prolongArray(images, items);
-      this._prolongArray(repeats, items);
-      this._prolongArray(tops, items);
-      this._prolongArray(lefts, items);
-      this._prolongArray(origins, items);
+      if(! this.getBackgroundImage()) {
+        return;
+      }
 
       if("background" in styles) {
         if(!qx.lang.Type.isArray(styles['background'])) {
@@ -142,54 +122,59 @@ qx.Mixin.define("qx.ui.decoration.MBackgroundImage",
         styles['background'] = [];
       }
 
-      for(var i=0;i<items;i++) {
-        var image = images[i];
-        var repeat = repeats[i];
-        var top = tops[i] || 0;
-        var left = lefts[i] || 0;
-        var origin = origins[i] || '';
+      var backgroundImageProperties = ['backgroundImage', 'backgroundRepeat', 'backgroundPositionY',
+        'backgroundPositionX', 'backgroundOrigin'];
 
-        if (top == null) {
-          top = 0;
-        }
-        if (left == null) {
-          left = 0;
-        }
-        if (!isNaN(top)) {
-          top += "px";
-        }
-        if (!isNaN(left)) {
-          left += "px";
-        }
+      (function (images, repeats, tops, lefts, origins) {
+        for(var i=0;i<images.length;i++) {
+          var image = images[i];
+          var repeat = repeats[i];
+          var top = tops[i] || 0;
+          var left = lefts[i] || 0;
+          var origin = origins[i] || '';
 
-        var id = qx.util.AliasManager.getInstance().resolve(image);
-        var source = qx.util.ResourceManager.getInstance().toUri(id);
+          if (top == null) {
+            top = 0;
+          }
+          if (left == null) {
+            left = 0;
+          }
+          if (!isNaN(top)) {
+            top += "px";
+          }
+          if (!isNaN(left)) {
+            left += "px";
+          }
 
-        var attrs = {
-          image: 'url(' + source + ')',
-          position: left + " " + top,
-          repeat: 'repeat',
-          origin: origin
-        };
-        if (repeat === "scale") {
-          attrs.size = "100% 100%";
-        } else {
-          attrs.repeat = repeat;
-        }
-        var imageMarkup = [attrs.image, attrs.position + ('size' in attrs ? ' / ' + attrs.size : ''), attrs.repeat, attrs.origin];
-        
-        styles["background"][this.getOrderGradientsFront() ? 'push' : 'unshift'](imageMarkup.join(' '));
+          var id = qx.util.AliasManager.getInstance().resolve(image);
+          var source = qx.util.ResourceManager.getInstance().toUri(id);
 
-        if (qx.core.Environment.get("qx.debug") &&
-          source &&  qx.lang.String.endsWith(source, ".png") &&
-          (repeat == "scale" || repeat == "no-repeat") &&
-          qx.core.Environment.get("engine.name") == "mshtml" &&
-          qx.core.Environment.get("browser.documentmode") < 9)
-        {
-          this.warn("Background PNGs with repeat == 'scale' or repeat == 'no-repeat'" +
-            " are not supported in this client! The image's resource id is '" + id + "'");
+          var attrs = {
+            image: 'url(' + source + ')',
+            position: left + " " + top,
+            repeat: 'repeat',
+            origin: origin
+          };
+          if (repeat === "scale") {
+            attrs.size = "100% 100%";
+          } else {
+            attrs.repeat = repeat;
+          }
+          var imageMarkup = [attrs.image, attrs.position + ('size' in attrs ? ' / ' + attrs.size : ''), attrs.repeat, attrs.origin];
+
+          styles["background"][this.getOrderGradientsFront() ? 'push' : 'unshift'](imageMarkup.join(' '));
+
+          if (qx.core.Environment.get("qx.debug") &&
+            source &&  qx.lang.String.endsWith(source, ".png") &&
+            (repeat == "scale" || repeat == "no-repeat") &&
+            qx.core.Environment.get("engine.name") == "mshtml" &&
+            qx.core.Environment.get("browser.documentmode") < 9)
+          {
+            this.warn("Background PNGs with repeat == 'scale' or repeat == 'no-repeat'" +
+              " are not supported in this client! The image's resource id is '" + id + "'");
+          }
         }
-      }
+      }).apply(this, this._getProlongedPropertyValueArrays(backgroundImageProperties));
     },
 
 

--- a/framework/source/class/qx/ui/decoration/MBackgroundImage.js
+++ b/framework/source/class/qx/ui/decoration/MBackgroundImage.js
@@ -174,7 +174,7 @@ qx.Mixin.define("qx.ui.decoration.MBackgroundImage",
               " are not supported in this client! The image's resource id is '" + id + "'");
           }
         }
-      }).apply(this, this._getProlongedPropertyValueArrays(backgroundImageProperties));
+      }).apply(this, this._getExtendedPropertyValueArrays(backgroundImageProperties));
     },
 
 

--- a/framework/source/class/qx/ui/decoration/MBackgroundImage.js
+++ b/framework/source/class/qx/ui/decoration/MBackgroundImage.js
@@ -110,11 +110,9 @@ qx.Mixin.define("qx.ui.decoration.MBackgroundImage",
      */
     _styleBackgroundImage : function(styles)
     {
+      // transform non-array values to an array containing that value
       var images = this.getBackgroundImage();
-      if(!images) {
-        return;
-      }
-
+      if(!images) { return; }
       if(!qx.lang.Type.isArray(images)) images = [images];
       var repeats = this.getBackgroundRepeat();
       if(!qx.lang.Type.isArray(repeats)) repeats = [repeats];
@@ -125,7 +123,10 @@ qx.Mixin.define("qx.ui.decoration.MBackgroundImage",
       var origins = this.getBackgroundOrigin();
       if(!qx.lang.Type.isArray(origins)) origins = [origins];
 
-
+      // Because it's possible to set multiple values for a property there's 
+      // a chance that not all properties have the same amount of values set.
+      // Prolong the value arrays by repeating existing values until all
+      // arrays match in length.
       var items = Math.max(images.length, repeats.length, tops.length, lefts.length);
       this._prolongArray(images, items);
       this._prolongArray(repeats, items);

--- a/framework/source/class/qx/ui/decoration/MBoxShadow.js
+++ b/framework/source/class/qx/ui/decoration/MBoxShadow.js
@@ -35,7 +35,6 @@ qx.Mixin.define("qx.ui.decoration.MBoxShadow",
     shadowHorizontalLength :
     {
       nullable : true,
-      check : "Integer",
       apply : "_applyBoxShadow"
     },
 
@@ -43,7 +42,6 @@ qx.Mixin.define("qx.ui.decoration.MBoxShadow",
     shadowVerticalLength :
     {
       nullable : true,
-      check : "Integer",
       apply : "_applyBoxShadow"
     },
 
@@ -51,7 +49,6 @@ qx.Mixin.define("qx.ui.decoration.MBoxShadow",
     shadowBlurRadius :
     {
       nullable : true,
-      check : "Integer",
       apply : "_applyBoxShadow"
     },
 
@@ -59,7 +56,6 @@ qx.Mixin.define("qx.ui.decoration.MBoxShadow",
     shadowSpreadRadius :
     {
       nullable : true,
-      check : "Integer",
       apply : "_applyBoxShadow"
     },
 
@@ -67,7 +63,6 @@ qx.Mixin.define("qx.ui.decoration.MBoxShadow",
     shadowColor :
     {
       nullable : true,
-      check : "Color",
       apply : "_applyBoxShadow"
     },
 
@@ -75,7 +70,6 @@ qx.Mixin.define("qx.ui.decoration.MBoxShadow",
     inset :
     {
       init : false,
-      check : "Boolean",
       apply : "_applyBoxShadow"
     },
 
@@ -106,31 +100,54 @@ qx.Mixin.define("qx.ui.decoration.MBoxShadow",
         return;
       }
 
-      if (qx.core.Environment.get("qx.theme"))
-      {
-        var Color = qx.theme.manager.Color.getInstance();
-        var color = Color.resolve(this.getShadowColor());
-      }
-      else
-      {
-        var color = this.getShadowColor();
+      propName = qx.bom.Style.getCssName(propName);
+
+      var vLengths = this.getShadowVerticalLength() || [0];
+      if(!qx.lang.Type.isArray(vLengths)) vLengths = [vLengths];
+      var hLengths = this.getShadowHorizontalLength() || [0];
+      if(!qx.lang.Type.isArray(hLengths)) hLengths = [hLengths];
+      var blurs = this.getShadowBlurRadius() || [0];
+      if(!qx.lang.Type.isArray(blurs)) blurs = [blurs];
+      var spreads = this.getShadowSpreadRadius() || [0];
+      if(!qx.lang.Type.isArray(spreads)) spreads = [spreads];
+      var colors = this.getShadowColor() || ["black"];
+      if(!qx.lang.Type.isArray(colors)) colors = [colors];
+      var insets = this.getInset();
+      if(!qx.lang.Type.isArray(insets)) insets = [!!insets];
+
+      var items = Math.max(vLengths.length, hLengths.length, blurs.length, spreads.length, colors.length, insets.length);
+      this._prolongArray(vLengths, items);
+      this._prolongArray(hLengths, items);
+      this._prolongArray(blurs, items);
+      this._prolongArray(spreads, items);
+      this._prolongArray(colors, items);
+      this._prolongArray(insets, items);
+
+      var Color = null;
+      if(qx.core.Environment.get("qx.theme")) {
+        Color = qx.theme.manager.Color.getInstance();
       }
 
-      if (color != null)
-      {
-        var vLength = this.getShadowVerticalLength() || 0;
-        var hLength = this.getShadowHorizontalLength() || 0;
-        var blur = this.getShadowBlurRadius() || 0;
-        var spread = this.getShadowSpreadRadius() || 0;
-        var inset = this.getInset() ? "inset " : "";
-        var value = inset + hLength + "px " + vLength + "px " + blur + "px " + spread + "px " + color;
+      for(var i=0;i<items;i++) {
+        var vLength = vLengths[i];
+        var hLength = hLengths[i];
+        var blur = blurs[i];
+        var spread = spreads[i];
+        var color = colors[i];
+        var inset = insets[i];
 
-        // apply or append the box shadow styles
-        propName = qx.bom.Style.getCssName(propName);
-        if (!styles[propName]) {
-          styles[propName] = value;
-        } else {
-          styles[propName] += "," + value;
+        if(Color) {
+          color = Color.resolve(color);
+        }
+
+        if(color != null) {
+          var value = (inset ? 'inset ' : '') + hLength + "px " + vLength + "px " + blur + "px " + spread + "px " + color;
+          // apply or append the box shadow styles
+          if (!styles[propName]) {
+            styles[propName] = value;
+          } else {
+            styles[propName] += "," + value;
+          }
         }
       }
     },

--- a/framework/source/class/qx/ui/decoration/MBoxShadow.js
+++ b/framework/source/class/qx/ui/decoration/MBoxShadow.js
@@ -102,6 +102,7 @@ qx.Mixin.define("qx.ui.decoration.MBoxShadow",
 
       propName = qx.bom.Style.getCssName(propName);
 
+      // transform non-array values to an array containing that value
       var vLengths = this.getShadowVerticalLength() || [0];
       if(!qx.lang.Type.isArray(vLengths)) vLengths = [vLengths];
       var hLengths = this.getShadowHorizontalLength() || [0];
@@ -115,6 +116,10 @@ qx.Mixin.define("qx.ui.decoration.MBoxShadow",
       var insets = this.getInset();
       if(!qx.lang.Type.isArray(insets)) insets = [!!insets];
 
+      // Because it's possible to set multiple values for a property there's 
+      // a chance that not all properties have the same amount of values set.
+      // Prolong the value arrays by repeating existing values until all
+      // arrays match in length.
       var items = Math.max(vLengths.length, hLengths.length, blurs.length, spreads.length, colors.length, insets.length);
       this._prolongArray(vLengths, items);
       this._prolongArray(hLengths, items);

--- a/framework/source/class/qx/ui/decoration/MBoxShadow.js
+++ b/framework/source/class/qx/ui/decoration/MBoxShadow.js
@@ -102,59 +102,38 @@ qx.Mixin.define("qx.ui.decoration.MBoxShadow",
 
       propName = qx.bom.Style.getCssName(propName);
 
-      // transform non-array values to an array containing that value
-      var vLengths = this.getShadowVerticalLength() || [0];
-      if(!qx.lang.Type.isArray(vLengths)) vLengths = [vLengths];
-      var hLengths = this.getShadowHorizontalLength() || [0];
-      if(!qx.lang.Type.isArray(hLengths)) hLengths = [hLengths];
-      var blurs = this.getShadowBlurRadius() || [0];
-      if(!qx.lang.Type.isArray(blurs)) blurs = [blurs];
-      var spreads = this.getShadowSpreadRadius() || [0];
-      if(!qx.lang.Type.isArray(spreads)) spreads = [spreads];
-      var colors = this.getShadowColor() || ["black"];
-      if(!qx.lang.Type.isArray(colors)) colors = [colors];
-      var insets = this.getInset();
-      if(!qx.lang.Type.isArray(insets)) insets = [!!insets];
-
-      // Because it's possible to set multiple values for a property there's 
-      // a chance that not all properties have the same amount of values set.
-      // Prolong the value arrays by repeating existing values until all
-      // arrays match in length.
-      var items = Math.max(vLengths.length, hLengths.length, blurs.length, spreads.length, colors.length, insets.length);
-      this._prolongArray(vLengths, items);
-      this._prolongArray(hLengths, items);
-      this._prolongArray(blurs, items);
-      this._prolongArray(spreads, items);
-      this._prolongArray(colors, items);
-      this._prolongArray(insets, items);
-
       var Color = null;
       if(qx.core.Environment.get("qx.theme")) {
         Color = qx.theme.manager.Color.getInstance();
       }
 
-      for(var i=0;i<items;i++) {
-        var vLength = vLengths[i];
-        var hLength = hLengths[i];
-        var blur = blurs[i];
-        var spread = spreads[i];
-        var color = colors[i];
-        var inset = insets[i];
+      var boxShadowProperties = ["shadowVerticalLength", "shadowHorizontalLength", "shadowBlurRadius",
+        "shadowSpreadRadius", "shadowColor", "inset"];
+        
+      (function(vLengths, hLengths, blurs, spreads, colors, insets) {
+        for(var i=0;i<vLengths.length;i++) {
+          var vLength = vLengths[i] || 0;
+          var hLength = hLengths[i] || 0;
+          var blur = blurs[i] || 0;
+          var spread = spreads[i] || 0;
+          var color = colors[i] || "black";
+          var inset = insets[i];
 
-        if(Color) {
-          color = Color.resolve(color);
-        }
+          if(Color) {
+            color = Color.resolve(color);
+          }
 
-        if(color != null) {
-          var value = (inset ? 'inset ' : '') + hLength + "px " + vLength + "px " + blur + "px " + spread + "px " + color;
-          // apply or append the box shadow styles
-          if (!styles[propName]) {
-            styles[propName] = value;
-          } else {
-            styles[propName] += "," + value;
+          if(color != null) {
+            var value = (inset ? 'inset ' : '') + hLength + "px " + vLength + "px " + blur + "px " + spread + "px " + color;
+            // apply or append the box shadow styles
+            if (!styles[propName]) {
+              styles[propName] = value;
+            } else {
+              styles[propName] += "," + value;
+            }
           }
         }
-      }
+      }).apply(this, this._getProlongedPropertyValueArrays(boxShadowProperties));
     },
 
 

--- a/framework/source/class/qx/ui/decoration/MBoxShadow.js
+++ b/framework/source/class/qx/ui/decoration/MBoxShadow.js
@@ -133,7 +133,7 @@ qx.Mixin.define("qx.ui.decoration.MBoxShadow",
             }
           }
         }
-      }).apply(this, this._getProlongedPropertyValueArrays(boxShadowProperties));
+      }).apply(this, this._getExtendedPropertyValueArrays(boxShadowProperties));
     },
 
 

--- a/framework/source/class/qx/ui/decoration/MLinearBackgroundGradient.js
+++ b/framework/source/class/qx/ui/decoration/MLinearBackgroundGradient.js
@@ -161,7 +161,7 @@ qx.Mixin.define("qx.ui.decoration.MLinearBackgroundGradient",
         var orderGradientsFront = 'getOrderGradientsFront' in this ? this.getOrderGradientsFront() : false;
         var operation = orderGradientsFront ? Array.prototype.unshift : Array.prototype.push;
         operation.apply(styles['background'], backgroundStyle);
-      }).apply(this, this._getProlongedPropertyValueArrays(gradientProperties));
+      }).apply(this, this._getExtendedPropertyValueArrays(gradientProperties));
     },
 
     /**

--- a/framework/source/class/qx/ui/decoration/MLinearBackgroundGradient.js
+++ b/framework/source/class/qx/ui/decoration/MLinearBackgroundGradient.js
@@ -48,7 +48,6 @@ qx.Mixin.define("qx.ui.decoration.MLinearBackgroundGradient",
      */
     startColor :
     {
-      check : "Color",
       nullable : true,
       apply : "_applyLinearBackgroundGradient"
     },
@@ -59,7 +58,6 @@ qx.Mixin.define("qx.ui.decoration.MLinearBackgroundGradient",
      */
     endColor :
     {
-      check : "Color",
       nullable : true,
       apply : "_applyLinearBackgroundGradient"
     },
@@ -67,7 +65,6 @@ qx.Mixin.define("qx.ui.decoration.MLinearBackgroundGradient",
     /** The orientation of the gradient. */
     orientation :
     {
-      check : ["horizontal", "vertical"],
       init : "vertical",
       apply : "_applyLinearBackgroundGradient"
     },
@@ -75,7 +72,6 @@ qx.Mixin.define("qx.ui.decoration.MLinearBackgroundGradient",
     /** Position in percent where to start the color. */
     startColorPosition :
     {
-      check : "Number",
       init : 0,
       apply : "_applyLinearBackgroundGradient"
     },
@@ -83,7 +79,6 @@ qx.Mixin.define("qx.ui.decoration.MLinearBackgroundGradient",
     /** Position in percent where to start the color. */
     endColorPosition :
     {
-      check : "Number",
       init : 100,
       apply : "_applyLinearBackgroundGradient"
     },
@@ -91,7 +86,6 @@ qx.Mixin.define("qx.ui.decoration.MLinearBackgroundGradient",
     /** Defines if the given positions are in % or px.*/
     colorPositionUnit :
     {
-      check : ["px", "%"],
       init : "%",
       apply : "_applyLinearBackgroundGradient"
     },
@@ -115,9 +109,6 @@ qx.Mixin.define("qx.ui.decoration.MLinearBackgroundGradient",
 
   members :
   {
-    __canvas : null,
-
-
     /**
      * Takes a styles map and adds the linear background styles in place to the
      * given map. This is the needed behavior for
@@ -126,191 +117,278 @@ qx.Mixin.define("qx.ui.decoration.MLinearBackgroundGradient",
      * @param styles {Map} A map to add the styles.
      */
     _styleLinearBackgroundGradient : function(styles) {
-      var colors = this.__getColors();
-      var startColor = colors.start;
-      var endColor = colors.end;
-      var value;
+      var backgroundStyle = [];
 
-      if (!startColor || !endColor) {
-        return;
-      }
+      var startColors = this.getStartColor();
+      if(!startColors) { return; }
+      if(!qx.lang.Type.isArray(startColors)) startColors = [startColors];
+      var endColors = this.getEndColor();
+      if(!endColors) { return; }
+      if(!qx.lang.Type.isArray(endColors)) endColors = [endColors];
+      var units = this.getColorPositionUnit();
+      if(!qx.lang.Type.isArray(units)) units = [units];
+      var orientations = this.getOrientation();
+      if(!qx.lang.Type.isArray(orientations)) orientations = [orientations];
+      var startColorPositions = this.getStartColorPosition();
+      if(!qx.lang.Type.isArray(startColorPositions)) startColorPositions = [startColorPositions];
+      var endColorPositions = this.getEndColorPosition();
+      if(!qx.lang.Type.isArray(endColorPositions)) endColorPositions = [endColorPositions];
 
-      var unit = this.getColorPositionUnit();
+      var items = Math.max(startColors.length, endColors.length, units.length, orientations.length);
+      this._prolongArray(startColors, items);
+      this._prolongArray(endColors, items);
+      this._prolongArray(units, items);
+      this._prolongArray(orientations, items);
+      this._prolongArray(startColorPositions, items);
+      this._prolongArray(endColorPositions, items);
 
-      // new implementation for webkit is available since chrome 10 --> version
+      var styleImpl = this.__styleLinearBackgroundGradientAccordingToSpec;
       if (qx.core.Environment.get("css.gradient.legacywebkit")) {
-        // webkit uses px values if non are given
-        unit = unit === "px" ? "" : unit;
-
-        if (this.getOrientation() == "horizontal") {
-          var startPos = this.getStartColorPosition() + unit +" 0" + unit;
-          var endPos = this.getEndColorPosition() + unit + " 0" + unit;
-        } else {
-          var startPos = "0" + unit + " " + this.getStartColorPosition() + unit;
-          var endPos = "0" + unit +" " + this.getEndColorPosition() + unit;
-        }
-
-        var color =
-          "from(" + startColor +
-          "),to(" + endColor + ")";
-
-        value = "-webkit-gradient(linear," + startPos + "," + endPos + "," + color + ")";
-        styles["background"] = value;
-
-      // IE9 canvas solution
+        styleImpl = this.__styleLinearBackgroundGradientForLegacyWebkit;
       } else if (qx.core.Environment.get("css.gradient.filter") &&
         !qx.core.Environment.get("css.gradient.linear") && qx.core.Environment.get("css.borderradius")) {
-
-          if (!this.__canvas) {
-            this.__canvas = document.createElement("canvas");
-          }
-
-          var isVertical = this.getOrientation() == "vertical";
-
-          var colors = this.__getColors();
-          var height = isVertical ? 200 : 1;
-          var width = isVertical ? 1 : 200;
-          var range = Math.max(100, this.getEndColorPosition() - this.getStartColorPosition());
-
-          // use the px difference as dimension
-          if (unit === "px") {
-            if (isVertical) {
-              height = Math.max(height, this.getEndColorPosition() - this.getStartColorPosition());
-            } else {
-              width = Math.max(width, this.getEndColorPosition() - this.getStartColorPosition());
-            }
-          } else {
-            if (isVertical) {
-              height = Math.max(height, (this.getEndColorPosition() - this.getStartColorPosition()) * 2);
-            } else {
-              width = Math.max(width, (this.getEndColorPosition() - this.getStartColorPosition()) * 2);
-            }
-          }
-
-          this.__canvas.width = width;
-          this.__canvas.height = height;
-          var ctx = this.__canvas.getContext('2d');
-
-          if (isVertical) {
-            var lingrad = ctx.createLinearGradient(0, 0, 0, height);
-          } else {
-            var lingrad = ctx.createLinearGradient(0, 0, width, 0);
-          }
-
-          // don't allow negative start values
-          if (unit === "%") {
-            lingrad.addColorStop(Math.max(0, this.getStartColorPosition()) / range, colors.start);
-            lingrad.addColorStop(this.getEndColorPosition() / range, colors.end);
-          } else {
-            var comp = isVertical ? height : width;
-            lingrad.addColorStop(Math.max(0, this.getStartColorPosition()) / comp, colors.start);
-            lingrad.addColorStop(this.getEndColorPosition() / comp, colors.end);
-          }
-
-          ctx.fillStyle = lingrad;
-          ctx.fillRect(0, 0, width, height);
-
-          var value = "url(" + this.__canvas.toDataURL() + ")";
-          styles["background-image"] = value;
-          if (unit === "%") {
-            if (isVertical) {
-              styles["background-size"] = "100% " + range + "%";
-            } else {
-              styles["background-size"] = range + "% 100%";
-            }
-          } else {
-            styles["background-size"] = isVertical ? height + "px 100%" : "100% " + width + "px";
-          }
-
-
-      // old IE filter fallback
+        styleImpl = this.__styleLinearBackgroundGradientWithCanvas;
       } else if (qx.core.Environment.get("css.gradient.filter") &&
-        !qx.core.Environment.get("css.gradient.linear"))
-      {
-        var colors = this.__getColors();
-        var type = this.getOrientation() == "horizontal" ? 1 : 0;
+        !qx.core.Environment.get("css.gradient.linear")) {
+        styleImpl = this.__styleLinearBackgroundGradientWithMSFilter;
+      }
 
-        var startColor = colors.start;
-        var endColor = colors.end;
+      for(var i=0;i<items;i++) {
+        var startColor = this.__getColor(startColors[i]);
+        var endColor = this.__getColor(endColors[i]);
+        var unit = units[i];
+        var orientation = orientations[i];
+        var startColorPosition = startColorPositions[i];
+        var endColorPosition = endColorPositions[i];
 
-        // convert rgb, hex3 and named colors to hex6
-        if (!qx.util.ColorUtil.isHex6String(startColor)) {
-          startColor = qx.util.ColorUtil.stringToRgb(startColor);
-          startColor = qx.util.ColorUtil.rgbToHexString(startColor);
-        }
-        if (!qx.util.ColorUtil.isHex6String(endColor)) {
-          endColor = qx.util.ColorUtil.stringToRgb(endColor);
-          endColor = qx.util.ColorUtil.rgbToHexString(endColor);
-        }
-
-        // get rid of the starting '#'
-        startColor = startColor.substring(1, startColor.length);
-        endColor = endColor.substring(1, endColor.length);
-
-        value = "progid:DXImageTransform.Microsoft.Gradient" +
-          "(GradientType=" + type + ", " +
-          "StartColorStr='#FF" + startColor + "', " +
-          "EndColorStr='#FF" + endColor + "';)";
-        if (styles["filter"]) {
-          styles["filter"] += ", " + value;
-        } else {
-          styles["filter"] = value;
-        }
-
-        // Elements with transparent backgrounds will not receive receive pointer
-
-        // events if a Gradient filter is set.
-        if (!styles["background-color"] ||
-            styles["background-color"] == "transparent")
-        {
-          // We don't support alpha transparency for the gradient color stops
-          // so it doesn't matter which color we set here.
-          styles["background-color"] = "white";
-        }
-
-      // spec like syntax
-      } else {
-        // WebKit, Opera and Gecko interpret 0deg as "to right"
-        var deg = this.getOrientation() == "horizontal" ? 0 : 270;
-
-        var start = startColor + " " + this.getStartColorPosition() + unit;
-        var end = endColor + " " + this.getEndColorPosition() + unit;
-
-        var prefixedName = qx.core.Environment.get("css.gradient.linear");
-        // Browsers supporting the unprefixed implementation interpret 0deg as
-        // "to top" as defined by the spec [BUG #6513]
-        if (prefixedName === "linear-gradient") {
-          deg = this.getOrientation() == "horizontal" ? deg + 90 : deg - 90;
-        }
-
-        value = prefixedName + "(" + deg + "deg, " + start + "," + end + ")";
-        if (styles["background-image"]) {
-          styles["background-image"] += ", " + value;
-        }
-        else {
-          styles["background-image"] = value;
+        if(!styleImpl(startColor, endColor, unit, orientation, startColorPosition, endColorPosition, styles, backgroundStyle)) {
+          break;
         }
       }
+      
+      if("background" in styles) {
+        if(!qx.lang.Type.isArray(styles['background'])) {
+          styles['background'] = [styles['background']];
+        }
+      } else {
+        styles['background'] = [];
+      }
+      var orderGradientsFront = 'getOrderGradientsFront' in this ? this.getOrderGradientsFront() : false;
+      var operation = orderGradientsFront ? Array.prototype.unshift : Array.prototype.push;
+      operation.apply(styles['background'], backgroundStyle);
     },
 
+    /**
+     * Compute CSS rules to style the background with gradients.
+     * This can be called multiple times and SHOULD layer the gradients on top of each other and on top of existing backgrounds.
+     * Legacy implementation for old WebKit browsers (Chrome < 10).
+     * 
+     * @param startColor {Color} The color to start the gradient with
+     * @param endColor {Color} The color to end the gradient with
+     * @param unit {Color} The unit in which startColorPosition and endColorPosition are measured
+     * @param orientation {String} Either 'horizontal' or 'vertical'
+     * @param startColorPosition {Number} The position of the gradient’s starting point, measured in `unit` units along the `orientation` axis from top or left
+     * @param endColorPosition {Number} The position of the gradient’s ending point, measured in `unit` units along the `orientation` axis from top or left
+     * @param styles {Map} The complete styles currently poised to be applied by decorators. Should not be written to in this method (use `backgroundStyle` for that)
+     * @param backgroundStyle {Map} This method should push new background styles onto this array.
+     *
+     * @return {Boolean} Whether this implementation supports multiple gradients atop each other (true).
+     */
+    __styleLinearBackgroundGradientForLegacyWebkit: function(startColor, endColor, unit, orientation, startColorPosition, endColorPosition, styles, backgroundStyle) {
+      // webkit uses px values if non are given
+      unit = unit === "px" ? "" : unit;
+
+      if (orientation == "horizontal") {
+        var startPos = startColorPosition + unit +" 0" + unit;
+        var endPos = endColorPosition + unit + " 0" + unit;
+      } else {
+        var startPos = "0" + unit + " " + startColorPosition + unit;
+        var endPos = "0" + unit +" " + endColorPosition + unit;
+      }
+
+      var color =
+        "from(" + startColor +
+        "),to(" + endColor + ")";
+
+      backgroundStyle.push("-webkit-gradient(linear," + startPos + "," + endPos + "," + color + ")");
+      return true;
+    },
 
     /**
-     * Helper to get start and end color.
-     * @return {Map} A map containing start and end color.
+     * Compute CSS rules to style the background with gradients.
+     * This can be called multiple times and SHOULD layer the gradients on top of each other and on top of existing backgrounds.
+     * IE9 canvas solution.
+     * 
+     * @param startColor {Color} The color to start the gradient with
+     * @param endColor {Color} The color to end the gradient with
+     * @param unit {Color} The unit in which startColorPosition and endColorPosition are measured
+     * @param orientation {String} Either 'horizontal' or 'vertical'
+     * @param startColorPosition {Number} The position of the gradient’s starting point, measured in `unit` units along the `orientation` axis from top or left
+     * @param endColorPosition {Number} The position of the gradient’s ending point, measured in `unit` units along the `orientation` axis from top or left
+     * @param styles {Map} The complete styles currently poised to be applied by decorators. Should not be written to in this method (use `backgroundStyle` for that)
+     * @param backgroundStyle {Map} This method should push new background styles onto this array.
+     *
+     * @return {Boolean} Whether this implementation supports multiple gradients atop each other (true).
      */
-    __getColors : function() {
-      if (qx.core.Environment.get("qx.theme"))
-      {
-        var Color = qx.theme.manager.Color.getInstance();
-        var startColor = Color.resolve(this.getStartColor());
-        var endColor = Color.resolve(this.getEndColor());
+    __styleLinearBackgroundGradientWithCanvas: function me(startColor, endColor, unit, orientation, startColorPosition, endColorPosition, styles, backgroundStyle) {
+      if (!me.__canvas) {
+        me.__canvas = document.createElement("canvas");
       }
-      else
-      {
-        var startColor = this.getStartColor();
-        var endColor = this.getEndColor();
+
+      var isVertical = orientation == "vertical";
+
+      var height = isVertical ? 200 : 1;
+      var width = isVertical ? 1 : 200;
+      var range = Math.max(100, endColorPosition - startColorPosition);
+
+      // use the px difference as dimension
+      if (unit === "px") {
+        if (isVertical) {
+          height = Math.max(height, endColorPosition - startColorPosition);
+        } else {
+          width = Math.max(width, endColorPosition - startColorPosition);
+        }
+      } else {
+        if (isVertical) {
+          height = Math.max(height, (endColorPosition - startColorPosition) * 2);
+        } else {
+          width = Math.max(width, (endColorPosition - startColorPosition) * 2);
+        }
       }
-      return {start: startColor, end: endColor};
+
+      me.__canvas.width = width;
+      me.__canvas.height = height;
+      var ctx = me.__canvas.getContext('2d');
+
+      if (isVertical) {
+        var lingrad = ctx.createLinearGradient(0, 0, 0, height);
+      } else {
+        var lingrad = ctx.createLinearGradient(0, 0, width, 0);
+      }
+
+      // don't allow negative start values
+      if (unit === "%") {
+        lingrad.addColorStop(Math.max(0, startColorPosition) / range, startColor);
+        lingrad.addColorStop(endColorPosition / range, endColor);
+      } else {
+        var comp = isVertical ? height : width;
+        lingrad.addColorStop(Math.max(0, startColorPosition) / comp, startColor);
+        lingrad.addColorStop(endColorPosition / comp, endColor);
+      }
+
+      //Clear the rect before drawing to allow for semitransparent colors
+      ctx.clearRect(0, 0, width, height);
+      ctx.fillStyle = lingrad;
+      ctx.fillRect(0, 0, width, height);
+
+      var size;
+      if (unit === "%") {
+        size = isVertical ? "100% " + range + "%" : range + "% 100%";
+      } else {
+        size = isVertical ? height + "px 100%" : "100% " + width + "px";
+      }
+      
+      backgroundStyle.push("url(" + me.__canvas.toDataURL() + ") " + size);
+      return true;
+    },
+
+    /**
+     * Compute CSS rules to style the background with gradients.
+     * This can be called multiple times and SHOULD layer the gradients on top of each other and on top of existing backgrounds.
+     * Old IE filter fallback.
+     * 
+     * @param startColor {Color} The color to start the gradient with
+     * @param endColor {Color} The color to end the gradient with
+     * @param unit {Color} The unit in which startColorPosition and endColorPosition are measured
+     * @param orientation {String} Either 'horizontal' or 'vertical'
+     * @param startColorPosition {Number} The position of the gradient’s starting point, measured in `unit` units along the `orientation` axis from top or left
+     * @param endColorPosition {Number} The position of the gradient’s ending point, measured in `unit` units along the `orientation` axis from top or left
+     * @param styles {Map} The complete styles currently poised to be applied by decorators. Should not be written to in this method (use `backgroundStyle` for that). Note: this particular implementation will do that because it needs to change the `filter` property.
+     * @param backgroundStyle {Map} This method should push new background styles onto this array.
+     *
+     * @return {Boolean} Whether this implementation supports multiple gradients atop each other (false).
+     */
+    __styleLinearBackgroundGradientWithMSFilter: function(startColor, endColor, unit, orientation, startColorPosition, endColorPosition, styles, backgroundStyle) {
+      var type = orientation == "horizontal" ? 1 : 0;
+
+
+      // convert rgb, hex3 and named colors to hex6
+      if (!qx.util.ColorUtil.isHex6String(startColor)) {
+        startColor = qx.util.ColorUtil.stringToRgb(startColor);
+        startColor = qx.util.ColorUtil.rgbToHexString(startColor);
+      }
+      if (!qx.util.ColorUtil.isHex6String(endColor)) {
+        endColor = qx.util.ColorUtil.stringToRgb(endColor);
+        endColor = qx.util.ColorUtil.rgbToHexString(endColor);
+      }
+
+      // get rid of the starting '#'
+      startColor = startColor.substring(1, startColor.length);
+      endColor = endColor.substring(1, endColor.length);
+
+      var value = "progid:DXImageTransform.Microsoft.Gradient" +
+        "(GradientType=" + type + ", " +
+        "StartColorStr='#FF" + startColor + "', " +
+        "EndColorStr='#FF" + endColor + "';)";
+      if (styles["filter"]) {
+        styles["filter"] += ", " + value;
+      } else {
+        styles["filter"] = value;
+      }
+
+      // Elements with transparent backgrounds will not receive receive pointer
+      // events if a Gradient filter is set.
+      if (!styles["background-color"] ||
+          styles["background-color"] == "transparent")
+      {
+        // We don't support alpha transparency for the gradient color stops
+        // so it doesn't matter which color we set here.
+        styles["background-color"] = "white";
+      }
+      return false;
+    },
+
+    /**
+     * Compute CSS rules to style the background with gradients.
+     * This can be called multiple times and SHOULD layer the gradients on top of each other and on top of existing backgrounds.
+     * Default implementation (uses spec-compliant syntax).
+     * 
+     * @param startColor {Color} The color to start the gradient with
+     * @param endColor {Color} The color to end the gradient with
+     * @param unit {Color} The unit in which startColorPosition and endColorPosition are measured
+     * @param orientation {String} Either 'horizontal' or 'vertical'
+     * @param startColorPosition {Number} The position of the gradient’s starting point, measured in `unit` units along the `orientation` axis from top or left
+     * @param endColorPosition {Number} The position of the gradient’s ending point, measured in `unit` units along the `orientation` axis from top or left
+     * @param styles {Map} The complete styles currently poised to be applied by decorators. Should not be written to in this method (use `backgroundStyle` for that)
+     * @param backgroundStyle {Map} This method should push new background styles onto this array.
+     *
+     * @return {Boolean} Whether this implementation supports multiple gradients atop each other (true).
+     */
+    __styleLinearBackgroundGradientAccordingToSpec: function(startColor, endColor, unit, orientation, startColorPosition, endColorPosition, styles, backgroundStyle) {
+      // WebKit, Opera and Gecko interpret 0deg as "to right"
+      var deg = orientation == "horizontal" ? 0 : 270;
+
+      var start = startColor + " " + startColorPosition + unit;
+      var end = endColor + " " + endColorPosition + unit;
+
+      var prefixedName = qx.core.Environment.get("css.gradient.linear");
+      // Browsers supporting the unprefixed implementation interpret 0deg as
+      // "to top" as defined by the spec [BUG #6513]
+      if (prefixedName === "linear-gradient") {
+        deg = orientation == "horizontal" ? deg + 90 : deg - 90;
+      }
+
+      backgroundStyle.push(prefixedName + "(" + deg + "deg, " + start + "," + end + ")");
+      return true;
+    },
+
+    /**
+     * Helper to get a resolved color from a name
+     * @return {Map} The resolved color
+     */
+    __getColor : function(color) {
+      return qx.core.Environment.get("qx.theme") ?
+        qx.theme.manager.Color.getInstance().resolve(color) : color;
     },
 
 

--- a/framework/source/class/qx/ui/decoration/MLinearBackgroundGradient.js
+++ b/framework/source/class/qx/ui/decoration/MLinearBackgroundGradient.js
@@ -119,33 +119,9 @@ qx.Mixin.define("qx.ui.decoration.MLinearBackgroundGradient",
     _styleLinearBackgroundGradient : function(styles) {
       var backgroundStyle = [];
 
-      // transform non-array values to an array containing that value
-      var startColors = this.getStartColor();
-      if(!startColors) { return; }
-      if(!qx.lang.Type.isArray(startColors)) startColors = [startColors];
-      var endColors = this.getEndColor();
-      if(!endColors) { return; }
-      if(!qx.lang.Type.isArray(endColors)) endColors = [endColors];
-      var units = this.getColorPositionUnit();
-      if(!qx.lang.Type.isArray(units)) units = [units];
-      var orientations = this.getOrientation();
-      if(!qx.lang.Type.isArray(orientations)) orientations = [orientations];
-      var startColorPositions = this.getStartColorPosition();
-      if(!qx.lang.Type.isArray(startColorPositions)) startColorPositions = [startColorPositions];
-      var endColorPositions = this.getEndColorPosition();
-      if(!qx.lang.Type.isArray(endColorPositions)) endColorPositions = [endColorPositions];
-
-      // Because it's possible to set multiple values for a property there's 
-      // a chance that not all properties have the same amount of values set.
-      // Prolong the value arrays by repeating existing values until all
-      // arrays match in length.
-      var items = Math.max(startColors.length, endColors.length, units.length, orientations.length);
-      this._prolongArray(startColors, items);
-      this._prolongArray(endColors, items);
-      this._prolongArray(units, items);
-      this._prolongArray(orientations, items);
-      this._prolongArray(startColorPositions, items);
-      this._prolongArray(endColorPositions, items);
+      if(!this.getStartColor() || !this.getEndColor()) {
+        return;
+      }
 
       var styleImpl = this.__styleLinearBackgroundGradientAccordingToSpec;
       if (qx.core.Environment.get("css.gradient.legacywebkit")) {
@@ -158,29 +134,34 @@ qx.Mixin.define("qx.ui.decoration.MLinearBackgroundGradient",
         styleImpl = this.__styleLinearBackgroundGradientWithMSFilter;
       }
 
-      for(var i=0;i<items;i++) {
-        var startColor = this.__getColor(startColors[i]);
-        var endColor = this.__getColor(endColors[i]);
-        var unit = units[i];
-        var orientation = orientations[i];
-        var startColorPosition = startColorPositions[i];
-        var endColorPosition = endColorPositions[i];
+      var gradientProperties = ["startColor", "endColor", "colorPositionUnit", "orientation",
+        "startColorPosition", "endColorPosition"];
 
-        if(!styleImpl(startColor, endColor, unit, orientation, startColorPosition, endColorPosition, styles, backgroundStyle)) {
-          break;
+      (function(startColors, endColors, units, orientations, startColorPositions, endColorPositions) {
+        for(var i=0;i<startColors.length;i++) {
+          var startColor = this.__getColor(startColors[i]);
+          var endColor = this.__getColor(endColors[i]);
+          var unit = units[i];
+          var orientation = orientations[i];
+          var startColorPosition = startColorPositions[i];
+          var endColorPosition = endColorPositions[i];
+
+          if(!styleImpl(startColor, endColor, unit, orientation, startColorPosition, endColorPosition, styles, backgroundStyle)) {
+            break;
+          }
         }
-      }
-      
-      if("background" in styles) {
-        if(!qx.lang.Type.isArray(styles['background'])) {
-          styles['background'] = [styles['background']];
+        
+        if("background" in styles) {
+          if(!qx.lang.Type.isArray(styles['background'])) {
+            styles['background'] = [styles['background']];
+          }
+        } else {
+          styles['background'] = [];
         }
-      } else {
-        styles['background'] = [];
-      }
-      var orderGradientsFront = 'getOrderGradientsFront' in this ? this.getOrderGradientsFront() : false;
-      var operation = orderGradientsFront ? Array.prototype.unshift : Array.prototype.push;
-      operation.apply(styles['background'], backgroundStyle);
+        var orderGradientsFront = 'getOrderGradientsFront' in this ? this.getOrderGradientsFront() : false;
+        var operation = orderGradientsFront ? Array.prototype.unshift : Array.prototype.push;
+        operation.apply(styles['background'], backgroundStyle);
+      }).apply(this, this._getProlongedPropertyValueArrays(gradientProperties));
     },
 
     /**

--- a/framework/source/class/qx/ui/decoration/MLinearBackgroundGradient.js
+++ b/framework/source/class/qx/ui/decoration/MLinearBackgroundGradient.js
@@ -119,6 +119,7 @@ qx.Mixin.define("qx.ui.decoration.MLinearBackgroundGradient",
     _styleLinearBackgroundGradient : function(styles) {
       var backgroundStyle = [];
 
+      // transform non-array values to an array containing that value
       var startColors = this.getStartColor();
       if(!startColors) { return; }
       if(!qx.lang.Type.isArray(startColors)) startColors = [startColors];
@@ -134,6 +135,10 @@ qx.Mixin.define("qx.ui.decoration.MLinearBackgroundGradient",
       var endColorPositions = this.getEndColorPosition();
       if(!qx.lang.Type.isArray(endColorPositions)) endColorPositions = [endColorPositions];
 
+      // Because it's possible to set multiple values for a property there's 
+      // a chance that not all properties have the same amount of values set.
+      // Prolong the value arrays by repeating existing values until all
+      // arrays match in length.
       var items = Math.max(startColors.length, endColors.length, units.length, orientations.length);
       this._prolongArray(startColors, items);
       this._prolongArray(endColors, items);


### PR DESCRIPTION
This is an updated PR based on https://github.com/qooxdoo/qooxdoo/pull/67
Bugreport here: http://bugzilla.qooxdoo.org/show_bug.cgi?id=7715
- I removed the `prolong` method defined in `qx.lang.Array` and defined a helper method in the `Decorator` class. I would have liked to put it in a helper class, but I'm not sure where such a class would belong.
- I left the checks out, because the reasoning [here](https://github.com/qooxdoo/qooxdoo/pull/67#issuecomment-75430195) made sense to me. If the checks are an absolute must, should I define custom check functions for every property to cover the constraints explained in the linked comment?
- I added some comments. If it's still lacking, let me know where and I'll add further documentation.
