### PR TITLE
replace qx.lang.String.startsWith & qx.lang.String.endsWith by their prototype counterparts

### DIFF
--- a/framework/source/class/qx/bom/element/Background.js
+++ b/framework/source/class/qx/bom/element/Background.js
@@ -93,7 +93,7 @@ qx.Class.define("qx.bom.element.Background",
       // only check the first 50 characters for performance, since we do not
       // know how long a base64 image url can be.
       var firstPartOfUrl = url.substr(0, 50);
-      return String.startsWith(firstPartOfUrl, "data:") && String.contains(firstPartOfUrl, "base64");
+      return firstPartOfUrl.startsWith("data:") && String.contains(firstPartOfUrl, "base64");
     },
 
 

--- a/framework/source/class/qx/bom/element/Decoration.js
+++ b/framework/source/class/qx/bom/element/Decoration.js
@@ -155,7 +155,7 @@ qx.Class.define("qx.bom.element.Decoration",
     getTagName : function(repeat, source)
     {
       if (source && qx.core.Environment.get("css.alphaimageloaderneeded") &&
-          this.__alphaFixRepeats[repeat] && qx.lang.String.endsWith(source, ".png"))
+          this.__alphaFixRepeats[repeat] && source.endsWith(".png"))
       {
         return "div";
       }

--- a/framework/source/class/qx/data/SingleValueBinding.js
+++ b/framework/source/class/qx/data/SingleValueBinding.js
@@ -839,7 +839,7 @@ qx.Class.define("qx.data.SingleValueBinding",
       for (var i = 0; i < propertyNames.length; i++) {
         var name = propertyNames[i];
         // if its an array property in the chain
-        if (qx.lang.String.endsWith(name, "]")) {
+        if (name.endsWith("]")) {
           // get the inner value of the array notation
           var arrayIndex = name.substring(name.indexOf("[") + 1, name.indexOf("]"));
 

--- a/framework/source/class/qx/io/remote/Exchange.js
+++ b/framework/source/class/qx/io/remote/Exchange.js
@@ -404,7 +404,7 @@ qx.Class.define("qx.io.remote.Exchange",
           var url = window.location.href;
 
           // Are we on a local page obtained via file: protocol?
-          if (qx.lang.String.startsWith(url.toLowerCase(), "file:"))
+          if (url.toLowerCase().startsWith("file:"))
           {
             // Yup. Can't issue remote requests from here.
             return ("Unknown status code. " +

--- a/framework/source/class/qx/module/util/String.js
+++ b/framework/source/class/qx/module/util/String.js
@@ -80,7 +80,9 @@ qx.Bootstrap.define("qx.module.util.String", {
      * @param substr {String} the substring to look for
      * @return {Boolean} whether the string starts with the given substring
      */
-    startsWith : qx.lang.String.startsWith,
+    startsWith : function (fullstr, substr) {
+      return fullstr.startsWith(substr);
+    },
 
 
     /**
@@ -92,7 +94,9 @@ qx.Bootstrap.define("qx.module.util.String", {
      * @param substr {String} the substring to look for
      * @return {Boolean} whether the string ends with the given substring
      */
-    endsWith : qx.lang.String.endsWith,
+    endsWith : function (fullstr, substr) {
+      return fullstr.endsWith(substr);
+    },
 
 
     /**

--- a/framework/source/class/qx/test/bom/Basic.js
+++ b/framework/source/class/qx/test/bom/Basic.js
@@ -84,7 +84,7 @@ qx.Class.define("qx.test.bom.Basic",
       this.assertTrue(attrib.get(document.getElementById("test5"), "readonly"));
 
       this.info("test6");
-      this.assert(qx.lang.String.endsWith(attrib.get(document.getElementById("test6"), "href"), "/foo.html"));
+      this.assert(attrib.get(document.getElementById("test6"), "href").endsWith("/foo.html"));
 
       var test6Color = style.get(document.getElementById("test6"), "color");
       this.assertCssColor("red", test6Color);

--- a/framework/source/class/qx/test/event/MockHandler.js
+++ b/framework/source/class/qx/test/event/MockHandler.js
@@ -74,7 +74,7 @@ qx.Class.define("qx.test.event.MockHandler",
     canHandleEvent : function(target, type)
     {
       this.calls.push(["canHandleEvent", target, type]);
-      return qx.lang.String.startsWith(type, "$test");
+      return type.startsWith("$test");
     },
 
 

--- a/framework/source/class/qx/test/ui/tree/virtual/AbstractTreeTest.js
+++ b/framework/source/class/qx/test/ui/tree/virtual/AbstractTreeTest.js
@@ -217,7 +217,7 @@ qx.Class.define("qx.test.ui.tree.virtual.AbstractTreeTest",
     {
       var name = item.getName();
       var prefix = "";
-      if (qx.lang.String.startsWith(name, "Node")) {
+      if (name.startsWith("Node")) {
         prefix = name.substr(5, name.length - 5) + ".";
       }
       return prefix;

--- a/framework/source/class/qx/ui/basic/Image.js
+++ b/framework/source/class/qx/ui/basic/Image.js
@@ -339,7 +339,7 @@ qx.Class.define("qx.ui.basic.Image",
         var source = this.getSource();
         var isPng = false;
         if (source != null) {
-          isPng = qx.lang.String.endsWith(source, ".png");
+          isPng = source.endsWith(".png");
         }
 
         if (this.getScale() && isPng && qx.core.Environment.get("css.alphaimageloaderneeded")) {
@@ -537,7 +537,7 @@ qx.Class.define("qx.ui.basic.Image",
       "mshtml" : function(source)
       {
         var alphaImageLoader = qx.core.Environment.get("css.alphaimageloaderneeded");
-        var isPng = qx.lang.String.endsWith(source, ".png");
+        var isPng = source.endsWith(".png");
 
         if (alphaImageLoader && isPng)
         {
@@ -587,7 +587,7 @@ qx.Class.define("qx.ui.basic.Image",
         {
           var pixel = "px";
           var styles = {};
-          
+
           //inherit styles from current element
           var currentStyles = currentContentElement.getAllStyles();
           if(currentStyles) {
@@ -741,9 +741,8 @@ qx.Class.define("qx.ui.basic.Image",
         // loading external images via HTTP/HTTPS is a common usecase, as is
         // using data URLs.
         var sourceLC = source.toLowerCase();
-        var startsWith = qx.lang.String.startsWith;
-        if (!startsWith(sourceLC, "http") &&
-            !startsWith(sourceLC, "data:image/"))
+        if (!sourceLC.startsWith("http") &&
+            !sourceLC.startsWith("data:image/"))
         {
           var self = this.self(arguments);
 

--- a/framework/source/class/qx/ui/decoration/MBackgroundImage.js
+++ b/framework/source/class/qx/ui/decoration/MBackgroundImage.js
@@ -19,8 +19,8 @@
 /**
  * Mixin for supporting the background images on decorators.
  * This mixin is usually used by {@link qx.ui.decoration.Decorator}.
- * 
- * It is possible to define multiple background images by setting an 
+ *
+ * It is possible to define multiple background images by setting an
  * array containing the needed values as the property value.
  * In case multiple values are specified, the values of the properties
  * are repeated until all match in length.
@@ -119,7 +119,7 @@ qx.Mixin.define("qx.ui.decoration.MBackgroundImage",
 
     /**
      * Whether to order gradients before Image-URL-based background declarations
-     * if both qx.ui.decoration.MBackgroundImage and 
+     * if both qx.ui.decoration.MBackgroundImage and
      * qx.ui.decoration.MLinearBackgroundGradient decorations are used.
      */
     orderGradientsFront :
@@ -193,7 +193,7 @@ qx.Mixin.define("qx.ui.decoration.MBackgroundImage",
           styles["background"][this.getOrderGradientsFront() ? 'push' : 'unshift'](imageMarkup.join(' '));
 
           if (qx.core.Environment.get("qx.debug") &&
-            source &&  qx.lang.String.endsWith(source, ".png") &&
+            source &&  source.endsWith(".png") &&
             (repeat == "scale" || repeat == "no-repeat") &&
             qx.core.Environment.get("engine.name") == "mshtml" &&
             qx.core.Environment.get("browser.documentmode") < 9)

--- a/framework/source/class/qx/ui/form/VirtualSelectBox.js
+++ b/framework/source/class/qx/ui/form/VirtualSelectBox.js
@@ -376,9 +376,7 @@ qx.Class.define("qx.ui.form.VirtualSelectBox",
           }
         }
 
-        if (
-          qx.lang.String.startsWith(value.toLowerCase(), searchValue.toLowerCase())
-        )
+        if ( value.toLowerCase().startsWith(searchValue.toLowerCase()) )
         {
           selection.push(item);
           break;

--- a/framework/source/class/qx/ui/mobile/container/Scroll.js
+++ b/framework/source/class/qx/ui/mobile/container/Scroll.js
@@ -226,7 +226,7 @@ qx.Class.define("qx.ui.mobile.container.Scroll",
       for (var i = 0; i < waypoints.length; i++) {
         var waypoint = waypoints[i];
         if (qx.lang.Type.isString(waypoint)) {
-          if (qx.lang.String.endsWith(waypoint, "%")) {
+          if (waypoint.endsWith("%")) {
             offset = parseInt(waypoint, 10) * (scrollSize / 100);
             results.push({
               "offset": offset,

--- a/framework/source/class/qx/ui/tree/VirtualTree.js
+++ b/framework/source/class/qx/ui/tree/VirtualTree.js
@@ -700,7 +700,7 @@ qx.Class.define("qx.ui.tree.VirtualTree",
       }
 
       // only continue when the effected property is the child property
-      if (qx.lang.String.startsWith(propertyName, this.getChildProperty()))
+      if ( propertyName.startsWith(this.getChildProperty()) )
       {
         var item = data.item;
 


### PR DESCRIPTION
- replaced `qx.lang.String.startsWith(foo,bar)` by `foo.startsWith(bar)`
- replaced `qx.lang.String.endsWith(foo,bar)` by `foo.endsWith(bar)`

Except for `qx.module.util.String` which I don't know what to do with.
