### PR TITLE
add recent OS X version user agent mappings

### DIFF
--- a/framework/source/class/qx/bom/client/OperatingSystem.js
+++ b/framework/source/class/qx/bom/client/OperatingSystem.js
@@ -126,6 +126,10 @@ qx.Bootstrap.define("qx.bom.client.OperatingSystem",
       "Win95" : "95",
 
       // OS X
+      "Mac OS X 10_12" : "10.12",
+      "Mac OS X 10.12" : "10.12",
+      "Mac OS X 10_11" : "10.11",
+      "Mac OS X 10.11" : "10.11",
       "Mac OS X 10_10" : "10.10",
       "Mac OS X 10.10" : "10.10",
       "Mac OS X 10_9" : "10.9",


### PR DESCRIPTION
added EL Capitan "10.11" and Sierra "10.12".

Without this PR qx.core.Environment.get("os.version") reports both as version 10.1
