### PR TITLE
Custom form fields, missing array and model field interfaces

### DIFF
--- a/framework/source/class/qx/test/data/controller/FormWithArrayAndModel.js
+++ b/framework/source/class/qx/test/data/controller/FormWithArrayAndModel.js
@@ -8,8 +8,7 @@
      2016 Martijn Evers, The Netherlands
 
    License:
-     LGPL: http://www.gnu.org/licenses/lgpl.html
-     EPL: http://www.eclipse.org/org/documents/epl-v10.php
+     MIT: https://opensource.org/licenses/MIT
      See the LICENSE file in the project's top-level directory for details.
 
    Authors:

--- a/framework/source/class/qx/test/data/controller/FormWithArrayAndModel.js
+++ b/framework/source/class/qx/test/data/controller/FormWithArrayAndModel.js
@@ -1,0 +1,146 @@
+/* ************************************************************************
+
+   qooxdoo - the new era of web development
+
+   http://qooxdoo.org
+
+   Copyright:
+     2016 Martijn Evers, The Netherlands
+
+   License:
+     LGPL: http://www.gnu.org/licenses/lgpl.html
+     EPL: http://www.eclipse.org/org/documents/epl-v10.php
+     See the LICENSE file in the project's top-level directory for details.
+
+   Authors:
+     * Martijn Evers (mever)
+
+************************************************************************ */
+
+/**
+ * @ignore(qx.test.data.controller.fixture.ArrayField)
+ */
+
+qx.Class.define("qx.test.data.controller.FormWithArrayAndModel",
+{
+  extend : qx.dev.unit.TestCase,
+
+  members :
+  {
+    /** @type {qx.test.data.controller.fixture.ArrayField} */
+    __arrayField : null,
+
+    /** @type {qx.ui.form.Form} */
+    __form : null,
+
+    /** @type {qx.core.Object} */
+    __model : null,
+
+
+    setUp : function() {
+
+      // imagine me being a table like widget containing two columns
+      qx.Class.define("qx.test.data.controller.fixture.ArrayField", {
+        extend : qx.ui.core.Widget,
+        implement : [ qx.ui.form.IArrayForm, qx.ui.form.IForm ],
+        include : [ qx.ui.form.MForm ],
+
+        events : {
+          changeValue : "qx.event.type.Data"
+        },
+
+        members : {
+          /** @type {qx.data.Array|null} */
+          __value : null,
+
+          /**
+           * @param value {qx.data.Array|null}
+           * @returns void
+           */
+          setValue : function(value) {
+            var oldValue = this.__value;
+            this.__value = value;
+            this.fireDataEvent("changeValue", value, oldValue);
+          },
+
+          /**
+           * @returns {qx.data.Array|null}
+           */
+          getValue : function() {return this.__value;},
+
+          /**
+           * @returns void
+           */
+          resetValue : function() {this.__value = null;}
+        }
+      });
+
+      this.__arrayField = new qx.test.data.controller.fixture.ArrayField();
+
+      this.__form = new qx.ui.form.Form();
+      this.__form.add(this.__arrayField, "One", null, "f1");
+
+      this.__model = qx.data.marshal.Json.createModel({f1: null, f2: null});
+    },
+
+
+    tearDown : function() {
+      this._disposeObjects("__arrayField", "__form", "__model");
+      qx.Class.undefine("qx.test.data.controller.fixture.ArrayField");
+    },
+
+
+    "test self update" : function() {
+      var arr = qx.data.marshal.Json.createModel([{c1: "1a1", c2: "1a2"}, {c1: "1b1", c2: "1b2"}]);
+      arr.setAutoDisposeItems(true);
+      this.__arrayField.setValue(arr);
+
+      // sync form and model, model (null) takes preference over form (arr)
+      var ctrl = new qx.data.controller.Form(this.__model, this.__form, true);
+      this.assertNull(this.__arrayField.getValue());
+      this.assertNull(this.__model.getF1());
+
+      // user changes field and hits ok button
+      this.__arrayField.setValue(arr);
+      ctrl.updateModel();
+
+      this.assertIdentical(arr, this.__model.getF1());
+      ctrl.dispose();
+      arr.dispose();
+    },
+
+
+    "test updating view" : function() {
+      var arr = qx.data.marshal.Json.createModel([{c1: "2a1", c2: "2a2"}, {c1: "2b1", c2: "2b2"}]);
+      arr.setAutoDisposeItems(true);
+      this.__arrayField.setValue(arr);
+
+      // sync form and model, model (null) takes preference over form (arr)
+      var ctrl = new qx.data.controller.Form(this.__model, this.__form);
+      this.assertNull(this.__arrayField.getValue());
+      this.assertNull(this.__model.getF1());
+
+      // user changes field and hits ok button
+      this.__arrayField.setValue(arr);
+
+      this.assertIdentical(arr, this.__model.getF1());
+      ctrl.dispose();
+      arr.dispose();
+    },
+
+
+    "test updating model" : function() {
+      var arr = qx.data.marshal.Json.createModel([{c1: "2a1", c2: "2a2"}, {c1: "2b1", c2: "2b2"}]);
+      arr.setAutoDisposeItems(true);
+
+      var ctrl = new qx.data.controller.Form(this.__model, this.__form);
+
+      // change model, view should follow
+      this.__model.setF1(arr);
+
+      this.assertIdentical(arr, this.__arrayField.getValue());
+      ctrl.dispose();
+      arr.dispose();
+    }
+  }
+});

