### PR TITLE
[BUG #9228] Fix image theme switch

### DIFF
--- a/framework/source/class/qx/ui/basic/Image.js
+++ b/framework/source/class/qx/ui/basic/Image.js
@@ -608,10 +608,14 @@ qx.Class.define("qx.ui.basic.Image",
 
           if (!currentContentElement.isVisible()) {
             elementToAdd.hide();
+          } else if (!elementToAdd.isVisible()) {
+            elementToAdd.show();
           }
 
           if (!currentContentElement.isIncluded()) {
             elementToAdd.exclude();
+          } else if (!elementToAdd.isIncluded()) {
+            elementToAdd.include();
           }
 
           var container = currentContentElement.getParent();

--- a/framework/source/class/qx/ui/basic/Image.js
+++ b/framework/source/class/qx/ui/basic/Image.js
@@ -563,7 +563,7 @@ qx.Class.define("qx.ui.basic.Image",
       {
         if (this.getScale() && this.__getMode() != "scaled") {
           this.__setMode("scaled");
-        } else if (!this.getScale() && this.__getMode("nonScaled")) {
+        } else if (!this.getScale() && this.__getMode() != "nonScaled") {
           this.__setMode("nonScaled");
         }
 


### PR DESCRIPTION
If you've an image which is styled with "source" in one theme and without "source" in the other, it gets "display: none" when switching the theme to the one without "source".

Switching back to the one with source restores the image+path, but does not remove the "display: none" - so the image is optically gone while it's in the DOM.

The PR fixes a typo in the usage of __getMode and takes care about initially restoring the values correctly.
