### PR TITLE
[BUG #9238] qx.util.ResourceManager: add method getIds which retrieves an array of existing IDs

### DIFF
--- a/framework/source/class/qx/util/ResourceManager.js
+++ b/framework/source/class/qx/util/ResourceManager.js
@@ -61,6 +61,30 @@ qx.Class.define("qx.util.ResourceManager",
 
   members :
   {
+    /**
+     * Get all known resource IDs.
+     *
+     * @param pathfragment{String|null|undefined} an options path fragment to check against with id.indexOf(pathfragment)
+     * @return {Array|null} an array containing the IDs or null if the registry is not initialized
+     */
+    getIds : function(pathfragment) {
+      var registry = this.self(arguments).__registry;
+      if(!registry) {
+        return null;
+      }
+  
+      var ids = [];
+      for (var id in registry) {
+        if (registry.hasOwnProperty(id)) {
+          if(pathfragment && id.indexOf(pathfragment) == -1) {
+            continue;
+          }
+          ids.push(id);
+        }
+      }
+  
+      return ids;
+    },
 
     /**
      * Whether the registry has information about the given resource.


### PR DESCRIPTION
For some situations it is very handy to know the ids registered by the manager.
