### PR TITLE
fixes a bug where changing the current tab of a tabview by code causes the tabview to gain focus

### DIFF
--- a/framework/source/class/qx/ui/tabview/TabView.js
+++ b/framework/source/class/qx/ui/tabview/TabView.js
@@ -24,6 +24,11 @@
  * A tab view is a multi page view where only one page is visible
  * at each moment. It is possible to switch the pages using the
  * buttons rendered by each page.
+ * 
+ * Note that prior to v6.0, when changing the currently selected tab via code
+ * (ie changing the selection property) TabView would automatically set the 
+ * focus to that tab; this is undesirable (and inconsistent with other parts
+ * of the framework) and is no longer done automatically.
  *
  * @childControl bar {qx.ui.container.SlideBar} slidebar for all tab buttons
  * @childControl pane {qx.ui.container.Stack} stack container to show one tab page

--- a/framework/source/class/qx/ui/tabview/TabView.js
+++ b/framework/source/class/qx/ui/tabview/TabView.js
@@ -563,7 +563,6 @@ qx.Class.define("qx.ui.tabview.TabView",
       {
         value = [button.getUserData("page")];
         pane.setSelection(value);
-        button.focus();
         this.scrollChildIntoView(button, null, null, false);
       }
       else


### PR DESCRIPTION
This was reported by @woprandi at http://stackoverflow.com/questions/38845275/qooxdoo-tabview-steals-focus and is demonstrated with this code:

``` javascript
var field = new qx.ui.form.TextField();
field.setLiveUpdate(true);
var tabs = new qx.ui.tabview.TabView("left").set({ maxHeight: 300 });

//field.addListener("blur", function() { debugger; });

this.getRoot().add(field);

this.getRoot().add(tabs, {left : 300});

var btn = new qx.ui.form.Button("change tab");
btn.addListener("execute", function() {
  var tab = tabs.getSelection()[0]||null;
  var index = tabs.getChildren().indexOf(tab);
  var next = tabs.getChildren()[index + 10]||null;
  if (next)
    tabs.setSelection([next]);
}, this);
this.getRoot().add(btn, { top: 100 });

field.addListener("changeValue", function() {
      var t = qx.lang.Array.clone(tabs.getChildren());

      if (t) {
        t.forEach(function(obj) {
          tabs.remove(obj);
        });
      }

      for (var i = 0; i < 50; i++) {
        tabs.add(new qx.ui.tabview.Page(Math.random().toString(36).substring(2, 5)));
      }

});
```
