### PR TITLE
Fix label oversizing in grids

### DIFF
--- a/framework/source/class/qx/bom/Label.js
+++ b/framework/source/class/qx/bom/Label.js
@@ -131,6 +131,7 @@ qx.Bootstrap.define("qx.bom.Label",
     {
       var styles = {};
 
+      styles.overflow = "hidden";
       if (html)
       {
         styles.whiteSpace = "normal";
@@ -142,7 +143,6 @@ qx.Bootstrap.define("qx.bom.Label",
       }
       else
       {
-        styles.overflow = "hidden";
         styles.whiteSpace = "nowrap";
         styles[qx.core.Environment.get("css.textoverflow")] = "ellipsis";
       }
@@ -181,7 +181,8 @@ qx.Bootstrap.define("qx.bom.Label",
       {
         el.useHtml = true;
       }
-      else if (!qx.core.Environment.get("css.textoverflow") &&
+
+      if (!qx.core.Environment.get("css.textoverflow") &&
         qx.core.Environment.get("html.xul"))
       {
         // Gecko as of Firefox 2.x and 3.0 does not support ellipsis

--- a/framework/source/class/qx/ui/layout/Grid.js
+++ b/framework/source/class/qx/ui/layout/Grid.js
@@ -1138,11 +1138,7 @@ qx.Class.define("qx.ui.layout.Grid",
 
           var cellSize = this.__getOuterSize(widget);
 
-          if (this.getColumnFlex(col) > 0) {
-            minWidth = Math.max(minWidth, cellSize.minWidth);
-          } else {
-            minWidth = Math.max(minWidth, cellSize.width);
-          }
+          minWidth = Math.max(minWidth, cellSize.minWidth);
 
           width = Math.max(width, cellSize.width);
         }


### PR DESCRIPTION
This pull request fixes a bug where the label is able to outgrow the maxWidth setting on a grid; the first commit fixes the grid so that it does not allow its own maxWidth setting to be exceeded, the second commit fixes label so that overflow is hidden otherwise the label still visually exceeds the maxWidth
