### PR TITLE
[Bug #9244] qx.ui.decoration.Abstract never assigns anything to __insets, though it seems the intention was to cache them

### DIFF
--- a/framework/source/class/qx/ui/decoration/Abstract.js
+++ b/framework/source/class/qx/ui/decoration/Abstract.js
@@ -74,11 +74,11 @@ qx.Class.define("qx.ui.decoration.Abstract",
     // interface implementation
     getInsets : function()
     {
-      if (this.__insets) {
-        return this.__insets;
+      if (!this.__insets) {
+        this.__insets = this._getDefaultInsets();
       }
 
-      return this._getDefaultInsets();
+      return this.__insets;
     }
   },
 


### PR DESCRIPTION
Proposed patch for bug http://bugzilla.qooxdoo.org/show_bug.cgi?id=9244 reported by Veronika Silvesterova.
