### PR TITLE
[BUG #9235] Change some form validation manager methods from private to protected to allow overrides

### DIFF
--- a/framework/source/class/qx/ui/form/validation/Manager.js
+++ b/framework/source/class/qx/ui/form/validation/Manager.js
@@ -234,13 +234,13 @@ qx.Class.define("qx.ui.form.validation.Manager",
         // ignore all form items without a validator
         if (validator == null) {
           // check for the required property
-          var validatorResult = this.__validateRequired(formItem);
+          var validatorResult = this._validateRequired(formItem);
           valid = valid && validatorResult;
           this.__syncValid = validatorResult && this.__syncValid;
           continue;
         }
 
-        var validatorResult = this.__validateItem(
+        var validatorResult = this._validateItem(
           this.__formItems[i], formItem.getValue()
         );
         // keep that order to ensure that null is returned on async cases
@@ -275,7 +275,7 @@ qx.Class.define("qx.ui.form.validation.Manager",
      * @param formItem {qx.ui.core.Widget} The form item to check.
      * @return {var} Validation result
      */
-    __validateRequired : function(formItem) {
+    _validateRequired : function(formItem) {
       if (formItem.getRequired()) {
         // if its a widget supporting the selection
         if (this.__supportsSingleSelection(formItem)) {
@@ -306,7 +306,7 @@ qx.Class.define("qx.ui.form.validation.Manager",
      * @return {Boolean|null} Validation result or <code>null</code> for async
      * validation
      */
-    __validateItem : function(dataEntry, value) {
+    _validateItem : function(dataEntry, value) {
       var formItem = dataEntry.item;
       var context = dataEntry.context;
       var validator = dataEntry.validator;


### PR DESCRIPTION
It is desirable to allow overriding the Methods __validateRequired and __validateItem to be able to intercept the validation. In our use case we want to allow required fields to only be required if they are enabled.

This could be simply achieved by overriding those methods and return true if the form items are isEnabled() === false
