### PR TITLE
Fix a serious error when maintaining addListenerOnce listener removal.

### DIFF
--- a/framework/package.json
+++ b/framework/package.json
@@ -24,6 +24,6 @@
     "karma-coverage": "^0.5.5",
     "karma-coveralls": "^1.1.2",
     "karma-firefox-launcher": "^0.1.7",
-    "karma-qooxdoo": "^0.4.4"
+    "karma-qooxdoo": "^0.4.6"
   }
 }

--- a/framework/source/class/qx/core/MEvent.js
+++ b/framework/source/class/qx/core/MEvent.js
@@ -64,19 +64,23 @@ qx.Mixin.define("qx.core.MEvent",
      *
      * @param type {String} name of the event type
      * @param listener {Function} event callback function
-     * @param self {Object ? window} reference to the 'this' variable inside the callback
+     * @param context {Object ? window} reference to the 'this' variable inside the callback
      * @param capture {Boolean ? false} Whether to attach the event to the
      *         capturing phase or the bubbling phase of the event. The default is
      *         to attach the event handler to the bubbling phase.
      * @return {String} An opaque id, which can be used to remove the event listener
      *         using the {@link #removeListenerById} method.
      */
-    addListenerOnce : function(type, listener, self, capture)
+    addListenerOnce : function(type, listener, context, capture)
     {
+      var self = this; // self is needed to remove the listener inside the callback
+      if (!context) {
+        context = this;
+      }
       var callback = function(e)
       {
-        this.removeListener(type, listener, self||this, capture);
-        listener.call(self||this, e);
+        self.removeListener(type, listener, context, capture);
+        listener.call(context, e);
       };
       // check for wrapped callback storage
       if (!listener.$$wrapped_callback) {
@@ -85,8 +89,7 @@ qx.Mixin.define("qx.core.MEvent",
       // store the call for each type in case the listener is
       // used for more than one type [BUG #8038]
       listener.$$wrapped_callback[type + this.$$hash] = callback;
-
-      return this.addListener(type, callback, this, capture);
+      return this.addListener(type, callback, context, capture);
     },
 
 

--- a/framework/source/class/qx/core/MEvent.js
+++ b/framework/source/class/qx/core/MEvent.js
@@ -75,7 +75,7 @@ qx.Mixin.define("qx.core.MEvent",
     {
       var callback = function(e)
       {
-        this.removeListener(type, listener, this, capture);
+        this.removeListener(type, listener, self||this, capture);
         listener.call(self||this, e);
       };
       // check for wrapped callback storage

--- a/framework/source/class/qx/test/core/Object.js
+++ b/framework/source/class/qx/test/core/Object.js
@@ -91,6 +91,22 @@ qx.Class.define("qx.test.core.Object",
     },
 
 
+    testAddListenerOnceWithDifferentContext : function()
+    {
+      var called = 0;
+      var listener = function() {
+        // debugger;
+        called++;
+      };
+      var context1 = {name: "context1"};
+      var context2 = {name: "context2"};
+      this.addListenerOnce("test", listener, context1);
+      this.addListenerOnce("test", listener, context2);
+      this.fireEvent("test");
+      this.assertEquals(2, called);
+    },
+
+
     testRemoveListenerById : function()
     {
       var id = this.addListener("testRemoveListenerById", function() {}, this, false);


### PR DESCRIPTION
When you add two _addListenerOnce_ calls with a different context, the second one gets removed after the first one was executed.

There's one place where it is even visible. Open the [current devel playground](http://qooxdoo.github.io/devel/playground) and take a look at the "Playground" string on the top left. It is cut off by an ellipsis.
