### PR TITLE
Add ISO8601 parsing support to qx.lang.normalize.Date #7175

### DIFF
--- a/framework/source/class/qx/bom/client/EcmaScript.js
+++ b/framework/source/class/qx/bom/client/EcmaScript.js
@@ -208,6 +208,23 @@ qx.Bootstrap.define("qx.bom.client.EcmaScript",
 
 
     /**
+     * Checks if 'parse' is supported on the Date object and whether it
+     * supports ISO-8601 parsing. Additionally it checks if 'parse' takes
+     * ISO-8601 date strings without timezone specifier and treats them as
+     * local (as per specification)
+     * @internal
+     * @return {Boolean} <code>true</code>, if the method supports ISO-8601
+     *   dates.
+     */
+    getDateParse : function ()
+    {
+      return typeof Date.parse === "function"     // Date.parse() is present...
+         && (Date.parse("2001-02-03T04:05:06.007") != // ...and it treats local
+             Date.parse("2001-02-03T04:05:06.007Z")); // dates as expected
+    },
+
+
+    /**
      * Checks if 'startsWith' is supported on the String object.
      * @internal
      * @return {Boolean} <code>true</code>, if the method is available.
@@ -254,6 +271,7 @@ qx.Bootstrap.define("qx.bom.client.EcmaScript",
 
     // date polyfill
     qx.core.Environment.add("ecmascript.date.now", statics.getDateNow);
+    qx.core.Environment.add("ecmascript.date.parse", statics.getDateParse);
 
     // error bugfix
     qx.core.Environment.add("ecmascript.error.toString", statics.getErrorToString);

--- a/framework/source/class/qx/core/Environment.js
+++ b/framework/source/class/qx/core/Environment.js
@@ -278,6 +278,10 @@
  *       <td>{@link qx.bom.client.EcmaScript#getDateNow}</td>
  *     </tr>
  *     <tr>
+ *       <td>ecmascript.date.parse<td><i>Boolean</i></td><td><code>true</code></td>
+ *       <td>{@link qx.bom.client.EcmaScript#getDateParse}</td>
+ *     </tr>
+ *     <tr>
  *       <td>ecmascript.error.toString</td><td><i>Boolean</i></td><td><code>true</code></td>
  *       <td>{@link qx.bom.client.EcmaScript#getErrorToString}</td>
  *     </tr>

--- a/framework/source/class/qx/lang/normalize/Date.js
+++ b/framework/source/class/qx/lang/normalize/Date.js
@@ -37,13 +37,80 @@ qx.Bootstrap.define("qx.lang.normalize.Date", {
      */
     now : function() {
       return +new Date();
+    },
+
+
+    /**
+     * Parses a string representation of a date and return number of
+     * milliseconds since Epoch or NaN if string is unrecognized.
+     *
+     * <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Date/parse">MDN documentation</a>
+     *
+     * Derived from <https://github.com/csnover/js-iso8601>: ©2011 Colin Snover
+     * <http://zetafleet.com>, MIT license
+     *
+     * @param dateString {String} A string representing an RFC2822 or ISO 8601
+     *   date (other formats may be used, but results may be unexpected).
+     * @return {Number|NaN} A number representing the milliseconds elapsed
+     *   since January 1, 1970, 00:00:00 UTC and the date obtained by parsing
+     *   the given string representation of a date.
+     *   If the argument doesn't represent a valid date, NaN is returned.
+     */
+    parse : function (dateString)
+    {
+      // Match input against ISO8601 regular expression
+      var captureGroups = /^(\d{4}|[+\-]\d{6})(?:-(\d{2})(?:-(\d{2}))?)?(?:T(\d{2}):(\d{2})(?::(\d{2})(?:\.(\d{3}))?)?(?:(Z)|([+\-])(\d{2})(?::(\d{2}))?)?)?$/.exec(dateString);
+      if (!captureGroups) {
+        return Date.originalParse(dateString);
+      }
+
+      // Just a date without time?
+      var noTime = [ 4, 5, 6, 7 ].every(function (i) {
+        return captureGroups[i] === undefined;
+      });
+
+      // Avoid invalid timestamps caused by undefined values being passed to Date.UTC
+      [ 1, 4, 5, 6, 7, 10, 11 ].forEach(function (i) {
+        captureGroups[i] = +captureGroups[i] || 0;
+      });
+      captureGroups[2] = (+captureGroups[2] || 1) - 1; // Allow undefined months
+      captureGroups[3] =  +captureGroups[3] || 1;      // Allow undefined days
+
+      // No timezone offset given and *not* just a date (without time)
+      if (captureGroups[8] !== "Z" && captureGroups[9] === undefined && !noTime)
+      { // => Treat as local
+        return new Date( captureGroups[1], captureGroups[2], captureGroups[3],
+                         captureGroups[4], captureGroups[5], captureGroups[6],
+                         captureGroups[7] ).getTime();
+      }
+
+      // Handle timezone offsets
+      var minutesOffset = 0;
+      if (captureGroups[8] !== "Z")
+      {
+        minutesOffset = captureGroups[10] * 60 + captureGroups[11];
+        if (captureGroups[9] === "+") {
+          minutesOffset = - minutesOffset;
+        }
+      }
+
+      // Return the number of milliseconds since Epoch
+      return Date.UTC( captureGroups[1], captureGroups[2], captureGroups[3],
+                       captureGroups[4], captureGroups[5] + minutesOffset,
+                       captureGroups[6], captureGroups[7] );
     }
   },
 
