### PR TITLE
Mark Remote as abstract

### DIFF
--- a/framework/source/class/qx/ui/table/model/Remote.js
+++ b/framework/source/class/qx/ui/table/model/Remote.js
@@ -31,9 +31,8 @@
  */
 qx.Class.define("qx.ui.table.model.Remote",
 {
+  type : "abstract",
   extend : qx.ui.table.model.Abstract,
-
-
 
 
   /*


### PR DESCRIPTION
The class `qx.ui.table.model.Remote` is supposed to be abstract (http://www.qooxdoo.org/current/apiviewer/#qx.ui.table.model.Remote) because you have to implements `_loadRowCount` and `_loadRowData` methods. But the class is not marked as abstract
