### PR TITLE
Call the applyer for the locale property in the constructor of qx.locale.Manager

### DIFF
--- a/framework/source/class/qx/locale/Manager.js
+++ b/framework/source/class/qx/locale/Manager.js
@@ -51,6 +51,7 @@ qx.Class.define("qx.locale.Manager",
     this.__translations = qx.$$translations || {};
     this.__locales      = qx.$$locales || {};
 
+    this.initLocale();
     this.__clientLocale = this.getLocale();
   },
 


### PR DESCRIPTION
To be shure the provite attribute __locale is initialized we have to invoke the applyer for the locale property by calling initLocale() in the constructor.
