### PR TITLE
#8976

### DIFF
--- a/framework/source/class/qx/ui/virtual/core/Pane.js
+++ b/framework/source/class/qx/ui/virtual/core/Pane.js
@@ -673,7 +673,24 @@ qx.Class.define("qx.ui.virtual.core.Pane",
     _onDbltap : function(e) {
        this.__handlePointerCellEvent(e, "cellDbltap");
     },
-
+    
+    /**
+     * Fixed scrollbar position whenever it is out of range
+     * it can happen when removing an item from the list reducing
+     * the max value for scrollY #8976
+     */
+    _checkScrollBounds: function() {
+      var maxx = this.getScrollMaxX();
+      var maxy = this.getScrollMaxY();
+      if (this.__scrollLeft < 0)
+        this.__scrollLeft = 0;
+      else if (this.__scrollLeft > maxx)
+        this.__scrollLeft = maxx;
+      if (this.__scrollTop < 0)
+        this.__scrollTop = 0;
+      else if (this.__scrollTop > maxy)
+        this.__scrollTop = maxy;
+    },
 
     /**
      * Converts a pointer event into a cell event and fires the cell event if the
@@ -713,8 +730,10 @@ qx.Class.define("qx.ui.virtual.core.Pane",
     syncWidget : function(jobs)
     {
       if (this.__jobs._fullUpdate) {
+        this._checkScrollBounds();
         this._fullUpdate();
       } else if (this.__jobs._updateScrollPosition) {
+        this._checkScrollBounds();
         this._updateScrollPosition();
       }
       this.__jobs = {};


### PR DESCRIPTION
When an item is removed from the List's model and the scrollbar was positionned to the bottom, reducing the list size will also reduce the maxScrollY making the current scrollTop out of range. When it happen then all click to item are selecting another one making the component unusable until scollbar is manualy scrolled up (see #8976).
