### PR TITLE
Added support for font resource versions.

### DIFF
--- a/framework/source/class/qx/bom/Font.js
+++ b/framework/source/class/qx/bom/Font.js
@@ -212,6 +212,26 @@ qx.Class.define("qx.bom.Font",
       nullable : true
     },
 
+    /**
+     * Version identifier that is appended to the URL to be loaded. Fonts
+     * that are defined thru themes may be managed by the resource manager.
+     * In this case updated fonts persist due to aggressive fontface caching
+     * of some browsers. To get around this, set the `version` property to
+     * the version of your font. It will be appended to the CSS URL and forces
+     * the browser to re-validate.
+     *
+     * The version needs to be URL friendly, so only characters, numbers,
+     * dash and dots are allowed here.
+     */
+    version :
+    {
+      check : function(value) {
+        return value === null || (typeof value === "string" && /^[a-zA-Z0-9.-]+$/.test(value));
+      },
+      init : null,
+      nullable : true
+    },
+
     /** A sorted list of font families */
     family :
     {

--- a/framework/source/class/qx/bom/webfonts/Manager.js
+++ b/framework/source/class/qx/bom/webfonts/Manager.js
@@ -143,6 +143,7 @@ qx.Class.define("qx.bom.webfonts.Manager", {
     {
       var sourceUrls = sourcesList.source;
       var comparisonString = sourcesList.comparisonString;
+      var version = sourcesList.version;
       var fontWeight = sourcesList.fontWeight;
       var fontStyle = sourcesList.fontStyle;
       var sources = [];
@@ -168,9 +169,9 @@ qx.Class.define("qx.bom.webfonts.Manager", {
           this.__queueInterval.start();
         }
 
-        this.__queue.push([familyName, sources, fontWeight, fontStyle, comparisonString, callback, context]);
+        this.__queue.push([familyName, sources, fontWeight, fontStyle, comparisonString, version, callback, context]);
       } else {
-        this.__require(familyName, sources, fontWeight, fontStyle, comparisonString, callback, context);
+        this.__require(familyName, sources, fontWeight, fontStyle, comparisonString, version, callback, context);
       }
     },
 
@@ -293,17 +294,18 @@ qx.Class.define("qx.bom.webfonts.Manager", {
      * @param fontStyle {String} the web font should be registered using an
      * fontStyle font style.
      * @param comparisonString {String} String to check whether the font has loaded or not
+     * @param version {String?} Optional version that is appended to the font URL to be able to override caching
      * @param callback {Function?} Optional event listener callback that will be
      * executed once the validator has determined whether the webFont was
      * applied correctly.
      * @param context {Object?} Optional context for the callback function
      */
-    __require : function(familyName, sources, fontWeight, fontStyle, comparisonString, callback, context)
+    __require : function(familyName, sources, fontWeight, fontStyle, comparisonString, version, callback, context)
     {
       var fontLookupKey = this.__createFontLookupKey(familyName, fontWeight, fontStyle);
       if (!qx.lang.Array.contains(this.__createdStyles, fontLookupKey)) {
         var sourcesMap = this.__getSourcesMap(sources);
-        var rule = this.__getRule(familyName, fontWeight, fontStyle, sourcesMap);
+        var rule = this.__getRule(familyName, fontWeight, fontStyle, sourcesMap, version);
 
         if (!rule) {
           throw new Error("Couldn't create @font-face rule for WebFont " + familyName + "!");
@@ -409,9 +411,10 @@ qx.Class.define("qx.bom.webfonts.Manager", {
      * @param fontStyle {String} the web font should be registered using an
      * fontStyle font style.
      * @param sourcesMap {Map} Map of font formats and sources
+     * @param version {String?} Optional version to be appended to the URL
      * @return {String} The computed CSS rule
      */
-    __getRule : function(familyName, fontWeight, fontStyle, sourcesMap)
+    __getRule : function(familyName, fontWeight, fontStyle, sourcesMap, version)
     {
       var rules = [];
 
@@ -421,7 +424,7 @@ qx.Class.define("qx.bom.webfonts.Manager", {
       for (var i=0,l=formatList.length; i<l; i++) {
         var format = formatList[i];
         if (sourcesMap[format]) {
-          rules.push(this.__getSourceForFormat(format, sourcesMap[format]));
+          rules.push(this.__getSourceForFormat(format, sourcesMap[format], version));
         }
       }
 
@@ -440,10 +443,15 @@ qx.Class.define("qx.bom.webfonts.Manager", {
 
      * @param format {String} The font format, one of eot, woff, ttf, svg
      * @param url {String} The font file's URL
+     * @param version {String?} Optional version to be appended to the URL
      * @return {String} The src directive
      */
-    __getSourceForFormat : function(format, url)
+    __getSourceForFormat : function(format, url, version)
     {
+      if (version) {
+        url += "?" + version;
+      }
+
       switch(format) {
         case "eot": return "url('" + url + "');" +
           "src: url('" + url + "?#iefix') format('embedded-opentype')";

--- a/framework/source/class/qx/bom/webfonts/WebFont.js
+++ b/framework/source/class/qx/bom/webfonts/WebFont.js
@@ -77,6 +77,7 @@ qx.Class.define("qx.bom.webfonts.WebFont", {
         families.push(familyName);
         var sourcesList = value[i];
         sourcesList.comparisonString = this.getComparisonString();
+        sourcesList.version = this.getVersion();
         qx.bom.webfonts.Manager.getInstance().require(familyName, sourcesList, this._onWebFontChangeStatus, this);
       }
 

--- a/framework/source/class/qx/test/bom/webfonts/Manager.js
+++ b/framework/source/class/qx/test/bom/webfonts/Manager.js
@@ -94,6 +94,7 @@ qx.Class.define("qx.test.bom.webfonts.Manager", {
     tearDown : function()
     {
       this.__manager.dispose();
+      qx.bom.webfonts.Manager.VALIDATION_TIMEOUT = 5000;
       delete qx.bom.webfonts.Manager.$$instance;
       this.__manager = null;
       this.assertEquals(this.__nodesBefore, document.body.childNodes.length, "Manager did not remove all nodes!");
@@ -162,9 +163,8 @@ qx.Class.define("qx.test.bom.webfonts.Manager", {
       this.wait(3000);
     },
 
-    "test: load webfont whith custom version" : function()
+    "test: load webfont with custom version" : function()
     {
-      qx.bom.webfonts.Manager.VALIDATION_TIMEOUT = 100;
       var font = new qx.bom.webfonts.WebFont();
       font.set({
         family: ["monospace"],
@@ -172,14 +172,13 @@ qx.Class.define("qx.test.bom.webfonts.Manager", {
         sources: [this.__fontDefinitions.finelinerScript]
       });
 
-      var that = this;
-      window.setTimeout(function() {
-        that.resume(function() {
+      qx.event.Timer.once(function() {
+        this.resume(function() {
           var foundRule = this.__findRule(this.__fontDefinitions.finelinerScript.source[0] + "\\?1\\.0");
           this.assertTrue(foundRule, "@font-face rule for custom version not found in document styles!");
-        }, that);
+        }, this);
 
-      }, 2000);
+      }, this, 2000);
 
       this.wait(3000);
     }

--- a/framework/source/class/qx/test/bom/webfonts/Manager.js
+++ b/framework/source/class/qx/test/bom/webfonts/Manager.js
@@ -160,6 +160,28 @@ qx.Class.define("qx.test.bom.webfonts.Manager", {
       }, 2000);
 
       this.wait(3000);
+    },
+
+    "test: load webfont whith custom version" : function()
+    {
+      qx.bom.webfonts.Manager.VALIDATION_TIMEOUT = 100;
+      var font = new qx.bom.webfonts.WebFont();
+      font.set({
+        family: ["monospace"],
+        version : "1.0",
+        sources: [this.__fontDefinitions.finelinerScript]
+      });
+
+      var that = this;
+      window.setTimeout(function() {
+        that.resume(function() {
+          var foundRule = this.__findRule(this.__fontDefinitions.finelinerScript.source[0] + "\\?1\\.0");
+          this.assertTrue(foundRule, "@font-face rule for custom version not found in document styles!");
+        }, that);
+
+      }, 2000);
+
+      this.wait(3000);
     }
   }
 });


### PR DESCRIPTION
Some browsers do aggressive fontface caching (namely Firefox and derivates) that completely ignores that there is an updated file on the serve, while others honour the sent headers. If you're loading resource manager controlled fonts, it is not possible to add a "?somehash" to the font source.

The pull requests adds _version_ support for the font theme definition to work around that problem.
