### PR TITLE
Fix BZ#9213 - Table select all rows w/ Ctrl+A

### DIFF
--- a/framework/source/class/qx/ui/table/Table.js
+++ b/framework/source/class/qx/ui/table/Table.js
@@ -189,7 +189,7 @@ qx.Class.define("qx.ui.table.Table",
 
     // Make focusable
     this.setTabIndex(1);
-    this.addListener("keypress", this._onKeyPress);
+    this.addListener("keyup", this._onKeyPress);
     this.addListener("focus", this._onFocusChanged);
     this.addListener("blur", this._onFocusChanged);
 

--- a/framework/source/class/qx/ui/table/Table.js
+++ b/framework/source/class/qx/ui/table/Table.js
@@ -189,7 +189,7 @@ qx.Class.define("qx.ui.table.Table",
 
     // Make focusable
     this.setTabIndex(1);
-    this.addListener("keyup", this._onKeyPress);
+    this.addListener("keydown", this._onKeyPress);
     this.addListener("focus", this._onFocusChanged);
     this.addListener("blur", this._onFocusChanged);
 


### PR DESCRIPTION
Using keyup rather than keypress fix the problem with Chrome as with CH4+, some "reserved browser key combinations" aren't anymore transmitted through keypress event:https://bugs.chromium.org/p/chromium/issues/detail?id=33056

Note I leave the related method name as _onKeyPress for backward compatibility. It can be adapted it necessary.
