### PR TITLE
Tweak utf-8 decoding in generator to allow unicode paths.

### DIFF
--- a/tool/bin/create-application.py
+++ b/tool/bin/create-application.py
@@ -33,7 +33,7 @@ from misc import Path
 
 
 SCRIPT_DIR    = qxenviron.scriptDir
-FRAMEWORK_DIR = os.path.normpath(os.path.join(SCRIPT_DIR, os.pardir, os.pardir))
+FRAMEWORK_DIR = os.path.normpath(os.path.join(SCRIPT_DIR, os.pardir, os.pardir).decode('utf-8'))
 SKELETON_DIR  = unicode(os.path.normpath(os.path.join(FRAMEWORK_DIR, "component", "skeleton")))
 GENERATE_PY   = unicode(os.path.normpath(os.path.join(FRAMEWORK_DIR, "tool", "data", "generator", "generate.tmpl.py")))
 PACKAGE_JSON  = unicode(os.path.normpath(os.path.join(FRAMEWORK_DIR, "tool", "grunt", "data", "package.tmpl.json")))

--- a/tool/pylib/generator/config/Config.py
+++ b/tool/pylib/generator/config/Config.py
@@ -100,8 +100,8 @@ class Config(object):
 
         self._data = data
         self._rawdata = deepcopy(data)
-        self._fname = os.path.abspath(fname)
-        self._dirname = os.path.dirname(self._fname)
+        self._fname = os.path.abspath(fname).decode('utf-8')
+        self._dirname = os.path.dirname(self._fname).decode('utf-8')
 
 
     def expandTopLevelKeys(self):
@@ -367,7 +367,7 @@ class Config(object):
     # lookup).
     def resolveIncludes(self, includeTree=graph.digraph()):
 
-        console.debug("including %s" % (self._fname.decode('utf-8') or "<unknown>",))
+        console.debug("including %s" % (self._fname or "<unknown>",))
         config  = self._data
         jobsmap = self.getJobsMap({})
 


### PR DESCRIPTION
I've located a couple of places that were problematic when utf-8 characters in path. At least it fixes the report from the ticket below. As I'm not 100% familiar with the generator code, there may be more cases. The mentioned case and usual generator calls look fine, though.

fixes #8959
