### PR TITLE
[Bug 8841] qx.ui.table.paneScroller startEditing: scrollCellVisible first argument is the column index, not the columns x position

### DIFF
--- a/framework/source/class/qx/ui/table/pane/Scroller.js
+++ b/framework/source/class/qx/ui/table/pane/Scroller.js
@@ -1826,7 +1826,7 @@ qx.Class.define("qx.ui.table.pane.Scroller",
         var value = tableModel.getValue(col, row);
 
         // scroll cell into view
-        this.scrollCellVisible(xPos, row);
+        this.scrollCellVisible(col, row);
 
         this.__cellEditorFactory = table.getTableColumnModel().getCellEditorFactory(col);
 


### PR DESCRIPTION
Fix proposed by Maxim Fedyashev.

See http://bugzilla.qooxdoo.org/show_bug.cgi?id=8841
