### PR TITLE
"comparator" option for properties

### DIFF
--- a/framework/source/class/qx/core/Property.js
+++ b/framework/source/class/qx/core/Property.js
@@ -273,7 +273,7 @@ qx.Bootstrap.define("qx.core.Property",
       transform    : "string",   // String
       deferredInit : "boolean",  // Boolean
       validate     : null,       // String, Function
-      comparator   : null        // String, Function
+      isEqual      : null        // String, Function
     },
 
 
@@ -814,7 +814,7 @@ qx.Bootstrap.define("qx.core.Property",
 
       var store = this.__getStore(variant, name);
 
-      this.__emitComparatorFunction(code, clazz, config, name);
+      this.__emitIsEqualFunction(code, clazz, config, name);
 
       this.__emitSetterPreConditions(code, config, name, variant, incomingValue);
 
@@ -901,35 +901,35 @@ qx.Bootstrap.define("qx.core.Property",
      * @param config {Object} The property configuration map
      * @param name {String} name of the property
      */
-    __emitComparatorFunction : function (code, clazz, config, name)
+    __emitIsEqualFunction : function (code, clazz, config, name)
     {
       code.push('var equ=');
 
-      if (typeof config.comparator === "function")
+      if (typeof config.isEqual === "function")
       {
         code.push('function(a,b){return !!', clazz.classname, '.$$properties.',
-                  name, '.comparator.call(this,a,b);};');
+                  name, '.isEqual.call(this,a,b);};');
       }
-      else if (typeof config.comparator === "string")
+      else if (typeof config.isEqual === "string")
       {
         var members = clazz.prototype;
         // Name of member?
-        if (members[config.comparator]!==undefined)
+        if (members[config.isEqual]!==undefined)
         {
-          code.push('this.', config.comparator, ';');
+          code.push('this.', config.isEqual, ';');
         }
         else // 'inline' code
         {
-          code.push('function(a,b){return !!(', config.comparator, ');};');
+          code.push('function(a,b){return !!(', config.isEqual, ');};');
         }
       }
-      else if (typeof config.comparator === "undefined")
+      else if (typeof config.isEqual === "undefined")
       {
         code.push('function(a,b){return a===b;};');
       }
       else
       {
-        throw new Error( "Invalid type for 'comparator' attribute " +
+        throw new Error( "Invalid type for 'isEqual' attribute " +
           "of property '" + name + "' in class '" + clazz.classname + "'" );
       }
     },

--- a/framework/source/class/qx/core/Property.js
+++ b/framework/source/class/qx/core/Property.js
@@ -1036,7 +1036,7 @@ qx.Bootstrap.define("qx.core.Property",
       );
 
       if (incomingValue) {
-        code.push('if(equ(this.', store, ',value))return value;');
+        code.push('if(equ.call(this,this.', store, ',value))return value;');
       } else if (resetValue) {
         code.push('if(this.', store, '===undefined)return;');
       }
@@ -1472,7 +1472,7 @@ qx.Bootstrap.define("qx.core.Property",
       code.push('}');
 
       // Compare old/new computed value
-      code.push('if(equ(old,computed))return value;');
+      code.push('if(equ.call(this,old,computed))return value;');
 
       // Note: At this point computed can be "inherit" or "undefined".
 
@@ -1519,7 +1519,7 @@ qx.Bootstrap.define("qx.core.Property",
       }
 
       // Compare old/new computed value
-      code.push('if(equ(old,computed))return value;');
+      code.push('if(equ.call(this,old,computed))return value;');
 
       // Normalize old value
       if (config.init !== undefined && variant !== "init") {

--- a/framework/source/class/qx/test/core/Property.js
+++ b/framework/source/class/qx/test/core/Property.js
@@ -600,6 +600,49 @@ qx.Class.define("qx.test.core.Property",
     },
 
 
+    testWrongComparatorDefinitions : function ()
+    {
+      if (qx.core.Environment.get("qx.debug"))
+      {
+        var re = new RegExp("Invalid type for 'comparator'.*");
+        var o = new qx.core.Object();
+
+        [
+          new Date(),   // date
+          [1,2,3],      // array
+          {},           // object
+          o,            // qooxdoo class
+          new RegExp(), // RegExp
+          null,         // null
+          true, false,  // boolean
+          123           // number
+        ].forEach(function (comparatorTestValue, i) {
+
+          var msg = "case[" + i + "] (" + String(comparatorTestValue) + ")";
+          this.assertException(function ()
+          {
+            qx.Class.define("qx.TestProperty", {
+              extend : qx.core.Object,
+              properties : {
+                prop : {
+                  check : "Number",
+                  comparator : comparatorTestValue
+                }
+              }
+            });
+            new qx.TestProperty().set({prop: 0});
+          }, Error, re, msg);
+
+          delete qx.TestProperty;
+        }, this);
+
+        o.dispose();
+
+      } // end-if (qx.core.Environment.get("qx.debug"))
+
+    },
+
+
     testComparatorInline : function ()
     {
       qx.Class.define("qx.TestProperty", {

--- a/framework/source/class/qx/test/core/Property.js
+++ b/framework/source/class/qx/test/core/Property.js
@@ -818,6 +818,38 @@ qx.Class.define("qx.test.core.Property",
       this.assertIdentical(object, context);
 
       object.dispose();
+    },
+
+
+    testComparatorBaseClassMember : function ()
+    {
+      var context, object;
+
+      qx.Class.define("qx.Super", {
+        extend : qx.core.Object,
+        members : {
+          __checkCtx : function (foo, bar) {
+            context = this;
+          }
+        }
+      });
+      qx.Class.define("qx.TestProperty", {
+        extend: qx.Super,
+        properties : {
+          prop : {
+            check : "Number",
+            nullable : true,
+            event : "changeProp",
+            comparator : "__checkCtx"
+          }
+        }
+      });
+
+      object = new qx.TestProperty().set({prop: 4711});
+
+      this.assertIdentical(object, context);
+
+      object.dispose();
     }
   }
 });

--- a/framework/source/class/qx/test/core/Property.js
+++ b/framework/source/class/qx/test/core/Property.js
@@ -574,7 +574,7 @@ qx.Class.define("qx.test.core.Property",
 
     /*
     ---------------------------------------------------------------------------
-       COMPERATOR OVERRIDE TEST
+       IS-EQUAL OVERRIDE TEST
     ---------------------------------------------------------------------------
     */
 
@@ -600,11 +600,11 @@ qx.Class.define("qx.test.core.Property",
     },
 
 
-    testWrongComparatorDefinitions : function ()
+    testWrongIsEqualDefinitions : function ()
     {
       if (qx.core.Environment.get("qx.debug"))
       {
-        var re = new RegExp("Invalid type for 'comparator'.*");
+        var re = new RegExp("Invalid type for 'isEqual'.*");
         var o = new qx.core.Object();
 
         [
@@ -616,9 +616,9 @@ qx.Class.define("qx.test.core.Property",
           null,         // null
           true, false,  // boolean
           123           // number
-        ].forEach(function (comparatorTestValue, i) {
+        ].forEach(function (isEqualTestValue, i) {
 
-          var msg = "case[" + i + "] (" + String(comparatorTestValue) + ")";
+          var msg = "case[" + i + "] (" + String(isEqualTestValue) + ")";
           this.assertException(function ()
           {
             qx.Class.define("qx.TestProperty", {
@@ -626,7 +626,7 @@ qx.Class.define("qx.test.core.Property",
               properties : {
                 prop : {
                   check : "Number",
-                  comparator : comparatorTestValue
+                  isEqual : isEqualTestValue
                 }
               }
             });
@@ -643,7 +643,7 @@ qx.Class.define("qx.test.core.Property",
     },
 
 
-    testComparatorInline : function ()
+    testIsEqualInline : function ()
     {
       qx.Class.define("qx.TestProperty", {
         extend : qx.core.Object,
@@ -652,7 +652,7 @@ qx.Class.define("qx.test.core.Property",
             check : "Number",
             nullable : true,
             event : "changeProp",
-            comparator : "Object.is(a, b)"
+            isEqual : "Object.is(a, b)"
           }
         }
       });
@@ -687,7 +687,7 @@ qx.Class.define("qx.test.core.Property",
     },
 
 
-    testComparatorFunction : function ()
+    testIsEqualFunction : function ()
     {
       qx.Class.define("qx.TestProperty", {
         extend : qx.core.Object,
@@ -696,7 +696,7 @@ qx.Class.define("qx.test.core.Property",
             check : "Number",
             nullable : true,
             event : "changeProp",
-            comparator : function (x,y) { return Object.is(x, y); }
+            isEqual : function (x,y) { return Object.is(x, y); }
           }
         }
       });
@@ -731,7 +731,7 @@ qx.Class.define("qx.test.core.Property",
     },
 
 
-    testComparatorMember : function ()
+    testIsEqualMember : function ()
     {
       qx.Class.define("qx.TestProperty", {
         extend : qx.core.Object,
@@ -740,7 +740,7 @@ qx.Class.define("qx.test.core.Property",
             check : "Number",
             nullable : true,
             event : "changeProp",
-            comparator : "__fooBar"
+            isEqual : "__fooBar"
           }
         },
         members : {
@@ -780,7 +780,7 @@ qx.Class.define("qx.test.core.Property",
     },
 
 
-    testComparatorInlineContext : function ()
+    testIsEqualInlineContext : function ()
     {
       var context, object;
 
@@ -791,7 +791,7 @@ qx.Class.define("qx.test.core.Property",
             check : "Number",
             nullable : true,
             event : "changeProp",
-            comparator : "(this.__checkCtx(a,b))"
+            isEqual : "(this.__checkCtx(a,b))"
           }
         },
         members : {
@@ -809,7 +809,7 @@ qx.Class.define("qx.test.core.Property",
     },
 
 
-    testComparatorFunctionContext : function ()
+    testIsEqualFunctionContext : function ()
     {
       var context, object;
 
@@ -820,7 +820,7 @@ qx.Class.define("qx.test.core.Property",
             check : "Number",
             nullable : true,
             event : "changeProp",
-            comparator : function (x, y) {
+            isEqual : function (x, y) {
               context = this;
             }
           }
@@ -835,7 +835,7 @@ qx.Class.define("qx.test.core.Property",
     },
 
 
-    testComparatorMemberContext : function ()
+    testIsEqualMemberContext : function ()
     {
       var context, object;
 
@@ -846,7 +846,7 @@ qx.Class.define("qx.test.core.Property",
             check : "Number",
             nullable : true,
             event : "changeProp",
-            comparator : "__checkCtx"
+            isEqual : "__checkCtx"
           }
         },
         members : {
@@ -864,7 +864,7 @@ qx.Class.define("qx.test.core.Property",
     },
 
 
-    testComparatorBaseClassMember : function ()
+    testIsEqualBaseClassMember : function ()
     {
       var context, object;
 
@@ -883,7 +883,7 @@ qx.Class.define("qx.test.core.Property",
             check : "Number",
             nullable : true,
             event : "changeProp",
-            comparator : "__checkCtx"
+            isEqual : "__checkCtx"
           }
         }
       });

--- a/framework/source/class/qx/test/core/Property.js
+++ b/framework/source/class/qx/test/core/Property.js
@@ -734,6 +734,90 @@ qx.Class.define("qx.test.core.Property",
       // @todo: check 'apply' and 'transform', too
 
       object.dispose();
+    },
+
+
+    testComparatorInlineContext : function ()
+    {
+      var context, object;
+
+      qx.Class.define("qx.TestProperty", {
+        extend : qx.core.Object,
+        properties : {
+          prop : {
+            check : "Number",
+            nullable : true,
+            event : "changeProp",
+            comparator : "(this.__checkCtx(a,b))"
+          }
+        },
+        members : {
+          __checkCtx : function (foo, bar) {
+            context = this;
+          }
+        }
+      });
+
+      object = new qx.TestProperty().set({prop: 4711});
+
+      this.assertIdentical(object, context);
+
+      object.dispose();
+    },
+
+
+    testComparatorFunctionContext : function ()
+    {
+      var context, object;
+
+      qx.Class.define("qx.TestProperty", {
+        extend : qx.core.Object,
+        properties : {
+          prop : {
+            check : "Number",
+            nullable : true,
+            event : "changeProp",
+            comparator : function (x, y) {
+              context = this;
+            }
+          }
+        }
+      });
+
+      object = new qx.TestProperty().set({prop: 4711});
+
+      this.assertIdentical(object, context);
+
+      object.dispose();
+    },
+
+
+    testComparatorMemberContext : function ()
+    {
+      var context, object;
+
+      qx.Class.define("qx.TestProperty", {
+        extend : qx.core.Object,
+        properties : {
+          prop : {
+            check : "Number",
+            nullable : true,
+            event : "changeProp",
+            comparator : "__checkCtx"
+          }
+        },
+        members : {
+          __checkCtx : function (foo, bar) {
+            context = this;
+          }
+        }
+      });
+
+      object = new qx.TestProperty().set({prop: 4711});
+
+      this.assertIdentical(object, context);
+
+      object.dispose();
     }
   }
 });

--- a/framework/source/class/qx/test/core/Property.js
+++ b/framework/source/class/qx/test/core/Property.js
@@ -569,7 +569,7 @@ qx.Class.define("qx.test.core.Property",
       }, "Change event not fired!");
 
       object.dispose();
-    }
+    },
 
 
     /*

--- a/framework/source/class/qx/test/core/Property.js
+++ b/framework/source/class/qx/test/core/Property.js
@@ -570,5 +570,170 @@ qx.Class.define("qx.test.core.Property",
 
       object.dispose();
     }
+
+
+    /*
+    ---------------------------------------------------------------------------
+       COMPERATOR OVERRIDE TEST
+    ---------------------------------------------------------------------------
+    */
+
+    /**
+     * Check whether the (numeric) value is negative zero (-0)
+     *
+     * @param value {number} Value to check
+     * @return {Boolean} whether the value is <code>-0</code>
+     */
+    __isNegativeZero : function (value) {
+      return value===0 && (1/value < 0); // 1/-0 => -Infinity
+    },
+
+
+    /**
+     * Check whether the (numeric) value is positive zero (+0)
+     *
+     * @param value {number} Value to check
+     * @return {Boolean} whether the value is <code>+0</code>
+     */
+    __isPositiveZero : function (value) {
+      return value===0 && (1/value > 0); // 1/+0 => +Infinity
+    },
+
+
+    testComparatorInline : function ()
+    {
+      qx.Class.define("qx.TestProperty", {
+        extend : qx.core.Object,
+        properties : {
+          prop : {
+            check : "Number",
+            nullable : true,
+            event : "changeProp",
+            comparator : "Object.is(a, b)"
+          }
+        }
+      });
+
+      var object = new qx.TestProperty();
+      object.setProp(0); // initialize with +0
+
+      //
+      // check for the event
+      //
+      var self = this;
+
+      // No change expected
+      this.assertEventNotFired(object, "changeProp", function () {
+        object.setProp(0);
+        object.setProp(+0);
+      }, function (e) {}, "'changeProp' event fired!");
+
+      // Change expected
+      this.assertEventFired(object, "changeProp", function () {
+        object.setProp(-0);
+      }, function (e) {
+        var isNegativeZero = self.__isNegativeZero( e.getData() );
+        var isPositiveZero = self.__isPositiveZero( e.getOldData() );
+        self.assertTrue(isNegativeZero, "Wrong data in the event!");
+        self.assertTrue(isPositiveZero, "Wrong old data in the event!");
+      }, "Change event not fired!");
+
+      // @todo: check 'apply' and 'transform', too
+
+      object.dispose();
+    },
+
+
+    testComparatorFunction : function ()
+    {
+      qx.Class.define("qx.TestProperty", {
+        extend : qx.core.Object,
+        properties : {
+          prop : {
+            check : "Number",
+            nullable : true,
+            event : "changeProp",
+            comparator : function (x,y) { return Object.is(x, y); }
+          }
+        }
+      });
+
+      var object = new qx.TestProperty();
+      object.setProp(0); // initialize with +0
+
+      //
+      // check for the event
+      //
+      var self = this;
+
+      // No change expected
+      this.assertEventNotFired(object, "changeProp", function () {
+        object.setProp(0);
+        object.setProp(+0);
+      }, function (e) {}, "'changeProp' event fired!");
+
+      // Change expected
+      this.assertEventFired(object, "changeProp", function () {
+        object.setProp(-0);
+      }, function (e) {
+        var isNegativeZero = self.__isNegativeZero( e.getData() );
+        var isPositiveZero = self.__isPositiveZero( e.getOldData() );
+        self.assertTrue(isNegativeZero, "Wrong data in the event!");
+        self.assertTrue(isPositiveZero, "Wrong old data in the event!");
+      }, "Change event not fired!");
+
+      // @todo: check 'apply' and 'transform', too
+
+      object.dispose();
+    },
+
+
+    testComparatorMember : function ()
+    {
+      qx.Class.define("qx.TestProperty", {
+        extend : qx.core.Object,
+        properties : {
+          prop : {
+            check : "Number",
+            nullable : true,
+            event : "changeProp",
+            comparator : "__fooBar"
+          }
+        },
+        members : {
+          __fooBar : function (foo, bar) {
+            return Object.is(foo, bar);
+          }
+        }
+      });
+
+      var object = new qx.TestProperty();
+      object.setProp(0); // initialize with +0
+
+      //
+      // check for the event
+      //
+      var self = this;
+
+      // No change expected
+      this.assertEventNotFired(object, "changeProp", function () {
+        object.setProp(0);
+        object.setProp(+0);
+      }, function (e) {}, "'changeProp' event fired!");
+
+      // Change expected
+      this.assertEventFired(object, "changeProp", function () {
+        object.setProp(-0);
+      }, function (e) {
+        var isNegativeZero = self.__isNegativeZero( e.getData() );
+        var isPositiveZero = self.__isPositiveZero( e.getOldData() );
+        self.assertTrue(isNegativeZero, "Wrong data in the event!");
+        self.assertTrue(isPositiveZero, "Wrong old data in the event!");
+      }, "Change event not fired!");
+
+      // @todo: check 'apply' and 'transform', too
+
+      object.dispose();
+    }
   }
 });


### PR DESCRIPTION
My proposal for the feature request #9039.
Allowed variations for "`comparator`" are
-  `comparator : "a==b" // String` (inline) parameter signature bool::(var a, var b)
-  `comparator : function (a,b) { return a===b; } // Function`
-  `comparator : "__checkIt" // String` (member function)
