### PR TITLE
#8977

### DIFF
--- a/framework/source/class/qx/data/controller/Form.js
+++ b/framework/source/class/qx/data/controller/Form.js
@@ -278,6 +278,11 @@ qx.Class.define("qx.data.controller.Form",
       if (this.getTarget() == null) {
         return;
       }
+      else {
+        // if form was validated with errors and model changes
+        // the errors should be cleared see #8977
+        this.getTarget().getValidationManager().reset();
+      }
 
       // model and target are available
       if (value != null) {


### PR DESCRIPTION
When a form is validated with errors and then the model of the form controller changes then the validator should be reset to clear previous errors or they will remain displayed erronously.
