### PR TITLE
Fix lint run in framework and lint source/class/qx/test/*

### DIFF
--- a/framework/config.json
+++ b/framework/config.json
@@ -310,6 +310,8 @@
 
     "lint-test" :
     {
+      "extend" : [ "lint" ],
+      "=exclude": [],
       "include": ["=qx.test.*"]
     },
 

--- a/framework/source/class/qx/test/Annotation.js
+++ b/framework/source/class/qx/test/Annotation.js
@@ -18,16 +18,21 @@
 
 qx.Class.define("qx.test.Annotation", {
   extend: qx.dev.unit.TestCase,
-  
+
   members: {
+
+    /**
+     * @lint ignoreReferenceField(@methodA)
+     * @lint ignoreReferenceField(@methodB)
+     */
     testBasic: function() {
       var clazzTop = qx.Class.define(null, {
           "@": [ "class-a-anno" ],
           extend: qx.core.Object,
-          
+
           "@construct": [ "construct-a-anno" ],
           "@destruct": [ "destruct-a-anno" ],
-          
+
           properties: {
             alpha: {
               init: null,
@@ -35,14 +40,14 @@ qx.Class.define("qx.test.Annotation", {
               "@": [ "property-alpha-anno" ]
             }
           },
-          
+
           members: {
             "@methodA": [ "method-a-anno" ],
             methodA: function() {
-              
+
             }
           },
-          
+
           statics : {
             "@staticA": [ "static-a-anno" ],
             staticA: function() {
@@ -50,10 +55,10 @@ qx.Class.define("qx.test.Annotation", {
             }
           }
         });
-      
+
       var clazzMiddle = qx.Class.define(null, {
         extend: clazzTop,
-        
+
         properties: {
           bravo: {
             init: null,
@@ -61,34 +66,34 @@ qx.Class.define("qx.test.Annotation", {
             "@": [ "property-bravo-anno" ]
           }
         },
-        
+
         members: {
           "@methodB": [ "method-b-anno" ],
           methodB: function() {
-            
+
           }
         }
       });
-      
+
       var clazzBottom = qx.Class.define(null, {
         extend: clazzMiddle,
         "@": [ "class-c-anno" ],
         "@construct": [ "construct-c-anno" ],
         "@destruct": [ "destruct-c-anno" ],
-        
+
         properties: {
           bravo: {
             refine: true,
             "@": [ "refined-bravo-anno" ]
           }
         },
-        
+
         members: {
           "@methodB": [ "refined-method-b-anno" ]
         }
       });
 
-      
+
       this.assertArrayEquals([ "class-a-anno" ], qx.Annotation.getOwnClass(clazzTop));
       this.assertArrayEquals([ "class-a-anno" ], qx.Annotation.getClass(clazzTop));
       this.assertArrayEquals([ "construct-a-anno" ], qx.Annotation.getConstructor(clazzTop));
@@ -96,14 +101,14 @@ qx.Class.define("qx.test.Annotation", {
       this.assertArrayEquals([ "method-a-anno" ], qx.Annotation.getOwnMember(clazzTop, "methodA"));
       this.assertArrayEquals([ "static-a-anno" ], qx.Annotation.getStatic(clazzTop, "staticA"));
       this.assertArrayEquals([ "property-alpha-anno" ], qx.Annotation.getProperty(clazzTop, "alpha"));
-      
+
       this.assertArrayEquals([ ], qx.Annotation.getOwnClass(clazzMiddle));
       this.assertArrayEquals([ "class-a-anno" ], qx.Annotation.getClass(clazzMiddle));
       this.assertArrayEquals([ ], qx.Annotation.getOwnConstructor(clazzMiddle));
       this.assertArrayEquals([ "construct-a-anno" ], qx.Annotation.getConstructor(clazzMiddle));
       this.assertArrayEquals([ ], qx.Annotation.getOwnDestructor(clazzMiddle));
       this.assertArrayEquals([ "destruct-a-anno" ], qx.Annotation.getDestructor(clazzMiddle));
-      
+
       this.assertArrayEquals([ ], qx.Annotation.getOwnMember(clazzMiddle, "methodA"));
       this.assertArrayEquals([ "method-a-anno" ], qx.Annotation.getMember(clazzMiddle, "methodA"));
       this.assertArrayEquals([ "method-b-anno" ], qx.Annotation.getMember(clazzMiddle, "methodB"));
@@ -111,46 +116,52 @@ qx.Class.define("qx.test.Annotation", {
       this.assertArrayEquals([ "property-alpha-anno" ], qx.Annotation.getProperty(clazzMiddle, "alpha"));
       this.assertArrayEquals([ "property-bravo-anno" ], qx.Annotation.getProperty(clazzMiddle, "bravo"));
       this.assertArrayEquals([ "bravo" ], qx.Annotation.getPropertiesByAnnotation(clazzBottom, "property-bravo-anno"));
-      
+
       this.assertArrayEquals([ "class-c-anno" ], qx.Annotation.getOwnClass(clazzBottom));
       this.assertArrayEquals([ "class-c-anno", "class-a-anno" ], qx.Annotation.getClass(clazzBottom));
       this.assertArrayEquals([ "construct-c-anno" ], qx.Annotation.getOwnConstructor(clazzBottom));
       this.assertArrayEquals([ "construct-c-anno", "construct-a-anno" ], qx.Annotation.getConstructor(clazzBottom));
       this.assertArrayEquals([ "destruct-c-anno" ], qx.Annotation.getOwnDestructor(clazzBottom));
       this.assertArrayEquals([ "destruct-c-anno", "destruct-a-anno" ], qx.Annotation.getDestructor(clazzBottom));
-      
+
       this.assertArrayEquals([ ], qx.Annotation.getOwnMember(clazzBottom, "methodA"));
       this.assertArrayEquals([ "method-a-anno" ], qx.Annotation.getMember(clazzBottom, "methodA"));
       this.assertArrayEquals([ "refined-method-b-anno", "method-b-anno" ], qx.Annotation.getMember(clazzBottom, "methodB"));
       this.assertArrayEquals([ "property-alpha-anno" ], qx.Annotation.getProperty(clazzBottom, "alpha"));
       this.assertArrayEquals([ "refined-bravo-anno", "property-bravo-anno" ], qx.Annotation.getProperty(clazzBottom, "bravo"));
       this.assertArrayEquals([ "refined-bravo-anno" ], qx.Annotation.getOwnProperty(clazzBottom, "bravo"));
-      
+
     },
-    
+
+
+    /**
+     * @lint ignoreReferenceField(@methodA)
+     * @lint ignoreReferenceField(@methodB)
+     */
     testByType: function() {
       var MyAnno = qx.Class.define(null, {
         extend: qx.core.Object,
-        
+
         construct: function(value) {
           this.base(arguments);
-          if (value)
+          if (value) {
             this.setValue(value);
+          }
         },
-        
+
         properties: {
           value: {
             init: 0
           }
         }
       });
-      
+
       var clazz = qx.Class.define(null, {
         extend: qx.core.Object,
-        
+
         "@construct": [ "construct-a-anno" ],
         "@destruct": [ "destruct-a-anno" ],
-        
+
         properties: {
           alpha: {
             init: null,
@@ -158,14 +169,14 @@ qx.Class.define("qx.test.Annotation", {
             "@": [ "property-alpha-anno", new MyAnno(2) ]
           }
         },
-        
+
         members: {
           "@methodA": [ "method-a-anno", new MyAnno(3) ],
           methodA: function() {
-            
+
           }
         },
-        
+
         statics : {
           "@staticA": [ "static-a-anno", new MyAnno(4) ],
           staticA: function() {
@@ -173,15 +184,15 @@ qx.Class.define("qx.test.Annotation", {
           }
         }
       });
-      
+
       var match = qx.Annotation.getProperty(clazz, "alpha", MyAnno);
       this.assertEquals(1, match.length);
       this.assertTrue(match[0] instanceof MyAnno);
-      
+
       var match = qx.Annotation.getOwnProperty(clazz, "alpha", MyAnno);
       this.assertEquals(1, match.length);
       this.assertTrue(match[0] instanceof MyAnno);
-      
+
       var match = qx.Annotation.getMember(clazz, "methodA", MyAnno);
       this.assertEquals(1, match.length);
       this.assertTrue(match[0] instanceof MyAnno);

--- a/framework/source/class/qx/test/Class.js
+++ b/framework/source/class/qx/test/Class.js
@@ -44,7 +44,7 @@ qx.Class.define("qx.test.Class",
 
     testOverridePropertyMethod : function() {
       this.require(["qx.debug"]);
-      
+
       var C = qx.Class.define(null, {
         extend : qx.core.Object,
         properties : {
@@ -56,7 +56,7 @@ qx.Class.define("qx.test.Class",
           }
         }
       });
-      
+
       var D = qx.Class.define(null, {
       	extend: C,
       	members: {
@@ -68,7 +68,7 @@ qx.Class.define("qx.test.Class",
       		}
       	}
       });
-      
+
       var d = new D();
       d.setProp("hello");
       this.assertEquals("hello-set-get", d.getProp());
@@ -350,6 +350,7 @@ qx.Class.define("qx.test.Class",
 
     testPatchWithConstructor : function()
     {
+      /** @lint ignoreUndeclaredPrivates(__p) */
       qx.Mixin.define("qx.MyMixin", {
         construct : function() {
           this.__p = "p";
@@ -385,6 +386,7 @@ qx.Class.define("qx.test.Class",
 
 
     testInclude : function() {
+      /** @lint ignoreUndeclaredPrivates(__p) */
       qx.Mixin.define("qx.MyMixin", {
         properties : {
           "property" : {init: "p"}
@@ -417,6 +419,7 @@ qx.Class.define("qx.test.Class",
 
 
     testIncludeWithConstructor : function() {
+      /** @lint ignoreUndeclaredPrivates(__p) */
       qx.Mixin.define("qx.MyMixin", {
         construct : function() {
           this.__p = "p";
@@ -474,7 +477,7 @@ qx.Class.define("qx.test.Class",
       });
 
       var subclasses = qx.Class.getSubclasses(qx.Insect);
-      
+
       // we should find 3 subclasses of qx.Insect
       this.assertEquals(Object.keys(subclasses).length,3);
 
@@ -485,7 +488,7 @@ qx.Class.define("qx.test.Class",
 
       // there should be no subclasses for qx.Firefly
       this.assertEquals(Object.keys(subclasses).length,0);
-      
+
       subclasses = qx.Class.getSubclasses(qx.Bug);
 
       // there should be no class qx.Bug

--- a/framework/source/class/qx/test/Interface.js
+++ b/framework/source/class/qx/test/Interface.js
@@ -71,6 +71,8 @@ qx.Class.define("qx.test.Interface",
         properties : { color : { } }
       });
 
+      new qx.test.i.Audi("audi");
+
       this.assertTrue(qx.Interface.classImplements(qx.test.i.Audi, qx.test.i.ICar));
       qx.Class.undefine("qx.test.i.Audi");
     },
@@ -98,6 +100,7 @@ qx.Class.define("qx.test.Interface",
 
           properties : { color : { } }
         });
+
       this.assertTrue(qx.Interface.classImplements(qx.test.i.Bmw1, qx.test.i.ICar));
       qx.Class.undefine("qx.test.i.Bmw1");
     },
@@ -171,7 +174,7 @@ qx.Class.define("qx.test.Interface",
       if (this.isDebugOn())
       {
         this.assertException(function() {
-          qx.test.i.ICar();
+          new qx.test.i.ICar();
         }, Error);
 
 

--- a/framework/source/class/qx/test/Interface.js
+++ b/framework/source/class/qx/test/Interface.js
@@ -71,8 +71,6 @@ qx.Class.define("qx.test.Interface",
         properties : { color : { } }
       });
 
-      var audi = new qx.test.i.Audi("audi");
-
       this.assertTrue(qx.Interface.classImplements(qx.test.i.Audi, qx.test.i.ICar));
       qx.Class.undefine("qx.test.i.Audi");
     },
@@ -173,7 +171,7 @@ qx.Class.define("qx.test.Interface",
       if (this.isDebugOn())
       {
         this.assertException(function() {
-          var i = new qx.test.i.ICar();
+          qx.test.i.ICar();
         }, Error);
 
 
@@ -365,7 +363,9 @@ qx.Class.define("qx.test.Interface",
             members :
             {
               getValue : function() {},
-              setValue : function(value) {}
+              setValue : function(value) {
+                value = value;
+              }
             }
           });
         });
@@ -377,7 +377,9 @@ qx.Class.define("qx.test.Interface",
         members :
         {
           getValue : function() {},
-          setValue : function(value) {}
+          setValue : function(value) {
+            value = value;
+          }
         }
       });
 
@@ -400,7 +402,9 @@ qx.Class.define("qx.test.Interface",
         members :
         {
           getValue : function() {},
-          setValue : function(value) {}
+          setValue : function(value) {
+            value = value;
+          }
         }
       });
     },

--- a/framework/source/class/qx/test/Mixin.js
+++ b/framework/source/class/qx/test/Mixin.js
@@ -234,15 +234,16 @@ qx.Class.define("qx.test.Mixin",
       {
         members :
         {
+          _b: null,
+
           sayJuhu : function() { return this.base(arguments) + " Kinners";},
 
-          /** @lint ignoreUndeclaredPrivates(__b) */
           foo : function(dontRecurs)
           {
             var s = "";
             if (!dontRecurs) {
-              this.__b = new qx.Patch2();
-              s += "++" + this.__b.foo(true) + "__";
+              this._b = new qx.Patch2();
+              s += "++" + this._b.foo(true) + "__";
             }
 
             s += this.base(arguments);
@@ -275,7 +276,7 @@ qx.Class.define("qx.test.Mixin",
       // the mixin member
       var o = new qx.Patch1();
       this.assertEquals("++bar__foo", o.foo());
-      o.__b.dispose();
+      o._b.dispose();
       o.dispose();
     }
   }

--- a/framework/source/class/qx/test/Part.js
+++ b/framework/source/class/qx/test/Part.js
@@ -140,10 +140,8 @@ qx.Class.define("qx.test.Part",
       qx.Part.$$instance = partLoader;
 
       var self = this;
-      var preloadExecuted = false;
       partLoader.preload(["affe", "juhu"], function(states) {
         self.resume(function() {
-          preloadExecuted = true;
           self.assertEquals(self, this, "context wrong");
           self.assertEquals("complete", states[0], "states wrong");
           self.assertEquals("initialized", states[1], "states wrong");

--- a/framework/source/class/qx/test/Theme.js
+++ b/framework/source/class/qx/test/Theme.js
@@ -25,6 +25,8 @@ qx.Class.define("qx.test.Theme",
 
   members :
   {
+    __formerTheme: null,
+
     setUp : function ()
     {
       this.__formerTheme = qx.theme.manager.Decoration.getInstance().getTheme();

--- a/framework/source/class/qx/test/Xml.js
+++ b/framework/source/class/qx/test/Xml.js
@@ -41,7 +41,7 @@ qx.Class.define("qx.test.Xml",
       var div = doc.createElement("div");
       this.assertEquals("div", div.tagName);
 
-      var xmlStr = '<html>' + '<body>Juhu <em id="toll">Kinners</em>. Wie geht es <em>Euch</em>?</body>' + '</html>';
+      var xmlStr = '<html><body>Juhu <em id="toll">Kinners</em>. Wie geht es <em>Euch</em>?</body></html>';
 
       var doc2 = qx.xml.Document.fromString(xmlStr);
       this.assertTrue(qx.dom.Node.isDocument(doc2));
@@ -54,7 +54,7 @@ qx.Class.define("qx.test.Xml",
     {
       var data = "<Root><Row>test1</Row><Row>test2</Row><Row>test3</Row></Root>";
 
-      var xml = qx.xml.Document.fromString(data);
+      qx.xml.Document.fromString(data);
       // this.debug("Converted to XML Document ", xml);
     },
 
@@ -155,7 +155,7 @@ qx.Class.define("qx.test.Xml",
 
       this.assertEquals("xsl:template", templates[0].tagName, "getElementsByTagNameNS for XML documents failed!");
 
-      var templates = qx.xml.Element.getElementsByTagNameNS(nsDoc.documentElement, "http://www.w3.org/1999/XSL/Transform", "template");
+      templates = qx.xml.Element.getElementsByTagNameNS(nsDoc.documentElement, "http://www.w3.org/1999/XSL/Transform", "template");
 
       this.assertEquals(2, templates.length, "getElementsByTagNameNS for element nodes failed!");
 

--- a/framework/source/class/qx/test/bom/AnimationFrame.js
+++ b/framework/source/class/qx/test/bom/AnimationFrame.js
@@ -24,6 +24,8 @@ qx.Class.define("qx.test.bom.AnimationFrame",
 
   members :
   {
+    __frame : null,
+
     setUp : function()
     {
       this.__frame = new qx.bom.AnimationFrame();

--- a/framework/source/class/qx/test/bom/Attribute.js
+++ b/framework/source/class/qx/test/bom/Attribute.js
@@ -160,7 +160,11 @@ qx.Class.define("qx.test.bom.Attribute",
       Attribute.set(this._input, "maxLength", 10);
       Attribute.set(this._input, "maxLength", null);
 
-      var maxLengthValue = qx.core.Environment.select("engine.name", this.__maxLengthValues);
+      var maxLengthValue = qx.core.Environment.select("engine.name", {
+        "mshtml"  : this.__maxLengthValues["mshtml"],
+        "webkit"  : this.__maxLengthValues["webkit"],
+        "default" : this.__maxLengthValues["default"]
+      });
 
       if (qx.core.Environment.get("browser.name") == "edge") {
         maxLengthValue = this.__maxLengthValues.mshtml;

--- a/framework/source/class/qx/test/bom/Blocker.js
+++ b/framework/source/class/qx/test/bom/Blocker.js
@@ -22,6 +22,8 @@ qx.Class.define("qx.test.bom.Blocker",
 
   members :
   {
+    __blocker : null,
+    __blockedElement : null,
 
     setUp : function() {
       this.__blocker = new qx.bom.Blocker();

--- a/framework/source/class/qx/test/bom/Font.js
+++ b/framework/source/class/qx/test/bom/Font.js
@@ -25,6 +25,8 @@ qx.Class.define("qx.test.bom.Font",
 
   members :
   {
+    __font : null,
+
     hasNoIe : function()
     {
       return qx.core.Environment.get("engine.name") !== "mshtml";
@@ -32,7 +34,7 @@ qx.Class.define("qx.test.bom.Font",
 
 
     setUp : function() {
-      this.__font = new qx.bom.Font;
+      this.__font = new qx.bom.Font();
     },
 
 
@@ -177,8 +179,6 @@ qx.Class.define("qx.test.bom.Font",
 
       // we expect a map with only 'fontFamily' set, otherwise the null values
       // which are returned are overwriting styles. Only return styles which are set.
-      var keys = Object.keys(styles);
-
       this.assertMap(styles, "Method 'getStyles' should return a map!");
       this.assertEquals(8, qx.lang.Object.getLength(styles), "Map should contain 8 key!");
       this.assertNotUndefined(styles.fontFamily, "Key 'fontFamily' has to be present!");

--- a/framework/source/class/qx/test/bom/Label.js
+++ b/framework/source/class/qx/test/bom/Label.js
@@ -22,6 +22,16 @@ qx.Class.define("qx.test.bom.Label",
 
   members :
   {
+    __boldStyle : null,
+    __italicStyle : null,
+    __boldItalicStyle : null,
+    __familyStyle : null,
+    __fontSize : null,
+    __fontSizeStyle : null,
+    __paddingStyle : null,
+    __marginStyle : null,
+    __allTogetherStyle : null,
+
     setUp : function()
     {
       this.__boldStyle = { fontWeight: "bold" };

--- a/framework/source/class/qx/test/bom/PageVisibility.js
+++ b/framework/source/class/qx/test/bom/PageVisibility.js
@@ -24,6 +24,8 @@ qx.Class.define("qx.test.bom.PageVisibility",
 
   members :
   {
+    __visibility : null,
+
     setUp : function() {
       this.__visibility = new qx.bom.PageVisibility();
     },

--- a/framework/source/class/qx/test/bom/Stylesheet.js
+++ b/framework/source/class/qx/test/bom/Stylesheet.js
@@ -29,6 +29,8 @@ qx.Class.define("qx.test.bom.Stylesheet",
 
   members :
   {
+    __sheet : null,
+
     tearDown : function()
     {
       if (this.__sheet) {
@@ -48,7 +50,6 @@ qx.Class.define("qx.test.bom.Stylesheet",
       var uri = qx.util.ResourceManager.getInstance().toUri("qx/test/style.css");
       qx.bom.Stylesheet.addImport(sheet, uri);
       if (sheet.cssRules) {
-        var rules = sheet.cssRules || sheet.rules;
         this.assertEquals(1, sheet.cssRules.length);
         this.assertNotUndefined(sheet.cssRules[0].href);
       }
@@ -113,7 +114,6 @@ qx.Class.define("qx.test.bom.Stylesheet",
       qx.bom.Stylesheet.addImport(sheet, uri);
       qx.bom.Stylesheet.removeAllImports(sheet);
       if (sheet.cssRules) {
-        var rules = sheet.cssRules || sheet.rules;
         this.assertEquals(0, sheet.cssRules.length);
       }
       else if (typeof sheet.cssText == "string") {
@@ -142,7 +142,6 @@ qx.Class.define("qx.test.bom.Stylesheet",
 
       qx.bom.Stylesheet.removeImport(sheet, uri);
       if (sheet.cssRules) {
-        var rules = sheet.cssRules || sheet.rules;
         this.assertEquals(0, sheet.cssRules.length);
       }
       else if (typeof sheet.cssText == "string") {

--- a/framework/source/class/qx/test/bom/element/AnimationHandle.js
+++ b/framework/source/class/qx/test/bom/element/AnimationHandle.js
@@ -23,6 +23,8 @@ qx.Class.define("qx.test.bom.element.AnimationHandle",
 
   members :
   {
+    __keys : null,
+
     setUp : function() {
       this.__keys = qx.core.Environment.get("css.animation");
       if (this.__keys == null) {

--- a/framework/source/class/qx/test/bom/element/AnimationJs.js
+++ b/framework/source/class/qx/test/bom/element/AnimationJs.js
@@ -61,7 +61,7 @@ qx.Class.define("qx.test.bom.element.AnimationJs",
         throw new qx.dev.unit.RequirementError();
       }
 
-      var handle = qx.bom.element.Animation.animate(this.__el, {
+      qx.bom.element.Animation.animate(this.__el, {
         "duration": 100,
         "keyFrames": {
           0 : { "width": "200px", "height": "200px" },

--- a/framework/source/class/qx/test/bom/element/Background.js
+++ b/framework/source/class/qx/test/bom/element/Background.js
@@ -29,6 +29,9 @@ qx.Class.define("qx.test.bom.element.Background",
 
   members :
   {
+    __divElement : null,
+    __backgroundUrlBase64 : null,
+
     setUp : function()
     {
       this.__divElement = document.createElement("div");

--- a/framework/source/class/qx/test/bom/element/BoxSizing.js
+++ b/framework/source/class/qx/test/bom/element/BoxSizing.js
@@ -22,16 +22,19 @@ qx.Class.define("qx.test.bom.element.BoxSizing",
 
   include : [qx.dev.unit.MRequirements],
 
-  members :
+  statics :
   {
-    __support :
+    SUPPORT :
     {
       mshtml : ["border-box", "content-box"],
       opera : ["border-box", "content-box"],
       gecko : ["border-box", "content-box"],
       webkit : ["border-box", "content-box"]
-    },
+    }
+  },
 
+  members :
+  {
     __el : null,
 
     setUp : function()
@@ -48,14 +51,14 @@ qx.Class.define("qx.test.bom.element.BoxSizing",
 
     hasBoxsizing : function()
     {
-      return !!qx.core.Environment.get("css.boxsizing");
+      return Boolean(qx.core.Environment.get("css.boxsizing"));
     },
 
     testGet : function()
     {
       this.require(["boxsizing"]);
 
-      var supported = this.__support[qx.core.Environment.get("engine.name")] || [];
+      var supported = qx.test.bom.element.BoxSizing.SUPPORT[qx.core.Environment.get("engine.name")] || [];
       this.assertInArray(qx.bom.element.BoxSizing.get(this.__el), supported);
     },
 
@@ -63,8 +66,8 @@ qx.Class.define("qx.test.bom.element.BoxSizing",
     {
       this.require(["boxsizing"]);
 
-      var allValues = this.__support["gecko"];
-      var supported = this.__support[qx.core.Environment.get("engine.name")] || [];
+      var allValues = qx.test.bom.element.BoxSizing.SUPPORT["gecko"];
+      var supported = qx.test.bom.element.BoxSizing.SUPPORT[qx.core.Environment.get("engine.name")] || [];
       for (var i=0, l=allValues.length; i<l; i++) {
         qx.bom.element.BoxSizing.set(this.__el, allValues[i]);
         if (supported.includes(allValues[i])) {

--- a/framework/source/class/qx/test/bom/element/Dimension.js
+++ b/framework/source/class/qx/test/bom/element/Dimension.js
@@ -22,6 +22,11 @@ qx.Class.define("qx.test.bom.element.Dimension",
 
   members :
   {
+    __inlineElement : null,
+    __inlineElementWithPadding : null,
+    __blockElement : null,
+    __blockElementWithPadding : null,
+
     setUp : function()
     {
       this.__inlineElement = document.createElement("span");

--- a/framework/source/class/qx/test/bom/media/MediaTestCase.js
+++ b/framework/source/class/qx/test/bom/media/MediaTestCase.js
@@ -96,7 +96,6 @@ qx.Class.define("qx.test.bom.media.MediaTestCase",
 
     testCurrentTime: function()
     {
-      var that = this;
       this.assertEquals(0, this._media.getCurrentTime());
     },
 

--- a/framework/source/class/qx/test/bom/request/Xhr.js
+++ b/framework/source/class/qx/test/bom/request/Xhr.js
@@ -327,8 +327,7 @@ qx.Class.define("qx.test.bom.request.Xhr",
     //
 
     "test: emit timeout": function() {
-      var req = this.req,
-          that = this;
+      var req = this.req;
 
       var timeout = this.stub(req, "_emit").withArgs("timeout");
 

--- a/framework/source/class/qx/test/bom/request/XhrWithRemote.js
+++ b/framework/source/class/qx/test/bom/request/XhrWithRemote.js
@@ -402,7 +402,6 @@ qx.Class.define("qx.test.bom.request.XhrWithRemote",
       var primeReq = this.req,
           url = this.noCache(this.getUrl("qx/test/xmlhttp/sample.txt")),
           states = [],
-          count = 0,
           that = this;
 
       primeReq.onreadystatechange = function() {

--- a/framework/source/class/qx/test/bom/rest/Resource.js
+++ b/framework/source/class/qx/test/bom/rest/Resource.js
@@ -28,6 +28,8 @@ qx.Class.define("qx.test.bom.rest.Resource",
 
   members:
   {
+    __reqs : null,
+
     setUp: function() {
       this.setUpDoubleRequest();
       this.setUpResource();
@@ -78,8 +80,7 @@ qx.Class.define("qx.test.bom.rest.Resource",
     //
 
     "test: configure request receives pre-configured but unsent request": function() {
-      var res = this.res,
-          req = this.req;
+      var res = this.res;
 
       res.configureRequest(qx.lang.Function.bind(function(req) {
         this.assertCalledWith(req.setMethod, "GET");
@@ -91,11 +92,10 @@ qx.Class.define("qx.test.bom.rest.Resource",
     },
 
     "test: configure request receives invocation details": function() {
-      var res = this.res,
-          req = this.req,
-          params = {},
-          data = {},
-          callback;
+      var res = this.res;
+      var params = {};
+      var data = {};
+      var callback;
 
       callback = this.spy(qx.lang.Function.bind(function(req, _action, _params, _data) {
         this.assertEquals("get", _action, "Unexpected action");
@@ -113,8 +113,8 @@ qx.Class.define("qx.test.bom.rest.Resource",
     //
 
     "test: map action": function() {
-      var res = this.res,
-          params;
+      var res = this.res;
+      var params;
 
       params = res._getRequestConfig("get");
 
@@ -123,8 +123,8 @@ qx.Class.define("qx.test.bom.rest.Resource",
     },
 
     "test: map action when base URL": function() {
-      var res = this.res,
-          params;
+      var res = this.res;
+      var params;
 
       res.setBaseUrl("http://example.com");
       params = res._getRequestConfig("get");
@@ -133,8 +133,8 @@ qx.Class.define("qx.test.bom.rest.Resource",
     },
 
     "test: map existing action": function() {
-      var res = this.res,
-          params;
+      var res = this.res;
+      var params;
 
       res.map("post", "GET", "/articles");
       params = res._getRequestConfig("post");
@@ -143,8 +143,7 @@ qx.Class.define("qx.test.bom.rest.Resource",
     },
 
     "test: map action creates method": function() {
-      var res = this.res,
-          req = this.req;
+      var res = this.res;
 
       this.assertFunction(res.get);
     },
@@ -152,8 +151,7 @@ qx.Class.define("qx.test.bom.rest.Resource",
     "test: map action throws when existing method": function() {
       this.require(["debug"]);
 
-      var res = this.res,
-          req = this.req;
+      var res = this.res;
 
       // For whatever reason
       res.popular = function() {};
@@ -166,8 +164,7 @@ qx.Class.define("qx.test.bom.rest.Resource",
     "test: map action does not throw when existing method is empty": function() {
       this.require(["debug"]);
 
-      var res = this.res,
-          req = this.req;
+      var res = this.res;
 
       // For documentation purposes
       res.get = (function() {});
@@ -176,8 +173,7 @@ qx.Class.define("qx.test.bom.rest.Resource",
     },
 
     "test: dynamically created action forwards arguments": function() {
-      var res = this.res,
-          req = this.req;
+      var res = this.res;
 
       this.spy(res, "invoke");
       res.get({}, 1, 2, 3);
@@ -192,11 +188,10 @@ qx.Class.define("qx.test.bom.rest.Resource",
     },
 
     "test: map actions from description": function() {
-      var req = this.req,
-          description,
-          res,
-          check = {},
-          params;
+      var description;
+      var res;
+      var check = {};
+      var params;
 
       description =
       {
@@ -222,7 +217,9 @@ qx.Class.define("qx.test.bom.rest.Resource",
       this.require(["debug"]);
 
       this.assertException(function() {
-        var res = new qx.bom.rest.Resource([]);
+        /* eslint-disable: no-new */
+        new qx.bom.rest.Resource([]);
+        /* eslint-enable: no-new */
       });
     },
 
@@ -244,18 +241,15 @@ qx.Class.define("qx.test.bom.rest.Resource",
     //
 
     "test: invoke action generically": function() {
-      var res = this.res,
-          req = this.req,
-          result;
+      var res = this.res;
 
-      result = res.invoke("get");
+      res.invoke("get");
 
       this.assertSend();
     },
 
     "test: invoke action": function() {
-      var res = this.res,
-          req = this.req;
+      var res = this.res;
 
       res.get();
 
@@ -263,8 +257,8 @@ qx.Class.define("qx.test.bom.rest.Resource",
     },
 
     "test: invoke action returns id of request": function() {
-      var res = this.res,
-          req = this.req;
+      var res = this.res;
+      var req = this.req;
 
       req.toHashCode.restore();
 
@@ -272,8 +266,9 @@ qx.Class.define("qx.test.bom.rest.Resource",
     },
 
     "test: invoke action while other is in progress": function() {
-      var res = this.res,
-          req1, req2;
+      var res = this.res;
+      var req1;
+      var req2;
 
       req1 = this.req;
       res.get();
@@ -288,9 +283,10 @@ qx.Class.define("qx.test.bom.rest.Resource",
     },
 
     "test: invoke same action handles multiple requests": function() {
-      var res = this.res,
-          req1, req2,
-          getSuccess = this.spy();
+      var res = this.res;
+      var req1;
+      var req2;
+      var getSuccess = this.spy();
 
       res.addListener("getSuccess", getSuccess);
 
@@ -309,8 +305,8 @@ qx.Class.define("qx.test.bom.rest.Resource",
     },
 
     "test: invoke action with positional params": function() {
-      var res = this.res,
-          req = this.req;
+      var res = this.res;
+      var req = this.req;
 
       res.map("get", "GET", "/photos/{id}");
       res.get({id: "1"});
@@ -319,8 +315,8 @@ qx.Class.define("qx.test.bom.rest.Resource",
     },
 
     "test: invoke action with positional params that evaluate to false": function() {
-      var res = this.res,
-          req = this.req;
+      var res = this.res;
+      var req = this.req;
 
       res.map("get", "GET", "/photos/{id}");
       res.get({id: 0});
@@ -329,8 +325,8 @@ qx.Class.define("qx.test.bom.rest.Resource",
     },
 
     "test: invoke action with non-string params": function() {
-      var res = this.res,
-          req = this.req;
+      var res = this.res;
+      var req = this.req;
 
       res.map("get", "GET", "/photos/{id}");
       res.get({id: 1});
@@ -339,8 +335,8 @@ qx.Class.define("qx.test.bom.rest.Resource",
     },
 
     "test: invoke action with params and data": function() {
-      var res = this.res,
-          req = this.req;
+      var res = this.res;
+      var req = this.req;
 
       res.map("put", "PUT", "/articles/{id}");
       res.put({id: "1"}, {article: '{title: "Affe"}'});
@@ -355,8 +351,8 @@ qx.Class.define("qx.test.bom.rest.Resource",
     },
 
     "test: invoke action with multiple positional params": function() {
-      var res = this.res,
-          req = this.req;
+      var res = this.res;
+      var req = this.req;
 
       res.map("get", "GET", "/photos/{id}/comments/{commentId}");
       res.get({id: "1", commentId: "2"});
@@ -365,8 +361,8 @@ qx.Class.define("qx.test.bom.rest.Resource",
     },
 
     "test: invoke action with positional params in query": function() {
-      var res = this.res,
-          req = this.req;
+      var res = this.res;
+      var req = this.req;
 
       res.map("get", "GET", "/photos/{id}/comments?id={commentId}");
       res.get({id: "1", commentId: "2"});
@@ -375,24 +371,24 @@ qx.Class.define("qx.test.bom.rest.Resource",
     },
 
     "test: invoke action with undefined params": function() {
-      var res = this.res,
-          req = this.req;
+      var res = this.res;
+      var req = this.req;
 
       res.get();
       this.assertCalled(req.send);
     },
 
     "test: invoke action with null params": function() {
-      var res = this.res,
-          req = this.req;
+      var res = this.res;
+      var req = this.req;
 
       res.get(null);
       this.assertCalled(req.send);
     },
 
     "test: invoke action when content type json": function() {
-      var res = this.res,
-          req = this.req;
+      var res = this.res;
+      var req = this.req;
 
       req.setRequestHeader.restore();
       req.getRequestHeader.restore();
@@ -411,8 +407,8 @@ qx.Class.define("qx.test.bom.rest.Resource",
     },
 
     "test: invoke action when content type json and get": function() {
-      var res = this.res,
-          req = this.req;
+      var res = this.res;
+      var req = this.req;
 
       req.setMethod.restore();
       req.getMethod.restore();
@@ -425,8 +421,8 @@ qx.Class.define("qx.test.bom.rest.Resource",
     },
 
     "test: invoke action for url with port": function() {
-      var res = this.res,
-          req = this.req;
+      var res = this.res;
+      var req = this.req;
 
       res.map("get", "GET", "http://example.com:8080/photos/{id}");
       res.get({id: "1"});
@@ -435,8 +431,8 @@ qx.Class.define("qx.test.bom.rest.Resource",
     },
 
     "test: invoke action for relative url": function() {
-      var res = this.res,
-          req = this.req;
+      var res = this.res;
+      var req = this.req;
 
       res.map("get", "GET", "{page}");
       res.get({page: "index"});
@@ -444,8 +440,8 @@ qx.Class.define("qx.test.bom.rest.Resource",
     },
 
     "test: invoke action for relative url with dots": function() {
-      var res = this.res,
-          req = this.req;
+      var res = this.res;
+      var req = this.req;
 
       res.map("get", "GET", "../{page}");
       res.get({page: "index"});
@@ -526,8 +522,8 @@ qx.Class.define("qx.test.bom.rest.Resource",
     //
 
     "test: abort action": function() {
-      var res = this.res,
-          req = this.req;
+      var res = this.res;
+      var req = this.req;
 
       res.get();
       res.abort("get");
@@ -536,8 +532,9 @@ qx.Class.define("qx.test.bom.rest.Resource",
     },
 
     "test: abort action when multiple requests": function() {
-      var res = this.res,
-          req1, req2;
+      var res = this.res;
+      var req1;
+      var req2;
 
       req1 = this.setUpDoubleRequest();
       res.get();
@@ -552,8 +549,8 @@ qx.Class.define("qx.test.bom.rest.Resource",
     },
 
     "test: abort by action id": function() {
-      var res = this.res,
-          req = this.req;
+      var res = this.res;
+      var req = this.req;
 
       req.toHashCode.restore();
 
@@ -568,8 +565,7 @@ qx.Class.define("qx.test.bom.rest.Resource",
     //
 
     "test: refresh action": function() {
-      var res = this.res,
-          req = this.req;
+      var res = this.res;
 
       res.get();
       this.assertSend();
@@ -579,8 +575,7 @@ qx.Class.define("qx.test.bom.rest.Resource",
     },
 
     "test: refresh action replaying previous params": function() {
-      var res = this.res,
-          req = this.req;
+      var res = this.res;
 
       res.map("get", "GET", "/photos/{id}");
       res.get({id: "1"});
@@ -591,8 +586,8 @@ qx.Class.define("qx.test.bom.rest.Resource",
     },
 
     "test: poll action": function() {
-      var res = this.res,
-          sandbox = this.getSandbox();
+      var res = this.res;
+      var sandbox = this.getSandbox();
 
       sandbox.useFakeTimers();
       this.spy(res, "refresh");
@@ -606,8 +601,8 @@ qx.Class.define("qx.test.bom.rest.Resource",
     },
 
     "test: not poll action when no response received yet": function() {
-      var res = this.res,
-          sandbox = this.getSandbox();
+      var res = this.res;
+      var sandbox = this.getSandbox();
 
       sandbox.useFakeTimers();
       this.spy(res, "refresh");
@@ -637,8 +632,7 @@ qx.Class.define("qx.test.bom.rest.Resource",
     },
 
     "test: poll action replaying previous params": function() {
-      var res = this.res,
-          req = this.req;
+      var res = this.res;
 
       res.map("get", "GET", "/photos/{id}");
       res.get({id: "1"});
@@ -649,9 +643,8 @@ qx.Class.define("qx.test.bom.rest.Resource",
     },
 
     "test: poll action repeatedly ends previous timer": function() {
-      var res = this.res,
-          sandbox = this.getSandbox(),
-          msg;
+      var res = this.res;
+      var sandbox = this.getSandbox();
 
       sandbox.useFakeTimers();
       this.stub(res, "refresh");
@@ -668,11 +661,11 @@ qx.Class.define("qx.test.bom.rest.Resource",
     },
 
     "test: poll many actions": function() {
-      var res = this.res,
-          sandbox = this.getSandbox(),
-          spy,
-          get,
-          post;
+      var res = this.res;
+      var sandbox = this.getSandbox();
+      var spy;
+      var get;
+      var post;
 
       this.stub(this.req, "dispose");
       sandbox.useFakeTimers();
@@ -694,10 +687,8 @@ qx.Class.define("qx.test.bom.rest.Resource",
     },
 
     "test: end poll action": function() {
-      var res = this.res,
-          sandbox = this.getSandbox(),
-          timer,
-          numCalled;
+      var res = this.res;
+      var sandbox = this.getSandbox();
 
       sandbox.useFakeTimers();
 
@@ -714,10 +705,9 @@ qx.Class.define("qx.test.bom.rest.Resource",
     },
 
     "test: end poll action does not end polling of other action": function() {
-      var res = this.res,
-          sandbox = this.getSandbox(),
-          timer,
-          spy;
+      var res = this.res;
+      var sandbox = this.getSandbox();
+      var spy;
 
       sandbox.useFakeTimers();
       spy = this.spy(res, "refresh").withArgs("get");
@@ -733,9 +723,8 @@ qx.Class.define("qx.test.bom.rest.Resource",
     },
 
     "test: restart poll action": function() {
-      var res = this.res,
-          sandbox = this.getSandbox(),
-          timer;
+      var res = this.res;
+      var sandbox = this.getSandbox();
 
       sandbox.useFakeTimers();
       this.respond();
@@ -751,9 +740,9 @@ qx.Class.define("qx.test.bom.rest.Resource",
     },
 
     "test: long poll action": function() {
-      var res = this.res,
-          req = this.req,
-          responses = [];
+      var res = this.res;
+      var req = this.req;
+      var responses = [];
 
       // undo this line from setUp() ...
       // this.injectStub(qx.bom.request, "SimpleXhr", req);
@@ -777,8 +766,8 @@ qx.Class.define("qx.test.bom.rest.Resource",
     },
 
     "test: throttle long poll": function() {
-      var res = this.res,
-          req = this.req;
+      var res = this.res;
+      var req = this.req;
 
       this.stub(req, "dispose");
       this.spy(res, "refresh");
@@ -801,9 +790,9 @@ qx.Class.define("qx.test.bom.rest.Resource",
     },
 
     "test: not throttle long poll when not received within limit": function() {
-      var res = this.res,
-          req = this.req,
-          sandbox = this.getSandbox();
+      var res = this.res;
+      var req = this.req;
+      var sandbox = this.getSandbox();
 
       // undo this line from setUp() ...
       // this.injectStub(qx.bom.request, "SimpleXhr", req);
@@ -830,9 +819,9 @@ qx.Class.define("qx.test.bom.rest.Resource",
     },
 
     "test: not throttle long poll when not received subsequently": function() {
-      var res = this.res,
-          req = this.req,
-          sandbox = this.getSandbox();
+      var res = this.res;
+      var req = this.req;
+      var sandbox = this.getSandbox();
 
       // undo this line from setUp() ...
       // this.injectStub(qx.bom.request, "SimpleXhr", req);
@@ -864,10 +853,9 @@ qx.Class.define("qx.test.bom.rest.Resource",
     },
 
     "test: end long poll action": function() {
-      var res = this.res,
-          req = this.req,
-          handlerId,
-          msg;
+      var res = this.res;
+      var req = this.req;
+      var handlerId;
 
       // undo this line from setUp() ...
       // this.injectStub(qx.bom.request, "SimpleXhr", req);
@@ -894,9 +882,9 @@ qx.Class.define("qx.test.bom.rest.Resource",
     //
 
     "test: fire actionSuccess": function() {
-      var res = this.res,
-          req = this.req,
-          that = this;
+      var res = this.res;
+      var req = this.req;
+      var that = this;
 
       res.get();
       this.assertEventFired(res, "getSuccess", function() {
@@ -909,9 +897,9 @@ qx.Class.define("qx.test.bom.rest.Resource",
     },
 
     "test: fire success": function() {
-      var res = this.res,
-          req = this.req,
-          that = this;
+      var res = this.res;
+      var req = this.req;
+      var that = this;
 
       res.get();
       this.assertEventFired(res, "success", function() {
@@ -924,9 +912,9 @@ qx.Class.define("qx.test.bom.rest.Resource",
     },
 
     "test: fire actionError": function() {
-      var res = this.res,
-          req = this.req,
-          that = this;
+      var res = this.res;
+      var req = this.req;
+      var that = this;
 
       res.get();
       this.assertEventFired(res, "getError", function() {
@@ -938,9 +926,9 @@ qx.Class.define("qx.test.bom.rest.Resource",
     },
 
     "test: fire error": function() {
-      var res = this.res,
-          req = this.req,
-          that = this;
+      var res = this.res;
+      var req = this.req;
+      var that = this;
 
       res.get();
       this.assertEventFired(res, "error", function() {
@@ -955,9 +943,7 @@ qx.Class.define("qx.test.bom.rest.Resource",
 
       qx.bom.request.SimpleXhr.restore();
 
-      var res = this.res,
-          req = this.req,
-          that = this;
+      var res = this.res;
 
       var listener = this.spy();
       res.on("started", listener);
@@ -977,8 +963,9 @@ qx.Class.define("qx.test.bom.rest.Resource",
     //
 
     "test: dispose requests": function() {
-      var res = this.res,
-          req1, req2;
+      var res = this.res;
+      var req1;
+      var req2;
 
       req1 = this.req;
       res.get();
@@ -998,8 +985,9 @@ qx.Class.define("qx.test.bom.rest.Resource",
     },
 
     "test: dispose requests of same action": function() {
-      var res = this.res,
-          req1, req2;
+      var res = this.res;
+      var req1;
+      var req2;
 
       req1 = this.req;
       res.get();
@@ -1019,8 +1007,8 @@ qx.Class.define("qx.test.bom.rest.Resource",
     },
 
     "test: dispose request on loadEnd": function() {
-      var res = this.res,
-          req = this.req;
+      var res = this.res;
+      var req = this.req;
 
       this.spy(req, "dispose");
 
@@ -1069,8 +1057,8 @@ qx.Class.define("qx.test.bom.rest.Resource",
     // Fake response but find and manipulate matching requests *within* res
     // which is important for tests with more than one request (e.g. poll and long poll)
     respondSubsequent: function(response, reqIdx, shouldStubResp) {
-      var response = response || "",
-          validReqIdx = (reqIdx !== undefined);
+      response = response || "";
+      var validReqIdx = (reqIdx !== undefined);
 
       // this.res.__requests isn't available after 'privates' optimization
       // so find it by some kind of feature detection - this isn't beautiful,

--- a/framework/source/class/qx/test/bom/webfonts/Manager.js
+++ b/framework/source/class/qx/test/bom/webfonts/Manager.js
@@ -28,30 +28,10 @@ qx.Class.define("qx.test.bom.webfonts.Manager", {
 
   members :
   {
-    __fontDefinitions :
-    {
-      finelinerScript :
-      {
-        family : "FinelinerScriptRegular",
-        source: [ qx.util.ResourceManager.getInstance().toUri("qx/test/webfonts/fineliner_script-webfont.woff"),
-                  qx.util.ResourceManager.getInstance().toUri("qx/test/webfonts/fineliner_script-webfont.ttf"),
-                  qx.util.ResourceManager.getInstance().toUri("qx/test/webfonts/fineliner_script-webfont.eot") ]
-      },
-      fontawesome :
-      {
-        family : "FontAwesome",
-        source: [ qx.util.ResourceManager.getInstance().toUri("qx/test/webfonts/fontawesome-webfont.woff"),
-                  qx.util.ResourceManager.getInstance().toUri("qx/test/webfonts/fontawesome-webfont.ttf"),
-                  qx.util.ResourceManager.getInstance().toUri("qx/test/webfonts/fontawesome-webfont.eot") ]
-      },
-      invalid :
-      {
-        family : "MonkeypooBold",
-        source: [ "404.woff",
-                  "404.ttf",
-                  "404.eot" ]
-      }
-    },
+    __fontDefinitions : null,
+    __nodesBefore : null,
+    __sheetsBefore : null,
+    __manager : null,
 
     __findRule : function(familyName)
     {
@@ -89,6 +69,30 @@ qx.Class.define("qx.test.bom.webfonts.Manager", {
       this.__nodesBefore = document.body.childNodes.length;
       this.__sheetsBefore = document.styleSheets.length;
       this.__manager = qx.bom.webfonts.Manager.getInstance();
+
+      this.__fontDefinitions = {
+        finelinerScript :
+        {
+          family : "FinelinerScriptRegular",
+          source: [ qx.util.ResourceManager.getInstance().toUri("qx/test/webfonts/fineliner_script-webfont.woff"),
+                    qx.util.ResourceManager.getInstance().toUri("qx/test/webfonts/fineliner_script-webfont.ttf"),
+                    qx.util.ResourceManager.getInstance().toUri("qx/test/webfonts/fineliner_script-webfont.eot") ]
+        },
+        fontawesome :
+        {
+          family : "FontAwesome",
+          source: [ qx.util.ResourceManager.getInstance().toUri("qx/test/webfonts/fontawesome-webfont.woff"),
+                    qx.util.ResourceManager.getInstance().toUri("qx/test/webfonts/fontawesome-webfont.ttf"),
+                    qx.util.ResourceManager.getInstance().toUri("qx/test/webfonts/fontawesome-webfont.eot") ]
+        },
+        invalid :
+        {
+          family : "MonkeypooBold",
+          source: [ "404.woff",
+                    "404.ttf",
+                    "404.eot" ]
+        }
+      };
     },
 
     tearDown : function()

--- a/framework/source/class/qx/test/bom/webfonts/Validator.js
+++ b/framework/source/class/qx/test/bom/webfonts/Validator.js
@@ -21,6 +21,9 @@ qx.Class.define("qx.test.bom.webfonts.Validator", {
 
   members :
   {
+    __val : null,
+    __nodesBefore : null,
+
     setUp : function()
     {
       this.__nodesBefore = document.body.childNodes.length;

--- a/framework/source/class/qx/test/core/Validation.js
+++ b/framework/source/class/qx/test/core/Validation.js
@@ -99,14 +99,21 @@ qx.Class.define("qx.test.core.Validation",
 
   members :
   {
+    __model: null,
 
     testNumber : function()
     {
       var model = this.__model;
       // test for some false inputs
-      this.assertException(function() {model.setNumber("test");}, qx.core.ValidationError, null, "A String is no number.");
-      this.assertException(function() {model.setNumber(new Date());}, qx.core.ValidationError, null, "A Date is no number.");
-      this.assertException(function() {model.setNumber(this);}, qx.core.ValidationError, null, "this is no number.");
+      this.assertException(
+        function() {model.setNumber("test");},
+        qx.core.ValidationError, null, "A String is no number.");
+      this.assertException(
+        function() {model.setNumber(new Date());},
+        qx.core.ValidationError, null, "A Date is no number.");
+      this.assertException(
+        function() {model.setNumber(this);},
+        qx.core.ValidationError, null, "this is no number.");
 
       // test an positive integer
       model.setNumber(12);
@@ -125,10 +132,18 @@ qx.Class.define("qx.test.core.Validation",
       var model = this.__model;
 
       // test some wrong addresses
-      this.assertException(function() {model.setEmail("test");}, qx.core.ValidationError, null, "test is a mailadress?");
-      this.assertException(function() {model.setEmail("@affe.de");}, qx.core.ValidationError, null, "@affe.de is never a mailadress!");
-      this.assertException(function() {model.setEmail("hans@@wurst.de");}, qx.core.ValidationError, null, "Are two @ allowed?");
-      this.assertException(function() {model.setEmail("m@a.d");}, qx.core.ValidationError, null, "m@a.d?");
+      this.assertException(
+        function() {model.setEmail("test");},
+        qx.core.ValidationError, null, "test is a mailadress?");
+      this.assertException(
+        function() {model.setEmail("@affe.de");},
+        qx.core.ValidationError, null, "@affe.de is never a mailadress!");
+      this.assertException(
+        function() {model.setEmail("hans@@wurst.de");},
+        qx.core.ValidationError, null, "Are two @ allowed?");
+      this.assertException(
+        function() {model.setEmail("m@a.d");},
+        qx.core.ValidationError, null, "m@a.d?");
 
       // test some working addresses
       model.setEmail("affe@zoo.de");
@@ -145,10 +160,18 @@ qx.Class.define("qx.test.core.Validation",
       var model = this.__model;
 
       // test some wrong inputs
-      this.assertException(function() {model.setString(1);}, qx.core.ValidationError, null, "A number is not a string!");
-      this.assertException(function() {model.setString(this);}, qx.core.ValidationError, null, "This test is not a string!");
-      this.assertException(function() {model.setString(true);}, qx.core.ValidationError, null, "A boolean is not a string!");
-      this.assertException(function() {model.setString(new Date());}, qx.core.ValidationError, null, "A Date-Object is not a string!");
+      this.assertException(
+        function() {model.setString(1);},
+        qx.core.ValidationError, null, "A number is not a string!");
+      this.assertException(
+        function() {model.setString(this);},
+        qx.core.ValidationError, null, "This test is not a string!");
+      this.assertException(
+        function() {model.setString(true);},
+        qx.core.ValidationError, null, "A boolean is not a string!");
+      this.assertException(
+        function() {model.setString(new Date());},
+        qx.core.ValidationError, null, "A Date-Object is not a string!");
 
       // Test some working inputs
       model.setString("affe@zoo.de");
@@ -161,10 +184,18 @@ qx.Class.define("qx.test.core.Validation",
       var model = this.__model;
 
       // test some wrong inputs
-      this.assertException(function() {model.setUrl(1);}, qx.core.ValidationError, null, "A number is not an url!");
-      this.assertException(function() {model.setUrl(false);}, qx.core.ValidationError, null, "A boolean is not an url!");
-      this.assertException(function() {model.setUrl("i am an url");}, qx.core.ValidationError, null, "'i am an url' as a string is not an url!");
-      this.assertException(function() {model.setUrl("http:/iamaurl");}, qx.core.ValidationError, null, "'http://iamaurl' is not an url!");
+      this.assertException(
+        function() {model.setUrl(1);},
+        qx.core.ValidationError, null, "A number is not an url!");
+      this.assertException(
+        function() {model.setUrl(false);},
+        qx.core.ValidationError, null, "A boolean is not an url!");
+      this.assertException(
+        function() {model.setUrl("i am an url");},
+        qx.core.ValidationError, null, "'i am an url' as a string is not an url!");
+      this.assertException(
+        function() {model.setUrl("http:/iamaurl");},
+        qx.core.ValidationError, null, "'http://iamaurl' is not an url!");
 
       // Test some working inputs
       model.setUrl("http://www.1und1.de");
@@ -182,11 +213,16 @@ qx.Class.define("qx.test.core.Validation",
       var model = this.__model;
 
       // test some wrong inputs
-      this.assertException(function() {model.setColor(1);}, qx.core.ValidationError, null, "A number is not a color!");
-      this.assertException(function() {model.setColor("");}, qx.core.ValidationError, null, "A empty string is not a color!");
-      this.assertException(function() {model.setColor("FFFFFF");}, qx.core.ValidationError, null, "FFFFFF (missing #) is not a color!");
-      this.assertException(function() {model.setColor("bluecolor");}, qx.core.ValidationError, null, "'bluecolor' is not a color!");
-      this.assertException(function() {model.setColor("#FFFFGG");}, qx.core.ValidationError, null, "#FFFFGG is not a color!");
+      this.assertException(
+        function() {model.setColor(1);}, qx.core.ValidationError, null, "A number is not a color!");
+      this.assertException(
+        function() {model.setColor("");}, qx.core.ValidationError, null, "A empty string is not a color!");
+      this.assertException(
+        function() {model.setColor("FFFFFF");}, qx.core.ValidationError, null, "FFFFFF (missing #) is not a color!");
+      this.assertException(
+        function() {model.setColor("bluecolor");}, qx.core.ValidationError, null, "'bluecolor' is not a color!");
+      this.assertException(
+        function() {model.setColor("#FFFFGG");}, qx.core.ValidationError, null, "#FFFFGG is not a color!");
 
       // Test some working inputs
       model.setColor("black");
@@ -203,8 +239,10 @@ qx.Class.define("qx.test.core.Validation",
       var model = this.__model;
 
       // test some wrong inputs (Rage defined from 1 to 2 including both)
-      this.assertException(function() {model.setRange(0.999999999);}, qx.core.ValidationError, null, "A 0.999999999 is not between 1 and 2.");
-      this.assertException(function() {model.setRange(2.000000001);}, qx.core.ValidationError, null, "A 2.000000001 is not between 1 and 2.");
+      this.assertException(
+        function() {model.setRange(0.999999999);}, qx.core.ValidationError, null, "A 0.999999999 is not between 1 and 2.");
+      this.assertException(
+        function() {model.setRange(2.000000001);}, qx.core.ValidationError, null, "A 2.000000001 is not between 1 and 2.");
 
       // Test some working inputs
       model.setRange(1);
@@ -221,9 +259,12 @@ qx.Class.define("qx.test.core.Validation",
       var model = this.__model;
 
       // test some wrong inputs (allowed are male and female)
-      this.assertException(function() {model.setArray(0.999999999);}, qx.core.ValidationError, null, "A 0.999999999 is not in ['male', 'female']");
-      this.assertException(function() {model.setArray("malle");}, qx.core.ValidationError, null, "'malle' is not in ['male', 'female']");
-      this.assertException(function() {model.setArray("");}, qx.core.ValidationError, null, "A empty string is not in ['male', 'female']");
+      this.assertException(
+        function() {model.setArray(0.999999999);}, qx.core.ValidationError, null, "A 0.999999999 is not in ['male', 'female']");
+      this.assertException(
+        function() {model.setArray("malle");}, qx.core.ValidationError, null, "'malle' is not in ['male', 'female']");
+      this.assertException(
+        function() {model.setArray("");}, qx.core.ValidationError, null, "A empty string is not in ['male', 'female']");
 
       // Test some working inputs
       model.setArray("male");
@@ -237,10 +278,14 @@ qx.Class.define("qx.test.core.Validation",
       var model = this.__model;
 
       // test some wrong inputs (String must be longer than 3)
-      this.assertException(function() {model.setCustom("");}, qx.core.ValidationError, null, "'' is too short");
-      this.assertException(function() {model.setCustom("1");}, qx.core.ValidationError, null, "'1' is too short");
-      this.assertException(function() {model.setCustom("12");}, qx.core.ValidationError, null, "'12' is too short");
-      this.assertException(function() {model.setCustom("123");}, qx.core.ValidationError, null, "'123' is too short");
+      this.assertException(
+        function() {model.setCustom("");}, qx.core.ValidationError, null, "'' is too short");
+      this.assertException(
+        function() {model.setCustom("1");}, qx.core.ValidationError, null, "'1' is too short");
+      this.assertException(
+        function() {model.setCustom("12");}, qx.core.ValidationError, null, "'12' is too short");
+      this.assertException(
+        function() {model.setCustom("123");}, qx.core.ValidationError, null, "'123' is too short");
 
       // Test some working inputs
       model.setCustom("male");
@@ -254,9 +299,12 @@ qx.Class.define("qx.test.core.Validation",
       var model = this.__model;
 
       // test some wrong inputs (Only digits)
-      this.assertException(function() {model.setRegExp("AFFE!");}, qx.core.ValidationError, null, "'AFFE!' does not fit /[0-9]*/.");
-      this.assertException(function() {model.setRegExp("_dfds_");}, qx.core.ValidationError, null, "_dfds_ does not fit /[0-9]*/.");
-      this.assertException(function() {model.setRegExp("$%&!&/%");}, qx.core.ValidationError, null, "$%&!&/% does not fit /[0-9]*/.");
+      this.assertException(
+        function() {model.setRegExp("AFFE!");}, qx.core.ValidationError, null, "'AFFE!' does not fit /[0-9]*/.");
+      this.assertException(
+        function() {model.setRegExp("_dfds_");}, qx.core.ValidationError, null, "_dfds_ does not fit /[0-9]*/.");
+      this.assertException(
+        function() {model.setRegExp("$%&!&/%");}, qx.core.ValidationError, null, "$%&!&/% does not fit /[0-9]*/.");
 
       // Test some working inputs
       model.setRegExp("abc");

--- a/framework/source/class/qx/test/data/store/Rest.js
+++ b/framework/source/class/qx/test/data/store/Rest.js
@@ -45,8 +45,7 @@ qx.Class.define("qx.test.data.store.Rest",
     },
 
     setUpDoubleRequest: function() {
-      var req = this.req = new qx.io.request.Xhr(),
-          res = this.res;
+      var req = this.req = new qx.io.request.Xhr();
 
       // Stub request methods, leave event system intact
       req = this.shallowStub(req, qx.io.request.AbstractRequest);
@@ -101,8 +100,8 @@ qx.Class.define("qx.test.data.store.Rest",
     "test: construct throws with missing action": function() {
       this.require(["debug"]);
 
-      var store,
-          res = this.res;
+      var res = this.res;
+      var store;
 
       this.assertException(function() {
         store = new qx.data.store.Rest(res, null);
@@ -111,8 +110,8 @@ qx.Class.define("qx.test.data.store.Rest",
     },
 
     "test: add listener for actionSuccess to res": function() {
-      var res = this.res,
-          store;
+      var res = this.res;
+      var store;
 
       this.stub(res, "addListener");
       store = new qx.data.store.Rest(res, "index");
@@ -121,10 +120,9 @@ qx.Class.define("qx.test.data.store.Rest",
     },
 
     "test: marshal response": function() {
-      var res = this.res,
-          store = this.store,
-          marshal = this.marshal,
-          data = {"key": "value"};
+      var res = this.res;
+      var marshal = this.marshal;
+      var data = {"key": "value"};
 
       res.index();
 
@@ -136,8 +134,8 @@ qx.Class.define("qx.test.data.store.Rest",
       // Do not stub marshal.Json
       qx.data.marshal.Json.restore();
 
-      var res = this.setUpResource(),
-          store = new qx.data.store.Rest(res, "index");
+      var res = this.setUpResource();
+      var store = new qx.data.store.Rest(res, "index");
 
       res.index();
       this.respond({"name": "Affe"});
@@ -149,9 +147,9 @@ qx.Class.define("qx.test.data.store.Rest",
       // Do not stub marshal.Json
       qx.data.marshal.Json.restore();
 
-      var res = this.setUpResource(),
-          store = new qx.data.store.Rest(res, "index"),
-          that = this;
+      var res = this.setUpResource();
+      var store = new qx.data.store.Rest(res, "index");
+      var that = this;
 
       res.index();
       this.assertEventFired(store, "changeModel", function() {
@@ -163,8 +161,8 @@ qx.Class.define("qx.test.data.store.Rest",
     },
 
     "test: configure request with delegate": function() {
-      var res = this.res,
-          req = this.req;
+      var res = this.res;
+      var req = this.req;
 
       var configureRequest = this.spy(function(req) {
         req.setUserData("affe", true);
@@ -188,8 +186,8 @@ qx.Class.define("qx.test.data.store.Rest",
     },
 
     "test: manipulate data with delegate before marshaling": function() {
-      var res = this.res,
-          data = {"name": "Tiger"};
+      var res = this.res;
+      var data = {"name": "Tiger"};
 
       var manipulateData = this.spy(function(data) {
         data.name = "Maus";

--- a/framework/source/class/qx/test/data/store/RestWithRemote.js
+++ b/framework/source/class/qx/test/data/store/RestWithRemote.js
@@ -35,9 +35,9 @@ qx.Class.define("qx.test.data.store.RestWithRemote",
   members:
   {
     setUp: function() {
-      var url = this.getUrl("qx/test/primitive.json"),
-          res = this.res = new qx.io.rest.Resource({index: {method: "GET", url: url} }),
-          store = this.store = new qx.data.store.Rest(res, "index");
+      var url = this.getUrl("qx/test/primitive.json");
+      var res = this.res = new qx.io.rest.Resource({index: {method: "GET", url: url} });
+      this.store = new qx.data.store.Rest(res, "index");
 
       res.configureRequest(function(req) {
         req.setParser(qx.util.ResponseParser.PARSER.json);
@@ -52,8 +52,8 @@ qx.Class.define("qx.test.data.store.RestWithRemote",
     },
 
     "test: populate store with response of resource action": function() {
-      var res = this.res,
-          store = this.store;
+      var res = this.res;
+      var store = this.store;
 
       res.addListener("success", function() {
         this.resume(function() {
@@ -66,9 +66,9 @@ qx.Class.define("qx.test.data.store.RestWithRemote",
     },
 
     "test: bind model property": function() {
-      var res = this.res,
-          store = this.store,
-          label = new qx.ui.basic.Label();
+      var res = this.res;
+      var store = this.store;
+      var label = new qx.ui.basic.Label();
 
       res.addListener("success", function() {
         this.resume(function() {

--- a/framework/source/class/qx/test/dev/Debug.js
+++ b/framework/source/class/qx/test/dev/Debug.js
@@ -44,7 +44,6 @@ qx.Class.define("qx.test.dev.Debug",
       this.assertArray(undisposed);
       this.assertEquals(1, undisposed.length);
       this.assertEquals(o, undisposed[0].object);
-      var stackOk = false;
       this.assertMatch(undisposed[0].stackTrace.join(" "), this.classname);
 
       n.dispose();

--- a/framework/source/class/qx/test/dev/unit/Sinon.js
+++ b/framework/source/class/qx/test/dev/unit/Sinon.js
@@ -235,9 +235,6 @@ qx.Class.define("qx.test.dev.unit.Sinon",
       var func = function() {};
       var obj = {"a": function() {}};
 
-      var spy = this.spy(func);
-      var stub = this.stub(obj, "a");
-      var xhr = this.useFakeXMLHttpRequest();
       var nxhr = window.XMLHttpRequest || window.ActiveXObject("Microsoft.XMLHTTP");
 
       this.getSandbox().restore();

--- a/framework/source/class/qx/test/dev/unit/Sinon.js
+++ b/framework/source/class/qx/test/dev/unit/Sinon.js
@@ -235,6 +235,10 @@ qx.Class.define("qx.test.dev.unit.Sinon",
       var func = function() {};
       var obj = {"a": function() {}};
 
+      this.spy(func);
+      this.stub(obj, "a");
+      this.useFakeXMLHttpRequest();
+
       var nxhr = window.XMLHttpRequest || window.ActiveXObject("Microsoft.XMLHTTP");
 
       this.getSandbox().restore();

--- a/framework/source/class/qx/test/dom/Hierarchy.js
+++ b/framework/source/class/qx/test/dom/Hierarchy.js
@@ -22,6 +22,13 @@ qx.Class.define("qx.test.dom.Hierarchy",
 
   members :
   {
+    __renderedElement : null,
+    __siblingElement : null,
+    __notDisplayedElement : null,
+    __childElement : null,
+    __childOfNotDisplayedElement : null,
+    __unRenderedElement : null,
+    __iframe : null,
 
     setUp : function()
     {
@@ -83,7 +90,7 @@ qx.Class.define("qx.test.dom.Hierarchy",
       qx.bom.Iframe.setSource(this.__iframe, src);
       document.body.appendChild(this.__iframe);
 
-      qx.event.Registration.addListener(this.__iframe, "load", function(e) {
+      qx.event.Registration.addListener(this.__iframe, "load", function() {
         this.resume(function() {
           this.assertTrue(qx.dom.Hierarchy.isRendered(this.__iframe));
         }, this);

--- a/framework/source/class/qx/test/event/MockHandler.js
+++ b/framework/source/class/qx/test/event/MockHandler.js
@@ -49,7 +49,10 @@ qx.Class.define("qx.test.event.MockHandler",
     IGNORE_CAN_HANDLE : false
   },
 
-
+  construct : function() {
+    this.base(arguments);
+    this.calls = [];
+  },
 
 
 
@@ -61,7 +64,7 @@ qx.Class.define("qx.test.event.MockHandler",
 
   members :
   {
-    calls : [],
+    calls : null,
 
     /*
     ---------------------------------------------------------------------------

--- a/framework/source/class/qx/test/event/message/Bus.js
+++ b/framework/source/class/qx/test/event/message/Bus.js
@@ -170,8 +170,6 @@ qx.Class.define("qx.test.event.message.Bus",
          flag = true;
       };
 
-      function anotherHandler() {};
-
       var messageBus = qx.event.message.Bus.getInstance();
       messageBus.subscribe("message", handler, this);
       var msg1 = new qx.event.message.Message("message", true);

--- a/framework/source/class/qx/test/html/Flash.js
+++ b/framework/source/class/qx/test/html/Flash.js
@@ -69,7 +69,6 @@ qx.Class.define("qx.test.html.Flash",
       this.__flash.setAttribute("attrib3", true);
       this.__flash.setAttribute("attrib4", false);
 
-      var map = this.__flash.getAttribute();
       this.assertIdentical("hoho", this.__flash.getAttributes().attrib1);
       this.assertIdentical("gogo", this.__flash.getAttributes().attrib2);
       this.assertTrue(this.__flash.getAttributes().attrib3);
@@ -97,7 +96,6 @@ qx.Class.define("qx.test.html.Flash",
       this.__flash.setParam("param3", true);
       this.__flash.setParam("param4", false);
 
-      var map = this.__flash.getParams();
       this.assertIdentical("hoho", this.__flash.getParams().param1);
       this.assertIdentical("gogo", this.__flash.getParams().param2);
       this.assertTrue(this.__flash.getParams().param3);

--- a/framework/source/class/qx/test/io/ImageLoader.js
+++ b/framework/source/class/qx/test/io/ImageLoader.js
@@ -29,6 +29,12 @@ qx.Class.define("qx.test.io.ImageLoader",
 
   members :
   {
+    __imageUri : null,
+    __wrongImageUri : null,
+    __vectorImageUri : null,
+    __wrongVectorImageUri : null,
+    __imageSource : null,
+
     setUp : function()
     {
       this.__imageUri = qx.util.ResourceManager.getInstance().toUri("qx/test/colorstrip.gif");
@@ -47,11 +53,11 @@ qx.Class.define("qx.test.io.ImageLoader",
     testLoadImageSuccess : function()
     {
       this.__imageSource = null;
-      qx.io.ImageLoader.load(this.__imageUri, function(source, entry) {
+      qx.io.ImageLoader.load(this.__imageUri, function(source) {
         this.__imageSource = source;
       }, this);
 
-      qx.event.Timer.once(function(e) {
+      qx.event.Timer.once(function() {
         var self = this;
         this.resume(function() {
           this.assertTrue(qx.io.ImageLoader.isLoaded(this.__imageSource));
@@ -65,11 +71,11 @@ qx.Class.define("qx.test.io.ImageLoader",
     testLoadVectorImageSuccess : function()
     {
       this.__imageSource = null;
-      qx.io.ImageLoader.load(this.__vectorImageUri, function(source, entry) {
+      qx.io.ImageLoader.load(this.__vectorImageUri, function(source) {
         this.__imageSource = source;
       }, this);
 
-      qx.event.Timer.once(function(e) {
+      qx.event.Timer.once(function() {
         var self = this;
         this.resume(function() {
           this.assertTrue(qx.io.ImageLoader.isLoaded(this.__imageSource));
@@ -83,11 +89,11 @@ qx.Class.define("qx.test.io.ImageLoader",
     testLoadImageFailure : function()
     {
       this.__imageSource = null;
-      qx.io.ImageLoader.load(this.__wrongImageUri, function(source, entry) {
+      qx.io.ImageLoader.load(this.__wrongImageUri, function(source) {
         this.__imageSource = source;
       }, this);
 
-      qx.event.Timer.once(function(e) {
+      qx.event.Timer.once(function() {
         var self = this;
         this.resume(function() {
           this.assertTrue(qx.io.ImageLoader.isFailed(this.__imageSource));
@@ -100,11 +106,11 @@ qx.Class.define("qx.test.io.ImageLoader",
     testLoadVectorImageFailure : function()
     {
       this.__imageSource = null;
-      qx.io.ImageLoader.load(this.__wrongVectorImageUri, function(source, entry) {
+      qx.io.ImageLoader.load(this.__wrongVectorImageUri, function(source) {
         this.__imageSource = source;
       }, this);
 
-      qx.event.Timer.once(function(e) {
+      qx.event.Timer.once(function() {
         var self = this;
         this.resume(function() {
           this.assertTrue(qx.io.ImageLoader.isFailed(this.__imageSource));
@@ -117,11 +123,11 @@ qx.Class.define("qx.test.io.ImageLoader",
     testImageWidth : function()
     {
       this.__imageSource = null;
-      qx.io.ImageLoader.load(this.__imageUri, function(source, entry) {
+      qx.io.ImageLoader.load(this.__imageUri, function(source) {
         this.__imageSource = source;
       }, this);
 
-      qx.event.Timer.once(function(e) {
+      qx.event.Timer.once(function() {
         var self = this;
         this.resume(function() {
           this.assertEquals(192, qx.io.ImageLoader.getWidth(this.__imageSource));
@@ -134,11 +140,11 @@ qx.Class.define("qx.test.io.ImageLoader",
     testVectorImageWidth : function()
     {
       this.__imageSource = null;
-      qx.io.ImageLoader.load(this.__vectorImageUri, function(source, entry) {
+      qx.io.ImageLoader.load(this.__vectorImageUri, function(source) {
         this.__imageSource = source;
       }, this);
 
-      qx.event.Timer.once(function(e) {
+      qx.event.Timer.once(function() {
         var self = this;
         this.resume(function() {
           this.assertEquals(192, qx.io.ImageLoader.getWidth(this.__imageSource));
@@ -151,11 +157,11 @@ qx.Class.define("qx.test.io.ImageLoader",
     testImageHeight : function()
     {
       this.__imageSource = null;
-      qx.io.ImageLoader.load(this.__imageUri, function(source, entry) {
+      qx.io.ImageLoader.load(this.__imageUri, function(source) {
         this.__imageSource = source;
       }, this);
 
-      qx.event.Timer.once(function(e) {
+      qx.event.Timer.once(function() {
         var self = this;
         this.resume(function() {
           this.assertEquals(10, qx.io.ImageLoader.getHeight(this.__imageSource));
@@ -168,11 +174,11 @@ qx.Class.define("qx.test.io.ImageLoader",
     testVectorImageHeight : function()
     {
       this.__imageSource = null;
-      qx.io.ImageLoader.load(this.__vectorImageUri, function(source, entry) {
+      qx.io.ImageLoader.load(this.__vectorImageUri, function(source) {
         this.__imageSource = source;
       }, this);
 
-      qx.event.Timer.once(function(e) {
+      qx.event.Timer.once(function() {
         var self = this;
         this.resume(function() {
           this.assertEquals(10, qx.io.ImageLoader.getHeight(this.__imageSource));
@@ -185,11 +191,11 @@ qx.Class.define("qx.test.io.ImageLoader",
     testImageSize : function()
     {
       this.__imageSource = null;
-      qx.io.ImageLoader.load(this.__imageUri, function(source, entry) {
+      qx.io.ImageLoader.load(this.__imageUri, function(source) {
         this.__imageSource = source;
       }, this);
 
-      qx.event.Timer.once(function(e) {
+      qx.event.Timer.once(function() {
         var self = this;
         this.resume(function() {
           var size = qx.io.ImageLoader.getSize(this.__imageSource);
@@ -204,11 +210,11 @@ qx.Class.define("qx.test.io.ImageLoader",
     testVectorImageSize : function()
     {
       this.__imageSource = null;
-      qx.io.ImageLoader.load(this.__vectorImageUri, function(source, entry) {
+      qx.io.ImageLoader.load(this.__vectorImageUri, function(source) {
         this.__imageSource = source;
       }, this);
 
-      qx.event.Timer.once(function(e) {
+      qx.event.Timer.once(function() {
         var self = this;
         this.resume(function() {
           var size = qx.io.ImageLoader.getSize(this.__imageSource);
@@ -223,11 +229,11 @@ qx.Class.define("qx.test.io.ImageLoader",
     testImageFormat : function()
     {
       this.__imageSource = null;
-      qx.io.ImageLoader.load(this.__imageUri, function(source, entry) {
+      qx.io.ImageLoader.load(this.__imageUri, function(source) {
         this.__imageSource = source;
       }, this);
 
-      qx.event.Timer.once(function(e) {
+      qx.event.Timer.once(function() {
         var self = this;
         this.resume(function() {
           this.assertEquals("gif", qx.io.ImageLoader.getFormat(this.__imageSource));

--- a/framework/source/class/qx/test/io/part/MockLoader.js
+++ b/framework/source/class/qx/test/io/part/MockLoader.js
@@ -4,11 +4,15 @@
  */
 qx.Bootstrap.define("qx.test.io.part.MockLoader",
 {
-  construct : function() {},
+  construct : function() {
+    this.parts = {"b":["b"]};
+    this.packages = {"b" : {uris: []}};
+    this.boot = "b";
+  },
   members :
   {
-    parts:{"b":["b"]},
-    packages : {"b" : {uris: []}},
-    boot: "b"
+    parts: null,
+    packages : null,
+    boot: null
   }
 });

--- a/framework/source/class/qx/test/io/part/MockPackage.js
+++ b/framework/source/class/qx/test/io/part/MockPackage.js
@@ -4,13 +4,16 @@ qx.Bootstrap.define("qx.test.io.part.MockPackage",
   {
     this.id = id;
     this.delay = delay || 0;
-    this.error = !!error;
+    this.error = Boolean(error);
     this.readyState = readyState || "initialized";
-    this.useClosure = !!useClosure;
+    this.useClosure = Boolean(useClosure);
   },
 
   members :
   {
+    __readyState : null,
+    __notifyPackageResult : null,
+
     getReadyState : function() {
       return this.readyState;
     },
@@ -55,17 +58,17 @@ qx.Bootstrap.define("qx.test.io.part.MockPackage",
     },
 
 
-    saveClosure : function(closure)
+    saveClosure : function()
     {
       if (this.readyState == "error") {
         return;
       }
 
-      if (!this._loadWithClosure) {
-        this.execute();
-      } else {
+      if (this._loadWithClosure) {
         this.__readyState = "cached";
         this.__notifyPackageResult(this);
+      } else {
+        this.execute();
       }
     },
 

--- a/framework/source/class/qx/test/io/part/Part.js
+++ b/framework/source/class/qx/test/io/part/Part.js
@@ -33,6 +33,7 @@ qx.Class.define("qx.test.io.part.Part",
   members :
   {
     __loader : null,
+    __dummyLoader : null,
 
     setUp : function()
     {

--- a/framework/source/class/qx/test/io/remote/RequestXhr.js
+++ b/framework/source/class/qx/test/io/remote/RequestXhr.js
@@ -130,12 +130,15 @@ qx.Class.define("qx.test.io.remote.RequestXhr",
       // Response header is "juhu"
       request.setUrl(this.getUrl("qx/test/xmlhttp/send_known_header.php"));
 
-      request.addListener("completed", function(e) { this.resume(function() {
-        this.assertEquals("kinners", e.getResponseHeader("juhu"), "Exact case match");
-        this.assertEquals("kinners", e.getResponseHeader("Juhu"), "Case insensitive match");
-      }, this); }, this);
+      request.addListener("completed",
+        function(e) {
+          this.resume(function() {
+            this.assertEquals("kinners", e.getResponseHeader("juhu"), "Exact case match");
+            this.assertEquals("kinners", e.getResponseHeader("Juhu"), "Case insensitive match");
+          }, this);
+        }, this
+      );
 
-      var that = this;
       window.setTimeout(function() {
         request.send();
       }, 1000);

--- a/framework/source/class/qx/test/io/rest/Resource.js
+++ b/framework/source/class/qx/test/io/rest/Resource.js
@@ -35,6 +35,8 @@ qx.Class.define("qx.test.io.rest.Resource",
 
   members:
   {
+    __reqs : null,
+
     setUp: function() {
       this.setUpDoubleRequest();
       this.setUpResource();
@@ -84,8 +86,7 @@ qx.Class.define("qx.test.io.rest.Resource",
     //
 
     "test: configure request receives pre-configured but unsent request": function() {
-      var res = this.res,
-          req = this.req;
+      var res = this.res;
 
       res.configureRequest(qx.lang.Function.bind(function(req) {
         this.assertCalledWith(req.setMethod, "GET");
@@ -97,11 +98,10 @@ qx.Class.define("qx.test.io.rest.Resource",
     },
 
     "test: configure request receives invocation details": function() {
-      var res = this.res,
-          req = this.req,
-          params = {},
-          data = {},
-          callback;
+      var res = this.res;
+      var params = {};
+      var data = {};
+      var callback;
 
       callback = this.spy(qx.lang.Function.bind(function(req, _action, _params, _data) {
         this.assertEquals("get", _action, "Unexpected action");
@@ -119,8 +119,8 @@ qx.Class.define("qx.test.io.rest.Resource",
     //
 
     "test: map action": function() {
-      var res = this.res,
-          params;
+      var res = this.res;
+      var params;
 
       params = res._getRequestConfig("get");
 
@@ -129,8 +129,8 @@ qx.Class.define("qx.test.io.rest.Resource",
     },
 
     "test: map action when base URL": function() {
-      var res = this.res,
-          params;
+      var res = this.res;
+      var params;
 
       res.setBaseUrl("http://example.com");
       params = res._getRequestConfig("get");
@@ -139,8 +139,8 @@ qx.Class.define("qx.test.io.rest.Resource",
     },
 
     "test: map existing action": function() {
-      var res = this.res,
-          params;
+      var res = this.res;
+      var params;
 
       res.map("post", "GET", "/articles");
       params = res._getRequestConfig("post");
@@ -149,8 +149,7 @@ qx.Class.define("qx.test.io.rest.Resource",
     },
 
     "test: map action creates method": function() {
-      var res = this.res,
-          req = this.req;
+      var res = this.res;
 
       this.assertFunction(res.get);
     },
@@ -158,8 +157,7 @@ qx.Class.define("qx.test.io.rest.Resource",
     "test: map action throws when existing method": function() {
       this.require(["debug"]);
 
-      var res = this.res,
-          req = this.req;
+      var res = this.res;
 
       // For whatever reason
       res.popular = function() {};
@@ -172,8 +170,7 @@ qx.Class.define("qx.test.io.rest.Resource",
     "test: map action does not throw when existing method is empty": function() {
       this.require(["debug"]);
 
-      var res = this.res,
-          req = this.req;
+      var res = this.res;
 
       // For documentation purposes
       res.get = (function() {});
@@ -182,8 +179,7 @@ qx.Class.define("qx.test.io.rest.Resource",
     },
 
     "test: dynamically created action forwards arguments": function() {
-      var res = this.res,
-          req = this.req;
+      var res = this.res;
 
       this.spy(res, "invoke");
       res.get({}, 1, 2, 3);
@@ -198,11 +194,10 @@ qx.Class.define("qx.test.io.rest.Resource",
     },
 
     "test: map actions from description": function() {
-      var req = this.req,
-          description,
-          res,
-          check = {},
-          params;
+      var description;
+      var res;
+      var check = {};
+      var params;
 
       description =
       {
@@ -228,7 +223,7 @@ qx.Class.define("qx.test.io.rest.Resource",
       this.require(["debug"]);
 
       this.assertException(function() {
-        var res = new qx.io.rest.Resource([]);
+        qx.io.rest.Resource([]);
       });
     },
 
@@ -250,18 +245,15 @@ qx.Class.define("qx.test.io.rest.Resource",
     //
 
     "test: invoke action generically": function() {
-      var res = this.res,
-          req = this.req,
-          result;
+      var res = this.res;
 
-      result = res.invoke("get");
+      res.invoke("get");
 
       this.assertSend();
     },
 
     "test: invoke action": function() {
-      var res = this.res,
-          req = this.req;
+      var res = this.res;
 
       res.get();
 
@@ -269,15 +261,15 @@ qx.Class.define("qx.test.io.rest.Resource",
     },
 
     "test: invoke action returns id of request": function() {
-      var res = this.res,
-          req = this.req;
+      var res = this.res;
 
       this.assertNumber(res.invoke("get"));
     },
 
     "test: invoke action while other is in progress": function() {
-      var res = this.res,
-          req1, req2;
+      var res = this.res;
+      var req1;
+      var req2;
 
       req1 = this.req;
       res.get();
@@ -292,9 +284,10 @@ qx.Class.define("qx.test.io.rest.Resource",
     },
 
     "test: invoke same action handles multiple requests": function() {
-      var res = this.res,
-          req1, req2,
-          getSuccess = this.spy();
+      var res = this.res;
+      var req1;
+      var req2;
+      var getSuccess = this.spy();
 
       res.addListener("getSuccess", getSuccess);
 
@@ -313,8 +306,8 @@ qx.Class.define("qx.test.io.rest.Resource",
     },
 
     "test: invoke action with positional params": function() {
-      var res = this.res,
-          req = this.req;
+      var res = this.res;
+      var req = this.req;
 
       res.map("get", "GET", "/photos/{id}");
       res.get({id: "1"});
@@ -323,8 +316,8 @@ qx.Class.define("qx.test.io.rest.Resource",
     },
 
     "test: invoke action with positional params that evaluate to false": function() {
-      var res = this.res,
-          req = this.req;
+      var res = this.res;
+      var req = this.req;
 
       res.map("get", "GET", "/photos/{id}");
       res.get({id: 0});
@@ -333,8 +326,8 @@ qx.Class.define("qx.test.io.rest.Resource",
     },
 
     "test: invoke action with non-string params": function() {
-      var res = this.res,
-          req = this.req;
+      var res = this.res;
+      var req = this.req;
 
       res.map("get", "GET", "/photos/{id}");
       res.get({id: 1});
@@ -343,8 +336,8 @@ qx.Class.define("qx.test.io.rest.Resource",
     },
 
     "test: invoke action with params and data": function() {
-      var res = this.res,
-          req = this.req;
+      var res = this.res;
+      var req = this.req;
 
       res.map("put", "PUT", "/articles/{id}");
       res.put({id: "1"}, {article: '{title: "Affe"}'});
@@ -359,8 +352,8 @@ qx.Class.define("qx.test.io.rest.Resource",
     },
 
     "test: invoke action with multiple positional params": function() {
-      var res = this.res,
-          req = this.req;
+      var res = this.res;
+      var req = this.req;
 
       res.map("get", "GET", "/photos/{id}/comments/{commentId}");
       res.get({id: "1", commentId: "2"});
@@ -369,8 +362,8 @@ qx.Class.define("qx.test.io.rest.Resource",
     },
 
     "test: invoke action with positional params in query": function() {
-      var res = this.res,
-          req = this.req;
+      var res = this.res;
+      var req = this.req;
 
       res.map("get", "GET", "/photos/{id}/comments?id={commentId}");
       res.get({id: "1", commentId: "2"});
@@ -379,24 +372,24 @@ qx.Class.define("qx.test.io.rest.Resource",
     },
 
     "test: invoke action with undefined params": function() {
-      var res = this.res,
-          req = this.req;
+      var res = this.res;
+      var req = this.req;
 
       res.get();
       this.assertCalled(req.send);
     },
 
     "test: invoke action with null params": function() {
-      var res = this.res,
-          req = this.req;
+      var res = this.res;
+      var req = this.req;
 
       res.get(null);
       this.assertCalled(req.send);
     },
 
     "test: invoke action when content type json": function() {
-      var res = this.res,
-          req = this.req;
+      var res = this.res;
+      var req = this.req;
 
       req.setRequestHeader.restore();
       req.getRequestHeader.restore();
@@ -415,8 +408,8 @@ qx.Class.define("qx.test.io.rest.Resource",
     },
 
     "test: invoke action when content type json and get": function() {
-      var res = this.res,
-          req = this.req;
+      var res = this.res;
+      var req = this.req;
 
       req.setMethod.restore();
       req.getMethod.restore();
@@ -429,8 +422,8 @@ qx.Class.define("qx.test.io.rest.Resource",
     },
 
     "test: invoke action for url with port": function() {
-      var res = this.res,
-          req = this.req;
+      var res = this.res;
+      var req = this.req;
 
       res.map("get", "GET", "http://example.com:8080/photos/{id}");
       res.get({id: "1"});
@@ -439,8 +432,8 @@ qx.Class.define("qx.test.io.rest.Resource",
     },
 
     "test: invoke action for relative url": function() {
-      var res = this.res,
-          req = this.req;
+      var res = this.res;
+      var req = this.req;
 
       res.map("get", "GET", "{page}");
       res.get({page: "index"});
@@ -448,8 +441,8 @@ qx.Class.define("qx.test.io.rest.Resource",
     },
 
     "test: invoke action for relative url with dots": function() {
-      var res = this.res,
-          req = this.req;
+      var res = this.res;
+      var req = this.req;
 
       res.map("get", "GET", "../{page}");
       res.get({page: "index"});
@@ -530,8 +523,8 @@ qx.Class.define("qx.test.io.rest.Resource",
     //
 
     "test: abort action": function() {
-      var res = this.res,
-          req = this.req;
+      var res = this.res;
+      var req = this.req;
 
       res.get();
       res.abort("get");
@@ -540,8 +533,9 @@ qx.Class.define("qx.test.io.rest.Resource",
     },
 
     "test: abort action when multiple requests": function() {
-      var res = this.res,
-          req1, req2;
+      var res = this.res;
+      var req1;
+      var req2;
 
       req1 = this.setUpDoubleRequest();
       res.get();
@@ -556,8 +550,8 @@ qx.Class.define("qx.test.io.rest.Resource",
     },
 
     "test: abort by action id": function() {
-      var res = this.res,
-          req = this.req;
+      var res = this.res;
+      var req = this.req;
 
       var id = res.get();
       res.abort(id);
@@ -570,8 +564,7 @@ qx.Class.define("qx.test.io.rest.Resource",
     //
 
     "test: refresh action": function() {
-      var res = this.res,
-          req = this.req;
+      var res = this.res;
 
       res.get();
       this.assertSend();
@@ -581,8 +574,7 @@ qx.Class.define("qx.test.io.rest.Resource",
     },
 
     "test: refresh action replaying previous params": function() {
-      var res = this.res,
-          req = this.req;
+      var res = this.res;
 
       res.map("get", "GET", "/photos/{id}");
       res.get({id: "1"});
@@ -593,8 +585,8 @@ qx.Class.define("qx.test.io.rest.Resource",
     },
 
     "test: poll action": function() {
-      var res = this.res,
-          sandbox = this.getSandbox();
+      var res = this.res;
+      var sandbox = this.getSandbox();
 
       sandbox.useFakeTimers();
       this.spy(res._resource, "refresh");
@@ -608,8 +600,8 @@ qx.Class.define("qx.test.io.rest.Resource",
     },
 
     "test: not poll action when no response received yet": function() {
-      var res = this.res,
-          sandbox = this.getSandbox();
+      var res = this.res;
+      var sandbox = this.getSandbox();
 
       sandbox.useFakeTimers();
       this.spy(res, "refresh");
@@ -639,8 +631,7 @@ qx.Class.define("qx.test.io.rest.Resource",
     },
 
     "test: poll action replaying previous params": function() {
-      var res = this.res,
-          req = this.req;
+      var res = this.res;
 
       res.map("get", "GET", "/photos/{id}");
       res.get({id: "1"});
@@ -651,9 +642,8 @@ qx.Class.define("qx.test.io.rest.Resource",
     },
 
     "test: poll action repeatedly ends previous timer": function() {
-      var res = this.res,
-          sandbox = this.getSandbox(),
-          msg;
+      var res = this.res;
+      var sandbox = this.getSandbox();
 
       sandbox.useFakeTimers();
       this.stub(res._resource, "refresh");
@@ -670,11 +660,11 @@ qx.Class.define("qx.test.io.rest.Resource",
     },
 
     "test: poll many actions": function() {
-      var res = this.res,
-          sandbox = this.getSandbox(),
-          spy,
-          get,
-          post;
+      var res = this.res;
+      var sandbox = this.getSandbox();
+      var spy;
+      var get;
+      var post;
 
       this.stub(this.req, "dispose");
       sandbox.useFakeTimers();
@@ -696,9 +686,9 @@ qx.Class.define("qx.test.io.rest.Resource",
     },
 
     "test: end poll action": function() {
-      var res = this.res,
-          sandbox = this.getSandbox(),
-          timer;
+      var res = this.res;
+      var sandbox = this.getSandbox();
+      var timer;
 
       sandbox.useFakeTimers();
 
@@ -715,10 +705,10 @@ qx.Class.define("qx.test.io.rest.Resource",
     },
 
     "test: end poll action does not end polling of other action": function() {
-      var res = this.res,
-          sandbox = this.getSandbox(),
-          timer,
-          spy;
+      var res = this.res;
+      var sandbox = this.getSandbox();
+      var timer;
+      var spy;
 
       sandbox.useFakeTimers();
       spy = this.spy(res._resource, "refresh").withArgs("get");
@@ -734,9 +724,9 @@ qx.Class.define("qx.test.io.rest.Resource",
     },
 
     "test: restart poll action": function() {
-      var res = this.res,
-          sandbox = this.getSandbox(),
-          timer;
+      var res = this.res;
+      var sandbox = this.getSandbox();
+      var timer;
 
       sandbox.useFakeTimers();
       this.respond();
@@ -752,9 +742,9 @@ qx.Class.define("qx.test.io.rest.Resource",
     },
 
     "test: long poll action": function() {
-      var res = this.res,
-          req = this.req,
-          responses = [];
+      var res = this.res;
+      var req = this.req;
+      var responses = [];
 
       this.stub(req, "dispose");
 
@@ -772,8 +762,8 @@ qx.Class.define("qx.test.io.rest.Resource",
     },
 
     "test: throttle long poll": function() {
-      var res = this.res,
-          req = this.req;
+      var res = this.res;
+      var req = this.req;
 
       this.stub(req, "dispose");
       this.spy(res, "refresh");
@@ -796,9 +786,9 @@ qx.Class.define("qx.test.io.rest.Resource",
     },
 
     "test: not throttle long poll when not received within limit": function() {
-      var res = this.res,
-          req = this.req,
-          sandbox = this.getSandbox();
+      var res = this.res;
+      var req = this.req;
+      var sandbox = this.getSandbox();
 
       this.stub(req, "dispose");
 
@@ -819,9 +809,9 @@ qx.Class.define("qx.test.io.rest.Resource",
     },
 
     "test: not throttle long poll when not received subsequently": function() {
-      var res = this.res,
-          req = this.req,
-          sandbox = this.getSandbox();
+      var res = this.res;
+      var req = this.req;
+      var sandbox = this.getSandbox();
 
       this.stub(req, "dispose");
 
@@ -847,10 +837,9 @@ qx.Class.define("qx.test.io.rest.Resource",
     },
 
     "test: end long poll action": function() {
-      var res = this.res,
-          req = this.req,
-          handlerId,
-          msg;
+      var res = this.res;
+      var req = this.req;
+      var handlerId;
 
       this.stub(req, "dispose");
       this.spy(res._resource, "refresh");
@@ -871,9 +860,9 @@ qx.Class.define("qx.test.io.rest.Resource",
     //
 
     "test: fire actionSuccess": function() {
-      var res = this.res,
-          req = this.req,
-          that = this;
+      var res = this.res;
+      var req = this.req;
+      var that = this;
 
       res.get();
       this.assertEventFired(res, "getSuccess", function() {
@@ -887,9 +876,9 @@ qx.Class.define("qx.test.io.rest.Resource",
     },
 
     "test: fire success": function() {
-      var res = this.res,
-          req = this.req,
-          that = this;
+      var res = this.res;
+      var req = this.req;
+      var that = this;
 
       res.get();
       this.assertEventFired(res, "success", function() {
@@ -903,9 +892,9 @@ qx.Class.define("qx.test.io.rest.Resource",
     },
 
     "test: fire actionError": function() {
-      var res = this.res,
-          req = this.req,
-          that = this;
+      var res = this.res;
+      var req = this.req;
+      var that = this;
 
       res.get();
       this.assertEventFired(res, "getError", function() {
@@ -917,9 +906,9 @@ qx.Class.define("qx.test.io.rest.Resource",
     },
 
     "test: fire error": function() {
-      var res = this.res,
-          req = this.req,
-          that = this;
+      var res = this.res;
+      var req = this.req;
+      var that = this;
 
       res.get();
       this.assertEventFired(res, "error", function() {
@@ -935,8 +924,9 @@ qx.Class.define("qx.test.io.rest.Resource",
     //
 
     "test: dispose requests": function() {
-      var res = this.res,
-          req1, req2;
+      var res = this.res;
+      var req1;
+      var req2;
 
       req1 = this.req;
       res.get();
@@ -956,8 +946,9 @@ qx.Class.define("qx.test.io.rest.Resource",
     },
 
     "test: dispose requests of same action": function() {
-      var res = this.res,
-          req1, req2;
+      var res = this.res;
+      var req1;
+      var req2;
 
       req1 = this.req;
       res.get();
@@ -977,8 +968,8 @@ qx.Class.define("qx.test.io.rest.Resource",
     },
 
     "test: dispose request on loadEnd": function() {
-      var res = this.res,
-          req = this.req;
+      var res = this.res;
+      var req = this.req;
 
       this.spy(req, "dispose");
 
@@ -1015,7 +1006,7 @@ qx.Class.define("qx.test.io.rest.Resource",
 
     // Fake response
     respond: function(response, req) {
-      var req = req || this.req;
+      req = req || this.req;
       response = response || "";
       req.isDone.returns(true);
       req.getPhase.returns("success");

--- a/framework/source/class/qx/test/io/rest/Resource.js
+++ b/framework/source/class/qx/test/io/rest/Resource.js
@@ -223,7 +223,7 @@ qx.Class.define("qx.test.io.rest.Resource",
       this.require(["debug"]);
 
       this.assertException(function() {
-        qx.io.rest.Resource([]);
+        new qx.io.rest.Resource([]);
       });
     },
 

--- a/framework/source/class/qx/test/lang/Json.js
+++ b/framework/source/class/qx/test/lang/Json.js
@@ -57,7 +57,6 @@ qx.Class.define("qx.test.lang.Json",
     {
       var obj = [new Date(0), "foo"];
 
-      var self = this;
       var replacer = function(key, value) {
         return this[key] instanceof Date ? 'Date(' + this[key].getTime() + ')' : value;
       };
@@ -168,14 +167,14 @@ qx.Class.define("qx.test.lang.Json",
       obj.foo = obj;
 
       this.assertException(function() {
-        var text = this.JSON.stringify(obj);
+        this.JSON.stringify(obj);
       });
 
       obj = [];
       obj[0] = obj;
 
       this.assertException(function() {
-        var text = this.JSON.stringify(obj);
+        this.JSON.stringify(obj);
       });
     },
 

--- a/framework/source/class/qx/test/log/Logger.js
+++ b/framework/source/class/qx/test/log/Logger.js
@@ -26,6 +26,8 @@ qx.Class.define("qx.test.log.Logger",
 
   members :
   {
+    __initialLogLevel : null,
+
     setUp : function()
     {
       this.__initialLogLevel = qx.log.Logger.getLevel();

--- a/framework/source/class/qx/test/log/RingBuffer.js
+++ b/framework/source/class/qx/test/log/RingBuffer.js
@@ -22,6 +22,8 @@ qx.Class.define("qx.test.log.RingBuffer",
 
   members :
   {
+    __initialLogLevel : null,
+
     setUp : function()
     {
       this.__initialLogLevel = qx.log.Logger.getLevel();

--- a/framework/source/class/qx/test/mobile/LocaleSwitch.js
+++ b/framework/source/class/qx/test/mobile/LocaleSwitch.js
@@ -96,7 +96,7 @@ qx.Class.define("qx.test.mobile.LocaleSwitch",
     testList : function()
     {
       var list = new qx.ui.mobile.list.List({
-        configureItem : function(item, data, row) {
+        configureItem : function(item, data) {
           item.setTitle(data.title);
           item.setSubtitle(data.subTitle);
         }
@@ -121,7 +121,7 @@ qx.Class.define("qx.test.mobile.LocaleSwitch",
 
       this.manager.setLocale("de_QX");
       var title0 = q(".list * .list-item-title").eq(0).getHtml();
-      this.assertEquals("Eins". title0);
+      this.assertEquals("Eins", title0);
       var subtitle0 = q(".list * .list-item-subtitle").eq(0).getHtml();
       this.assertEquals("Zwei", subtitle0);
       var title1 = q(".list * .list-item-title").eq(1).getHtml();
@@ -136,7 +136,7 @@ qx.Class.define("qx.test.mobile.LocaleSwitch",
     __testListEn : function() {
       //debugger
       var title0 = q(".list * .list-item-title").eq(0).getHtml();
-      this.assertEquals("test one". title0);
+      this.assertEquals("test one", title0);
       var subtitle0 = q(".list * .list-item-subtitle").eq(0).getHtml();
       this.assertEquals("test two", subtitle0);
       var title1 = q(".list * .list-item-title").eq(1).getHtml();

--- a/framework/source/class/qx/test/mobile/core/Widget.js
+++ b/framework/source/class/qx/test/mobile/core/Widget.js
@@ -136,7 +136,7 @@ qx.Class.define("qx.test.mobile.core.Widget",
       if (qx.core.Environment.get("qx.debug"))
       {
         this.assertException(function() {
-          qx.ui.mobile.core.Widget().set({id:"affe"});
+          new qx.ui.mobile.core.Widget().set({id:"affe"});
         });
       }
 

--- a/framework/source/class/qx/test/mobile/core/Widget.js
+++ b/framework/source/class/qx/test/mobile/core/Widget.js
@@ -136,7 +136,7 @@ qx.Class.define("qx.test.mobile.core.Widget",
       if (qx.core.Environment.get("qx.debug"))
       {
         this.assertException(function() {
-          var widget2 = new qx.ui.mobile.core.Widget().set({id:"affe"});
+          qx.ui.mobile.core.Widget().set({id:"affe"});
         });
       }
 

--- a/framework/source/class/qx/test/mobile/form/SingleRenderer.js
+++ b/framework/source/class/qx/test/mobile/form/SingleRenderer.js
@@ -26,7 +26,7 @@ qx.Class.define("qx.test.mobile.form.SingleRenderer",
     __b : null,
     __t : null,
     __s : null,
-
+    __renderer: null,
 
     setUp : function() {
       this.base(arguments);

--- a/framework/source/class/qx/test/performance/Object.js
+++ b/framework/source/class/qx/test/performance/Object.js
@@ -5,6 +5,8 @@ qx.Class.define("qx.test.performance.Object",
 
   members :
   {
+    __objects: null,
+
     CREATE_ITERATIONS : 100000,
 
 

--- a/framework/source/class/qx/test/performance/widget/WidgetWithDecorator.js
+++ b/framework/source/class/qx/test/performance/widget/WidgetWithDecorator.js
@@ -13,6 +13,8 @@ qx.Class.define("qx.test.performance.widget.WidgetWithDecorator",
 
   members :
   {
+    __decorator: null,
+
     _createWidget : function() {
       return new qx.ui.core.Widget().set({decorator: this.__decorator});
     }

--- a/framework/source/class/qx/test/theme/manager/Decoration.js
+++ b/framework/source/class/qx/test/theme/manager/Decoration.js
@@ -22,6 +22,8 @@ qx.Class.define("qx.test.theme.manager.Decoration",
 
   members :
   {
+    __formerTheme : null,
+
     setUp : function() {
       this.manager = qx.theme.manager.Decoration.getInstance();
       this.__formerTheme = this.manager.getTheme();
@@ -143,7 +145,6 @@ qx.Class.define("qx.test.theme.manager.Decoration",
 
       this.manager.setTheme(qx.test.Theme.themes.B);
       var selector = this.manager.addCssClass("test-add-css");
-      var sheet = qx.ui.style.Stylesheet.getInstance();
       var elem = document.createElement("div");
       elem.setAttribute("class", selector);
       document.body.appendChild(elem);

--- a/framework/source/class/qx/test/theme/manager/Font.js
+++ b/framework/source/class/qx/test/theme/manager/Font.js
@@ -22,6 +22,8 @@ qx.Class.define("qx.test.theme.manager.Font",
 
   members :
   {
+    __formerTheme : null,
+
     setUp : function() {
       this.manager = qx.theme.manager.Font.getInstance();
       this.__formerTheme = this.manager.getTheme();

--- a/framework/source/class/qx/test/theme/manager/Icon.js
+++ b/framework/source/class/qx/test/theme/manager/Icon.js
@@ -22,6 +22,8 @@ qx.Class.define("qx.test.theme.manager.Icon",
 
   members :
   {
+    __formerTheme: null,
+
     setUp : function() {
       this.manager = qx.theme.manager.Icon.getInstance();
       this.__formerTheme = this.manager.getTheme();

--- a/framework/source/class/qx/test/theme/manager/Meta.js
+++ b/framework/source/class/qx/test/theme/manager/Meta.js
@@ -96,6 +96,7 @@ qx.Class.define("qx.test.theme.manager.Meta",
 
   members :
   {
+    __button : null,
     __formerTheme : null,
 
     __linerGradientRegExp: /(orange.*yellow|rgb\(255, 165, 0\).*rgb\(255, 255, 0\)|data:image\/png;base64,iVBORw0K)/,

--- a/framework/source/class/qx/test/theme/simple/Appearance.js
+++ b/framework/source/class/qx/test/theme/simple/Appearance.js
@@ -247,7 +247,7 @@ qx.Class.define("qx.test.theme.simple.Appearance",
 
       this.assertIdentical("pointer", style.cursor);
 
-      states.first = false,
+      states.first = false;
       style = styleFunc(states);
 
       this.assertIdentical("table-header-cell", style.decorator);
@@ -434,13 +434,6 @@ qx.Class.define("qx.test.theme.simple.Appearance",
       var style = this.__obj["treevirtual-end"].style();
 
       this.assertIdentical(qx.theme.simple.Image.URLS["treevirtual-end"], style.icon);
-    },
-
-    testTreeVirtualCross : function()
-    {
-      var style = this.__obj["treevirtual-cross"].style();
-
-      this.assertIdentical(qx.theme.simple.Image.URLS["treevirtual-cross"], style.icon);
     },
 
     testTreeVirtualCross : function()

--- a/framework/source/class/qx/test/type/BaseArray.js
+++ b/framework/source/class/qx/test/type/BaseArray.js
@@ -120,7 +120,7 @@ qx.Class.define("qx.test.type.BaseArray",
     testArrayUnshift : function()
     {
       var list = new qx.test.type.TestArray(2, 3, 4, 5);
-      var length = list.unshift(1);
+      list.unshift(1);
       this.assertArrayEquals([1, 2, 3, 4, 5], list);
     },
 
@@ -136,11 +136,11 @@ qx.Class.define("qx.test.type.BaseArray",
     testArraySort : function()
     {
       var list = new qx.test.type.TestArray(3, 5, 1, -1);
-      var sorted = list.sort();
+      list.sort();
       this.assertArrayEquals([-1, 1, 3, 5], list);
 
       var list = new qx.test.type.TestArray(3, 5, 1, -1);
-      var sorted = list.sort(function(a, b) {
+      list.sort(function(a, b) {
         return a > b ? -1 : 1;
       });
       this.assertArrayEquals([5, 3, 1, -1], list);

--- a/framework/source/class/qx/test/ui/ChildrenHandling.js
+++ b/framework/source/class/qx/test/ui/ChildrenHandling.js
@@ -193,7 +193,6 @@ qx.Class.define("qx.test.ui.ChildrenHandling",
 
       if (this.isDebugOn())
       {
-        var self = this;
         this.assertException(function() {
           parent.addBefore(w1, w2);
         }, qx.core.AssertionError, "", "add new widget before non child");
@@ -214,7 +213,6 @@ qx.Class.define("qx.test.ui.ChildrenHandling",
 
       if (this.isDebugOn())
       {
-        var self = this;
         this.assertException(function() {
           parent.addBefore(c3, w2);
         }, qx.core.AssertionError, "", "add existing before non child");
@@ -255,7 +253,6 @@ qx.Class.define("qx.test.ui.ChildrenHandling",
 
       if (this.isDebugOn())
       {
-        var self = this;
         this.assertException(function() {
           parent.addAfter(w1, w2);
         }, qx.core.AssertionError, "", "add new widget after non child");
@@ -276,7 +273,6 @@ qx.Class.define("qx.test.ui.ChildrenHandling",
 
       if (this.isDebugOn())
       {
-        var self = this;
         this.assertException(function() {
           parent.addAfter(c1, w2);
         }, qx.core.AssertionError, "", "add existing after non child");

--- a/framework/source/class/qx/test/ui/basic/Atom.js
+++ b/framework/source/class/qx/test/ui/basic/Atom.js
@@ -33,7 +33,7 @@ qx.Class.define("qx.test.ui.basic.Atom",
       var a = new qx.ui.basic.Atom('test').set({selectable: true});
       this.getRoot().add(a);
       this.flush();
-      var l = a.getChildControl('label');	
+      var l = a.getChildControl('label');
       this.assertEquals("on", l.getContentElement().getDomElement().getAttribute("qxselectable"));
       a.destroy();
     },
@@ -42,7 +42,7 @@ qx.Class.define("qx.test.ui.basic.Atom",
       var a = new qx.ui.basic.Atom('test').set({selectable: false});
       this.getRoot().add(a);
       this.flush();
-      var l = a.getChildControl('label');	
+      var l = a.getChildControl('label');
       this.assertEquals("off", l.getContentElement().getDomElement().getAttribute("qxselectable"));
       a.destroy();
     },
@@ -52,7 +52,7 @@ qx.Class.define("qx.test.ui.basic.Atom",
       a.setSelectable(true);
       this.getRoot().add(a);
       this.flush();
-      var l = a.getChildControl('label');	
+      var l = a.getChildControl('label');
       this.assertEquals("on", l.getContentElement().getDomElement().getAttribute("qxselectable"));
       a.destroy();
     },
@@ -62,7 +62,7 @@ qx.Class.define("qx.test.ui.basic.Atom",
       a.setSelectable(false);
       this.getRoot().add(a);
       this.flush();
-      var l = a.getChildControl('label');	
+      var l = a.getChildControl('label');
       this.assertEquals("off", l.getContentElement().getDomElement().getAttribute("qxselectable"));
       a.destroy();
     }

--- a/framework/source/class/qx/test/ui/command/Group.js
+++ b/framework/source/class/qx/test/ui/command/Group.js
@@ -44,7 +44,6 @@ qx.Class.define("qx.test.ui.command.Group",
 
     testHasCommand : function()
     {
-      var handler = this.spy();
       var group = new qx.ui.command.Group();
       var cmd = new qx.ui.command.Command("Meta+T");
 

--- a/framework/source/class/qx/test/ui/command/GroupManager.js
+++ b/framework/source/class/qx/test/ui/command/GroupManager.js
@@ -71,10 +71,7 @@ qx.Class.define("qx.test.ui.command.GroupManager",
       var manager = new qx.ui.command.GroupManager();
 
       var group = new qx.ui.command.Group();
-      var cmd = new qx.ui.command.Command("Meta+T");
-
       var group2 = new qx.ui.command.Group();
-      var cmd2 = new qx.ui.command.Command("Meta+T");
 
       manager.add(group);
       manager.add(group2);

--- a/framework/source/class/qx/test/ui/container/Stack.js
+++ b/framework/source/class/qx/test/ui/container/Stack.js
@@ -28,7 +28,7 @@ qx.Class.define("qx.test.ui.container.Stack",
 
 
     setUp : function() {
-      var stack = this.__stack = new qx.ui.container.Stack();
+      this.__stack = new qx.ui.container.Stack();
 
       var c1 = this.__c1 = new qx.ui.container.Composite();
       var c2 = this.__c2 = new qx.ui.container.Composite();

--- a/framework/source/class/qx/test/ui/core/Blocker.js
+++ b/framework/source/class/qx/test/ui/core/Blocker.js
@@ -22,6 +22,8 @@ qx.Class.define("qx.test.ui.core.Blocker",
   members :
   {
     __blocker : null,
+    __unblockedEventFired : null,
+    __blockedEventFired : null,
 
     setUp : function() {
       this.base(arguments);

--- a/framework/source/class/qx/test/ui/decoration/LinearGradient.js
+++ b/framework/source/class/qx/test/ui/decoration/LinearGradient.js
@@ -22,6 +22,9 @@ qx.Class.define("qx.test.ui.decoration.LinearGradient",
 
   members :
   {
+    __w : null,
+    __dec : null,
+
     setUp : function() {
       this.__w = new qx.ui.core.Widget();
       this.__w.setHeight(100);

--- a/framework/source/class/qx/test/ui/form/AbstractSelectBox.js
+++ b/framework/source/class/qx/test/ui/form/AbstractSelectBox.js
@@ -21,12 +21,15 @@ qx.Class.define("qx.test.ui.form.AbstractSelectBox",
 
   members :
   {
+    __selectBox : null,
+    __comboBox : null,
+
     setUp : function()
     {
-      this.__selectBox = new qx.ui.form.SelectBox;
+      this.__selectBox = new qx.ui.form.SelectBox();
       this.getRoot().add(this.__selectBox);
 
-      this.__comboBox = new qx.ui.form.ComboBox;
+      this.__comboBox = new qx.ui.form.ComboBox();
       this.getRoot().add(this.__comboBox);
 
       this.flush();

--- a/framework/source/class/qx/test/ui/form/AbstractVirtualBox.js
+++ b/framework/source/class/qx/test/ui/form/AbstractVirtualBox.js
@@ -21,12 +21,15 @@ qx.Class.define("qx.test.ui.form.AbstractVirtualBox",
 
   members :
   {
+    __comboBox : null,
+    __selectBox : null,
+
     setUp : function()
     {
-      this.__selectBox = new qx.ui.form.VirtualSelectBox;
+      this.__selectBox = new qx.ui.form.VirtualSelectBox();
       this.getRoot().add(this.__selectBox);
 
-      this.__comboBox = new qx.ui.form.VirtualComboBox;
+      this.__comboBox = new qx.ui.form.VirtualComboBox();
       this.getRoot().add(this.__comboBox);
 
       this.flush();

--- a/framework/source/class/qx/test/ui/form/DateField.js
+++ b/framework/source/class/qx/test/ui/form/DateField.js
@@ -22,6 +22,8 @@ qx.Class.define("qx.test.ui.form.DateField",
 
   members:
   {
+    __datefield : null,
+
     setUp: function() {
       this.__datefield = new qx.ui.form.DateField();
       this.getRoot().add(this.__datefield);
@@ -33,20 +35,20 @@ qx.Class.define("qx.test.ui.form.DateField",
     },
 
     "test: setting value sets date of chooser": function() {
-      var datefield = this.__datefield,
-          chooser = datefield.getChildControl("list"),
-          date = new Date();
+      var datefield = this.__datefield;
+      var chooser = datefield.getChildControl("list");
+      var date = new Date();
 
       datefield.setValue(date);
       this.assertEquals(date, chooser.getValue());
     },
 
     "test: choosing date fills in formatted date": function() {
-      var datefield = this.__datefield,
-          textfield = datefield.getChildControl("textfield"),
-          chooser =  datefield.getChildControl("list"),
-          date = new Date(),
-          dateStr = this.formatDate(date);
+      var datefield = this.__datefield;
+      var textfield = datefield.getChildControl("textfield");
+      var chooser =  datefield.getChildControl("list");
+      var date = new Date();
+      var dateStr = this.formatDate(date);
 
       chooser.setValue(date);
 

--- a/framework/source/class/qx/test/ui/form/RadioButtonGroup.js
+++ b/framework/source/class/qx/test/ui/form/RadioButtonGroup.js
@@ -20,6 +20,9 @@ qx.Class.define("qx.test.ui.form.RadioButtonGroup",
     extend: qx.test.ui.LayoutTestCase,
 
     members: {
+      __radioButtons : null,
+      __radioButtonGroup : null,
+
       setUp: function () {
         this.__radioButtonGroup = new qx.ui.form.RadioButtonGroup();
 

--- a/framework/source/class/qx/test/ui/form/RadioGroup.js
+++ b/framework/source/class/qx/test/ui/form/RadioGroup.js
@@ -21,9 +21,12 @@ qx.Class.define("qx.test.ui.form.RadioGroup",
 
   members :
   {
+    __radioGroup : null,
+    __radioButtons : null,
+
     setUp : function()
     {
-      this.__radioGroup = new qx.ui.form.RadioGroup;
+      this.__radioGroup = new qx.ui.form.RadioGroup();
       this.__radioGroup.setAllowEmptySelection(true);
 
       this.__radioButtons = [];
@@ -55,7 +58,7 @@ qx.Class.define("qx.test.ui.form.RadioGroup",
 
     testHiddenRadioButtons : function()
     {
-      var composite = new qx.ui.container.Composite;
+      var composite = new qx.ui.container.Composite();
       for (var i=0, j=this.__radioButtons.length; i<j; i++) {
         composite.add(this.__radioButtons[i]);
       }

--- a/framework/source/class/qx/test/ui/form/Slider.js
+++ b/framework/source/class/qx/test/ui/form/Slider.js
@@ -21,6 +21,8 @@ qx.Class.define("qx.test.ui.form.Slider",
 
   members :
   {
+    __slider : null,
+
     setUp : function() {
       this.__slider = new qx.ui.form.Slider();
       this.__slider.setWidth(100);

--- a/framework/source/class/qx/test/ui/form/virtual/VirtualDropDownList.js
+++ b/framework/source/class/qx/test/ui/form/virtual/VirtualDropDownList.js
@@ -161,7 +161,6 @@ qx.Class.define("qx.test.ui.form.virtual.VirtualDropDownList",
       var invalidItem = model.getItem(2);
       this.assertFalse(filteredModel.contains(invalidItem));
 
-      var that = this;
       this.__checkEvent(selection, function() {
         selection.push(invalidItem);
       }, 2);
@@ -175,7 +174,6 @@ qx.Class.define("qx.test.ui.form.virtual.VirtualDropDownList",
     {
       var selection = this.__dropdown.getSelection();
 
-      var that = this;
       var newItem = model.getItem(2);
       this.__checkEvent(selection, function() {
         selection.push(newItem);
@@ -183,8 +181,6 @@ qx.Class.define("qx.test.ui.form.virtual.VirtualDropDownList",
 
       this.__checkSelection(newItem);
 
-
-      var that = this;
       newItem = model.getItem(4);
       this.__checkEvent(selection, function() {
         selection.splice(0, 1, newItem).dispose();

--- a/framework/source/class/qx/test/ui/form/virtual/VirtualSelectBox.js
+++ b/framework/source/class/qx/test/ui/form/virtual/VirtualSelectBox.js
@@ -23,6 +23,7 @@ qx.Class.define("qx.test.ui.form.virtual.VirtualSelectBox",
   members :
   {
     __selectBox : null,
+    __model : null,
 
 
     setUp : function()

--- a/framework/source/class/qx/test/ui/list/Group.js
+++ b/framework/source/class/qx/test/ui/list/Group.js
@@ -22,13 +22,15 @@ qx.Class.define("qx.test.ui.list.Group",
 
   members :
   {
-    __names : ["Luise Siemer", "Trauhard Franke", "Sarina Wilde", "Florine Bähr",
-       "Sigurd Adolph", "Sigmund Kurz", "Pankratius Hill", "Gerlinda Seel",
-       "Trixi Clauß", "Cecilia Hemmer", "Rosely Fröhlich", "Annemargret Hunger",
-       "Dietgar Münster", "Bertwin Joseph", "Edwina Schwarz", "Riana Dirks"],
-
     createModelData : function() {
-      return qx.data.marshal.Json.createModel(this.__names);
+      var names = [
+        "Luise Siemer", "Trauhard Franke", "Sarina Wilde", "Florine Bähr",
+        "Sigurd Adolph", "Sigmund Kurz", "Pankratius Hill", "Gerlinda Seel",
+        "Trixi Clauß", "Cecilia Hemmer", "Rosely Fröhlich", "Annemargret Hunger",
+        "Dietgar Münster", "Bertwin Joseph", "Edwina Schwarz", "Riana Dirks"
+      ];
+
+      return qx.data.marshal.Json.createModel(names);
     },
 
 

--- a/framework/source/class/qx/test/ui/list/ObjectGroup.js
+++ b/framework/source/class/qx/test/ui/list/ObjectGroup.js
@@ -22,11 +22,6 @@ qx.Class.define("qx.test.ui.list.ObjectGroup",
 
   members :
   {
-    __names : ["Luise Siemer", "Trauhard Franke", "Sarina Wilde", "Florine Bähr",
-       "Sigurd Adolph", "Sigmund Kurz", "Pankratius Hill", "Gerlinda Seel",
-       "Trixi Clauß", "Cecilia Hemmer", "Rosely Fröhlich", "Annemargret Hunger",
-       "Dietgar Münster", "Bertwin Joseph", "Edwina Schwarz", "Riana Dirks"],
-
     __groups : null,
 
     createModelData : function() {
@@ -34,8 +29,15 @@ qx.Class.define("qx.test.ui.list.ObjectGroup",
       model.setAutoDisposeItems(true);
       var groups = this.__groups = {};
 
-      for (var i = 0; i < this.__names.length; i++) {
-        var name = this.__names[i];
+      var names = [
+        "Luise Siemer", "Trauhard Franke", "Sarina Wilde", "Florine Bähr",
+        "Sigurd Adolph", "Sigmund Kurz", "Pankratius Hill", "Gerlinda Seel",
+        "Trixi Clauß", "Cecilia Hemmer", "Rosely Fröhlich", "Annemargret Hunger",
+        "Dietgar Münster", "Bertwin Joseph", "Edwina Schwarz", "Riana Dirks"
+      ];
+
+      for (var i = 0; i < names.length; i++) {
+        var name = names[i];
         var groupName = name.charAt(0);
         var group = groups[groupName];
 

--- a/framework/source/class/qx/test/ui/root/Inline.js
+++ b/framework/source/class/qx/test/ui/root/Inline.js
@@ -22,6 +22,8 @@ qx.Class.define("qx.test.ui.root.Inline",
 
   members :
   {
+    __inlineIsleElement : null,
+
     setUp : function()
     {
       this.__inlineIsleElement = qx.dom.Element.create("div");
@@ -40,7 +42,7 @@ qx.Class.define("qx.test.ui.root.Inline",
     testAppearEvent : function()
     {
       var inlineRoot = new qx.ui.root.Inline(this.__inlineIsleElement);
-      inlineRoot.addListener("appear", function(e)
+      inlineRoot.addListener("appear", function()
       {
         this.resume(function() {
           this.assertTrue(qx.dom.Element.isInDom(inlineRoot.getContentElement().getDomElement()));

--- a/framework/source/class/qx/test/ui/toolbar/ToolBar.js
+++ b/framework/source/class/qx/test/ui/toolbar/ToolBar.js
@@ -21,6 +21,11 @@ qx.Class.define("qx.test.ui.toolbar.ToolBar",
 
   members :
   {
+    __toolbar : null,
+    __b1 : null,
+    __b2 : null,
+    __b3 : null,
+
      setUp : function()
     {
       this.base(arguments);
@@ -150,10 +155,10 @@ qx.Class.define("qx.test.ui.toolbar.ToolBar",
       this.assertEquals("both", this.__b2.getShow());
       this.assertEquals("both", this.__b3.getShow());
     },
-    
+
     testRemoveChildByIndex : function() {
       this.__toolbar.removeAll();
-      
+
       // setup toolbar with three buttons
       this.__toolbar.add(this.__b1);
       this.__toolbar.add(this.__b2);
@@ -166,15 +171,15 @@ qx.Class.define("qx.test.ui.toolbar.ToolBar",
       // assert removing child at index 1
       var childB2 = this.__toolbar.removeAt(1);
       this.assertEquals(childB2, this.__b2);
-      
+
       // assert length of remaining and removed children array being now 2
       var children = this.__toolbar.removeAll();
       this.assertEquals(2, children.length);
     },
-    
+
     testRemoveAllChildren : function() {
       this.__toolbar.removeAll();
-      
+
       // setup toolbar with two buttons
       this.__toolbar.add(this.__b1);
       this.__toolbar.add(this.__b2);

--- a/framework/source/class/qx/test/ui/tree/virtual/Sorting.js
+++ b/framework/source/class/qx/test/ui/tree/virtual/Sorting.js
@@ -98,7 +98,7 @@ qx.Class.define("qx.test.ui.tree.virtual.Sorting",
       };
 
       var sortedModel = this.createModel(1);
-      var root = this.createModelAndSetModel(1);
+      this.createModelAndSetModel(1);
 
       // remove filtered node "Node 2"
       sortedModel.getChildren().removeAt(2);
@@ -176,7 +176,7 @@ qx.Class.define("qx.test.ui.tree.virtual.Sorting",
 
     __logModel : function(model, level)
     {
-      level = level != null ? level : 0;
+      level = level === null ? 0 : level;
 
       var prefix = "";
       for (var i = 0; i < level; i++) {
@@ -184,7 +184,7 @@ qx.Class.define("qx.test.ui.tree.virtual.Sorting",
       }
       console.log(prefix + ">", model.getName());
 
-      if (model.getChildren == null) {
+      if (model.getChildren === null) {
         return;
       }
 

--- a/framework/source/class/qx/test/ui/tree/virtual/WidgetProvider.js
+++ b/framework/source/class/qx/test/ui/tree/virtual/WidgetProvider.js
@@ -294,7 +294,7 @@ qx.Class.define("qx.test.ui.tree.virtual.WidgetProvider",
       var newWidget2Bindungs = widget2.getBindings().length;
       var newModelBindungs = this.getLookupTable().getBindings().length;
       this.assertEquals(oldWidget1Bindungs, newWidget1Bindungs, "Binding on first widget is not removed!");
-      this.assertEquals(oldWidget1Bindungs, newWidget1Bindungs, "Binding on second widget is not removed!");
+      this.assertEquals(oldWidget2Bindungs, newWidget2Bindungs, "Binding on second widget is not removed!");
       this.assertEquals(oldModelBindungs, newModelBindungs, "Binding on model is not removed!");
 
       widget1.dispose();

--- a/framework/source/class/qx/test/ui/tree/virtual/WidgetProvider.js
+++ b/framework/source/class/qx/test/ui/tree/virtual/WidgetProvider.js
@@ -238,17 +238,17 @@ qx.Class.define("qx.test.ui.tree.virtual.WidgetProvider",
     testRemoveBindingsFromNode : function()
     {
       var widget = new qx.ui.tree.VirtualTreeItem();
-      var oldWidgetBindungs = widget.getBindings().length;
-      var oldModelBindungs = this.getLookupTable().getBindings().length;
+      var oldWidgetBindings = widget.getBindings().length;
+      var oldModelBindings = this.getLookupTable().getBindings().length;
 
       this.provider._bindItem(widget, 0);
       this.provider._removeBindingsFrom(widget);
 
-      var newWidgetBindungs = widget.getBindings().length;
-      var newModelBindungs = this.getLookupTable().getBindings().length;
+      var newWidgetBindings = widget.getBindings().length;
+      var newModelBindings = this.getLookupTable().getBindings().length;
 
-      this.assertEquals(oldWidgetBindungs, newWidgetBindungs, "Binding on widget is not removed!");
-      this.assertEquals(oldModelBindungs, newModelBindungs, "Binding on model is not removed!");
+      this.assertEquals(oldWidgetBindings, newWidgetBindings, "Binding on widget is not removed!");
+      this.assertEquals(oldModelBindings, newModelBindings, "Binding on model is not removed!");
 
       widget.dispose();
     },
@@ -257,18 +257,18 @@ qx.Class.define("qx.test.ui.tree.virtual.WidgetProvider",
     testReverseBinding : function()
     {
       var widget = new qx.ui.tree.VirtualTreeItem();
-      var oldWidgetBindungs = widget.getBindings().length;
-      var oldModelBindungs = this.getLookupTable().getBindings().length;
+      var oldWidgetBindings = widget.getBindings().length;
+      var oldModelBindings = this.getLookupTable().getBindings().length;
 
       this.provider.bindPropertyReverse("name", "label", null, widget, 0);
       widget.setLabel("ort-zerreiber");
       this.assertEquals("ort-zerreiber", this.model.getName());
 
       this.provider._removeBindingsFrom(widget);
-      var newWidgetBindungs = widget.getBindings().length;
-      var newModelBindungs = this.getLookupTable().getBindings().length;
-      this.assertEquals(oldWidgetBindungs, newWidgetBindungs, "Binding on widget is not removed!");
-      this.assertEquals(oldModelBindungs, newModelBindungs, "Binding on model is not removed!");
+      var newWidgetBindings = widget.getBindings().length;
+      var newModelBindings = this.getLookupTable().getBindings().length;
+      this.assertEquals(oldWidgetBindings, newWidgetBindings, "Binding on widget is not removed!");
+      this.assertEquals(oldModelBindings, newModelBindings, "Binding on model is not removed!");
 
       widget.dispose();
     },
@@ -279,9 +279,9 @@ qx.Class.define("qx.test.ui.tree.virtual.WidgetProvider",
       var widget1 = new qx.ui.tree.VirtualTreeItem();
       var widget2 = new qx.ui.tree.VirtualTreeItem();
 
-      var oldWidget1Bindungs = widget1.getBindings().length;
-      var oldWidget2Bindungs = widget2.getBindings().length;
-      var oldModelBindungs = this.getLookupTable().getBindings().length;
+      var oldWidget1Bindings = widget1.getBindings().length;
+      var oldWidget2Bindings = widget2.getBindings().length;
+      var oldModelBindings = this.getLookupTable().getBindings().length;
 
       this.provider.bindProperty("name", "label", null, widget1, 0);
       this.provider.bindProperty("name", "label", null, widget2, 1);
@@ -290,12 +290,12 @@ qx.Class.define("qx.test.ui.tree.virtual.WidgetProvider",
 
       this.provider.removeBindings();
 
-      var newWidget1Bindungs = widget1.getBindings().length;
-      var newWidget2Bindungs = widget2.getBindings().length;
-      var newModelBindungs = this.getLookupTable().getBindings().length;
-      this.assertEquals(oldWidget1Bindungs, newWidget1Bindungs, "Binding on first widget is not removed!");
-      this.assertEquals(oldWidget2Bindungs, newWidget2Bindungs, "Binding on second widget is not removed!");
-      this.assertEquals(oldModelBindungs, newModelBindungs, "Binding on model is not removed!");
+      var newWidget1Bindings = widget1.getBindings().length;
+      var newWidget2Bindings = widget2.getBindings().length;
+      var newModelBindings = this.getLookupTable().getBindings().length;
+      this.assertEquals(oldWidget1Bindings, newWidget1Bindings, "Binding on first widget is not removed!");
+      this.assertEquals(oldWidget2Bindings, newWidget2Bindings, "Binding on second widget is not removed!");
+      this.assertEquals(oldModelBindings, newModelBindings, "Binding on model is not removed!");
 
       widget1.dispose();
       widget2.dispose();

--- a/framework/source/class/qx/test/ui/virtual/Axis.js
+++ b/framework/source/class/qx/test/ui/virtual/Axis.js
@@ -351,13 +351,11 @@ qx.Class.define("qx.test.ui.virtual.Axis",
     testPerformanceSetupBestCase : function()
     {
       //window.top.console.profile("setup (best case)");
-      var start = new Date();
       for (var i=0; i<this.SETUP_ITER; i++)
       {
         this.axis.__ranges = null;
         this.axis.getItemAtPosition(0);
       }
-      var end = new Date();
       //window.top.console.profileEnd();
 
       // this.warn("setup time (best case): " + ((end - start) / this.SETUP_ITER) + "ms");
@@ -371,13 +369,11 @@ qx.Class.define("qx.test.ui.virtual.Axis",
       }
 
       //window.top.console.profile("setup (worst case)");
-      var start = new Date();
       for (var i=0; i<this.SETUP_ITER; i++)
       {
         this.axis.__ranges = null;
         this.axis.getItemAtPosition(0);
       }
-      var end = new Date();
       //window.top.console.profileEnd();
 
       // this.warn("setup time (worst case): " + ((end - start) / this.SETUP_ITER) + "ms");
@@ -391,11 +387,9 @@ qx.Class.define("qx.test.ui.virtual.Axis",
       var max = this.axis.getTotalSize();
 
       //window.top.console.profile("find (best case)");
-      var start = new Date();
       for (var i=0; i<this.FIND_ITER; i++) {
         this.axis.getItemAtPosition((i*17) % max);
       }
-      var end = new Date();
       //window.top.console.profileEnd();
 
       // this.warn("find time (best case): " + ((end - start) / this.FIND_ITER) + "ms");
@@ -412,11 +406,9 @@ qx.Class.define("qx.test.ui.virtual.Axis",
       var max = this.axis.getTotalSize();
 
       //window.top.console.profile("find (worst case)");
-      var start = new Date();
       for (var i=0; i<this.FIND_ITER; i++) {
         this.axis.getItemAtPosition((i*17) % max);
       }
-      var end = new Date();
       //window.top.console.profileEnd();
 
       // this.warn("find time (worst case): " + ((end - start) / this.FIND_ITER) + "ms");

--- a/framework/source/class/qx/test/ui/virtual/PointerEventMock.js
+++ b/framework/source/class/qx/test/ui/virtual/PointerEventMock.js
@@ -29,6 +29,8 @@ qx.Class.define("qx.test.ui.virtual.PointerEventMock",
 
   members :
   {
+    __config : null,
+
     clone : function() {
       return this;
     },

--- a/framework/source/class/qx/test/ui/virtual/layer/HtmlCell.js
+++ b/framework/source/class/qx/test/ui/virtual/layer/HtmlCell.js
@@ -23,6 +23,8 @@ qx.Class.define("qx.test.ui.virtual.layer.HtmlCell",
 
   members :
   {
+    __cellRenderer : null,
+
     tearDown : function() {
       this.base(arguments);
       this.__cellRenderer.dispose();
@@ -39,7 +41,7 @@ qx.Class.define("qx.test.ui.virtual.layer.HtmlCell",
       return this.__cellRenderer.getCellProperties(row + " / " + column, {});
     },
 
-    _assertCells : function(firstRow, firstColumn, rowCount, columnCount, msg)
+    _assertCells : function(firstRow, firstColumn, rowCount, columnCount)
     {
       var children = this.layer.getContentElement().getDomElement().childNodes;
 
@@ -52,7 +54,7 @@ qx.Class.define("qx.test.ui.virtual.layer.HtmlCell",
           var row = firstRow + y;
           var column = firstColumn + x;
 
-          var cellEl = children[y*columnCount + x];
+          var cellEl = children[(y * columnCount) + x];
           this.assertEquals(row + " / " + column, cellEl.innerHTML);
         }
       }

--- a/framework/source/class/qx/test/ui/virtual/layer/HtmlCellSpan.js
+++ b/framework/source/class/qx/test/ui/virtual/layer/HtmlCellSpan.js
@@ -23,6 +23,10 @@ qx.Class.define("qx.test.ui.virtual.layer.HtmlCellSpan",
 
   members :
   {
+    __rowConfig : null,
+    __columnConfig : null,
+    __cellRenderer : null,
+
     tearDown : function() {
       this.base(arguments);
       this.__cellRenderer.dispose();
@@ -50,7 +54,7 @@ qx.Class.define("qx.test.ui.virtual.layer.HtmlCellSpan",
     },
 
 
-    _assertCells : function(firstRow, firstColumn, rowCount, columnCount, msg)
+    _assertCells : function(firstRow, firstColumn, rowCount, columnCount)
     {
       var children = this.layer.getContentElement().getDomElement().childNodes;
 
@@ -63,7 +67,7 @@ qx.Class.define("qx.test.ui.virtual.layer.HtmlCellSpan",
           var row = firstRow + y;
           var column = firstColumn + x;
 
-          var cellEl = children[y*columnCount + x];
+          var cellEl = children[(y * columnCount) + x];
           this.assertEquals(row + " / " + column, cellEl.innerHTML);
         }
       }

--- a/framework/source/class/qx/test/ui/virtual/layer/WidgetCellSpan.js
+++ b/framework/source/class/qx/test/ui/virtual/layer/WidgetCellSpan.js
@@ -23,6 +23,11 @@ qx.Class.define("qx.test.ui.virtual.layer.WidgetCellSpan",
 
   members :
   {
+    __pool : null,
+    __columnConfig : null,
+    __rowConfig : null,
+    __cellRenderer : null,
+
     setUp : function()
     {
       this._pool = [];
@@ -67,7 +72,7 @@ qx.Class.define("qx.test.ui.virtual.layer.WidgetCellSpan",
     },
 
 
-    _assertCells : function(firstRow, firstColumn, rowCount, columnCount, msg)
+    _assertCells : function(firstRow, firstColumn, rowCount, columnCount)
     {
       var children = this.layer._cellLayer._getChildren();
 
@@ -80,7 +85,7 @@ qx.Class.define("qx.test.ui.virtual.layer.WidgetCellSpan",
           var row = firstRow + y;
           var column = firstColumn + x;
 
-          var widget = children[y*columnCount + x];
+          var widget = children[(y * columnCount) + x];
           this.assertEquals(row, widget.getUserData("cell.row"));
           this.assertEquals(column, widget.getUserData("cell.column"));
         }
@@ -105,7 +110,7 @@ qx.Class.define("qx.test.ui.virtual.layer.WidgetCellSpan",
             return row == 1 && column == 2 ? null : widget;
           },
 
-          poolCellWidget : function(widget) {
+          poolCellWidget : function() {
           }
         },
         rowConfig, columnConfig

--- a/framework/source/class/qx/test/ui/virtual/performance/AbstractLayerTest.js
+++ b/framework/source/class/qx/test/ui/virtual/performance/AbstractLayerTest.js
@@ -130,7 +130,9 @@ qx.Class.define("qx.test.ui.virtual.performance.AbstractLayerTest",
 
     profile : function(name, fcn, context, count)
     {
-      if (window.console && window.console.profile) console.profile(name + "; " + this.classname);
+      if (window.console && window.console.profile) {
+        console.profile(name + "; " + this.classname);
+      }
 
       var times = [];
       for (var i=0,l=count; i<l; i++)
@@ -148,7 +150,9 @@ qx.Class.define("qx.test.ui.virtual.performance.AbstractLayerTest",
       //this.warn(";" + name + "; avg(" + avg + "ms); " + times.join("ms; ") + "ms;");
       this.warn(";" + name + ";avg:" + avg + ";" + times.join(";"));
 
-      if (window.console && window.console.profile) console.profileEnd(name + " " + this.classname);
+      if (window.console && window.console.profile) {
+        console.profileEnd(name + " " + this.classname);
+      }
     }
   }
 

--- a/framework/source/class/qx/test/ui/virtual/performance/HtmlDivCell.js
+++ b/framework/source/class/qx/test/ui/virtual/performance/HtmlDivCell.js
@@ -23,6 +23,8 @@ qx.Class.define("qx.test.ui.virtual.performance.HtmlDivCell",
 
   members :
   {
+    __cellRenderer : null,
+
     getLayer : function()
     {
       this.__cellRenderer = new qx.ui.virtual.cell.Cell();

--- a/framework/source/class/qx/test/ui/virtual/performance/layer/DomPoolCell.js
+++ b/framework/source/class/qx/test/ui/virtual/performance/layer/DomPoolCell.js
@@ -42,7 +42,6 @@ qx.Class.define("qx.test.ui.virtual.performance.layer.DomPoolCell",
     )
     {
       qx.ui.core.queue.Manager.flush();
-      var start = new Date();
       var el = this.getContentElement().getDomElement();
       if (!el) {
         return;

--- a/framework/source/class/qx/test/util/DateFormat.js
+++ b/framework/source/class/qx/test/util/DateFormat.js
@@ -24,35 +24,37 @@ qx.Class.define("qx.test.util.DateFormat",
 
   members :
   {
+    __dates : null,
 
-  // result contain an object with what should be expected, the result to test the date against
-  __dates : [
-    {'date' : new Date(2000, 2, 14), 'result' : {}},
-    {'date' : new Date(2006, 2, 14), 'result' : {}},
-    {'date' : new Date(2007, 3, 14), 'result' : {}},
-    {'date' : new Date(2009, 10, 30), 'result' : {}},
-    {'date' : new Date(2009, 8 ,30), 'result' : {}},
-    {'date' : new Date(2011, 3, 15), 'result' : {}},
-    {'date' : new Date(2011, 3, 16), 'result' : {}},
-    {'date' : new Date(2011, 3, 17), 'result' : {}},
-    {'date' : new Date(2011, 0, 26), 'result' : {'weekOfYear' : 4}},
-    {'date' : new Date(2011, 0, 1), 'result' : {'weekOfYear' : 52}},
-    {'date' : new Date(2011, 0, 3), 'result' : {'weekOfYear' : 1}},
-    {'date' : new Date(2011, 0, 10), 'result' : {'weekOfYear' : 2}},
-    {'date' : new Date(2011, 9, 3), 'result' : {'dayOfYear' : 276, 'era': {'abbrev': 'AD', 'fullName': 'Anno Domini', 'narrow': 'A'}}},
-    {'date' : new Date(2011,0,4), 'result' : {'dayOfYear' : 4, 'dayOfWeek': 2}},
-    {'date' : new Date(2011,0,4), 'result' : {'dayOfYear' : 4, 'dayOfWeek': 2}},
-    {'date' : new Date(2011,0,4,9,9,9), 'result' : {'h_hour': 9, 'K_hour': 9, 'H_hour': 9, 'k_hour': 9}},
-    {'date' : new Date(2011,0,4,14,9,9), 'result' : {'h_hour': 2, 'K_hour': 2, 'H_hour': 14, 'k_hour': 14}},
-    {'date' : new Date(2011,0,4,0,9,9), 'result' : {'h_hour': 12, 'K_hour': 0, 'H_hour': 0, 'k_hour': 24}},
-    {'date' : new Date(2011,0,4,12,9,9), 'result' : {'h_hour': 12, 'K_hour': 0, 'H_hour': 12, 'k_hour': 12}},
-    {'date' : new Date(2010,12,4,0,0,0), 'result' : {'h_hour': 12, 'K_hour': 0, 'H_hour': 0, 'k_hour': 24}},
-    {'date' : new Date(-20,10,14), 'result' : {'era': {'abbrev': 'BC', 'fullName': 'Before Christ', 'narrow': 'B'}}},
-    {'date' : new Date(2012, 4, 24, 11, 49, 57, 1), 'result' : {}},
-    {'date' : new Date(2012, 4, 24, 11, 49, 57, 12), 'result' : {}},
-    {'date' : new Date(2012, 4, 24, 11, 49, 57, 123), 'result' : {}}
-
-  ],
+    setUp : function() {
+      // result contain an object with what should be expected, the result to test the date against
+      this.__dates = [
+        {'date' : new Date(2000, 2, 14), 'result' : {}},
+        {'date' : new Date(2006, 2, 14), 'result' : {}},
+        {'date' : new Date(2007, 3, 14), 'result' : {}},
+        {'date' : new Date(2009, 10, 30), 'result' : {}},
+        {'date' : new Date(2009, 8 ,30), 'result' : {}},
+        {'date' : new Date(2011, 3, 15), 'result' : {}},
+        {'date' : new Date(2011, 3, 16), 'result' : {}},
+        {'date' : new Date(2011, 3, 17), 'result' : {}},
+        {'date' : new Date(2011, 0, 26), 'result' : {'weekOfYear' : 4}},
+        {'date' : new Date(2011, 0, 1), 'result' : {'weekOfYear' : 52}},
+        {'date' : new Date(2011, 0, 3), 'result' : {'weekOfYear' : 1}},
+        {'date' : new Date(2011, 0, 10), 'result' : {'weekOfYear' : 2}},
+        {'date' : new Date(2011, 9, 3), 'result' : {'dayOfYear' : 276, 'era': {'abbrev': 'AD', 'fullName': 'Anno Domini', 'narrow': 'A'}}},
+        {'date' : new Date(2011,0,4), 'result' : {'dayOfYear' : 4, 'dayOfWeek': 2}},
+        {'date' : new Date(2011,0,4), 'result' : {'dayOfYear' : 4, 'dayOfWeek': 2}},
+        {'date' : new Date(2011,0,4,9,9,9), 'result' : {'h_hour': 9, 'K_hour': 9, 'H_hour': 9, 'k_hour': 9}},
+        {'date' : new Date(2011,0,4,14,9,9), 'result' : {'h_hour': 2, 'K_hour': 2, 'H_hour': 14, 'k_hour': 14}},
+        {'date' : new Date(2011,0,4,0,9,9), 'result' : {'h_hour': 12, 'K_hour': 0, 'H_hour': 0, 'k_hour': 24}},
+        {'date' : new Date(2011,0,4,12,9,9), 'result' : {'h_hour': 12, 'K_hour': 0, 'H_hour': 12, 'k_hour': 12}},
+        {'date' : new Date(2010,12,4,0,0,0), 'result' : {'h_hour': 12, 'K_hour': 0, 'H_hour': 0, 'k_hour': 24}},
+        {'date' : new Date(-20,10,14), 'result' : {'era': {'abbrev': 'BC', 'fullName': 'Before Christ', 'narrow': 'B'}}},
+        {'date' : new Date(2012, 4, 24, 11, 49, 57, 1), 'result' : {}},
+        {'date' : new Date(2012, 4, 24, 11, 49, 57, 12), 'result' : {}},
+        {'date' : new Date(2012, 4, 24, 11, 49, 57, 123), 'result' : {}}
+      ];
+    },
 
     tearDown : function() {
       qx.locale.Manager.getInstance().resetLocale();
@@ -532,7 +534,6 @@ qx.Class.define("qx.test.util.DateFormat",
 
     testPattern_e_parse : function(){
       var df, parsedDate;
-      var locale = qx.locale.Manager.getInstance().getLocale();
       for(var i=0; i<this.__dates.length; i++)
       {
         var date = this.__dates[i].date;
@@ -828,8 +829,6 @@ qx.Class.define("qx.test.util.DateFormat",
     var dfDE = new qx.util.format.DateFormat("EEEE yyyy-mm-dd","de_DE");
     var dfUS = new qx.util.format.DateFormat("EEEE yyyy-mm-dd","en_US");
     var d = new Date();
-
-    var frenchFormatteddateString = dfFR.format(d);
 
     this.assertEquals(df.format(d),dfUS.format(d));
 

--- a/framework/source/class/qx/test/util/DateMock.js
+++ b/framework/source/class/qx/test/util/DateMock.js
@@ -28,6 +28,8 @@ qx.Class.define("qx.test.util.DateMock",
 
   members :
   {
+    __date : null,
+
     getFullYear : function() {
       return this.__date.fullYear;
     },

--- a/framework/source/class/qx/test/util/DisposeUtil.js
+++ b/framework/source/class/qx/test/util/DisposeUtil.js
@@ -24,8 +24,6 @@ qx.Class.define("qx.test.util.DisposeUtil",
   {
     testDestroyContainer : function()
     {
-      var self = this;
-
       var container = new qx.ui.container.Composite(new qx.ui.layout.VBox());
       var childContainer1 = new qx.ui.container.Composite(new qx.ui.layout.Canvas());
       var childContainer2 = new qx.ui.container.Composite(new qx.ui.layout.Canvas());

--- a/framework/source/class/qx/test/util/Request.js
+++ b/framework/source/class/qx/test/util/Request.js
@@ -23,9 +23,8 @@ qx.Class.define("qx.test.util.Request",
   members :
   {
     "test: isCrossDomain() returns true with cross-domain URL": function() {
-      var location = window.location,
-          origin = location.protocol + "//" + location.host,
-          isCrossDomain = qx.util.Request.isCrossDomain;
+      var location = window.location;
+      var isCrossDomain = qx.util.Request.isCrossDomain;
 
       this.assertTrue(isCrossDomain("http://cross.domain"), "cross");
       this.assertTrue(isCrossDomain(location.protocol + "//" + location.hostname + ":123456"), "port");
@@ -33,9 +32,9 @@ qx.Class.define("qx.test.util.Request",
     },
 
     "test: isCrossDomain() returns false with same-origin URL": function() {
-      var location = window.location,
-          origin = location.protocol + "//" + location.host,
-          isCrossDomain = qx.util.Request.isCrossDomain;
+      var location = window.location;
+      var origin = location.protocol + "//" + location.host;
+      var isCrossDomain = qx.util.Request.isCrossDomain;
 
       this.assertFalse(isCrossDomain(origin));
       this.assertFalse(isCrossDomain("data.json"), "simple url");

--- a/framework/source/class/qx/test/util/ResponseParser.js
+++ b/framework/source/class/qx/test/util/ResponseParser.js
@@ -65,7 +65,6 @@ qx.Class.define("qx.test.util.ResponseParser",
     },
 
     "test: getParser() detects deprecated xml": function() {
-      var xml = qx.util.ResponseParser.PARSER.xml;
       this.__assertParser("text/xml");
     },
 

--- a/framework/source/class/qx/test/util/StringBuilder.js
+++ b/framework/source/class/qx/test/util/StringBuilder.js
@@ -21,6 +21,8 @@ qx.Class.define("qx.test.util.StringBuilder",
 
   members :
   {
+    __sb : null,
+
     setUp : function() {
       this.__sb = new qx.util.StringBuilder();
     },
@@ -52,4 +54,3 @@ qx.Class.define("qx.test.util.StringBuilder",
     }
   }
 });
-

--- a/tool/pylib/ecmascript/transform/check/lint.py
+++ b/tool/pylib/ecmascript/transform/check/lint.py
@@ -88,7 +88,6 @@ class LintChecker(treeutil.NodeVisitor):
             self.visit(cld)
 
     def visit_function(self, node):
-        #print "visiting", node.type
         if not self.opts.ignore_undefined_globals:
             self.unknown_globals(node.scope)
         if not self.opts.ignore_shadowing_locals:
@@ -98,6 +97,9 @@ class LintChecker(treeutil.NodeVisitor):
             self.function_used_deprecated(node)
         if not self.opts.ignore_multiple_vardecls:
             self.function_multiple_var_decls(node)
+
+        self.function_params(node)
+
         # recurse
         for cld in node.children:
             self.visit(cld)
@@ -111,6 +113,13 @@ class LintChecker(treeutil.NodeVisitor):
 
 
     # - ---------------------------------------------------------------------------
+
+    def function_params(self, funcnode):
+        params = funcnode.getChild("params")
+        for param in params.children:
+            if param.type == "constant":
+                issue = warn("Constant as parameter name in function declaration", self.file_name, funcnode)
+                self.issues.append(issue)
 
     def function_used_deprecated(self, funcnode):
         # take advantage of Scope() objects


### PR DESCRIPTION
This is a follow up of #9154.

I couldn't fix these warnings, please some else fix that:
- Warning: qx.test.ui.basic.Atom (50, 25): Constant as parameter name in function declaration
- Warning: qx.test.Annotation (40, 25): Reference values are shared across all instances: '@methodA'
- Warning: qx.test.Annotation (66, 23): Reference values are shared across all instances: '@methodB'
- Warning: qx.test.Annotation (87, 23): Reference values are shared across all instances: '@methodB'
- Warning: qx.test.Annotation (163, 23): Reference values are shared across all instances: '@methodA'
- Warning: qx.test.bom.Attribute (163, 55): qx.core.Environment.select: second parameter is not a map.
- Warning: qx.test.Mixin (243, 15): Using an undeclared private class feature: '__b'
- Warning: qx.test.Mixin (244, 27): Using an undeclared private class feature: '__b'
- Warning: qx.test.Class (398, 11): Using an undeclared private class feature: '__p'
- Warning: qx.test.Class (406, 20): Using an undeclared private class feature: '__p'
- Warning: qx.test.Class (465, 11): Using an undeclared private class feature: '__p'
- Warning: qx.test.Class (473, 20): Using an undeclared private class feature: '__p'
