### PR TITLE
Convert target if required

### DIFF
--- a/framework/source/class/qx/ui/core/MDragDropScrolling.js
+++ b/framework/source/class/qx/ui/core/MDragDropScrolling.js
@@ -293,7 +293,13 @@ qx.Mixin.define("qx.ui.core.MDragDropScrolling",
         this.__dragScrollTimer.stop();
       }
 
-      var target = e.getOriginalTarget();
+      var target;
+      if (e.getOriginalTarget() instanceof qx.ui.core.Widget) {
+        target = e.getOriginalTarget();
+      }
+      else {
+        target = qx.ui.core.Widget.getWidgetByElement(e.getOriginalTarget());
+      }
       if (!target) {
         return;
       }


### PR DESCRIPTION
This is a follow up to #142. I needed to remove the original fork because I accidently pushed some non easy revertable stuff to master. Sigh.

As requested, there's a check for qx.ui.core.Widget now.
