### PR TITLE
Prevent check box toggling and stopping event when pressing enter

### DIFF
--- a/framework/source/class/qx/ui/form/CheckBox.js
+++ b/framework/source/class/qx/ui/form/CheckBox.js
@@ -107,6 +107,50 @@ qx.Class.define("qx.ui.form.CheckBox",
       "toolTipText",
       "value",
       "menu"
-    ]
+    ],
+
+    /**
+     * Listener method for "keydown" event.<br/>
+     * Removes "abandoned" and adds "pressed" state
+     * for the keys "Enter" or "Space"
+     *
+     * @param e {Event} Key event
+     */
+    _onKeyDown : function(e)
+    {
+      switch(e.getKeyIdentifier())
+      {
+        case "Space":
+          this.removeState("abandoned");
+          this.addState("pressed");
+
+          e.stopPropagation();
+      }
+    },
+
+
+    /**
+     * Listener method for "keyup" event.<br/>
+     * Removes "abandoned" and "pressed" state (if "pressed" state is set)
+     * for the keys "Enter" or "Space". It also toggles the {@link #value} property.
+     *
+     * @param e {Event} Key event
+     */
+    _onKeyUp : function(e)
+    {
+      if (!this.hasState("pressed")) {
+        return;
+      }
+
+      switch(e.getKeyIdentifier())
+      {
+        case "Space":
+          this.removeState("abandoned");
+          this.execute();
+
+          this.removeState("pressed");
+          e.stopPropagation();
+      }
+    }
   }
 });

--- a/framework/source/class/qx/ui/form/CheckBox.js
+++ b/framework/source/class/qx/ui/form/CheckBox.js
@@ -112,7 +112,7 @@ qx.Class.define("qx.ui.form.CheckBox",
     /**
      * Listener method for "keydown" event.<br/>
      * Removes "abandoned" and adds "pressed" state
-     * for the keys "Enter" or "Space"
+     * for the key "Space"
      *
      * @param e {Event} Key event
      */
@@ -132,7 +132,7 @@ qx.Class.define("qx.ui.form.CheckBox",
     /**
      * Listener method for "keyup" event.<br/>
      * Removes "abandoned" and "pressed" state (if "pressed" state is set)
-     * for the keys "Enter" or "Space". It also toggles the {@link #value} property.
+     * for the key "Space". It also toggles the {@link #value} property.
      *
      * @param e {Event} Key event
      */


### PR DESCRIPTION
PR for #9118.

The check box doesn't toggle and doesn't stop the event when pressing enter while it's focused anymore.