--- a/framework/source/class/qx/test/ui/form/FormManager.js
+++ b/framework/source/class/qx/test/ui/form/FormManager.js
@@ -568,6 +568,22 @@ qx.Class.define("qx.test.ui.form.FormManager",
       (new qx.ui.form.renderer.Double(this.__form)).dispose();
 
       b1.dispose();
+    },
+
+    testGetItem : function()
+    {
+      var f1 = new qx.ui.form.TextField();
+      var f2 = new qx.ui.form.TextField();
+      var f3 = new qx.ui.form.TextField();
+      this.__form.add(f1, "a");
+      this.__form.add(f2, "c");
+      this.__form.add(f3, "label", null, "x");
+      this.assertIdentical(f1, this.__form.getItem("a"));
+      this.assertNull(this.__form.getItem("b"));
+      this.assertIdentical(f2, this.__form.getItem("c"));
+      this.assertNull(this.__form.getItem("label"));
+      this.assertIdentical(f3, this.__form.getItem("x"));
+      [f1, f2, f3].forEach(function(o) {o.dispose();});
     }
 
   }

--- a/framework/source/class/qx/ui/form/Form.js
+++ b/framework/source/class/qx/ui/form/Form.js
@@ -291,6 +291,26 @@ qx.Class.define("qx.ui.form.Form",
     },
 
 
+    /**
+     * Return an item by name.
+     *
+     * @param name {string} Item name.
+     * @return {qx.ui.form.IForm|null} The form item or null.
+     */
+    getItem : function(name) {
+      for (var i = 0; i < this.__groups.length; i++) {
+        var group = this.__groups[i];
+        for (var j = 0; j < group.names.length; j++) {
+          if (group.names[j] === name) {
+            return group.items[j];
+          }
+        }
+      }
+
+      return null;
+    },
+
+
     /*
     ---------------------------------------------------------------------------
        RESET SUPPORT

--- a/framework/source/class/qx/ui/form/IArrayForm.js
+++ b/framework/source/class/qx/ui/form/IArrayForm.js
@@ -8,8 +8,7 @@
      2016 Martijn Evers, The Netherlands
 
    License:
-     LGPL: http://www.gnu.org/licenses/lgpl.html
-     EPL: http://www.eclipse.org/org/documents/epl-v10.php
+     MIT: https://opensource.org/licenses/MIT
      See the LICENSE file in the project's top-level directory for details.
 
    Authors:

--- a/framework/source/class/qx/ui/form/IArrayForm.js
+++ b/framework/source/class/qx/ui/form/IArrayForm.js
@@ -1,0 +1,76 @@
+/* ************************************************************************
+
+   qooxdoo - the new era of web development
+
+   http://qooxdoo.org
+
+   Copyright:
+     2016 Martijn Evers, The Netherlands
+
+   License:
+     LGPL: http://www.gnu.org/licenses/lgpl.html
+     EPL: http://www.eclipse.org/org/documents/epl-v10.php
+     See the LICENSE file in the project's top-level directory for details.
+
+   Authors:
+     * Martijn Evers (mever)
+
+************************************************************************ */
+
+/**
+ * Form interface for all form widgets which have arrays as their primary data type.
+ */
+qx.Interface.define("qx.ui.form.IArrayForm",
+{
+  /*
+  *****************************************************************************
+     EVENTS
+  *****************************************************************************
+  */
+
+  events :
+  {
+    /** Fired when the value was modified */
+    "changeValue" : "qx.event.type.Data"
+  },
+
+
+
+  /*
+  *****************************************************************************
+     MEMBERS
+  *****************************************************************************
+  */
+
+  members :
+  {
+    /*
+    ---------------------------------------------------------------------------
+      VALUE PROPERTY
+    ---------------------------------------------------------------------------
+    */
+
+    /**
+     * Sets the element's value.
+     *
+     * @param value {qx.data.Array|null} The new value of the element.
+     */
+    setValue : function(value) {
+      return arguments.length == 1;
+    },
+
+
+    /**
+     * Resets the element's value to its initial value.
+     */
+    resetValue : function() {},
+
+
+    /**
+     * The element's user set value.
+     *
+     * @return {qx.data.Array|null} The value.
+     */
+    getValue : function() {}
+  }
+});

--- a/framework/source/class/qx/ui/form/IModelForm.js
+++ b/framework/source/class/qx/ui/form/IModelForm.js
@@ -8,8 +8,7 @@
      2016 Martijn Evers, The Netherlands
 
    License:
