### PR TITLE
String "startsWith()" and "endsWith()" polyfills ...ECMAScript 2015 (6th Edition, ECMA-262)

### DIFF
--- a/framework/source/class/qx/bom/client/EcmaScript.js
+++ b/framework/source/class/qx/bom/client/EcmaScript.js
@@ -207,6 +207,27 @@ qx.Bootstrap.define("qx.bom.client.EcmaScript",
       return !!Date.now;
     },
 
+
+    /**
+     * Checks if 'startsWith' is supported on the String object.
+     * @internal
+     * @return {Boolean} <code>true</code>, if the method is available.
+     */
+    getStringStartsWith : function() {
+      return typeof String.prototype.startsWith === "function";
+    },
+
+
+    /**
+     * Checks if 'endsWith' is supported on the String object.
+     * @internal
+     * @return {Boolean} <code>true</code>, if the method is available.
+     */
+    getStringEndsWith : function() {
+      return typeof String.prototype.endsWith === "function";
+    },
+
+
     /**
      * Checks if 'trim' is supported on the String object.
      * @internal
@@ -246,6 +267,8 @@ qx.Bootstrap.define("qx.bom.client.EcmaScript",
     qx.core.Environment.add("ecmascript.object.keys", statics.getObjectKeys);
 
     // string polyfill
+    qx.core.Environment.add("ecmascript.string.startsWith", statics.getStringStartsWith);
+    qx.core.Environment.add("ecmascript.string.endsWith", statics.getStringEndsWith);
     qx.core.Environment.add("ecmascript.string.trim", statics.getStringTrim);
   }
 });

--- a/framework/source/class/qx/core/Environment.js
+++ b/framework/source/class/qx/core/Environment.js
@@ -287,6 +287,14 @@
  *       <td>{@link qx.bom.client.EcmaScript#getStringTrim}</td>
  *     </tr>
  *     <tr>
+ *       <td>ecmascript.string.startsWith</td><td><i>Boolean</i></td><td><code>true</code></td>
+ *       <td>{@link qx.bom.client.EcmaScript#getStringStartsWith}</td>
+ *     </tr>
+ *     <tr>
+ *       <td>ecmascript.string.endsWith</td><td><i>Boolean</i></td><td><code>true</code></td>
+ *       <td>{@link qx.bom.client.EcmaScript#getStringEndsWith}</td>
+ *     </tr>
+ *     <tr>
  *       <td colspan="4"><b>engine</b></td>
  *     </tr>
  *     <tr>

--- a/framework/source/class/qx/lang/String.js
+++ b/framework/source/class/qx/lang/String.js
@@ -189,24 +189,28 @@ qx.Bootstrap.define("qx.lang.String",
     /**
      * Check whether the string starts with the given substring
      *
+     * @deprecated {6.0} Please use String instance startsWith method instead
+     *
      * @param fullstr {String} the string to search in
      * @param substr {String} the substring to look for
      * @return {Boolean} whether the string starts with the given substring
      */
     startsWith : function(fullstr, substr) {
-      return fullstr.indexOf(substr) === 0;
+      return fullstr.startsWith(substr);
     },
 
 
     /**
      * Check whether the string ends with the given substring
      *
+     * @deprecated {6.0} Please use String instance endsWith method instead
+     *
      * @param fullstr {String} the string to search in
      * @param substr {String} the substring to look for
      * @return {Boolean} whether the string ends with the given substring
      */
     endsWith : function(fullstr, substr) {
-      return fullstr.substring(fullstr.length - substr.length, fullstr.length) === substr;
+      return fullstr.endsWith(fullstr);
     },
 
 

