### PR TITLE
Fix broken playground after merging automatic memory management

### DIFF
--- a/application/playground/source/class/playground/view/RiaPlayArea.js
+++ b/application/playground/source/class/playground/view/RiaPlayArea.js
@@ -115,7 +115,9 @@ qx.Class.define("playground.view.RiaPlayArea",
       qx.ui.core.queue.Manager.flush();
 
       var playRootEl = this._dummy.getContentElement().getDomElement();
-      this._playRoot = new qx.ui.root.Inline(playRootEl);
+      var innerRoot = document.createElement("div");
+      playRootEl.appendChild(innerRoot);
+      this._playRoot = new qx.ui.root.Inline(innerRoot);
       this._playRoot._setLayout(new qx.ui.layout.Canvas());
 
       var self = this;


### PR DESCRIPTION
fixes a bug in playground where it reuses a DomElement for the Inline playground application which causes an exception because that's not allowed; the changes for automatic memory management added assertion checks which caught the problem.
