### PR TITLE
Fix qx.test.uti.DateFormat.testChangingLocales

### DIFF
--- a/framework/source/class/qx/test/util/DateFormat.js
+++ b/framework/source/class/qx/test/util/DateFormat.js
@@ -803,6 +803,7 @@ qx.Class.define("qx.test.util.DateFormat",
   testChangingLocales : function()
   {
     var manager = qx.locale.Manager.getInstance();
+    manager.resetLocale();
     var initialLocale = manager.getLocale();
     
     manager.setLocale('en_US');


### PR DESCRIPTION
The test assumes that on start the locale managers locale property is at
init state, but this is not shure if we had run other tests before which
also set a locale. So just reset the locale manager before starting.
