### PR TITLE
Workaround for an issue where decorator styles are not applied in any specific order

### DIFF
--- a/framework/source/class/qx/test/theme/manager/Decoration.js
+++ b/framework/source/class/qx/test/theme/manager/Decoration.js
@@ -122,6 +122,34 @@ qx.Class.define("qx.test.theme.manager.Decoration",
       }, function(e) {
         that.assertIdentical(e.getData(), qx.test.Theme.themes.A, "Setting theme failed!");
       });
+    },
+
+
+    testAddCssClass : function()
+    {
+      qx.Theme.define("qx.test.Theme.themes.B", {
+        aliases : {
+          decoration: "test/decoration",
+          custom : "test/custom"
+        },
+        decorations : {
+          "test-add-css": {
+            style: {
+              backgroundColor: "red",
+              backgroundImage: "icon/16/places/folder-open.png"
+            }
+          }
+        }
+      });
+
+      this.manager.setTheme(qx.test.Theme.themes.B);
+      var selector = this.manager.addCssClass("test-add-css");
+      var sheet = qx.ui.style.Stylesheet.getInstance();
+      var elem = document.createElement("div");
+      elem.setAttribute("class", selector);
+      document.body.appendChild(elem);
+      var compStyle = window.getComputedStyle(elem);
+      this.assertEquals("255,0,0", qx.util.ColorUtil.cssStringToRgb(compStyle.getPropertyValue("background-color")));
     }
   }
 });

--- a/framework/source/class/qx/theme/manager/Decoration.js
+++ b/framework/source/class/qx/theme/manager/Decoration.js
@@ -122,8 +122,11 @@ qx.Class.define("qx.theme.manager.Decoration",
       // create and add a CSS rule
       var css = "";
       var styles = instance.getStyles(true);
-      for (var key in styles) {
-
+      
+      // Sort the styles so that more specific styles come after the group styles, 
+      //  eg background-color comes after background
+      var t = this;
+      Object.keys(styles).sort().forEach(function(key) {
         // if we find a map value, use it as pseudo class
         if (qx.Bootstrap.isObject(styles[key])) {
           var innerCss = "";
@@ -133,14 +136,14 @@ qx.Class.define("qx.theme.manager.Decoration",
             inner = true;
             innerCss += innerKey + ":" + innerStyles[innerKey] + ";";
           }
-          var innerSelector = this.__legacyIe ? selector :
+          var innerSelector = t.__legacyIe ? selector :
             selector + (inner ? ":" : "");
-          this.__rules.push(innerSelector + key);
+          t.__rules.push(innerSelector + key);
           sheet.addRule(innerSelector + key, innerCss);
-          continue;
+          return;
         }
         css += key + ":" + styles[key] + ";";
-      }
+      });
 
       if (css) {
         sheet.addRule(selector, css);

--- a/framework/source/class/qx/theme/manager/Decoration.js
+++ b/framework/source/class/qx/theme/manager/Decoration.js
@@ -127,6 +127,7 @@ qx.Class.define("qx.theme.manager.Decoration",
       //  eg background-color comes after background.  The reordering is only applied
       //  to rules which begin with the names in REORDER; the sort order is alphabetical
       //  so that short cut rules come before actual
+      var t = this;
       Object.keys(styles).sort().forEach(function(key) {
         // if we find a map value, use it as pseudo class
         if (qx.Bootstrap.isObject(styles[key])) {

--- a/framework/source/class/qx/theme/manager/Decoration.js
+++ b/framework/source/class/qx/theme/manager/Decoration.js
@@ -127,23 +127,7 @@ qx.Class.define("qx.theme.manager.Decoration",
       //  eg background-color comes after background.  The reordering is only applied
       //  to rules which begin with the names in REORDER; the sort order is alphabetical
       //  so that short cut rules come before actual
-      var t = this;
-      var orderedStyles = [];
-      var unorderedStyles = [];
-      var REORDER = [ "background" ];
-      var savedStyles = {};
-      for (var key in styles) {
-        var needsOrdering = REORDER.some(function(start) {
-          return key.length >= start.length && key.substring(0, start.length) == start;
-        });
-        if (needsOrdering) {
-          unorderedStyles.push(key);
-        } else {
-          orderedStyles.push(key);
-        }
-      }
-      qx.lang.Array.append(orderedStyles, unorderedStyles.sort());
-      orderedStyles.forEach(function(key) {
+      Object.keys(styles).sort().forEach(function(key) {
         // if we find a map value, use it as pseudo class
         if (qx.Bootstrap.isObject(styles[key])) {
           var innerCss = "";

--- a/framework/source/class/qx/theme/manager/Decoration.js
+++ b/framework/source/class/qx/theme/manager/Decoration.js
@@ -124,9 +124,26 @@ qx.Class.define("qx.theme.manager.Decoration",
       var styles = instance.getStyles(true);
       
       // Sort the styles so that more specific styles come after the group styles, 
-      //  eg background-color comes after background
+      //  eg background-color comes after background.  The reordering is only applied
+      //  to rules which begin with the names in REORDER; the sort order is alphabetical
+      //  so that short cut rules come before actual
       var t = this;
-      Object.keys(styles).sort().forEach(function(key) {
+      var orderedStyles = [];
+      var unorderedStyles = [];
+      var REORDER = [ "background" ];
+      var savedStyles = {};
+      for (var key in styles) {
+        var needsOrdering = REORDER.some(function(start) {
+          return key.length >= start.length && key.substring(0, start.length) == start;
+        });
+        if (needsOrdering) {
+          unorderedStyles.push(key);
+        } else {
+          orderedStyles.push(key);
+        }
+      }
+      qx.lang.Array.append(orderedStyles, unorderedStyles.sort());
+      orderedStyles.forEach(function(key) {
         // if we find a map value, use it as pseudo class
         if (qx.Bootstrap.isObject(styles[key])) {
           var innerCss = "";


### PR DESCRIPTION
This fixes a bug where CSS styles are applied in a random order, but order is important eg for `background` must come before `background-color`.

Please see also https://github.com/qooxdoo/qooxdoo/issues/9034
