### PR TITLE
This fixes issue https://github.com/qooxdoo/qooxdoo/issues/9071 where events are fired incorrectly during startup

### DIFF
--- a/framework/source/class/qx/ui/form/core/VirtualDropDownList.js
+++ b/framework/source/class/qx/ui/form/core/VirtualDropDownList.js
@@ -316,7 +316,6 @@ qx.Class.define("qx.ui.form.core.VirtualDropDownList",
      * @param event {qx.event.type.Data} The change event.
      */
     _onChangeModel : function(event) {
-      this.getSelection().removeAll();
     },
 
 


### PR DESCRIPTION
Please see issue https://github.com/qooxdoo/qooxdoo/issues/9071.

The `getSelection().removeAll()` is not necessary because it is already being kept synchronised via change listener, and event ordering means that `removeAll()` undoes the work done by synchronisation
