### PR TITLE
Eliminate discrepancy of the locale property between qx.locale.Manager and qx.util.format.NumberFormat

### DIFF
--- a/framework/source/class/qx/bom/client/Locale.js
+++ b/framework/source/class/qx/bom/client/Locale.js
@@ -102,5 +102,6 @@ qx.Bootstrap.define("qx.bom.client.Locale",
   defer : function(statics) {
     qx.core.Environment.add("locale", statics.getLocale);
     qx.core.Environment.add("locale.variant", statics.getVariant);
+    qx.core.Environment.add("locale.default", "C");
   }
 });

--- a/framework/source/class/qx/core/Environment.js
+++ b/framework/source/class/qx/core/Environment.js
@@ -559,6 +559,10 @@
  *       <td>locale.variant</td><td><i>String</i></td><td><code>de</code></td>
  *       <td>{@link qx.bom.client.Locale#getVariant}</td>
  *     </tr>
+ *     <tr>
+ *       <td>locale.default</td><td><i>String</i></td><td><code>C</code></td>
+ *       <td>default locale C as in good tradition of unix</td>
+ *     </tr>
 
  *     <tr>
  *       <td colspan="4"><b>os</b></td>

--- a/framework/source/class/qx/locale/Manager.js
+++ b/framework/source/class/qx/locale/Manager.js
@@ -50,18 +50,8 @@ qx.Class.define("qx.locale.Manager",
     this.__translations = qx.$$translations || {};
     this.__locales      = qx.$$locales || {};
 
-    var locale = qx.core.Environment.get("locale");
-    var variant = qx.core.Environment.get("locale.variant");
-    if (variant !== "") {
-      locale += "_" + variant;
-    }
-
-    this.__clientLocale = locale;
-
-    this.setLocale(locale || this.__defaultLocale);
+    this.__clientLocale = this.getLocale();
   },
-
-
 
 
   /*
@@ -186,9 +176,18 @@ qx.Class.define("qx.locale.Manager",
     locale :
     {
       check : "String",
-      nullable : true,
       apply : "_applyLocale",
-      event : "changeLocale"
+      event : "changeLocale",
+      init : (function() { 
+        var locale = qx.core.Environment.get("locale");
+        if(!locale || locale === "") {
+          return qx.core.Environment.get("locale.default");
+        }
+        var variant = qx.core.Environment.get("locale.variant");
+        if (variant !== "") {
+          locale += "_" + variant;
+        }
+        return locale; })()
     }
   },
 
@@ -204,7 +203,7 @@ qx.Class.define("qx.locale.Manager",
   members :
   {
 
-    __defaultLocale : "C",
+    __defaultLocale : qx.core.Environment.get("locale.default"),
     __locale : null,
     __language : null,
     __translations : null,

--- a/framework/source/class/qx/test/locale/Locale.js
+++ b/framework/source/class/qx/test/locale/Locale.js
@@ -206,7 +206,7 @@ qx.Class.define("qx.test.locale.Locale",
 
       // try the reset of the locale
       manager.resetLocale();
-      this.assertEquals(null, manager.getLocale());
+      this.assertEquals(locale, manager.getLocale());
 
       // make sure we set the locale which was there before the test
       manager.setLocale(oldLocale);

--- a/framework/source/class/qx/test/util/DateFormat.js
+++ b/framework/source/class/qx/test/util/DateFormat.js
@@ -803,9 +803,12 @@ qx.Class.define("qx.test.util.DateFormat",
   testChangingLocales : function()
   {
     var manager = qx.locale.Manager.getInstance();
+    var initialLocale = manager.getLocale();
+    
     manager.setLocale('en_US');
 
     var df = new qx.util.format.DateFormat("EEEE yyyy-mm-dd");
+    var dfinitial = new qx.util.format.DateFormat("EEEE yyyy-mm-dd", initialLocale);
     var dfFR = new qx.util.format.DateFormat("EEEE yyyy-mm-dd","fr_FR");
     var dfDE = new qx.util.format.DateFormat("EEEE yyyy-mm-dd","de_DE");
     var dfUS = new qx.util.format.DateFormat("EEEE yyyy-mm-dd","en_US");
@@ -821,7 +824,7 @@ qx.Class.define("qx.test.util.DateFormat",
     this.assertEquals(df.format(d),dfDE.format(d));
 
     manager.resetLocale();
-    this.assertEquals(df.format(d),dfUS.format(d));
+    this.assertEquals(df.format(d),dfinitial.format(d));
 
     manager.setLocale('fr_FR');
     this.assertEquals(df.format(d),dfFR.format(d));
@@ -835,6 +838,7 @@ qx.Class.define("qx.test.util.DateFormat",
     dfFR.resetLocale();
 
     df.dispose();
+    dfinitial.dispose();
     dfFR.dispose();
     dfDE.dispose();
     dfUS.dispose();


### PR DESCRIPTION
qx.locale.Manager defines property locale nullable : true, but
qx.util.format.NumberFormat does not, but the properties get bound by
single value binding, which causes null value exceptions on
qx.locale.Manager.getInstance().resetLocale().

This PR changes the locale property of qx.locale.Manager being
initialized with the current client locale, or if not available with the
default locale "C" which is now availavle as a variable via
qx.core.Environment.get("locale.default")
