### PR TITLE
Added dispose check for debounced functions

### DIFF
--- a/framework/source/class/qx/util/Function.js
+++ b/framework/source/class/qx/util/Function.js
@@ -77,7 +77,14 @@ qx.Bootstrap.define("qx.util.Function", {
               delete this.intervalId;
 
               if (this.immediate === false) {
-                callback.apply(context, this.args);
+                if (context && context.isDisposed && context.isDisposed()) {
+                  qx.log.Logger.warn(
+                    "The context object '" + context + "' of the debounced call '" +
+                    this + "'is already disposed.");
+                }
+                else {
+                  callback.apply(context, this.args);
+                }
               }
             }
             this.fired = false;


### PR DESCRIPTION
Sync the behaviour of debounce function calls with the one used in event, defere, etc.: add a warning instead of indirectly rising exceptions.
