### PR TITLE
[BUG #9251] qx.html.Element: call this.show() on fadeIn animation end to ensure full functionality

### DIFF
--- a/framework/source/class/qx/html/Element.js
+++ b/framework/source/class/qx/html/Element.js
@@ -1565,7 +1565,10 @@ qx.Class.define("qx.html.Element",
         col.push(this.__element);
       }
       if (this.__element) {
-        col.fadeIn(duration);
+        col.fadeIn(duration).once("animationEnd", function() {
+          this.show();
+          qx.html.Element.flush();
+        }, this);
         return col.getAnimationHandles()[0];
       }
     },


### PR DESCRIPTION
Proposed fix for issue in thread http://qooxdoo.678.n2.nabble.com/qx-ui-core-Widget-fadeIn-fadeOut-issue-td7587961.html based on a workarraound from kreimerkreimer@gmail.com
