### PR TITLE
[#9167] Raise timeout for event test in Flash tests

### DIFF
--- a/framework/source/class/qx/test/ui/embed/Flash.js
+++ b/framework/source/class/qx/test/ui/embed/Flash.js
@@ -106,7 +106,7 @@ qx.Class.define("qx.test.ui.embed.Flash",
       this.__flash.addListener("timeout", test.timeout);
 
       var that = this;
-      this.wait(2000, function()
+      this.wait(8000, function()
       {
         that.assertCalled(loading);
         that.assertCalled(loaded);


### PR DESCRIPTION
Attempt to raise the timeout for the qx.test.ui.embed.Flash event tests in order to fix the failing tests in travis.

Maybe a fix for https://github.com/qooxdoo/qooxdoo/issues/9167
