### PR TITLE
Fixes memory leak in qx.event.message.Bus

### DIFF
--- a/framework/source/class/qx/event/message/Bus.js
+++ b/framework/source/class/qx/event/message/Bus.js
@@ -322,7 +322,16 @@ qx.Class.define("qx.event.message.Bus",
     dispatchByName : function(name, data)
     {
       var message = new qx.event.message.Message(name, data);
-      return this.dispatch(message);
+
+      // Dispatch the message
+      var ret = this.dispatch(message);
+
+      // We instantiated this message, so it's our responsibility to dispose it.
+      message.dispose();
+      message = null;
+
+      // Let 'em know whether this message was dispatched to any subscribers.
+      return ret;
     },
 
 


### PR DESCRIPTION
It is the responsibility of the dude who instantiates an object to ensure that
the object is disposed. The method dispatchByName was instantiating a
qx.event.message.Message object and setting its 'data' property. That data can
be large, and that property data does not get freed (by Chrome 50 nor 52) when
the object goes out of scope.

This commit ensures that the object is properly disposed.

(Note that when the dispatch() method is called directly from outside of
qooxdoo, it is the caller's responsibility to free the message that she has
instantiated and passed in. Only in the case of dispatchByName is the Message
object instantiated internally, and thus must be disposed internally.)

Derrell
