### PR TITLE
Fix target detection and usage

### DIFF
--- a/framework/source/class/qx/ui/core/MDragDropScrolling.js
+++ b/framework/source/class/qx/ui/core/MDragDropScrolling.js
@@ -293,7 +293,7 @@ qx.Mixin.define("qx.ui.core.MDragDropScrolling",
         this.__dragScrollTimer.stop();
       }
 
-      var target = e.getOriginalTarget();
+      var target = qx.ui.core.Widget.getWidgetByElement(e.getOriginalTarget());
       if (!target) {
         return;
       }


### PR DESCRIPTION
In certain cases it is not possible to drag'n drop without running into errors. Looks like the mixin does stuff with an Element instead of a Widget.
