### PR TITLE
MProperty.set always return instance

### DIFF
--- a/framework/source/class/qx/core/MProperty.js
+++ b/framework/source/class/qx/core/MProperty.js
@@ -52,7 +52,8 @@ qx.Mixin.define("qx.core.MProperty",
           throw new Error("No such property: " + data);
         }
 
-        return this[setter[data]](value);
+        this[setter[data]](value);
+        return this;
       }
       else
       {


### PR DESCRIPTION
This fix the bugs http://bugs.qooxdoo.org/show_bug.cgi?id=9199

now MProperty.set will always return current instance (for chaining).
