### PR TITLE
statics optimisation breaks the websitewidgetbrowser

### DIFF
--- a/component/standalone/website/module.json
+++ b/component/standalone/website/module.json
@@ -87,7 +87,6 @@
             "strings",
             "variables",
             "variants",
-            "statics",
             "whitespace"
           ],
           "format" : false


### PR DESCRIPTION
component/standalone/website/module.json, line 90 in “min-options” job - the statics optimisation is breaking it
