### PR TITLE
Improve performance when adding widgets

### DIFF
--- a/framework/source/class/qx/ui/core/queue/Appearance.js
+++ b/framework/source/class/qx/ui/core/queue/Appearance.js
@@ -28,6 +28,9 @@ qx.Class.define("qx.ui.core.queue.Appearance",
   {
     /** @type {Array} This contains all the queued widgets for the next flush. */
     __queue : [],
+    
+    /** @type {Map} map of widgets by hash code which are in the queue */
+    __lookup : {},
 
 
     /**
@@ -37,7 +40,10 @@ qx.Class.define("qx.ui.core.queue.Appearance",
      * @param widget {qx.ui.core.Widget} The widget to clear
      */
     remove : function(widget) {
-      qx.lang.Array.remove(this.__queue, widget);
+    	if (this.__lookup[widget.$$hash]) {
+    		qx.lang.Array.remove(this.__queue, widget);
+    		delete this.__lookup[widget.$$hash];
+    	}
     },
 
 
@@ -50,12 +56,12 @@ qx.Class.define("qx.ui.core.queue.Appearance",
      */
     add : function(widget)
     {
-      var queue = this.__queue;
-      if (qx.lang.Array.contains(queue, widget)) {
+      if (this.__lookup[widget.$$hash]) {
         return;
       }
 
-      queue.unshift(widget);
+      this.__queue.unshift(widget);
+      this.__lookup[widget.$$hash] = widget;
       qx.ui.core.queue.Manager.scheduleFlush("appearance");
     },
 
@@ -67,7 +73,7 @@ qx.Class.define("qx.ui.core.queue.Appearance",
      * @return {Boolean} <code>true</code> if the widget is queued
      */
     has : function(widget) {
-      return qx.lang.Array.contains(this.__queue, widget);
+      return !!this.__lookup[widget.$$hash];
     },
 
 
@@ -88,6 +94,7 @@ qx.Class.define("qx.ui.core.queue.Appearance",
         // Order is important to allow the same widget to be re-queued directly
         obj = queue[i];
         queue.splice(i, 1);
+        delete this.__lookup[obj.$$hash]
 
         // Only apply to currently visible widgets
         if (Visibility.isVisible(obj)) {

--- a/framework/source/class/qx/ui/core/queue/Visibility.js
+++ b/framework/source/class/qx/ui/core/queue/Visibility.js
@@ -27,6 +27,9 @@ qx.Class.define("qx.ui.core.queue.Visibility",
   {
     /** @type {Array} This contains all the queued widgets for the next flush. */
     __queue : [],
+    
+    /** @type {Map} map of widgets by hash code which are in the queue */
+    __lookup : {},
 
 
     /** @type {Map} Maps hash codes to visibility */
@@ -41,8 +44,11 @@ qx.Class.define("qx.ui.core.queue.Visibility",
      */
     remove : function(widget)
     {
+    	if (this.__lookup[widget.$$hash]) {
+	      delete this.__lookup[widget.$$hash];
+	      qx.lang.Array.remove(this.__queue, widget);
+    	}
       delete this.__data[widget.$$hash];
-      qx.lang.Array.remove(this.__queue, widget);
     },
 
 
@@ -101,12 +107,12 @@ qx.Class.define("qx.ui.core.queue.Visibility",
      */
     add : function(widget)
     {
-      var queue = this.__queue;
-      if (qx.lang.Array.contains(queue, widget)) {
+      if (this.__lookup[widget.$$hash]) {
         return;
       }
 
-      queue.unshift(widget);
+      this.__queue.unshift(widget);
+      this.__lookup[widget.$$hash] = widget;
       qx.ui.core.queue.Manager.scheduleFlush("visibility");
     },
 
@@ -168,6 +174,7 @@ qx.Class.define("qx.ui.core.queue.Visibility",
 
       // Recreate the array is cheaper compared to keep a sparse array over time
       this.__queue = [];
+      this.__lookup = {};
     }
   }
 });


### PR DESCRIPTION
When adding widgets to an application, the time taken to add a widget increases proportionally to the number of widgets which are being created.  Once the program stops adding widgets and allows the UI to be drawn, the time it takes resets to “normal”.  This is because when a widget is created, it is added to a queue for UI rendering (`qx.ui.core.queue.Appearance`) and another for detection of visibility (`qx.ui.core.queue.Visibility`), and the larger these queues get the longer it takes to add to the queue because the queues are backed by arrays and `qx.lang.Array.contains` is used to prevent duplicates (i.e. a linear, unindexed search is used).  

Note that this slow down happens whether the parent widget is added to the UI or not - so for example, adding the widgets to a `qx.ui.tabview.Page` but not adding that page to a `TabView` does not prevent the slow down.

The demo app http://tinyurl.com/z24qx6r creates 10 `qx.ui.tabview.Page`’s with identical content; this is the time taken to create each page:

```
page 0: 164ms
page 1: 175ms
page 2: 268ms
page 3: 350ms
page 4: 384ms
page 5: 424ms
page 6: 483ms
page 7: 537ms
page 8: 590ms
page 9: 652ms
```

This PR patches the code to use a lookup via widget hash code instead of scanning the array; this changes the timings so that they are at least as good as before, and are not affected by the size of the queue:

```
page 0: 160ms
page 1: 137ms
page 2: 132ms
page 3: 135ms
page 4: 125ms
page 5: 133ms
page 6: 135ms
page 7: 163ms
page 8: 126ms
page 9: 128ms
```

The time taken actually reduces, presumably because the browser’s optimiser is able to help, in this case with a further 22% improvement in performance.
