### PR TITLE
source-server-nodejs

### DIFF
--- a/tool/grunt/data/Gruntfile.tmpl.js
+++ b/tool/grunt/data/Gruntfile.tmpl.js
@@ -16,6 +16,45 @@ module.exports = function(grunt) {
       "QOOXDOO_PATH" : "${REL_QOOXDOO_PATH}",
       "LOCALES": ["en"],
       "QXTHEME": "${Namespace}.theme.Theme"
+    },
+
+    'http-server': {
+ 
+        'dev': {
+ 
+            // the server root directory 
+            root: ".",
+ 
+            // the server port 
+            // can also be written as a function, e.g. 
+            // port: function() { return 8282; } 
+            port: 9999,
+ 
+            // the host ip address 
+            // If specified to, for example, "127.0.0.1" the server will 
+            // only be available on that ip. 
+            // Specify "0.0.0.0" to be available everywhere 
+            host: "127.0.0.1",
+ 
+            showDir : true,
+            autoIndex: true,
+ 
+            // server default file extension 
+            ext: "html",
+ 
+            // specify a logger function. By default the requests are 
+            // sent to stdout. 
+            // logFn: function(req, res, error) {},
+ 
+            // Proxies all requests which can't be resolved locally to the given url 
+            // Note this this will disable 'showDir' 
+            // proxy: "http://mybackendserver.com",
+
+            // Tell grunt task to open the browser 
+            openBrowser : true
+ 
+        }
+ 
     }
 
     /*
@@ -33,6 +72,14 @@ module.exports = function(grunt) {
   grunt.initConfig(mergedConf);
 
   qx.task.registerTasks(grunt);
+
+  // // 3. Where we tell Grunt we plan to use this plug-in.
+  // grunt.loadNpmTasks('grunt-contrib-concat');
+  grunt.loadNpmTasks('grunt-http-server');
+
+  // // 4. Where we tell Grunt what to do when we type "grunt" into the terminal.
+  // grunt.registerTask('default', ['concat']);
+  grunt.registerTask('source-server-nodejs', ['http-server:dev']);
 
   // grunt.loadNpmTasks('grunt-my-plugin');
 };

--- a/tool/grunt/data/package.tmpl.json
+++ b/tool/grunt/data/package.tmpl.json
@@ -4,6 +4,7 @@
   "repository" : {},
   "devDependencies": {
     "grunt": "~0.4.2",
-    "grunt-contrib-clean": "~0.5.0"
+    "grunt-contrib-clean": "~0.5.0",
+    "grunt-http-server": "^1.13.0"
   }
 }


### PR DESCRIPTION
Added grunt task source-server-nodejs to the grunt templates.
Now you have the choice between
grunt source-server               -> python SimpleHttpServer
grunt source-server-nodejs   -> node grunt-http-server
