### PR TITLE
fixes a bug in qx.data.controller.List where changes to the model in

### DIFF
--- a/framework/source/class/qx/data/controller/List.js
+++ b/framework/source/class/qx/data/controller/List.js
@@ -409,9 +409,7 @@ qx.Class.define("qx.data.controller.List",
       qx.ui.core.queue.Widget.add(this);
 
       // update on filtered lists... (bindings need to be renewed)
-      if (this.__lookupTable.length != this.getModel().getLength()) {
-        this.update();
-      }
+      this.update();
     },
 
 


### PR DESCRIPTION
which the length of the array stays the same prevents the bindings from
being updated properly.  Without this fix, the Controller will update
the ListItem label but not it's model.
