### PR TITLE
Forward property selectable from Atom to its label child control

### DIFF
--- a/framework/source/class/qx/test/ui/basic/Atom.js
+++ b/framework/source/class/qx/test/ui/basic/Atom.js
@@ -1,0 +1,56 @@
+/* ************************************************************************
+
+   qooxdoo - the new era of web development
+
+   http://qooxdoo.org
+
+   Copyright:
+     2016- Oetiker+Partner AG, Switzerland, http://www.oetiker.ch
+
+   License:
+     MIT: https://opensource.org/licenses/MIT
+     See the LICENSE file in the project's top-level directory for details.
+
+   Authors:
+   * Fritz Zaucker (fritz.zaucker@oetiker.ch)
+
+************************************************************************ */
+
+/**
+ * @asset(qx/test/webfonts/*)
+ */
+
+qx.Class.define("qx.test.ui.basic.Atom",
+{
+  extend : qx.test.ui.LayoutTestCase,
+
+  include : [qx.dev.unit.MRequirements, qx.dev.unit.MMock],
+
+  members :
+  {
+    tearDown : function()
+    {
+      this.base(arguments);
+      this.getSandbox().restore();
+      qx.bom.webfonts.Manager.getInstance().dispose();
+      delete qx.bom.webfonts.Manager.$$instance;
+    },
+
+    testSelectableSet : function() {
+      var a = new qx.ui.basic.Atom();
+      var l = a.getChildControl('label');	
+      a.setSelectable(true);
+      this.assert(l.getContentElement().getAttribute("qxselectable"));
+      l.dispose();
+    },
+
+    testSelectableUnset : function() {
+      var a = new qx.ui.basic.Atom();
+      var l = a.getChildControl('label');	
+      l.setSelectable(false);
+      this.assert(! l.getContentElement().getAttribute("qxselectable"));
+      l.dispose();
+    },
+
+  }
+});

--- a/framework/source/class/qx/test/ui/basic/Atom.js
+++ b/framework/source/class/qx/test/ui/basic/Atom.js
@@ -16,10 +16,6 @@
 
 ************************************************************************ */
 
-/**
- * @asset(qx/test/webfonts/*)
- */
-
 qx.Class.define("qx.test.ui.basic.Atom",
 {
   extend : qx.test.ui.LayoutTestCase,

--- a/framework/source/class/qx/test/ui/basic/Atom.js
+++ b/framework/source/class/qx/test/ui/basic/Atom.js
@@ -20,17 +20,12 @@ qx.Class.define("qx.test.ui.basic.Atom",
 {
   extend : qx.test.ui.LayoutTestCase,
 
-<<<<<<< HEAD
   include : [qx.dev.unit.MMock],
-=======
-  include : [qx.dev.unit.MRequirements, qx.dev.unit.MMock],
->>>>>>> 4db393876743f81ce2fcf21465b8512054d3df0b
 
   members :
   {
     tearDown : function()
     {
-<<<<<<< HEAD
       this.getSandbox().restore();
     },
 
@@ -46,12 +41,6 @@ qx.Class.define("qx.test.ui.basic.Atom",
       var l = a.getChildControl('label');	
       this.assert(! l.getContentElement().getAttribute("qxselectable"));
       l.dispose();
-=======
-      this.base(arguments);
-      this.getSandbox().restore();
-      qx.bom.webfonts.Manager.getInstance().dispose();
-      delete qx.bom.webfonts.Manager.$$instance;
->>>>>>> 4db393876743f81ce2fcf21465b8512054d3df0b
     },
 
     testSelectableSet : function() {
@@ -68,11 +57,7 @@ qx.Class.define("qx.test.ui.basic.Atom",
       l.setSelectable(false);
       this.assert(! l.getContentElement().getAttribute("qxselectable"));
       l.dispose();
-<<<<<<< HEAD
-    },
-=======
     }
->>>>>>> 4db393876743f81ce2fcf21465b8512054d3df0b
 
   }
 });

--- a/framework/source/class/qx/test/ui/basic/Atom.js
+++ b/framework/source/class/qx/test/ui/basic/Atom.js
@@ -46,7 +46,7 @@ qx.Class.define("qx.test.ui.basic.Atom",
       l.setSelectable(false);
       this.assert(! l.getContentElement().getAttribute("qxselectable"));
       l.dispose();
-    },
+    }
 
   }
 });

