### PR TITLE
added qx.core.Object.isDisposing() 

### DIFF
--- a/framework/source/class/qx/core/Object.js
+++ b/framework/source/class/qx/core/Object.js
@@ -280,6 +280,7 @@ qx.Class.define("qx.core.Object",
 
       // Mark as disposed (directly, not at end, to omit recursions)
       this.$$disposed = true;
+      this.$$disposing = true;
       this.$$instance = null;
       this.$$allowconstruct = null;
 
@@ -319,6 +320,8 @@ qx.Class.define("qx.core.Object",
         clazz = clazz.superclass;
       }
 
+      this.$$disposing = false;
+      
       // Additional checks
       if (qx.core.Environment.get("qx.debug"))
       {

--- a/framework/source/class/qx/core/Object.js
+++ b/framework/source/class/qx/core/Object.js
@@ -257,6 +257,17 @@ qx.Class.define("qx.core.Object",
 
 
     /**
+     * Returns true if the object is being disposed, ie this.dispose() has started but 
+     * not finished
+     *
+     * @return {Boolean} Whether the object is being disposed
+     */
+    isDisposing : function() {
+      return this.$$disposing || false;
+    },
+
+
+    /**
      * Dispose this object
      *
      */

--- a/framework/source/class/qx/event/dispatch/Direct.js
+++ b/framework/source/class/qx/event/dispatch/Direct.js
@@ -123,7 +123,7 @@ qx.Class.define("qx.event.dispatch.Direct",
 
           if (qx.core.Environment.get("qx.debug")) {
             // warn if the context is disposed
-            if (context && context.isDisposed && context.isDisposed()) {
+            if (context && context.isDisposed && context.isDisposed() && !context.isDisposing()) {
               this.warn(
                 "The context object '" + context + "' for the event '" +
                 type + "' of '" + target + "'is already disposed."


### PR DESCRIPTION
When disposing an object, the $$disposed flag is set immediately but during dispose methods can be called which trigger warnings because isDisposed() returns true; however, the object is in the process of being disposed which means that these warnings should be suppressed because it is normal (for example) to set a property to null during dispose, and therefore changeXxxx events can legitimately fire during dispose.  

This fix allows objects to determine that the dispose() method is in progress (as opposed to having completed); also in this PR is a fix to qx.event.dispatch.Direct which was generating a number of warnings in my use case, which could be legitimately suppressed.  The number of warnings generated can be significant and make it harder to identify other issues during disposal