-     LGPL: http://www.gnu.org/licenses/lgpl.html
-     EPL: http://www.eclipse.org/org/documents/epl-v10.php
+     MIT: https://opensource.org/licenses/MIT
      See the LICENSE file in the project's top-level directory for details.
 
    Authors:

--- a/framework/source/class/qx/ui/form/IModelForm.js
+++ b/framework/source/class/qx/ui/form/IModelForm.js
@@ -1,0 +1,77 @@
+/* ************************************************************************
+
+   qooxdoo - the new era of web development
+
+   http://qooxdoo.org
+
+   Copyright:
+     2016 Martijn Evers, The Netherlands
+
+   License:
+     LGPL: http://www.gnu.org/licenses/lgpl.html
+     EPL: http://www.eclipse.org/org/documents/epl-v10.php
+     See the LICENSE file in the project's top-level directory for details.
+
+   Authors:
+     * Martijn Evers (mever)
+
+************************************************************************ */
+
+/**
+ * Form interface for all form widgets which have an
+ * model object (i.e. {qx.core.Object}) as their primary data type.
+ */
+qx.Interface.define("qx.ui.form.IModelForm",
+{
+  /*
+  *****************************************************************************
+     EVENTS
+  *****************************************************************************
+  */
+
+  events :
+  {
+    /** Fired when the value was modified */
+    "changeValue" : "qx.event.type.Data"
+  },
+
+
+
+  /*
+  *****************************************************************************
+     MEMBERS
+  *****************************************************************************
+  */
+
+  members :
+  {
+    /*
+    ---------------------------------------------------------------------------
+      VALUE PROPERTY
+    ---------------------------------------------------------------------------
+    */
+
+    /**
+     * Sets the element's value.
+     *
+     * @param value {qx.core.Object|null} The new value of the element.
+     */
+    setValue : function(value) {
+      return arguments.length == 1;
+    },
+
+
+    /**
+     * Resets the element's value to its initial value.
+     */
+    resetValue : function() {},
+
+
+    /**
+     * The element's user set value.
+     *
+     * @return {qx.core.Object|null} The value.
+     */
+    getValue : function() {}
+  }
+});

--- a/framework/source/class/qx/ui/form/Resetter.js
+++ b/framework/source/class/qx/ui/form/Resetter.js
@@ -244,6 +244,7 @@ qx.Class.define("qx.ui.form.Resetter",
         qx.Class.hasInterface(clazz, qx.ui.form.IColorForm) ||
         qx.Class.hasInterface(clazz, qx.ui.form.IDateForm) ||
         qx.Class.hasInterface(clazz, qx.ui.form.INumberForm) ||
+        qx.Class.hasInterface(clazz, qx.ui.form.IArrayForm) ||
         qx.Class.hasInterface(clazz, qx.ui.form.IStringForm)
       );
     }

--- a/framework/source/class/qx/ui/form/Resetter.js
+++ b/framework/source/class/qx/ui/form/Resetter.js
@@ -245,6 +245,7 @@ qx.Class.define("qx.ui.form.Resetter",
         qx.Class.hasInterface(clazz, qx.ui.form.IDateForm) ||
         qx.Class.hasInterface(clazz, qx.ui.form.INumberForm) ||
         qx.Class.hasInterface(clazz, qx.ui.form.IArrayForm) ||
+        qx.Class.hasInterface(clazz, qx.ui.form.IModelForm) ||
         qx.Class.hasInterface(clazz, qx.ui.form.IStringForm)
       );
     }


### PR DESCRIPTION
Hello,

To make a new field for cooperation with the form component one needs to implement `{qx.ui.form.IForm}` and an interface for setting, getting and resetting the input value. Currently these interfaces have been defined for the latter (all from the `{qx.ui.form}` package):
`IRange`, `INumberForm`, `IStringForm`, `IDateForm`, `IColorForm`, `IBooleanForm` and the little more complicated; `IModelSelection`. Leaving out `{qx.ui.form.IExecutable}` and `{qx.ui.form.IModel}` as those are not meant for accessing the input value, the later only as model for the selection which is actually representing the input value.

The two interfaces I am missing now (from the `{qx.ui.form}` package) are: `IArrayForm` and `IModelForm`. Allowing access to {qx.data.Array} and {qx.core.Object} values, respectively.

I also think it shouldn't matter if the form knows if a field contains a selection or not. In some fields the input value may be a selection while in others the input value may be a list. Both input values represented by an `{qx.data.Array}`. While the former field has a model from which the selection is derived, the later has none (as the value is directly added by the end-user). But this is a side track I would like to discuss further before making a PR.

Using this perspective of the form component I already build a form manager which replaced the task of form controller in my application, allowing form models with nested values (i.e. order model with order lines array). This manager already uses these 'complex' fields using downstream constructs. But now I am confident enough to discuss the possibility of adding them as interfaces upstream.

If the community likes this approach I am happy to contribute a PR.

Regards,
Martijn
