### PR TITLE
- made package.json "licenses" property compliant to "https://bintray.com/docs/api/#_get_package" format

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "5.1.0",
   "description": "Universal JavaScript Framework",
   "author": "The qooxdoo project",
-  "license": "LGPL/EPL",
+  "licenses": ["LGPL", "EPL"],
   "homepage": "http://qooxdoo.org",
   "repository": {
     "type": "git",


### PR DESCRIPTION
[issue-9072](https://github.com/qooxdoo/qooxdoo/issues/9072)
- made package.json "licenses" property compliant to "https://bintray.com/docs/api/#_get_package" format
