### PR TITLE
issue #9189 fix for gecko not supporting padding-box anymore

### DIFF
--- a/framework/source/class/qx/test/bom/element/BoxSizing.js
+++ b/framework/source/class/qx/test/bom/element/BoxSizing.js
@@ -28,7 +28,7 @@ qx.Class.define("qx.test.bom.element.BoxSizing",
     {
       mshtml : ["border-box", "content-box"],
       opera : ["border-box", "content-box"],
-      gecko : ["border-box", "content-box", "padding-box"],
+      gecko : ["border-box", "content-box"],
       webkit : ["border-box", "content-box"]
     },
 


### PR DESCRIPTION
This removes the boxsizing support test for gecko.

As per changelog for firefox 50 https://developer.mozilla.org/de/Firefox/Releases/50#Changes_for_Web_developers padding-box has been removed.

https://github.com/qooxdoo/qooxdoo/issues/9189
