### PR TITLE
Fix qx.test.bom.Location tests in non headless firefox and chrome

### DIFF
--- a/component/testrunner/source/html/tests-source.html
+++ b/component/testrunner/source/html/tests-source.html
@@ -11,5 +11,5 @@
   <script language="JavaScript" type="text/javascript" src="../script/tests-source.js"></script>
   <style type="text/css">html,body{margin:0;padding:0;}body{padding:10px;font:11px normal Tahoma,sans-serif;}</style>
 </head>
-<body>Document Content</body>
+<body></body>
 </html>

--- a/component/testrunner/source/html/tests.html
+++ b/component/testrunner/source/html/tests.html
@@ -11,5 +11,5 @@
   <script language="JavaScript" type="text/javascript" src="../script/tests.js"></script>
   <style type="text/css">html,body{margin:0;padding:0;}body{padding:10px;font:11px normal Tahoma,sans-serif;}</style>
 </head>
-<body>Document Content</body>
+<body></body>
 </html>


### PR DESCRIPTION
6 tests failed in qx.test.bom.Location because a testnode is created and added as a direct child to the document.body. This is at least true for chrome 50 and firefox 46 on windows 7.

The tests create additional elements within the testnode, awaiting the testnode being the only child of the body. With this assumption the testnodes assume to be positioned at the top of the body. But this is not true, as the iframe html code contains text which creates a text node as the first child, making the tests fail.

The fix deletes the unnecessary text within the body tag of the html templates making all test succeed within qx.test.bom.Location.
