### PR TITLE
fix for #9083 - change license for openhex to MIT

### DIFF
--- a/framework/source/class/qx/ui/table/cellrenderer/Date.js
+++ b/framework/source/class/qx/ui/table/cellrenderer/Date.js
@@ -8,8 +8,7 @@
      2007 OpenHex SPRL, http://www.openhex.org
 
    License:
-     LGPL: http://www.gnu.org/licenses/lgpl.html
-     EPL: http://www.eclipse.org/org/documents/epl-v10.php
+     MIT: https://opensource.org/licenses/MIT
      See the LICENSE file in the project's top-level directory for details.
 
    Authors:

--- a/framework/source/class/qx/ui/table/cellrenderer/Html.js
+++ b/framework/source/class/qx/ui/table/cellrenderer/Html.js
@@ -8,8 +8,7 @@
      2007 OpenHex SPRL, http://www.openhex.org
 
    License:
-     LGPL: http://www.gnu.org/licenses/lgpl.html
-     EPL: http://www.eclipse.org/org/documents/epl-v10.php
+     MIT: https://opensource.org/licenses/MIT
      See the LICENSE file in the project's top-level directory for details.
 
    Authors:

--- a/framework/source/class/qx/ui/table/cellrenderer/Number.js
+++ b/framework/source/class/qx/ui/table/cellrenderer/Number.js
@@ -8,8 +8,7 @@
      2007 OpenHex SPRL, http://www.openhex.org
 
    License:
-     LGPL: http://www.gnu.org/licenses/lgpl.html
-     EPL: http://www.eclipse.org/org/documents/epl-v10.php
+     MIT: https://opensource.org/licenses/MIT
      See the LICENSE file in the project's top-level directory for details.
 
    Authors:

--- a/framework/source/class/qx/ui/table/cellrenderer/String.js
+++ b/framework/source/class/qx/ui/table/cellrenderer/String.js
@@ -8,8 +8,7 @@
      2007 OpenHex SPRL, http://www.openhex.org
 
    License:
-     LGPL: http://www.gnu.org/licenses/lgpl.html
-     EPL: http://www.eclipse.org/org/documents/epl-v10.php
+     MIT: https://opensource.org/licenses/MIT
      See the LICENSE file in the project's top-level directory for details.
 
    Authors:


### PR DESCRIPTION
fix for #9083 - change license for openhex to MIT
