### PR TITLE
Added qx.core.MProperty#isPropertyInitialized

### DIFF
--- a/framework/source/class/qx/core/MProperty.js
+++ b/framework/source/class/qx/core/MProperty.js
@@ -137,7 +137,9 @@ qx.Mixin.define("qx.core.MProperty",
      */
     isPropertyInitialized : function(prop)
     {
-      qx.core.Assert.assertString(prop);
+      if (qx.core.Environment.get("qx.debug")) {
+        qx.core.Assert.assertString(prop);
+      }
 
       if (!this["get" + qx.Bootstrap.firstUp(prop)]) {
         throw new Error("No such property: " + prop);

--- a/framework/source/class/qx/core/MProperty.js
+++ b/framework/source/class/qx/core/MProperty.js
@@ -125,6 +125,26 @@ qx.Mixin.define("qx.core.MProperty",
 
 
       this[resetter[prop]]();
+    },
+
+    /**
+     * Checks if the property is initialized, i.e. has a defined init value or
+     * has got a value by a setter method.
+     *
+     * @param prop {String} Name of the property
+     * @returns {Boolean} If the property is initialized
+     * @throws {Error} If the property defined does not exist
+     */
+    isPropertyInitialized : function(prop)
+    {
+      qx.core.Assert.assertString(prop);
+
+      if (!this["get" + qx.Bootstrap.firstUp(prop)]) {
+        throw new Error("No such property: " + prop);
+      }
+
+      return this["$$user_" + prop] !== undefined ||
+        this["$$init_" + prop] !== undefined;
     }
   }
 });

--- a/framework/source/class/qx/core/MProperty.js
+++ b/framework/source/class/qx/core/MProperty.js
@@ -139,10 +139,10 @@ qx.Mixin.define("qx.core.MProperty",
     {
       if (qx.core.Environment.get("qx.debug")) {
         qx.core.Assert.assertString(prop);
-      }
 
-      if (!this["get" + qx.Bootstrap.firstUp(prop)]) {
-        throw new Error("No such property: " + prop);
+        if (!this["get" + qx.Bootstrap.firstUp(prop)]) {
+          throw new Error("No such property: " + prop);
+        }
       }
 
       return this["$$user_" + prop] !== undefined ||

--- a/framework/source/class/qx/test/core/Object.js
+++ b/framework/source/class/qx/test/core/Object.js
@@ -363,6 +363,28 @@ qx.Class.define("qx.test.core.Object",
 
       qx.Class.undefine("qx.test.Single");
       o.dispose();
+    },
+
+
+    testIsPropertyInitialized : function()
+    {
+      qx.Class.define("qx.test.MyClass", {
+        extend : qx.core.Object,
+        properties :
+        {
+          a : {},
+          b : {init : false}
+        }
+      });
+      var o = new qx.test.MyClass();
+
+      this.assertFalse(o.isPropertyInitialized("a"));
+      o.setA(false);
+      this.assertTrue(o.isPropertyInitialized("a"));
+      this.assertTrue(o.isPropertyInitialized("b"));
+
+      qx.Class.undefine("qx.test.MyClass");
+      o.dispose();
     }
   }
 });


### PR DESCRIPTION
If you got a property `foo` which is not initialized and you call `getFoo()`, you'll get an error that the property is not initialized. You must either enclose it in a try-catch block or set an init value for the property. 

This PR introduces a small function to check if a property is initialized.
