### PR TITLE
[Bug #9243] drag&drop handler: attach the pointerdown event to the capturing phase

### DIFF
--- a/framework/source/class/qx/event/handler/DragDrop.js
+++ b/framework/source/class/qx/event/handler/DragDrop.js
@@ -51,7 +51,7 @@ qx.Class.define("qx.event.handler.DragDrop",
 
     // Initialize listener
     this.__manager.addListener(this.__root, "longtap", this._onLongtap, this);
-    this.__manager.addListener(this.__root, "pointerdown", this._onPointerdown, this);
+    this.__manager.addListener(this.__root, "pointerdown", this._onPointerdown, this, true);
 
     qx.event.Registration.addListener(window, "blur", this._onWindowBlur, this);
 


### PR DESCRIPTION
allowing widgets to stop event propagation of the pointerdown event.

This makes drag and drop working again for form buttons.
