### PR TITLE
Add .npmignore for the npm packaging.

### DIFF
--- a/framework/.npmignore
+++ b/framework/.npmignore
@@ -1,0 +1,9 @@
+node_modules/
+source/resource/source/
+test/
+.eslint*
+.gitignore
+generate.py
+Gruntfile.js
+karma*
+npm-debug.log


### PR DESCRIPTION
If we gonna create a NPM Package of the framework we need this file to not include unneeded files in the npm package.

Signed-off-by: Rene Jochum rene@jochums.at