-  defer : function(statics) {
+  defer : function (statics)
+  {
     // Date.now
     if (!qx.core.Environment.get("ecmascript.date.now")) {
       Date.now = statics.now;
+    }
+    // Date.parse
+    if (!qx.core.Environment.get("ecmascript.date.parse")) {
+      Date.originalParse = Date.parse || function (dateString) { return NaN; };
+      Date.parse = statics.parse;
     }
   }
 });

--- a/framework/source/class/qx/lang/normalize/Date.js
+++ b/framework/source/class/qx/lang/normalize/Date.js
@@ -35,7 +35,7 @@ qx.Bootstrap.define("qx.lang.normalize.Date", {
      *
      * @return {Integer} Milliseconds since the Unix Epoch
      */
-    now : function() {
+    now : function () {
       return +new Date();
     },
 

--- a/framework/source/class/qx/test/lang/normalize/Date.js
+++ b/framework/source/class/qx/test/lang/normalize/Date.js
@@ -1,0 +1,99 @@
+/* ************************************************************************
+
+   qooxdoo - the new era of web development
+
+   http://qooxdoo.org
+
+   Copyright:
+     2016 1&1 Internet AG, Germany, http://www.1und1.de
+
+   License:
+     MIT: https://opensource.org/licenses/MIT
+     See the LICENSE file in the project's top-level directory for details.
+
+   Authors:
+     * George Nikolaidis (gnikolaidis)
+     * Peter Schneider (ps)
+
+************************************************************************ */
+
+/**
+ * @require(qx.lang.normalize.Date)
+ */
+qx.Class.define("qx.test.lang.normalize.Date",
+{
+  extend : qx.dev.unit.TestCase,
+
+  members :
+  {
+    "test parse()" : function ()
+    {
+      var sixHours = 6 * 60 * 60 * 1000;
+      var sixHoursThirty = sixHours + 30 * 60 * 1000;
+
+      var february = new Date(new Date().getFullYear(), 1, 1);
+      var localOffset = february.getTimezoneOffset() * 6e4; // [milliseconds]
+      // qx.log.Logger.info("localOffset:" + localOffset);
+
+      // Date part
+
+      this.assertIdentical(Date.parse("1970-01-01"), Date.UTC(1970, 0, 1, 0, 0, 0, 0), "Unix epoch");
+
+      this.assertIdentical(Date.parse("2001"), Date.UTC(2001, 0, 1, 0, 0, 0, 0), "2001");
+      this.assertIdentical(Date.parse("2001-02"), Date.UTC(2001, 1, 1, 0, 0, 0, 0), "2001-02");
+      this.assertIdentical(Date.parse("2001-02-03"), Date.UTC(2001, 1, 3, 0, 0, 0, 0), "2001-02-03");
+
+      this.assertIdentical(Date.parse("-002001"), Date.UTC(-2001, 0, 1, 0, 0, 0, 0), "-002001");
+      this.assertIdentical(Date.parse("-002001-02"), Date.UTC(-2001, 1, 1, 0, 0, 0, 0), "-002001-02");
+      this.assertIdentical(Date.parse("-002001-02-03"), Date.UTC(-2001, 1, 3, 0, 0, 0, 0), "-002001-02-03");
+
+      this.assertIdentical(Date.parse("+010000-02"), Date.UTC(10000, 1, 1, 0, 0, 0, 0), "+010000-02");
+      this.assertIdentical(Date.parse("+010000-02-03"), Date.UTC(10000, 1, 3, 0, 0, 0, 0), "+010000-02-03");
+      this.assertIdentical(Date.parse("-010000-02"), Date.UTC(-10000, 1, 1, 0, 0, 0, 0), "-010000-02");
+      this.assertIdentical(Date.parse("-010000-02-03"), Date.UTC(-10000, 1, 3, 0, 0, 0, 0), "-010000-02-03");
+
+      this.assertTrue(isNaN(Date.parse("asdf")), "invalid YYYY (non-digits)");
+      this.assertTrue(isNaN(Date.parse("1970-as-df")), "invalid YYYY-MM-DD (non-digits)");
+      this.assertTrue(isNaN(Date.parse("19700101")), "invalid YYYY-MM-DD (missing hyphens)");
+
+      // Time part
+
+      this.assertIdentical(Date.parse("2001-02-03T04:05"), Date.UTC(2001, 1, 3, 4, 5, 0, 0) + localOffset, "2001-02-03T04:05");
+      this.assertIdentical(Date.parse("2001-02-03T04:05:06"), Date.UTC(2001, 1, 3, 4, 5, 6, 0) + localOffset, "2001-02-03T04:05:06");
+      this.assertIdentical(Date.parse("2001-02-03T04:05:06.007"), Date.UTC(2001, 1, 3, 4, 5, 6, 7) + localOffset, "2001-02-03T04:05:06.007");
+
+      this.assertIdentical(Date.parse("2001-02-03T04:05Z"), Date.UTC(2001, 1, 3, 4, 5, 0, 0), "2001-02-03T04:05Z");
+      this.assertIdentical(Date.parse("2001-02-03T04:05:06Z"), Date.UTC(2001, 1, 3, 4, 5, 6, 0), "2001-02-03T04:05:06Z");
+      this.assertIdentical(Date.parse("2001-02-03T04:05:06.007Z"), Date.UTC(2001, 1, 3, 4, 5, 6, 7), "2001-02-03T04:05:06.007Z");
+
+      this.assertIdentical(Date.parse("2001-02-03T04:05-00:00"), Date.UTC(2001, 1, 3, 4, 5, 0, 0), "2001-02-03T04:05-00:00");
+      this.assertIdentical(Date.parse("2001-02-03T04:05:06-00:00"), Date.UTC(2001, 1, 3, 4, 5, 6, 0), "2001-02-03T04:05:06-00:00");
+      this.assertIdentical(Date.parse("2001-02-03T04:05:06.007-00:00"), Date.UTC(2001, 1, 3, 4, 5, 6, 7), "2001-02-03T04:05:06.007-00:00");
+
+      this.assertIdentical(Date.parse("2001-02-03T04:05+00:00"), Date.UTC(2001, 1, 3, 4, 5, 0, 0), "2001-02-03T04:05+00:00");
+      this.assertIdentical(Date.parse("2001-02-03T04:05:06+00:00"), Date.UTC(2001, 1, 3, 4, 5, 6, 0), "2001-02-03T04:05:06+00:00");
+      this.assertIdentical(Date.parse("2001-02-03T04:05:06.007+00:00"), Date.UTC(2001, 1, 3, 4, 5, 6, 7), "2001-02-03T04:05:06.007+00:00");
+
+      this.assertIdentical(Date.parse("2001-02-03T04:05-06:30"), Date.UTC(2001, 1, 3, 4, 5, 0, 0) + sixHoursThirty, "2001-02-03T04:05-06:30");
+      this.assertIdentical(Date.parse("2001-02-03T04:05:06-06:30"), Date.UTC(2001, 1, 3, 4, 5, 6, 0) + sixHoursThirty, "2001-02-03T04:05:06-06:30");
+      this.assertIdentical(Date.parse("2001-02-03T04:05:06.007-06:30"), Date.UTC(2001, 1, 3, 4, 5, 6, 7) + sixHoursThirty, "2001-02-03T04:05:06.007-06:30");
+
+      this.assertIdentical(Date.parse("2001-02-03T04:05+06:30"), Date.UTC(2001, 1, 3, 4, 5, 0, 0) - sixHoursThirty, "2001-02-03T04:05+06:30");
+      this.assertIdentical(Date.parse("2001-02-03T04:05:06+06:30"), Date.UTC(2001, 1, 3, 4, 5, 6, 0) - sixHoursThirty, "2001-02-03T04:05:06+06:30");
+      this.assertIdentical(Date.parse("2001-02-03T04:05:06.007+06:30"), Date.UTC(2001, 1, 3, 4, 5, 6, 7) - sixHoursThirty, "2001-02-03T04:05:06.007+06:30");
+
+      this.assertIdentical(Date.parse("2001T04:05:06.007"), Date.UTC(2001, 0, 1, 4, 5, 6, 7) + localOffset, "2001T04:05:06.007");
+      this.assertIdentical(Date.parse("2001-02T04:05:06.007"), Date.UTC(2001, 1, 1, 4, 5, 6, 7) + localOffset, "2001-02T04:05:06.007");
+      this.assertIdentical(Date.parse("2001-02-03T04:05:06.007"), Date.UTC(2001, 1, 3, 4, 5, 6, 7) + localOffset, "2001-02-03T04:05:06.007");
+      this.assertIdentical(Date.parse("2001-02-03T04:05:06.007-06:30"), Date.UTC(2001, 1, 3, 4, 5, 6, 7) + sixHoursThirty, "2001-02-03T04:05:06.007-06:30");
+
+      this.assertIdentical(Date.parse("-010000T04:05"), Date.UTC(-10000, 0, 1, 4, 5, 0, 0) + localOffset, "-010000T04:05");
+      this.assertIdentical(Date.parse("-010000-02T04:05"), Date.UTC(-10000, 1, 1, 4, 5, 0, 0) + localOffset, "-010000-02T04:05");
+      this.assertIdentical(Date.parse("-010000-02-03T04:05"), Date.UTC(-10000, 1, 3, 4, 5, 0, 0) + localOffset, "-010000-02-03T04:05");
+
+      this.assertTrue(isNaN(Date.parse("1970-01-01T00:00:00,000")), "invalid date-time (comma instead of dot)");
+      this.assertTrue(isNaN(Date.parse("1970-01-01T0000")), "invalid date-time (missing colon in time part)");
+      this.assertTrue(isNaN(Date.parse("1970-01-01T00:00.000")), "invalid date-time (msec with missing seconds)");
+    }
+  }
+});

--- a/framework/source/class/qx/ui/tabview/TabView.js
+++ b/framework/source/class/qx/ui/tabview/TabView.js
@@ -24,6 +24,11 @@
  * A tab view is a multi page view where only one page is visible
  * at each moment. It is possible to switch the pages using the
  * buttons rendered by each page.
+ * 
+ * Note that prior to v6.0, when changing the currently selected tab via code
+ * (ie changing the selection property) TabView would automatically set the 
+ * focus to that tab; this is undesirable (and inconsistent with other parts
+ * of the framework) and is no longer done automatically.
  *
  * @childControl bar {qx.ui.container.SlideBar} slidebar for all tab buttons
  * @childControl pane {qx.ui.container.Stack} stack container to show one tab page

--- a/framework/source/class/qx/ui/tabview/TabView.js
+++ b/framework/source/class/qx/ui/tabview/TabView.js
@@ -563,7 +563,6 @@ qx.Class.define("qx.ui.tabview.TabView",
       {
         value = [button.getUserData("page")];
         pane.setSelection(value);
-        button.focus();
         this.scrollChildIntoView(button, null, null, false);
       }
       else


### PR DESCRIPTION
This is the PR in response to the discussion at https://github.com/qooxdoo/qooxdoo/pull/9112

Note: That this PR does only provide one (standard confirm) `parse`. (see discussion above)

Note: The check `qx.bom.client.EcmaScript#getDateParse` might return `false` when run in a timezone equal to GMT, but then the only thing that happens is that the (already compliant) `Date.parse` method might get replaced by our (also compliant) `Date.parse`. So it's fail-save.
But if someone has a better idea,...bring it on :grinning: 
