### PR TITLE
Add method getSubcontrolId returning the id used in _createChildControlImpl

### DIFF
--- a/framework/source/class/qx/test/ui/core/Widget.js
+++ b/framework/source/class/qx/test/ui/core/Widget.js
@@ -321,6 +321,41 @@ qx.Class.define("qx.test.ui.core.Widget",
       qx.Class.undefine("qx.test.ui.core.W");
     },
 
+    testChildGetSubcontrolId : function() {
+      qx.Class.define("qx.test.ui.core.W", {
+        extend : qx.ui.core.Widget,
+
+        members : {
+          _createChildControlImpl : function(id, hash)
+          {
+            var control;
+      
+            switch(id)
+            {
+              case "xyz":
+                control = new qx.ui.core.Widget();
+                break;
+      
+            }
+      
+            return control || this.base(arguments, id);
+          }
+        }
+      });
+
+      var w = new qx.test.ui.core.W();
+
+      var child = w.getChildControl("xyz");
+      this.flush();
+      this.assertEquals("xyz", child.getSubcontrolId());
+      
+      this.assertNull(w.getSubcontrolId());
+
+      child.dispose();
+      w.dispose();
+      qx.Class.undefine("qx.test.ui.core.W");
+    },
+
 
     testCreateChildControlHash: function(){
       qx.Class.define("qx.test.ui.core.W", {

--- a/framework/source/class/qx/ui/core/Widget.js
+++ b/framework/source/class/qx/ui/core/Widget.js
@@ -3687,6 +3687,19 @@ qx.Class.define("qx.ui.core.Widget",
     },
 
 
+    /**
+     * Return the ID of the current widget if it is a created as a 
+     * subcontrol of another widget. 
+     * 
+     * See the first parameter id in {@link qx.ui.core.Widget#_createChildControlImpl} 
+     *
+     * @param id {String|null} ID of the current widget or null if it was not created as a subcontrol
+     */
+    getSubcontrolId : function()
+    {
+      return this.$$subcontrol || null;
+    },
+
 
 
     /*

--- a/framework/source/class/qx/ui/core/Widget.js
+++ b/framework/source/class/qx/ui/core/Widget.js
@@ -3688,8 +3688,7 @@ qx.Class.define("qx.ui.core.Widget",
 
 
     /**
-     * Return the ID of the current widget if it is a created as a 
-     * subcontrol of another widget. 
+     * Return the ID (name) if this instance was a created as a child control of another widget. 
      * 
      * See the first parameter id in {@link qx.ui.core.Widget#_createChildControlImpl} 
      *


### PR DESCRIPTION
This allows, e.g. while listening to the createChildControl event, retrieval of the used id during child control creation.
