### PR TITLE
Restrict ::-webkit-scrollbar rule to top mobile id

### DIFF
--- a/framework/source/resource/qx/mobile/scss/common/_scroller.scss
+++ b/framework/source/resource/qx/mobile/scss/common/_scroller.scss
@@ -36,8 +36,10 @@
 }
 
 // Disable horizontal scrollbar on native scroll mode.
-::-webkit-scrollbar {
-  display:none;
+// Restrict the rule to the top mobile app element and its
+// children.
+#qx_id_0::-webkit-scrollbar, #qx_id_0 *::-webkit-scrollbar {
+  display: none;
 }
 
 // Fix for iOS 7 webkit-scrolling issue on orientationchange.


### PR DESCRIPTION
Restrict the rule to the top mobile app element and its children.

Fixes #202 where in playground both the desktop and mobile theme are applied as the playground allows running mobile and desktop code.
