### PR TITLE
Reset global cursor after a window closes

### DIFF
--- a/framework/source/class/qx/ui/core/MResizable.js
+++ b/framework/source/class/qx/ui/core/MResizable.js
@@ -618,7 +618,10 @@ qx.Mixin.define("qx.ui.core.MResizable",
 
   destruct : function()
   {
-    this.getApplicationRoot().resetGlobalCursor();
+    if(this.getCursor()) {
+      this.getApplicationRoot().resetGlobalCursor();
+    }
+    
     if (this.__resizeFrame != null && !qx.core.ObjectRegistry.inShutDown)
     {
       this.__resizeFrame.destroy();

--- a/framework/source/class/qx/ui/core/MResizable.js
+++ b/framework/source/class/qx/ui/core/MResizable.js
@@ -618,6 +618,7 @@ qx.Mixin.define("qx.ui.core.MResizable",
 
   destruct : function()
   {
+    this.getApplicationRoot().resetGlobalCursor();
     if (this.__resizeFrame != null && !qx.core.ObjectRegistry.inShutDown)
     {
       this.__resizeFrame.destroy();


### PR DESCRIPTION
This is a fix for an old bug see second issue of this [bug](https://github.com/qooxdoo/qooxdoo/issues/8936). Demonstration of the bug in the playground [here](http://tinyurl.com/zekfy25).
