### PR TITLE
fix for rhino (Json is broken)

### DIFF
--- a/framework/source/class/qx/lang/Json.js
+++ b/framework/source/class/qx/lang/Json.js
@@ -230,6 +230,11 @@ qx.Bootstrap.define("qx.lang.Json",
 
 /*! JSON v3.2.5 | http://bestiejs.github.io/json3 | Copyright 2012-2013, Kit Cambridge | http://kit.mit-license.org */
 (function (window) {
+  // This polyfill does not work under Rhino because it cannot convert POJO to object (it tries
+  //  to serialise the class)
+  if (qx.core.Environment.get("runtime.name") === "rhino" || qx.core.Environment.get("runtime.name") === undefined)
+    return;
+  
   // Convenience aliases.
   var getClass = {}.toString, isProperty, forEach, undef;
 


### PR DESCRIPTION
The qx.lang.Json polyfill does not work under Rhino because it cannot convert a POJO to object; the polyfill sees the objects getClass method and ends up trying to serialise the entire Class heirarchy too.  Rhino's implementation of JSON.stringify knows how to avoid this, so the fix is to disable the polyfil.  Arguably a bug in Rhino, but as Rhino doesn't get a huge amount of development any more (except individual patches) this is an essential work around.
