### PR TITLE
Work around exception when pressing Enter in non focusable TextField

### DIFF
--- a/framework/source/class/qx/ui/form/TextField.js
+++ b/framework/source/class/qx/ui/form/TextField.js
@@ -92,7 +92,17 @@ qx.Class.define("qx.ui.form.TextField",
     _onKeyPress : function(evt) {
       // On return
       if (evt.getKeyIdentifier() == "Enter") {
-        this.blur();
+        if (this.isFocusable()) {
+          this.blur();
+        }
+        else {
+           // When the text field is not focusable, blur() will raise an exception on
+           // touch devices and the virtual keyboard is not closed. To work around this
+           // issue, we're enabling the focus just for the blur() call.
+           this.setFocusable(true);
+           this.blur();
+           this.setFocusable(false);
+        }
       }
     }
   },


### PR DESCRIPTION
In widgets where TextField is a child control, TextField is mostly added
using setFocusable(false). Focus is handeled in the parent widget.
Pressing "Enter" in such widgets (Spinner, etc.) results in an exception
in these cases, because the virtual keyboard is hidden with blur() -
which is not supported on non focusable TextField.