--- a/framework/source/class/qx/test/ui/basic/Atom.js
+++ b/framework/source/class/qx/test/ui/basic/Atom.js
@@ -16,24 +16,31 @@
 
 ************************************************************************ */
 
-/**
- * @asset(qx/test/webfonts/*)
- */
-
 qx.Class.define("qx.test.ui.basic.Atom",
 {
   extend : qx.test.ui.LayoutTestCase,
 
-  include : [qx.dev.unit.MRequirements, qx.dev.unit.MMock],
+  include : [qx.dev.unit.MMock],
 
   members :
   {
     tearDown : function()
     {
-      this.base(arguments);
       this.getSandbox().restore();
-      qx.bom.webfonts.Manager.getInstance().dispose();
-      delete qx.bom.webfonts.Manager.$$instance;
+    },
+
+    testSelectableSetOnCreation : function() {
+      var a = new qx.ui.basic.Atom().set({selectable: true});
+      var l = a.getChildControl('label');	
+      this.assert(l.getContentElement().getAttribute("qxselectable"));
+      l.dispose();
+    },
+
+    testSelectableUnSetOnCreation : function() {
+      var a = new qx.ui.basic.Atom().set({selectable: false});
+      var l = a.getChildControl('label');	
+      this.assert(! l.getContentElement().getAttribute("qxselectable"));
+      l.dispose();
     },
 
     testSelectableSet : function() {

--- a/framework/source/class/qx/test/ui/basic/Label.js
+++ b/framework/source/class/qx/test/ui/basic/Label.js
@@ -188,7 +188,7 @@ qx.Class.define("qx.test.ui.basic.Label",
       font1.dispose();
     },
 
-    testBudy : function() {
+    testBuddy : function() {
       var label = new qx.ui.basic.Label();
       var textfield1 = new qx.ui.form.TextField();
       var textfield2 = new qx.ui.form.TextField();

--- a/framework/source/class/qx/test/ui/basic/Label.js
+++ b/framework/source/class/qx/test/ui/basic/Label.js
@@ -74,6 +74,20 @@ qx.Class.define("qx.test.ui.basic.Label",
     },
 
 
+    testSelectableSet : function() {
+      var l = new qx.ui.basic.Label();
+      l.setSelectable(true);
+      this.assert(l.getContentElement().getAttribute("qxselectable"));
+      l.dispose();
+    },
+
+    testSelectableUnset : function() {
+      var l = new qx.ui.basic.Label();
+      l.setSelectable(false);
+      this.assert(! l.getContentElement().getAttribute("qxselectable"));
+      l.dispose();
+    },
+
     testWrapSet : function() {
       var l = new qx.ui.basic.Label();
       l.setRich(true);

--- a/framework/source/class/qx/ui/basic/Atom.js
+++ b/framework/source/class/qx/ui/basic/Atom.js
@@ -125,8 +125,8 @@ qx.Class.define("qx.ui.basic.Atom",
     selectable :
     {
       refine : true,
-      init : false,
-      apply : "_applySelectable"
+      init   : false,
+      event  : "changeSelectable"
     },
 
 
@@ -222,7 +222,7 @@ qx.Class.define("qx.ui.basic.Atom",
           control = new qx.ui.basic.Label(this.getLabel());
           control.setAnonymous(true);
           control.setRich(this.getRich());
-	  control.setSelectable(this.getSelectable());
+	  this.bind("selectable", control, "selectable");
           this._add(control);
           if (this.getLabel() == null || this.getShow() === "icon") {
             control.exclude();
@@ -298,16 +298,6 @@ qx.Class.define("qx.ui.basic.Atom",
       var label = this.getChildControl("label", true);
       if (label) {
         label.setRich(value);
-      }
-    },
-
-
-    // property apply
-    _applySelectable : function(value, old)
-    {
-      var label = this.getChildControl("label", true);
-      if (label) {
-        label.setSelectable(value);
       }
     },
 

--- a/framework/source/class/qx/ui/basic/Atom.js
+++ b/framework/source/class/qx/ui/basic/Atom.js
@@ -121,6 +121,15 @@ qx.Class.define("qx.ui.basic.Atom",
     },
 
 
+    /** this sets the property on the label child control */
+    selectable :
+    {
+      refine : true,
+      init : false
+      apply : "_applySelectable",
+    },
+
+
     /** Any URI String supported by qx.ui.basic.Image to display an icon */
     icon :
     {
@@ -288,6 +297,16 @@ qx.Class.define("qx.ui.basic.Atom",
       var label = this.getChildControl("label", true);
       if (label) {
         label.setRich(value);
+      }
+    },
+
+
+    // property apply
+    _applySelectable : function(value, old)
+    {
+      var label = this.getChildControl("label", true);
+      if (label) {
+        label.setSelectable(value);
       }
     },
 

--- a/framework/source/class/qx/ui/basic/Atom.js
+++ b/framework/source/class/qx/ui/basic/Atom.js
@@ -213,6 +213,7 @@ qx.Class.define("qx.ui.basic.Atom",
           control = new qx.ui.basic.Label(this.getLabel());
           control.setAnonymous(true);
           control.setRich(this.getRich());
+          control.setSelectable(this.getSelectable());
           this._add(control);
           if (this.getLabel() == null || this.getShow() === "icon") {
             control.exclude();

--- a/framework/source/class/qx/ui/basic/Atom.js
+++ b/framework/source/class/qx/ui/basic/Atom.js
@@ -222,6 +222,7 @@ qx.Class.define("qx.ui.basic.Atom",
           control = new qx.ui.basic.Label(this.getLabel());
           control.setAnonymous(true);
           control.setRich(this.getRich());
+	  control.setSelectable(this.getSelectable());
           this._add(control);
           if (this.getLabel() == null || this.getShow() === "icon") {
             control.exclude();

--- a/framework/source/class/qx/ui/basic/Atom.js
+++ b/framework/source/class/qx/ui/basic/Atom.js
@@ -121,15 +121,6 @@ qx.Class.define("qx.ui.basic.Atom",
     },
 
 
-    /** this sets the property on the label child control */
-    selectable :
-    {
-      refine : true,
-      init   : false,
-      event  : "changeSelectable"
-    },
-
-
     /** Any URI String supported by qx.ui.basic.Image to display an icon */
     icon :
     {
@@ -222,7 +213,7 @@ qx.Class.define("qx.ui.basic.Atom",
           control = new qx.ui.basic.Label(this.getLabel());
           control.setAnonymous(true);
           control.setRich(this.getRich());
-	  this.bind("selectable", control, "selectable");
+          control.setSelectable(this.getSelectable());
           this._add(control);
           if (this.getLabel() == null || this.getShow() === "icon") {
             control.exclude();

--- a/framework/source/class/qx/ui/basic/Atom.js
+++ b/framework/source/class/qx/ui/basic/Atom.js
@@ -125,8 +125,8 @@ qx.Class.define("qx.ui.basic.Atom",
     selectable :
     {
       refine : true,
-      init : false
-      apply : "_applySelectable",
+      init : false,
+      apply : "_applySelectable"
     },
 
 


### PR DESCRIPTION
Setting the selectable property on Atom has no effect so far. It must be "forwarded" to its child control "label".
