### PR TITLE
Logger add filters

### DIFF
--- a/framework/source/class/qx/core/MLogging.js
+++ b/framework/source/class/qx/core/MLogging.js
@@ -77,11 +77,14 @@ qx.Mixin.define("qx.core.MLogging",
 
 
     /**
-     * Prints the current stack trace
+     * Logs an error message with the current stack trace
      *
+     * @param varargs {var} The item(s) to log. Any number of arguments is
+     * supported. If an argument is not a string, the object dump will be
+     * logged.
      */
-    trace : function() {
-      this.__Logger.trace(this);
+    trace : function(varargs) {
+      this.__logMessage("trace", arguments);
     },
 
 

--- a/framework/source/class/qx/log/Logger.js
+++ b/framework/source/class/qx/log/Logger.js
@@ -509,18 +509,28 @@ qx.Bootstrap.define("qx.log.Logger",
      */
     __getAppenders: function(className, level) {
       var levels = this.__levels;
-      if (levels[level] < levels[this.__level])
-        return [];
       
-      if (!this.__filters.length)
+      // If no filters, then all appenders apply
+      if (!this.__filters.length) {
+        // Check the default level
+        if (levels[level] < levels[this.__level])
+          return [];
         return this.__appenders;
+      }
+      
       var names = [];
       for (var i = 0; i < this.__filters.length; i++) {
         var filter = this.__filters[i];
+        
+        // Filters only apply to certain levels
         if (levels[level] < levels[filter.level])
           continue;
+        
+        // No duplicates
         if (filter.appenderName && qx.lang.Array.contains(names, filter.appenderName))
           continue;
+        
+        // Test
         if (filter.loggerMatch.test(className)) {
           if (filter.appenderName)
             names.push(filter.appenderName);
@@ -528,12 +538,12 @@ qx.Bootstrap.define("qx.log.Logger",
             return this.__appenders;
         }
       }
+      
+      // Map appender names into appenders
       var appenders = [];
       var appendersByName = this.__appendersByName;
-      names.forEach(function(name, index) {
-        var appender = appendersByName[name];
-        if (appender)
-          appenders.push(appender);
+      appenders = names.map(function(name) {
+        return appendersByName[name];
       });
       return appenders;
     },

--- a/framework/source/class/qx/log/Logger.js
+++ b/framework/source/class/qx/log/Logger.js
@@ -97,7 +97,15 @@ qx.Bootstrap.define("qx.log.Logger",
     */
 
     /** @type {Map} Map of all known appenders by ID */
-    __appender : {},
+    __appenders : [],
+    
+    
+    /** @type {Map} Map of all known appenders by name */
+    __appendersByName: {},
+    
+    
+    /** @type {Array} Array of filters to apply when selecting appenders to append to */
+    __filters: [],
 
 
     /** @type {Integer} Last free appender ID */

--- a/framework/source/class/qx/log/Logger.js
+++ b/framework/source/class/qx/log/Logger.js
@@ -240,14 +240,20 @@ qx.Bootstrap.define("qx.log.Logger",
      * Prints the current stack trace at level "info"
      *
      * @param object {Object?} Contextual object (either instance or static class)
+     * @param message {var} Any number of arguments supported. An argument may
+     *   have any JavaScript data type. All data is serialized immediately and
+     *   does not keep references to other objects.
      */
-    trace : function(object) {
-      var trace = qx.dev.StackTrace.getStackTrace();
-      qx.log.Logger.__log("trace",
-      [(typeof object !== "undefined" ? [object].concat(trace) : trace).join("\n")]);
+    trace : function(object, message) {
+      if (qx.log.Logger.isLoggerEnabled("trace", object)) {
+        var trace = qx.dev.StackTrace.getStackTrace();
+        var args = qx.lang.Array.fromArguments(arguments);
+        args.push(trace.join("\n"));
+        qx.log.Logger.__log("trace", args);
+      }
     },
-
-
+    
+    
     /**
      * Prints a method deprecation warning and a stack trace if the setting
      * <code>qx.debug</code> is set to <code>true</code>.
@@ -434,7 +440,10 @@ qx.Bootstrap.define("qx.log.Logger",
     /** @type {Map} cache of appenders for a given logger and level */
     __appendersCache: {},
     
-    
+
+    /**
+     * Detects the name of the logger to use for an object
+     */
     __getLoggerName: function(object) {
       if (object) {
         if (object.classname)
@@ -443,6 +452,16 @@ qx.Bootstrap.define("qx.log.Logger",
           return object;
       }
       return "[default]";
+    },
+
+
+    /**
+     * Detects whether a logger level is enabled for an object
+     */
+    isLoggerEnabled: function(level, object) {
+      var loggerName = this.__getLoggerName(object);
+      var appenders = this.__getAppenders(loggerName, level);
+      return !!appenders.length;
     },
 
 

--- a/framework/source/class/qx/log/Logger.js
+++ b/framework/source/class/qx/log/Logger.js
@@ -431,6 +431,9 @@ qx.Bootstrap.define("qx.log.Logger",
       error : 4
     },
     
+    /** @type {Map} cache of appenders for a given logger and level */
+    __appendersCache: {},
+    
     
     __getLoggerName: function(object) {
       if (object) {
@@ -518,6 +521,12 @@ qx.Bootstrap.define("qx.log.Logger",
         return this.__appenders;
       }
       
+      // Check the cache
+      var cacheId = className + "|" + level;
+      var appenders = this.__appendersCache[cacheId];
+      if (appenders !== undefined)
+        return appenders;
+      
       var names = [];
       for (var i = 0; i < this.__filters.length; i++) {
         var filter = this.__filters[i];
@@ -531,11 +540,11 @@ qx.Bootstrap.define("qx.log.Logger",
           continue;
         
         // Test
-        if (filter.loggerMatch.test(className)) {
+        if (!filter.loggerMatch || filter.loggerMatch.test(className)) {
           if (filter.appenderName)
             names.push(filter.appenderName);
           else
-            return this.__appenders;
+            return this.__appendersCache[cacheId] = this.__appenders;
         }
       }
       
@@ -545,7 +554,7 @@ qx.Bootstrap.define("qx.log.Logger",
       appenders = names.map(function(name) {
         return appendersByName[name];
       });
-      return appenders;
+      return this.__appendersCache[cacheId] = appenders;
     },
     
     

--- a/framework/source/class/qx/log/Logger.js
+++ b/framework/source/class/qx/log/Logger.js
@@ -126,16 +126,19 @@ qx.Bootstrap.define("qx.log.Logger",
 
       // Register appender
       var id = this.__id++;
-      this.__appender[id] = appender;
+      this.__appenders[id] = appender;
+      this.__appendersByName[appender.classname] = appender;
       appender.$$id = id;
       var levels = this.__levels;
 
       // Insert previous messages
       var entries = this.__buffer.getAllLogEvents();
       for (var i=0, l=entries.length; i<l; i++) {
-        if (levels[entries[i].level] >= levels[this.__level]) {
-          appender.process(entries[i]);
-        }
+        var entry = entries[i];
+
+        var appenders = this.__getAppenders(entry.loggerName, entry.level);
+        if (qx.lang.Array.contains(appenders, appender))
+          appender.process(entry);
       }
     },
 
@@ -152,9 +155,24 @@ qx.Bootstrap.define("qx.log.Logger",
         return;
       }
 
-      delete this.__appender[id];
+      delete this.__appendersByName[appender.classname];
+      delete this.__appenders[id];
       delete appender.$$id;
     },
+
+
+    /**
+     * Adds a filter that specifies the appenders to use for a given logger name (classname)
+     * @param logger {String|RegExp} the pattern to match in the logger name
+     * @param appenderName {String?} the name of the appender class, if undefined then all appenders
+     * @param level {String?} the minimum logging level to use the appender, if undefined the default level is used
+     */
+    addFilter: function(logger, appenderName, level) {
+      if (typeof logger == "string")
+        logger = new RegExp(logger);
+      this.__filters.push({ loggerMatch: logger, level: level||this.__level, appenderName: appenderName });
+    },
+
 
 
 
@@ -225,7 +243,7 @@ qx.Bootstrap.define("qx.log.Logger",
      */
     trace : function(object) {
       var trace = qx.dev.StackTrace.getStackTrace();
-      qx.log.Logger.__log("info",
+      qx.log.Logger.__log("trace",
       [(typeof object !== "undefined" ? [object].concat(trace) : trace).join("\n")]);
     },
 
@@ -406,10 +424,22 @@ qx.Bootstrap.define("qx.log.Logger",
     /** @type {Map} Numeric translation of log levels */
     __levels :
     {
-      debug : 0,
-      info : 1,
-      warn : 2,
-      error : 3
+      trace: 0,
+      debug : 1,
+      info : 2,
+      warn : 3,
+      error : 4
+    },
+    
+    
+    __getLoggerName: function(object) {
+      if (object) {
+        if (object.classname)
+          return object.classname;
+        if (typeof object == "string")
+          return object;
+      }
+      return "[default]";
     },
 
 
@@ -422,14 +452,15 @@ qx.Bootstrap.define("qx.log.Logger",
      */
     __log : function(level, args)
     {
-      // Filter according to level
-      var levels = this.__levels;
-      if (levels[level] < levels[this.__level]) {
+      // Get object and determine appenders
+      var object = args.length < 2 ? null : args[0];
+      var loggerName = this.__getLoggerName(object);
+      var appenders = this.__getAppenders(loggerName, level);
+      if (!appenders.length) {
         return;
       }
-
+      
       // Serialize and cache
-      var object = args.length < 2 ? null : args[0];
       var start = object ? 1 : 0;
       var items = [];
       for (var i=start, l=args.length; i<l; i++) {
@@ -443,6 +474,7 @@ qx.Bootstrap.define("qx.log.Logger",
         time : time,
         offset : time-qx.Bootstrap.LOADSTART,
         level: level,
+        loggerName: loggerName,
         items: items,
         // store window to allow cross frame logging
         win: window
@@ -465,12 +497,48 @@ qx.Bootstrap.define("qx.log.Logger",
       this.__buffer.process(entry);
 
       // Send to appenders
-      var appender = this.__appender;
-      for (var id in appender) {
-        appender[id].process(entry);
+      for (var id in appenders) {
+        appenders[id].process(entry);
       }
     },
+    
 
+    
+    /**
+     * Finds the appenders for a given classname
+     */
+    __getAppenders: function(className, level) {
+      var levels = this.__levels;
+      if (levels[level] < levels[this.__level])
+        return [];
+      
+      if (!this.__filters.length)
+        return this.__appenders;
+      var names = [];
+      for (var i = 0; i < this.__filters.length; i++) {
+        var filter = this.__filters[i];
+        if (levels[level] < levels[filter.level])
+          continue;
+        if (filter.appenderName && qx.lang.Array.contains(names, filter.appenderName))
+          continue;
+        if (filter.loggerMatch.test(className)) {
+          if (filter.appenderName)
+            names.push(filter.appenderName);
+          else
+            return this.__appenders;
+        }
+      }
+      var appenders = [];
+      var appendersByName = this.__appendersByName;
+      names.forEach(function(name, index) {
+        var appender = appendersByName[name];
+        if (appender)
+          appenders.push(appender);
+      });
+      return appenders;
+    },
+    
+    
 
     /**
      * Detects the type of the variable given.

--- a/framework/source/class/qx/log/Logger.js
+++ b/framework/source/class/qx/log/Logger.js
@@ -497,9 +497,9 @@ qx.Bootstrap.define("qx.log.Logger",
       this.__buffer.process(entry);
 
       // Send to appenders
-      for (var id in appenders) {
-        appenders[id].process(entry);
-      }
+      appenders.forEach(function(appender) {
+        appender.process(entry);
+      });
     },
     
 

--- a/framework/source/class/qx/log/Logger.js
+++ b/framework/source/class/qx/log/Logger.js
@@ -199,7 +199,7 @@ qx.Bootstrap.define("qx.log.Logger",
      * logging information you would use this:
      * 
      *  <pre class="javascript">
-     *    qx.log.Logger.addFilter(/^qx.ui/, null, "debug");
+     *    qx.log.Logger.addFilter(/^qx\.ui/, null, "debug");
      *  </pre>
      *
      * Note that while the default is to log everything, as soon as you apply one filter
@@ -214,9 +214,9 @@ qx.Bootstrap.define("qx.log.Logger",
      * allows you to specify that log messages only go to one destination; for example:
      * 
      *  <pre class="javascript">
-     *    qx.log.Logger.addFilter(/^qx.ui/, "qx.log.appender.Console", "warn");
-     *    qx.log.Logger.addFilter(/^qx.io/, "qx.log.appender.Native", "debug");
-     *    qx.log.Logger.addFilter(/^qx.io/, "qx.log.appender.Console", "error");
+     *    qx.log.Logger.addFilter(/^qx\.ui/, "qx.log.appender.Console", "warn");
+     *    qx.log.Logger.addFilter(/^qx\.io/, "qx.log.appender.Native", "debug");
+     *    qx.log.Logger.addFilter(/^qx\.io/, "qx.log.appender.Console", "error");
      *  </pre>
      *
      * In this example, qx.ui.* will only go to the Console appender and only if a warning

--- a/framework/source/class/qx/test/log/Filters.js
+++ b/framework/source/class/qx/test/log/Filters.js
@@ -1,0 +1,64 @@
+/* ************************************************************************
+
+   qooxdoo - the new era of web development
+
+   http://qooxdoo.org
+
+   Copyright:
+     2004-2009 1&1 Internet AG, Germany, http://www.1und1.de
+
+   License:
+     LGPL: http://www.gnu.org/licenses/lgpl.html
+     EPL: http://www.eclipse.org/org/documents/epl-v10.php
+     See the LICENSE file in the project's top-level directory for details.
+
+   Authors:
+ * Fabian Jakobs (fjakobs)
+
+ ************************************************************************ */
+
+qx.Class.define("qx.test.log.Filters", {
+  extend: qx.dev.unit.TestCase,
+
+  members: {
+    testFilters: function() {
+      qx.log.appender.Native;
+
+      var Logger = qx.log.Logger;
+      qx.Class.define("my.TestLogger", {
+        statics: {
+          count: 0,
+          process: function(entry) {
+            this.count++;
+            var args = qx.log.appender.Util.toText(entry);
+            (console[entry.level] || console.log).call(console, "TestLogger: " + args);
+          }
+        },
+
+        defer: function(statics) {
+          qx.log.Logger.register(statics);
+        }
+      });
+
+      Logger.addFilter("afdemo", "qx.log.appender.Native")
+      Logger.addFilter(/^test-level/, "my.TestLogger", "warn");
+
+      var TestLogger = my.TestLogger;
+      TestLogger.count = 0;
+
+      this.trace("Trace Test");
+      this.debug("Debug Test");
+      this.warn("Warn Test");
+      this.error("Error Test");
+      this.info("Info Test");
+
+      Logger.trace("test-level", "Trace Test");
+      Logger.debug("test-level", "Debug Test");
+      Logger.info("test-level", "Info Test");
+      Logger.warn("test-level", "Warn Test");
+      Logger.error("test-level", "Error Test");
+      qx.core.Assert.assertEquals(2, TestLogger.count);
+
+    }
+  }
+});

--- a/framework/source/class/qx/test/log/Filters.js
+++ b/framework/source/class/qx/test/log/Filters.js
@@ -8,12 +8,11 @@
      2004-2009 1&1 Internet AG, Germany, http://www.1und1.de
 
    License:
-     LGPL: http://www.gnu.org/licenses/lgpl.html
-     EPL: http://www.eclipse.org/org/documents/epl-v10.php
+     MIT: https://opensource.org/licenses/MIT
      See the LICENSE file in the project's top-level directory for details.
 
    Authors:
- * Fabian Jakobs (fjakobs)
+   * John Spackman (john.spackman@zenesis.com)
 
  ************************************************************************ */
 

--- a/framework/source/class/qx/util/RingBuffer.js
+++ b/framework/source/class/qx/util/RingBuffer.js
@@ -113,6 +113,15 @@ qx.Bootstrap.define("qx.util.RingBuffer",
         this.__entriesStoredSinceMark++;
       }
     },
+    
+    
+    /**
+     * Returns the number of entries stored
+     * @return {Integer}
+     */
+    getNumEntriesStored: function() {
+      return this.__entriesStored;
+    },
 
 
     /**


### PR DESCRIPTION
This enhancement allows filters to be specified to qx.log.Logger at runtime which control what log messages got to what Appenders; the filters are based on a regular expression matched against the class name of the object which is making the log.

This patch also adds "trace" as a seperate logging level so that each individual appender can decide whether to pass stack information on.

If no filters are applied, then the behaviour is unchanged from previous versions.
