### PR TITLE
Ugly fix for issue #9174 selectbox closes popup unexpectidly when clicking on the list scrollbar when using native scrollbars

### DIFF
--- a/framework/source/class/qx/ui/form/AbstractSelectBox.js
+++ b/framework/source/class/qx/ui/form/AbstractSelectBox.js
@@ -123,6 +123,10 @@ qx.Class.define("qx.ui.form.AbstractSelectBox",
 
   members :
   {
+    // inhibit blur flag for MS Edge fix for issue [ISSUE #9174]
+    __inhibitBlur : false,
+
+
     // overridden
     _createChildControlImpl : function(id, hash)
     {
@@ -144,6 +148,12 @@ qx.Class.define("qx.ui.form.AbstractSelectBox",
           control.addListener("changeSelection", this._onListChangeSelection, this);
           control.addListener("pointerdown", this._onListPointerDown, this);
           control.getChildControl("pane").addListener("tap", this.close, this);
+
+          // MS Edge only fix for [ISSUE #9174]
+          if(qx.core.Environment.get("browser.name") == "edge") {
+            control.getChildControl("scrollbar-y").addListener("pointerdown", this.__onScrollbarYPointerDown, this);
+            control.getChildControl("scrollbar-y").addListener("pointerup", this.__onScrollbarYPointerUp, this);
+          }
           break;
 
         case "popup":
@@ -272,7 +282,38 @@ qx.Class.define("qx.ui.form.AbstractSelectBox",
      */
     _onBlur : function(e)
     {
+      // MS Edge only fix for [ISSUE #9174] 
+      if(qx.core.Environment.get("browser.name") == "edge") {
+        if(this.__inhibitBlur === true) {
+          this.__inhibitBlur = false;
+          this.focus();
+          return;
+        }
+      }
+      
       this.close();
+    },
+
+
+    /**
+     * Handler for the pointerdown event of scrollbar-y child of the list 
+     * MS Edge only fix for [ISSUE #9174] 
+     * 
+     * @param e {qx.event.type.Pointer} The pointerdown event.
+     */
+    __onScrollbarYPointerDown : function(e) {
+      this.__inhibitBlur = true;
+    },
+
+
+    /**
+     * Handler for the pointerup event of scrollbar-y child of the list 
+     * MS Edge only fix for [ISSUE #9174] 
+     * 
+     * @param e {qx.event.type.Pointer} The pointerup event.
+     */
+    __onScrollbarYPointerUp : function(e) {
+      this.__inhibitBlur = false;
     },
 
 

--- a/framework/source/class/qx/ui/form/AbstractSelectBox.js
+++ b/framework/source/class/qx/ui/form/AbstractSelectBox.js
@@ -280,19 +280,23 @@ qx.Class.define("qx.ui.form.AbstractSelectBox",
      *
      * @param e {qx.event.type.Focus} The blur event.
      */
-    _onBlur : function(e)
+    _onBlur : qx.core.Environment.select("browser.name",
     {
-      // MS Edge only fix for [ISSUE #9174] 
-      if(qx.core.Environment.get("browser.name") == "edge") {
+      "edge" : function(e) {
+        // MS Edge only fix for [ISSUE #9174] 
         if(this.__inhibitBlur === true) {
           this.__inhibitBlur = false;
           this.focus();
           return;
         }
+        
+        this.close();
+      },
+
+      "default" : function(e) {
+        this.close();
       }
-      
-      this.close();
-    },
+    }),
 
 
     /**
@@ -301,9 +305,14 @@ qx.Class.define("qx.ui.form.AbstractSelectBox",
      * 
      * @param e {qx.event.type.Pointer} The pointerdown event.
      */
-    __onScrollbarYPointerDown : function(e) {
-      this.__inhibitBlur = true;
-    },
+    __onScrollbarYPointerDown : qx.core.Environment.select("browser.name",
+    {
+      "edge" : function(e) {
+        this.__inhibitBlur = true;
+      },
+
+      "default" : null
+    }),
 
 
     /**
@@ -312,9 +321,14 @@ qx.Class.define("qx.ui.form.AbstractSelectBox",
      * 
      * @param e {qx.event.type.Pointer} The pointerup event.
      */
-    __onScrollbarYPointerUp : function(e) {
-      this.__inhibitBlur = false;
-    },
+    __onScrollbarYPointerUp : qx.core.Environment.select("browser.name",
+    {
+      "edge" : function(e) {
+        this.__inhibitBlur = false;
+      },
+
+      "default" : null
+    }),
 
 
     /**

--- a/framework/source/class/qx/ui/form/AbstractSelectBox.js
+++ b/framework/source/class/qx/ui/form/AbstractSelectBox.js
@@ -151,8 +151,11 @@ qx.Class.define("qx.ui.form.AbstractSelectBox",
 
           // MS Edge only fix for [ISSUE #9174]
           if(qx.core.Environment.get("browser.name") == "edge") {
-            control.getChildControl("scrollbar-y").addListener("pointerdown", this.__onScrollbarYPointerDown, this);
-            control.getChildControl("scrollbar-y").addListener("pointerup", this.__onScrollbarYPointerUp, this);
+            var scrollbar = control.getChildControl("scrollbar-y");
+            if(scrollbar.classname == "qx.ui.core.scroll.NativeScrollBar") { 
+              scrollbar.addListener("pointerdown", this.__onScrollbarYPointerDown, this);
+              scrollbar.addListener("pointerup", this.__onScrollbarYPointerUp, this);
+            }
           }
           break;
 


### PR DESCRIPTION
This is more a workaround until the real cause in issue #9174 is fixed.
