### PR TITLE
Fix null assertion when setting q.u.w.Desktop WindowManager.

### DIFF
--- a/framework/source/class/qx/ui/window/IWindowManager.js
+++ b/framework/source/class/qx/ui/window/IWindowManager.js
@@ -29,10 +29,12 @@ qx.Interface.define("qx.ui.window.IWindowManager",
     /**
      * Connect the window manager to the window desktop
      *
-     * @param desktop {IDesktop} The connected desktop
+     * @param desktop {IDesktop|null} The connected desktop or null
      */
     setDesktop : function(desktop) {
-      this.assertInterface(desktop, qx.ui.window.IDesktop);
+      if (desktop !== null) {
+        this.assertInterface(desktop, qx.ui.window.IDesktop);
+      }
     },
 
     /**


### PR DESCRIPTION
I'm not sure if this is the right way to fix this.

[Here](https://github.com/qooxdoo/qooxdoo/blob/master/framework/source/class/qx/ui/window/MDesktop.js#L110) we reset the old WindowManager by setting it to null.

This will raise an error in the assertInterface code.

Signed-off-by: Rene Jochum rene@jochums.at
