### PR TITLE
use travis matrix build to test for multiple chrome and firefox versions

### DIFF
--- a/.travis-browser-setup.sh
+++ b/.travis-browser-setup.sh
@@ -1,0 +1,17 @@
+#!/bin/bash
+
+if [ $QXBROWSER = Firefox ]; then
+    wget -O /tmp/firefox.tar.bz2 "https://download.mozilla.org/?product=firefox-${QXVERSION}&lang=en-US&os=linux64"
+    tar xf /tmp/firefox.tar.bz2
+else
+    wget -O /tmp/chrome.deb https://dl.google.com/linux/direct/google-chrome-${QXVERSION}_current_amd64.deb
+    dpkg --extract /tmp/chrome.deb chrome-x
+    if [ $QXVERSION = stable ]; then
+        mv chrome-x/opt/google/chrome chrome
+        mv chrome/google-chrome chrome/google-chrome-stable
+    else
+        mv chrome-x/opt/google/chrome-$QXVERSION chrome
+        rm chrome/google-chrome
+    fi
+    ln -s google-chrome-$QXVERSION chrome/google-chrome
+fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,18 +2,29 @@ sudo: false
 language: php
 php:
   - "5.6"
+env:
+  - QXBROWSER=Firefox QXVERSION=latest
+  - QXBROWSER=Firefox QXVERSION=esr-latest
+  - QXBROWSER=Firefox QXVERSION=beta-latest
+  - QXBROWSER=Chrome_travis_ci QXVERSION=stable
+  - QXBROWSER=Chrome_travis_ci QXVERSION=beta
+  - QXBROWSER=Chrome_travis_ci QXVERSION=unstable
+
 cache:
   directories:
-  - /tmp/qx5.1  
-addons:
-  firefox: "latest"
+  - /tmp/qx5.1
+
 install:
+  - ./.travis-browser-setup.sh
+  - export CHROME_BIN=`pwd`/chrome/google-chrome
+  - export PATH=`pwd`/firefox:$PATH
   - cd framework
   - npm install
   - ./generate.py -sI test-source
+
 before_script:
-  - "export DISPLAY=:99.0"
-  - "sh -e /etc/init.d/xvfb start"
+  - export DISPLAY=:99.0
+  - sh -e /etc/init.d/xvfb start
   - "php -S 0.0.0.0:31323 &> /dev/null &"
   - sleep 3
 script:

--- a/framework/karma.conf.js
+++ b/framework/karma.conf.js
@@ -29,6 +29,12 @@ module.exports = function(config) {
       // 'source/class/qx/{*.js,!(test)/**/*.js}': 'coverage'
     },
 
+    customLaunchers: {  
+      Chrome_travis_ci: {
+        base: 'Chrome',
+        flags: ['--no-sandbox']
+      }
+    },
 
     // test results reporter to use
     // possible values: 'dots', 'progress'

--- a/framework/package.json
+++ b/framework/package.json
@@ -10,7 +10,7 @@
     "test": "karma start",
     "pretest" : "php -S 127.0.0.1:31323 &> /dev/null &",
     "posttest" : "pkill -f 'php -S 127.0.0.1:31323' &> /dev/null",
-    "travis-test": "karma start --reporters=dots --browsers=Firefox",
+    "travis-test": "karma start --reporters=dots  --browsers=$QXBROWSER",
     "coverage": "karma start karma-coverage.conf.js",
     "precoverage" : "php -S 127.0.0.1:31323 &> /dev/null &",
     "postcoverage" : "pkill -f 'php -S 127.0.0.1:31323' &> /dev/null"


### PR DESCRIPTION
With travis matrix feature this new setup lets us test different browsers and versions in parallel ... at the moment only chrome and firefox are supported ... since saucelab is free for oss as well, it would certainly make sense to use them as a browser source in the future.
