### PR TITLE
fix for issue #210

### DIFF
--- a/tool/pylib/ecmascript/backend/api.py
+++ b/tool/pylib/ecmascript/backend/api.py
@@ -1412,10 +1412,15 @@ def dependendClassIterator(docTree, classNode):
     if superClassName:
         directDependencies.append(superClassName)
 
-    for list_ in ["mixins", "interfaces", "superMixins", "superInterfaces"]:
+    for list_ in ["mixins", "interfaces"]:
         listItems = classNode.get(list_, False)
         if listItems:
             directDependencies.extend(listItems.split(","))
+
+    for list_ in ["superMixins", "superInterfaces"]:
+        listNode = classNode.getChild(list_, False)
+        if listNode:
+            directDependencies.extend([depNode.get("name") for depNode in listNode.children])
 
     for dep in directDependencies:
         for cls in dependendClassIterator(docTree, classNodeFromDocTree(docTree, dep)):


### PR DESCRIPTION
This fixes issue #210 for a skeleton app as described in the issue (with two interfaces extending each other).

The underlying bug was that mixins and interfaces where treated like classes when climbing the inheritance hierarchy. Unfortunately, classes encode their super classes as a string attribute in the AST, whereas interfaces (and, I presume, mixins) encode their corresponding super interfaces as a list of dedicated child nodes. So I split the code to treat these different encodings individually.

I haven't tested this extensively, particularly not for mixins. But at least the new code doesn't seem to break things, running 'api-verify' in the framework yielded the same results before and after the change.

Obviously, "the right thing" would be to have the ASTs modelled more homogeniously for those kinds of meta objects, but that would be a major refactoring which I wouldn't dare at the moment.
