### PR TITLE
Wrong syntax in qx.test.ui.basic.Atom test method declaration

### DIFF
--- a/framework/source/class/qx/test/ui/basic/Atom.js
+++ b/framework/source/class/qx/test/ui/basic/Atom.js
@@ -47,7 +47,7 @@ qx.Class.define("qx.test.ui.basic.Atom",
       a.destroy();
     },
 
-    testSelectableSet : function('test') {
+    testSelectableSet : function() {
       var a = new qx.ui.basic.Atom();
       a.setSelectable(true);
       this.getRoot().add(a);

--- a/framework/source/class/qx/test/ui/basic/Atom.js
+++ b/framework/source/class/qx/test/ui/basic/Atom.js
@@ -48,7 +48,7 @@ qx.Class.define("qx.test.ui.basic.Atom",
     },
 
     testSelectableSet : function() {
-      var a = new qx.ui.basic.Atom();
+      var a = new qx.ui.basic.Atom('test');
       a.setSelectable(true);
       this.getRoot().add(a);
       this.flush();


### PR DESCRIPTION
There is accidentaly a string literal "test" in the method declaration.
