### PR TITLE
adding ignoreUndeclaredPrivates to @lint hint

### DIFF
--- a/documentation/manual/source/pages/development/api_jsdoc_ref.rst
+++ b/documentation/manual/source/pages/development/api_jsdoc_ref.rst
@@ -763,6 +763,9 @@ Description
              * **ignoreJsdocKey**
 
                JSDoc @ keys which are either unknown (i.e. not documented on this page) or do not comply with the syntax given here.
+             * **ignoreUndeclaredPrivates**
+
+               Private members in class code which are not declared in the class map.
       * - name
         - The identifier which the lint subkey should be applied to.
 

--- a/framework/source/class/qx/test/Mixin.js
+++ b/framework/source/class/qx/test/Mixin.js
@@ -236,6 +236,7 @@ qx.Class.define("qx.test.Mixin",
         {
           sayJuhu : function() { return this.base(arguments) + " Kinners";},
 
+          /** @lint ignoreUndeclaredPrivates(__b) */
           foo : function(dontRecurs)
           {
             var s = "";

--- a/tool/pylib/ecmascript/transform/check/lint.py
+++ b/tool/pylib/ecmascript/transform/check/lint.py
@@ -333,8 +333,13 @@ class LintChecker(treeutil.NodeVisitor):
                         function_privs = self.function_uses_local_privs(val.children[0])
                         for priv, node in function_privs:
                             if priv not in private_keys:
-                                issue = warn("Using an undeclared private class feature: '%s'" % priv, self.file_name, node)
-                                self.issues.append(issue)
+                                ok = False
+                                at_hints = get_at_hints(node)
+                                if at_hints:
+                                    ok = self.is_name_lint_filtered(priv, at_hints, "ignoreUndeclaredPrivates")
+                                if not ok:
+                                    issue = warn("Using an undeclared private class feature: '%s'" % priv, self.file_name, node)
+                                    self.issues.append(issue)
 
 
     ##


### PR DESCRIPTION
This solves the issue with qx.test.Mixin's __b. See the Mixin class for @lint syntax.
I also fixed the framework's "lint-test" job so that it acutally works :-).

I'll update the manual once the PR is accepted.