--- a/framework/source/class/qx/lang/String.js
+++ b/framework/source/class/qx/lang/String.js
@@ -210,7 +210,7 @@ qx.Bootstrap.define("qx.lang.String",
      * @return {Boolean} whether the string ends with the given substring
      */
     endsWith : function(fullstr, substr) {
-      return fullstr.endsWith(fullstr);
+      return fullstr.endsWith(substr);
     },
 
 

--- a/framework/source/class/qx/lang/normalize/String.js
+++ b/framework/source/class/qx/lang/normalize/String.js
@@ -38,13 +38,66 @@ qx.Bootstrap.define("qx.lang.normalize.String", {
      */
     trim : function() {
       return this.replace(/^\s+|\s+$/g,'');
+    },
+
+
+    /**
+     * Determines whether a string begins with the characters of another
+     * string, returning true or false as appropriate.
+     *
+     * @param searchString {String} The characters to be searched for at the
+     *   start of this string.
+     * @param position {Integer?0} The position in this string at which to
+     *   begin searching for <code>searchString</code>.
+     * @return {Boolean} Whether the string begins with the other string.
+     */
+    startsWith : function (searchString, position)
+    {
+      position = position || 0;
+      return this.substr(position, searchString.length) === searchString;
+    },
+
+
+    /**
+     * Determines whether a ends with the characters of another string,
+     * returning true or false as appropriate.
+     *
+     * @param searchString {String} The characters to be searched for at the
+     *   end of this string.
+     * @param position {Integer?length} Search within this string as if this
+     *   string were only this long; defaults to this string's actual length,
+     *   clamped within the range established by this string's length.
+     * @return {Boolean} Whether the string ends with the other string.
+     */
+    endsWith : function (searchString, position)
+    {
+      var subjectString = this.toString();
+      if (  typeof position !== 'number'
+         || !isFinite(position)
+         || Math.floor(position) !== position
+         || position > subjectString.length ) {
+        position = subjectString.length;
+      }
+      position -= searchString.length;
+      var lastIndex = subjectString.indexOf(searchString, position);
+      return lastIndex !== -1 && lastIndex === position;
     }
+
   },
 
-  defer : function(statics) {
+  defer : function(statics)
+  {
     // trim
     if (!qx.core.Environment.get("ecmascript.string.trim")) {
       String.prototype.trim = statics.trim;
+    }
+    // startsWith
+    if (!qx.core.Environment.get("ecmascript.string.startsWith")) {
+      String.prototype.startsWith = statics.startsWith;
+    }
+    // endsWith
+    if (!qx.core.Environment.get("ecmascript.string.endsWith")) {
+      String.prototype.endsWith = statics.endsWith;
     }
   }
 });

--- a/framework/source/class/qx/test/core/Environment.js
+++ b/framework/source/class/qx/test/core/Environment.js
@@ -456,6 +456,9 @@ qx.Class.define("qx.test.core.Environment",
       this.assertBoolean(qx.core.Environment.get("ecmascript.object.keys"));
       this.assertBoolean(qx.core.Environment.get("ecmascript.date.now"));
       this.assertBoolean(qx.core.Environment.get("ecmascript.error.toString"));
+      this.assertBoolean(qx.core.Environment.get("ecmascript.string.trim"));
+      this.assertBoolean(qx.core.Environment.get("ecmascript.string.endsWith"));
+      this.assertBoolean(qx.core.Environment.get("ecmascript.string.startsWith"));
     },
 
     testDataUrl : function() {

--- a/framework/source/class/qx/test/lang/normalize/String.js
+++ b/framework/source/class/qx/test/lang/normalize/String.js
@@ -28,10 +28,31 @@ qx.Class.define("qx.test.lang.normalize.String",
 
   members :
   {
-    testTrim : function() {
+    "test trim()" : function ()
+    {
       this.assertEquals("y", "   y".trim());
       this.assertEquals("y", "y   ".trim());
       this.assertEquals("y", " y  ".trim());
+    },
+
+
+    "test startsWith()" : function ()
+    {
+      var str = "To be, or not to be, that is the question.";
+
+      this.assertTrue ( str.startsWith("To be")         ); // true
+      this.assertFalse( str.startsWith("not to be")     ); // false
+      this.assertTrue ( str.startsWith("not to be", 10) ); // true
+    }
+
+
+    "test endsWith()" : function ()
+    {
+      var str = "To be, or not to be, that is the question.";
+
+      this.assertTrue ( str.endsWith("question.") ); // true
+      this.assertFalse( str.endsWith("to be")     ); // false
+      this.assertTrue ( str.endsWith("to be", 19) ); // true
     }
   }
 });

--- a/framework/source/class/qx/test/lang/normalize/String.js
+++ b/framework/source/class/qx/test/lang/normalize/String.js
@@ -53,6 +53,21 @@ qx.Class.define("qx.test.lang.normalize.String",
       this.assertTrue ( str.endsWith("question.") ); // true
       this.assertFalse( str.endsWith("to be")     ); // false
       this.assertTrue ( str.endsWith("to be", 19) ); // true
+
+      //
+      // Increase test covarage
+      //
+
+      // not finite
+      this.assertTrue ( str.endsWith("question.", Number.POSITIVE_INFINITY) );
+      this.assertFalse( str.endsWith("to be"    , Number.POSITIVE_INFINITY) );
+      // float
+      this.assertTrue ( str.endsWith("question.", 42.2) );
+      this.assertFalse( str.endsWith("to be"    , 42.2) );
+      // len > str.length
+      this.assertTrue ( str.endsWith("question.", 43) );
+      this.assertFalse( str.endsWith("to be"    , 43) );
+
     }
   }
 });

--- a/framework/source/class/qx/test/lang/normalize/String.js
+++ b/framework/source/class/qx/test/lang/normalize/String.js
@@ -43,7 +43,7 @@ qx.Class.define("qx.test.lang.normalize.String",
       this.assertTrue ( str.startsWith("To be")         ); // true
       this.assertFalse( str.startsWith("not to be")     ); // false
       this.assertTrue ( str.startsWith("not to be", 10) ); // true
-    }
+    },
 
 
     "test endsWith()" : function ()


### PR DESCRIPTION
Hi there,

here's my PR for the polyfills for the String prototype methods `startsWith` and `endsWith`.

I always found it irritating that there are still some clients (IE) missing this and I had to use
`qx.lang.String.startsWith(str, "foo")` instead of the easy to read `str.startsWith("foo")` :smile: 

Including tests & environment checks

References:
https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/startsWith
https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/endsWith
