### PR TITLE
Making debugging easier - prevent unnecessary exceptions

### DIFF
--- a/framework/source/class/qx/bom/client/Plugin.js
+++ b/framework/source/class/qx/bom/client/Plugin.js
@@ -55,8 +55,10 @@ qx.Bootstrap.define("qx.bom.client.Plugin",
       try {
         // in IE11 Preview, ActiveXObject is undefined but instances can
         // still be created
-        return (typeof (new window.ActiveXObject("Microsoft.XMLHTTP")) === "object" ||
-          typeof (new window.ActiveXObject("MSXML2.DOMDocument.6.0")) === "object");
+        return window.ActiveXObject !== undefined && 
+          (typeof (new window.ActiveXObject("Microsoft.XMLHTTP")) === "object" ||
+           typeof (new window.ActiveXObject("MSXML2.DOMDocument.6.0")) === "object"
+          );
       } catch(ex) {
         return false;
       }

--- a/framework/source/class/qx/data/controller/Form.js
+++ b/framework/source/class/qx/data/controller/Form.js
@@ -319,7 +319,7 @@ qx.Class.define("qx.data.controller.Form",
         // ignore not working items
         } catch (ex) {
           if (qx.core.Environment.get("qx.debug")) {
-            this.warn("Could not bind property " + name + " of " + this.getModel());
+            this.warn("Could not bind property " + name + " of " + this.getModel() + ":\n" + ex.stack);
           }
         }
       }

--- a/framework/source/class/qx/event/handler/Focus.js
+++ b/framework/source/class/qx/event/handler/Focus.js
@@ -239,7 +239,7 @@ qx.Class.define("qx.event.handler.Focus",
             // Fixed cursor position issue with IE, only when nothing is selected.
             // See [BUG #3519] for details.
             var selection = qx.bom.Selection.get(element);
-            if (selection.length == 0) {
+            if (selection.length == 0 && typeof element.createTextRange == "function") {
               var textRange = element.createTextRange();
               textRange.moveStart('character', element.value.length);
               textRange.collapse();
@@ -814,7 +814,8 @@ qx.Class.define("qx.event.handler.Focus",
             // is not what we like when changing the focus element.
             // So we clear it
             try {
-              document.selection.empty();
+              if (document.selection)
+                document.selection.empty();
             } catch (ex) {
               // ignore 'Unknown runtime error'
             }

--- a/framework/source/class/qx/ui/form/DateField.js
+++ b/framework/source/class/qx/ui/form/DateField.js
@@ -296,6 +296,8 @@ qx.Class.define("qx.ui.form.DateField",
 
       // return the parsed date
       try {
+        if (textfieldValue == null || textfieldValue.length == 0)
+          return null;
         return this.getDateFormat().parse(textfieldValue);
       } catch (ex) {
         return null;
@@ -378,8 +380,10 @@ qx.Class.define("qx.ui.form.DateField",
       {
         var textfield = this.getChildControl("textfield");
         var dateStr = textfield.getValue();
-        var currentDate = old.parse(dateStr);
-        textfield.setValue(value.format(currentDate));
+        if (dateStr != null) {
+          var currentDate = old.parse(dateStr);
+          textfield.setValue(value.format(currentDate));
+        }
       }
       catch (ex) {
         // do nothing if the former date could not be parsed


### PR DESCRIPTION
When debugging an app and "Pause on all exceptions" _has_ to be turned on, unnecessary exceptions can be a real pain and make it much harder to find the one exception you are really searching for.  The patches prevented many dozens of exceptions in my application startup (particularly DateField).
