### PR TITLE
Add missing unit tests for string handling

### DIFF
--- a/framework/source/class/qx/test/lang/String.js
+++ b/framework/source/class/qx/test/lang/String.js
@@ -20,6 +20,7 @@
 qx.Class.define("qx.test.lang.String",
 {
   extend : qx.dev.unit.TestCase,
+  include : [qx.dev.unit.MMock],
 
   members :
   {
@@ -228,22 +229,15 @@ qx.Class.define("qx.test.lang.String",
       var str = "This is a <script>foobar</script>test";
 
       this.assertIdentical(qx.lang.String.stripScripts(str), "This is a test");
-
-      var nativeGlobalEval = qx.lang.Function.globalEval;
-      var called = false;
       
-      // Patch to check if the function has been called by the stripScripts function
-      qx.lang.Function.globalEval = function(str) {
-          nativeGlobalEval(str);
-          called = true;
-      };
+      var spy = this.spy(qx.lang.Function, "globalEval");
 
       str = "This is a test with<script>console.log('foobar');</script> script";
 
       this.assertIdentical(qx.lang.String.stripScripts(str, true), "This is a test with script");
-      this.assertIdentical(called, true);
-
-      qx.lang.Function.globalEval = nativeGlobalEval;
+      this.assertCalledOnce(spy);
+      
+      spy.restore();
     }
   }
 });

--- a/framework/source/class/qx/test/lang/String.js
+++ b/framework/source/class/qx/test/lang/String.js
@@ -213,6 +213,36 @@ qx.Class.define("qx.test.lang.String",
       this.assertEquals('"abc \\"defg\\" hij"', qx.lang.String.quote('abc "defg" hij'));
       this.assertEquals('"abc \\\\defg\\\\ hij"', qx.lang.String.quote('abc \\defg\\ hij'));
       this.assertEquals('"abc \\"defg\\\\ hij"', qx.lang.String.quote('abc "defg\\ hij'));
+    },
+
+    testTrim : function()
+    {
+      var str = "     foo bar     ";
+
+      this.assertIdentical(qx.lang.String.trimLeft(str), "foo bar     ");
+      this.assertIdentical(qx.lang.String.trimRight(str), "     foo bar");
+    },
+
+    testStripScripts : function()
+    {
+      var str = "This is a <script>foobar</script>test";
+
+      this.assertIdentical(qx.lang.String.stripScripts(str), "This is a test");
+
+      var nativeGlobalEval = qx.lang.Function.globalEval;
+      var called = false;
+
+      qx.lang.Function.globalEval = function(str) {
+          nativeGlobalEval(str);
+          called = true;
+      };
+
+      str = "This is a test with<script>console.log('foobar');</script> script";
+
+      this.assertIdentical(qx.lang.String.stripScripts(str, true), "This is a test with script");
+      this.assertIdentical(called, true);
+
+      qx.lang.Function.globalEval = nativeGlobalEval;
     }
   }
 });

--- a/framework/source/class/qx/test/lang/String.js
+++ b/framework/source/class/qx/test/lang/String.js
@@ -231,7 +231,8 @@ qx.Class.define("qx.test.lang.String",
 
       var nativeGlobalEval = qx.lang.Function.globalEval;
       var called = false;
-
+      
+      // Patch to check if the function has been called by the stripScripts function
       qx.lang.Function.globalEval = function(str) {
           nativeGlobalEval(str);
           called = true;


### PR DESCRIPTION
Add the last unit tests to have qx.lang.String class 100% covered.
I had to patch qx.lang.Function.globalEval to check if it's correctly called but I don't know if it is the best way to do.
