### PR TITLE
Improve filtering performance on table

### DIFF
--- a/framework/source/class/qx/core/Assert.js
+++ b/framework/source/class/qx/core/Assert.js
@@ -471,6 +471,24 @@ qx.Bootstrap.define("qx.core.Assert",
 
 
     /**
+     * Assert that the value is NOT an item in the given array
+     *
+     * @param value {var} Value to check
+     * @param array {Array} List of values
+     * @param msg {String} Message to be shown if the assertion fails
+     */
+    assertNotInArray : function(value, array, msg) {
+      array.indexOf(value) === -1 || this.__fail(
+          msg || "",
+          qx.lang.String.format(
+            "The value '%1' must not have any of the values defined in the array '%2'",
+            [value, array]
+          )
+        );
+    },
+
+
+    /**
      * Assert that both array have identical array items.
      *
      * @param expected {Array} The expected array

--- a/framework/source/class/qx/core/MAssert.js
+++ b/framework/source/class/qx/core/MAssert.js
@@ -266,6 +266,18 @@ qx.Mixin.define("qx.core.MAssert",
 
 
     /**
+     * Assert that the value is NOT an item in the given array
+     *
+     * @param value {var} Value to check
+     * @param array {Array} List of values
+     * @param msg {String} Message to be shown if the assertion fails
+     */
+    assertNotInArray : function(value, array, msg) {
+      qx.core.Assert.assertNotInArray(value, array, msg);
+    },
+
+
+    /**
      * Assert that both array have identical array items.
      *
      * @param expected {Array} The expected array

--- a/framework/source/class/qx/test/ui/table/model/Filtered.js
+++ b/framework/source/class/qx/test/ui/table/model/Filtered.js
@@ -46,44 +46,89 @@ qx.Class.define("qx.test.ui.table.model.Filtered",
       }];
       table.getTableModel().setColumns(["a"]);
       table.getTableModel().setDataAsMapArray(data);
-      table.getTableModel().addBetweenFilter("!between", 4, 6, "a");
-      table.getTableModel().applyFilters();
       return table;
     },
-    testSimple : function()
-    {
-      var table = this.createTable();
-      this.assertIdentical(3, table.getTableModel().getRowCount(), "Only 3 rows are not filtered");
-      
-      table.destroy();
-    },
-    testInArray : function()
-    {
-      var table = this.createTable();
-      var data = table.getTableModel().getDataAsMapArray();
-      var listA = [];
-      for (var i = 0; i < data.length; ++i) {
-        listA.push(data[i]['a']);
-      }
-      this.assertInArray(4, listA, "Must be in array");
-      this.assertInArray(5, listA, "Must be in array");
-      this.assertInArray(6, listA, "Must be in array");
-      
-      table.destroy();
-    },
-    testNotInArray : function()
-    {
-      var table = this.createTable();
-      var data = table.getTableModel().getDataAsMapArray();
-      var listA = [];
-      for (var i = 0; i < data.length; ++i) {
-        listA.push(data[i]['a']);
-      }
 
-      // assertNotInArray function could be useful in qx.dev.unit.TestCase class
-      this.assert(listA.indexOf(3) == -1, "Must not be in array");
-      this.assert(listA.indexOf(7) == -1, "Must not be in array");
-      
+    testBetween : function()
+    {
+      var table = this.createTable();
+      var model = table.getTableModel();
+
+      model.addBetweenFilter("!between", 4, 6, "a");
+      model.applyFilters();
+
+      this.assertIdentical(3, model.getRowCount());
+
+      var data = model.getDataAsMapArray();
+      var listA = [];
+
+      data.forEach(function(obj) {
+        listA.push(obj.a);
+      });
+
+      this.assertNotInArray(3, listA);
+      this.assertInArray(4, listA);
+      this.assertInArray(5, listA);
+      this.assertInArray(6, listA);
+      this.assertNotInArray(7, listA);
+
+      table.destroy();
+    },
+
+    testNotBetween : function()
+    {
+      var table = this.createTable();
+      var model = table.getTableModel();
+
+      model.addBetweenFilter("between", 2, 8, "a");
+      model.applyFilters();
+
+      var data = table.getTableModel().getDataAsMapArray();
+      var listA = [];
+
+      data.forEach(function(obj) {
+        listA.push(obj.a);
+      });
+
+      this.assertNotInArray(3, listA);
+      this.assertNotInArray(7, listA);
+      this.assertInArray(1, listA);
+      this.assertInArray(9, listA);
+
+      table.destroy();
+    },
+
+    testNumericFilter : function()
+    {
+      var table = this.createTable();
+      var model = table.getTableModel();
+
+      model.addNumericFilter("==", 8, "a");
+      model.applyFilters();
+
+      this.assertIdentical(9, model.getRowCount());
+
+      model.resetHiddenRows();
+
+      model.addNumericFilter("<", 4, "a");
+      model.applyFilters();
+
+      this.assertIdentical(7, model.getRowCount());
+
+      model.resetHiddenRows();
+
+      model.addNumericFilter(">=", 9, "a");
+      model.applyFilters();
+
+      this.assertIdentical(8, model.getRowCount());
+
+      model.resetHiddenRows();
+
+      model.addNumericFilter("!=", 1, "a");
+      model.applyFilters();
+
+      this.assertIdentical(1, model.getRowCount());
+
       table.destroy();
     }
   }

--- a/framework/source/class/qx/ui/table/model/Filtered.js
+++ b/framework/source/class/qx/ui/table/model/Filtered.js
@@ -108,11 +108,19 @@ qx.Class.define("qx.ui.table.model.Filtered",
      * @param the_needle {String} String to search
      * @param the_haystack {Array} Array, which should be searched
      * @return {Boolean} whether the search string was found.
-     * @deprecated {6.0} Use qx.lang.Array.contains instead
+     * @deprecated {6.0}
      */
     _js_in_array : function(the_needle, the_haystack)
     {
-      return qx.lang.Array.contains(the_haystack, the_needle);
+      var the_hay = the_haystack.toString();
+
+      if (the_hay == '') {
+        return false;
+      }
+
+      var the_pattern = new RegExp(the_needle, 'g');
+      var matched = the_pattern.test(the_haystack);
+      return matched;
     },
 
 

--- a/framework/source/class/qx/ui/table/model/Filtered.js
+++ b/framework/source/class/qx/ui/table/model/Filtered.js
@@ -78,10 +78,10 @@ qx.Class.define("qx.ui.table.model.Filtered",
   {
     this.base(arguments);
 
-    this.numericAllowed = new Array("==", "!=", ">", "<", ">=", "<=");
-    this.betweenAllowed = new Array("between", "!between");
+    this.numericAllowed = ["==", "!=", ">", "<", ">=", "<="];
+    this.betweenAllowed = ["between", "!between"];
     this.__applyingFilters = false;
-    this.Filters = new Array();
+    this.Filters = [];
 
   },
 
@@ -98,6 +98,7 @@ qx.Class.define("qx.ui.table.model.Filtered",
      * @param the_needle {String} String to search
      * @param the_haystack {Array} Array, which should be searched
      * @return {Boolean} whether the search string was found.
+     * @deprecated {6.0} Use qx.lang.Array.contains instead
      */
     _js_in_array : function(the_needle, the_haystack)
     {
@@ -135,7 +136,7 @@ qx.Class.define("qx.ui.table.model.Filtered",
      */
     addBetweenFilter : function(filter, value1, value2, target)
     {
-      if (this._js_in_array(filter, this.betweenAllowed) && target != null)
+      if (qx.lang.Array.contains(this.betweenAllowed, filter) && target != null)
       {
         if (value1 != null && value2 != null) {
           var temp = new Array(filter, value1, value2, target);
@@ -171,7 +172,7 @@ qx.Class.define("qx.ui.table.model.Filtered",
     {
       var temp = null;
 
-      if (this._js_in_array(filter, this.numericAllowed) && target != null)
+      if (qx.lang.Array.contains(this.numericAllowed, filter) && target != null)
       {
         if (value1 != null) {
           temp = [filter, value1, target];
@@ -260,18 +261,15 @@ qx.Class.define("qx.ui.table.model.Filtered",
       var compareValue;
       var rowArr = this.getData();
       var rowLength = rowArr.length;
-      var count;
-      var hidden = 0;
       var rowsToHide = [];
-      for (var row = 0; row<rowLength;row++)
+
+      for (var row = 0; row < rowLength; row++)
       {
         filter_test = false;
         for (i in this.Filters)
         {
 
-          if (this._js_in_array(this.Filters[i][0],
-                                this.numericAllowed) &&
-              filter_test == false)
+          if (qx.lang.Array.contains(this.numericAllowed, this.Filters[i][0]))
           {
             compareValue = this.getValueById(this.Filters[i][2], row);
             switch(this.Filters[i][0])
@@ -319,9 +317,7 @@ qx.Class.define("qx.ui.table.model.Filtered",
               break;
             }
           }
-          else if (this._js_in_array(this.Filters[i][0],
-                                     this.betweenAllowed) &&
-                   filter_test == false)
+          else if (qx.lang.Array.contains(this.betweenAllowed, this.Filters[i][0]))
           {
             compareValue = this.getValueById(this.Filters[i][3], row);
 
@@ -344,52 +340,52 @@ qx.Class.define("qx.ui.table.model.Filtered",
               break;
             }
           }
-          else if (this.Filters[i][0] == "regex" && filter_test == false)
+          else if (this.Filters[i][0] === "regex")
           {
             compareValue = this.getValueById(this.Filters[i][2], row);
 
             var the_pattern = new RegExp(this.Filters[i][1], this.Filters[i][3]);
             filter_test = the_pattern.test(compareValue);
           }
-          else if (this.Filters[i][0] == "notregex" && filter_test == false)
+          else if (this.Filters[i][0] === "notregex")
           {
             compareValue = this.getValueById(this.Filters[i][2], row);
 
             var the_pattern = new RegExp(this.Filters[i][1], this.Filters[i][3]);
             filter_test = !the_pattern.test(compareValue);
           }
+
+          if (filter_test === true) {
+            break;
+          }
         }
 
         // instead of hiding a single row, push it into the hiding-store for later hiding.
-        if (filter_test == true) {
+        if (filter_test === true) {
           rowsToHide.push(row);
         }
       }
 
-      var rowsToHideLength = rowsToHide.length;
-      for (i = 0; i < rowsToHideLength; i++) {
-        row = rowsToHide[i];
-        count = 1;
-        // count direct follow-up rows
-        while (i + 1 < rowsToHide.length && rowsToHide[i] == rowsToHide[i+1]-1) {
-          count++;
-          i++;
-        }
-        this.hideRows(row - hidden, count, false);
-
-        hidden += count;
+      if (!this.__applyingFilters) {
+        this.__fullArr = rowArr.slice(0);
+        this.__applyingFilters = true;
       }
 
-      var data =
-      {
-        firstRow    : 0,
-        lastRow     : this.getData().length - 1,
-        firstColumn : 0,
-        lastColumn  : this.getColumnCount() - 1
-      };
+      rowArr = rowArr.filter(function(row, index) {
+        return !qx.lang.Array.contains(rowsToHide, index);
+      });
 
-      // Inform the listeners
-      this.fireDataEvent("dataChanged", data);
+      this._rowArr = rowArr;
+
+       var data = {
+         firstRow    : 0,
+         lastRow     : this._rowArr.length - 1,
+         firstColumn : 0,
+         lastColumn  : this.getColumnCount() - 1
+       };
+
+       // Inform the listeners
+       this.fireDataEvent("dataChanged", data);
     },
 
 

--- a/framework/source/class/qx/ui/table/model/Filtered.js
+++ b/framework/source/class/qx/ui/table/model/Filtered.js
@@ -78,8 +78,17 @@ qx.Class.define("qx.ui.table.model.Filtered",
   {
     this.base(arguments);
 
-    this.numericAllowed = ["==", "!=", ">", "<", ">=", "<="];
-    this.betweenAllowed = ["between", "!between"];
+    this.__filterTypes = {
+      "==" : "numeric",
+      "!=" : "numeric",
+      ">" : "numeric",
+      "<" : "numeric",
+      "<=" : "numeric",
+      ">=" : "numeric",
+      "between": "between",
+      "!between": "between"
+    };
+
     this.__applyingFilters = false;
     this.Filters = [];
 
@@ -90,6 +99,7 @@ qx.Class.define("qx.ui.table.model.Filtered",
   {
     __fullArr : null,
     __applyingFilters : null,
+    __filterTypes : null,
 
 
     /**
@@ -102,15 +112,7 @@ qx.Class.define("qx.ui.table.model.Filtered",
      */
     _js_in_array : function(the_needle, the_haystack)
     {
-      var the_hay = the_haystack.toString();
-
-      if (the_hay == '') {
-        return false;
-      }
-
-      var the_pattern = new RegExp(the_needle, 'g');
-      var matched = the_pattern.test(the_haystack);
-      return matched;
+      return qx.lang.Array.contains(the_haystack, the_needle);
     },
 
 
@@ -136,7 +138,7 @@ qx.Class.define("qx.ui.table.model.Filtered",
      */
     addBetweenFilter : function(filter, value1, value2, target)
     {
-      if (qx.lang.Array.contains(this.betweenAllowed, filter) && target != null)
+      if (this.__filterTypes[filter] === "between" && target != null)
       {
         if (value1 != null && value2 != null) {
           var temp = new Array(filter, value1, value2, target);
@@ -172,7 +174,7 @@ qx.Class.define("qx.ui.table.model.Filtered",
     {
       var temp = null;
 
-      if (qx.lang.Array.contains(this.numericAllowed, filter) && target != null)
+      if (this.__filterTypes[filter] === "numeric" && target != null)
       {
         if (value1 != null) {
           temp = [filter, value1, target];
@@ -206,7 +208,12 @@ qx.Class.define("qx.ui.table.model.Filtered",
     addRegex : function(regex, target, ignorecase)
     {
       var regexarg;
-      if (ignorecase) { regexarg ='gi'; } else { regexarg ='g'; }
+      if (ignorecase) {
+        regexarg ='gi';
+      } else {
+        regexarg ='g';
+      }
+
       if (regex != null && target != null) {
         var temp = new Array("regex", regex, target, regexarg);
       }
@@ -238,7 +245,12 @@ qx.Class.define("qx.ui.table.model.Filtered",
     addNotRegex : function(regex, target, ignorecase)
     {
       var regexarg;
-      if (ignorecase) { regexarg ='gi'; } else { regexarg ='g'; }
+      if (ignorecase) {
+        regexarg ='gi';
+      } else {
+        regexarg ='g';
+      }
+
       if (regex != null && target != null) {
         var temp = new Array("notregex", regex, target, regexarg);
       }
@@ -269,7 +281,7 @@ qx.Class.define("qx.ui.table.model.Filtered",
         for (i in this.Filters)
         {
 
-          if (qx.lang.Array.contains(this.numericAllowed, this.Filters[i][0]))
+          if (this.__filterTypes[this.Filters[i][0]] === "numeric")
           {
             compareValue = this.getValueById(this.Filters[i][2], row);
             switch(this.Filters[i][0])
@@ -317,7 +329,7 @@ qx.Class.define("qx.ui.table.model.Filtered",
               break;
             }
           }
-          else if (qx.lang.Array.contains(this.betweenAllowed, this.Filters[i][0]))
+          else if (this.__filterTypes[this.Filters[i][0]] === "between")
           {
             compareValue = this.getValueById(this.Filters[i][3], row);
 
@@ -468,7 +480,6 @@ qx.Class.define("qx.ui.table.model.Filtered",
 
   destruct : function()
   {
-    this.__fullArr = this.numericAllowed = this.betweenAllowed =
-      this.Filters = null;
+    this.__fullArr = this.__filterTypes = this.Filters = null;
   }
 });

--- a/framework/source/class/qx/ui/table/model/Simple.js
+++ b/framework/source/class/qx/ui/table/model/Simple.js
@@ -29,7 +29,7 @@ qx.Class.define("qx.ui.table.model.Simple",
   {
     this.base(arguments);
 
-    this.__rowArr = [];
+    this._rowArr = [];
     this.__sortColumnIndex = -1;
 
     // Array of objects, each with property "ascending" and "descending"
@@ -148,7 +148,7 @@ qx.Class.define("qx.ui.table.model.Simple",
 
   members :
   {
-    __rowArr : null,
+    _rowArr : null,
     __editableColArr : null,
     __sortableColArr : null,
     __sortMethods : null,
@@ -159,7 +159,7 @@ qx.Class.define("qx.ui.table.model.Simple",
     // overridden
     getRowData : function(rowIndex)
     {
-      var rowData = this.__rowArr[rowIndex];
+      var rowData = this._rowArr[rowIndex];
       if (rowData == null || rowData.originalData == null) {
         return rowData;
       } else {
@@ -177,7 +177,7 @@ qx.Class.define("qx.ui.table.model.Simple",
      */
     getRowDataAsMap : function(rowIndex)
     {
-      var rowData = this.__rowArr[rowIndex];
+      var rowData = this._rowArr[rowIndex];
 
       if (rowData != null) {
         var map = {};
@@ -327,7 +327,7 @@ qx.Class.define("qx.ui.table.model.Simple",
       }
 
       comparator.columnIndex = columnIndex;
-      this.__rowArr.sort(comparator);
+      this._rowArr.sort(comparator);
 
       this.__sortColumnIndex = columnIndex;
       this.__sortAscending = ascending;
@@ -466,25 +466,25 @@ qx.Class.define("qx.ui.table.model.Simple",
 
     // overridden
     getRowCount : function() {
-      return this.__rowArr.length;
+      return this._rowArr.length;
     },
 
     // overridden
     getValue : function(columnIndex, rowIndex)
     {
-      if (rowIndex < 0 || rowIndex >= this.__rowArr.length) {
-        throw new Error("this.__rowArr out of bounds: " + rowIndex + " (0.." + this.__rowArr.length + ")");
+      if (rowIndex < 0 || rowIndex >= this._rowArr.length) {
+        throw new Error("this._rowArr out of bounds: " + rowIndex + " (0.." + this._rowArr.length + ")");
       }
 
-      return this.__rowArr[rowIndex][columnIndex];
+      return this._rowArr[rowIndex][columnIndex];
     },
 
     // overridden
     setValue : function(columnIndex, rowIndex, value)
     {
-      if (this.__rowArr[rowIndex][columnIndex] != value)
+      if (this._rowArr[rowIndex][columnIndex] != value)
       {
-        this.__rowArr[rowIndex][columnIndex] = value;
+        this._rowArr[rowIndex][columnIndex] = value;
 
         // Inform the listeners
         if (this.hasListener("dataChanged"))
@@ -517,7 +517,7 @@ qx.Class.define("qx.ui.table.model.Simple",
      */
     setData : function(rowArr, clearSorting)
     {
-      this.__rowArr = rowArr;
+      this._rowArr = rowArr;
 
       // Inform the listeners
       if (this.hasListener("dataChanged"))
@@ -550,7 +550,7 @@ qx.Class.define("qx.ui.table.model.Simple",
      *           in this model.
      */
     getData : function() {
-      return this.__rowArr;
+      return this._rowArr;
     },
 
 
@@ -583,20 +583,20 @@ qx.Class.define("qx.ui.table.model.Simple",
     addRows : function(rowArr, startIndex, clearSorting)
     {
       if (startIndex == null) {
-        startIndex = this.__rowArr.length;
+        startIndex = this._rowArr.length;
       }
 
       // Prepare the rowArr so it can be used for apply
       rowArr.splice(0, 0, startIndex, 0);
 
       // Insert the new rows
-      Array.prototype.splice.apply(this.__rowArr, rowArr);
+      Array.prototype.splice.apply(this._rowArr, rowArr);
 
       // Inform the listeners
       var data =
       {
         firstRow    : startIndex,
-        lastRow     : this.__rowArr.length - 1,
+        lastRow     : this._rowArr.length - 1,
         firstColumn : 0,
         lastColumn  : this.getColumnCount() - 1
       };
@@ -649,13 +649,13 @@ qx.Class.define("qx.ui.table.model.Simple",
       rowArr.splice(0, 0, startIndex, rowArr.length);
 
       // Replace rows
-      Array.prototype.splice.apply(this.__rowArr, rowArr);
+      Array.prototype.splice.apply(this._rowArr, rowArr);
 
       // Inform the listeners
       var data =
       {
         firstRow    : startIndex,
-        lastRow     : this.__rowArr.length - 1,
+        lastRow     : this._rowArr.length - 1,
         firstColumn : 0,
         lastColumn  : this.getColumnCount() - 1
       };
@@ -695,13 +695,13 @@ qx.Class.define("qx.ui.table.model.Simple",
      */
     removeRows : function(startIndex, howMany, clearSorting)
     {
-      this.__rowArr.splice(startIndex, howMany);
+      this._rowArr.splice(startIndex, howMany);
 
       // Inform the listeners
       var data =
       {
         firstRow    : startIndex,
-        lastRow     : this.__rowArr.length - 1,
+        lastRow     : this._rowArr.length - 1,
         firstColumn : 0,
         lastColumn  : this.getColumnCount() - 1,
         removeStart : startIndex,
@@ -754,7 +754,7 @@ qx.Class.define("qx.ui.table.model.Simple",
 
   destruct : function()
   {
-    this.__rowArr = this.__editableColArr = this.__sortMethods =
+    this._rowArr = this.__editableColArr = this.__sortMethods =
       this.__sortableColArr = null;
   }
 });


### PR DESCRIPTION
Improve filtering performance by avoiding to call `hideRows` for each piece of rows to hide. Any tips to improve this PR is welcome
