### PR TITLE
Fix lint run in framework

### DIFF
--- a/framework/config.json
+++ b/framework/config.json
@@ -309,6 +309,8 @@
 
     "lint-test" :
     {
+      "extend" : [ "lint" ],
+      "=exclude": [],
       "include": ["=qx.test.*"]
     },
 

--- a/tool/pylib/ecmascript/transform/check/lint.py
+++ b/tool/pylib/ecmascript/transform/check/lint.py
@@ -88,7 +88,6 @@ class LintChecker(treeutil.NodeVisitor):
             self.visit(cld)
 
     def visit_function(self, node):
-        #print "visiting", node.type
         if not self.opts.ignore_undefined_globals:
             self.unknown_globals(node.scope)
         if not self.opts.ignore_shadowing_locals:
@@ -98,6 +97,9 @@ class LintChecker(treeutil.NodeVisitor):
             self.function_used_deprecated(node)
         if not self.opts.ignore_multiple_vardecls:
             self.function_multiple_var_decls(node)
+
+        self.function_params(node)
+
         # recurse
         for cld in node.children:
             self.visit(cld)
@@ -111,6 +113,13 @@ class LintChecker(treeutil.NodeVisitor):
 
 
     # - ---------------------------------------------------------------------------
+
+    def function_params(self, funcnode):
+        params = funcnode.getChild("params")
+        for param in params.children:
+            if param.type == "constant":
+                issue = warn("Constant as parameter name in function declaration", self.file_name, funcnode)
+                self.issues.append(issue)
 
     def function_used_deprecated(self, funcnode):
         # take advantage of Scope() objects


### PR DESCRIPTION
This commit makes the linter constant aware in function arguments
and enables 'lint-test' to run properly.

refs #9153
