### PR TITLE
Fix VirtualDropDownList internal list selection keeps receiving bubbling events after being disposed

### DIFF
--- a/framework/source/class/qx/ui/form/core/VirtualDropDownList.js
+++ b/framework/source/class/qx/ui/form/core/VirtualDropDownList.js
@@ -393,15 +393,7 @@ qx.Class.define("qx.ui.form.core.VirtualDropDownList",
       }
       else
       {
-        var nativeArray = target.toArray();
-        qx.lang.Array.removeAll(nativeArray);
-        for (var i = 0; i < source.getLength(); i++) {
-          nativeArray.push(source.getItem(i));
-        }
-        target.length = nativeArray.length;
-
-        // necessary for keeping preselected items in sync
-        target.fireDataEvent("change", {});
+        target.splice.apply(target, [0, target.length].concat(source.toArray())).dispose();
       }
     },
 

--- a/framework/source/class/qx/ui/form/core/VirtualDropDownList.js
+++ b/framework/source/class/qx/ui/form/core/VirtualDropDownList.js
@@ -393,7 +393,14 @@ qx.Class.define("qx.ui.form.core.VirtualDropDownList",
       }
       else
       {
-        target.splice.apply(target, [0, target.length].concat(source.toArray())).dispose();
+        // build arguments array for splice(0, target.length, source[0], source[1], ...)
+        var spliceArg = [0, target.length];
+        spliceArg = spliceArg.concat(source.toArray());
+
+        // use apply since it allow to use an array as the argument array
+        // (calling splice directly with an array insert it in the array on which splice is called)
+        // don't forget to dispose the array created by splice
+        target.splice.apply(target, spliceArg).dispose();
       }
     },
 


### PR DESCRIPTION
Fix for #8990 

I use splice on the `qx.data.Array` which remove bubbling event listeners unlike manual modification of the native array.
