### PR TITLE
completing manual entry on using external JS libs

### DIFF
--- a/documentation/manual/source/pages/development/using_non_qx_libs.rst
+++ b/documentation/manual/source/pages/development/using_non_qx_libs.rst
@@ -90,11 +90,12 @@ Step-by-Step Instructions
           construct: function() {
             // initialize the script loading
             var dynLoader = new qx.util.DynamicScriptLoader([
-                "ponycharts/PonyCharts.js"
+                "ponycharts/ponycharts.js"
             ]);
 
             dynLoader.addListenerOnce('ready',function(e){
               console.log("all scripts have been loaded!");
+              ThePonyChartsTopLevelSymbol.initialize();
             });
 
             dynLoader.addListener('failed',function(e){

--- a/documentation/manual/source/pages/development/using_non_qx_libs.rst
+++ b/documentation/manual/source/pages/development/using_non_qx_libs.rst
@@ -13,47 +13,47 @@ Using the third-party library like a resource of your application
 
 Let's assume you found this wonderful %{JS} library for charting, called *PonyCharts*. It is available as minified *ponycharts.js* download from the project's web site. It exposes an API for creating and manipulating charts, and you want ot use such charts as part of your %{qooxdoo} application. This means calling into the library's API from your %{qooxdoo} code, which in turn means the library has to be loaded ahead of your code in the browser.
 
-1. As a first step, copy the *.js* file into your app's resource tree, e.g. as
+#. As a first step, copy the *.js* file into your app's resource tree, e.g. as
 
-    ::
+   ::
 
-        source/resource/ponycharts/ponycharts.js
+       source/resource/ponycharts/ponycharts.js
 
-2. Then, make sure your new resource is used by your application code. The main consequence of this is that the *.js* file will be copied over to the build tree of your application, and is being made known to ${qooxdoo}'s ResourceManager. You achieve that by adding an *@asset* hint to the main class of your application or library.
+#. Then, make sure your new resource is used by your application code. The main consequence of this is that the *.js* file will be copied over to the build tree of your application, and is being made known to ${qooxdoo}'s ResourceManager. You achieve that by adding an *@asset* hint to the main class of your application or library.
 
-    ::
+   ::
 
-        /**
-         * This is the main class of your custom application "foo".
-         *
-         * @asset(foo/*)
-         * @asset(ponycharts/ponycharts.js)
-         */
-        qx.Class.define("foo.Application",
-            ...
+       /**
+        * This is the main class of your custom application "foo".
+        *
+        * @asset(foo/*)
+        * @asset(ponycharts/ponycharts.js)
+        */
+       qx.Class.define("foo.Application",
+           ...
                 
-It makes sense to add the *.js* file under its own directory, thereby creating a namespace for it. This allows you to use wildcards should the third-party lib consist of multiple files (e.g. comes with an *.css* file, images, etc.). You could then write
+   It makes sense to add the *.js* file under its own directory, thereby creating a namespace for it. This allows you to use wildcards should the third-party lib consist of multiple files (e.g. comes with an *.css* file, images, etc.). You could then write
 
-    ::
+   ::
 
-        /**
-         * ...
-         * @asset(ponycharts/*)
-         */
+       /**
+        * ...
+        * @asset(ponycharts/*)
+        */
 
-3. Make sure the PonyCharts *.js* file is loaded before your application code. A simple way to achieve this is to use the :ref:`add-script <pages/tool/generator/generator_config_ref#add-script>` config key. In your `config.json`, under *jobs*, add a *common* job like this.
+#. Make sure the PonyCharts *.js* file is loaded before your application code. A simple way to achieve this is to use the :ref:`add-script <pages/tool/generator/generator_config_ref#add-script>` config key. In your `config.json`, under *jobs*, add a *common* job like this.
 
-    ::
+   ::
 
-        "common" : {
-            "add-script" : [
-                {
-                    "uri" : "resource/ponycharts/ponycharts.js"
-                }
-            ]
-        }
+       "common" : {
+           "add-script" : [
+               {
+                   "uri" : "resource/ponycharts/ponycharts.js"
+               }
+           ]
+       }
 
-This will assure the lib is loaded in source and build versions of your app before your code starts. You can now code happily against PonyChart's API.
+   This will assure the lib is loaded in source and build versions of your app before your code starts. You can now code happily against PonyChart's API.
 
 
 Wrapping the third-party code in an own %{qooxdoo} library
@@ -66,31 +66,76 @@ There is a more elaborate way to use an external %{JS} package, by wrapping it i
 - Exposing the package's API through a qooxdoo class.
 - Automatic dependency management wherever the wrapper class is used.
 
-Here are the necessary steps.
+Step-by-Step Instructions
+--------------------------
 
-1. Create a fresh %{qooxdoo} project using `create-application.py`.
-2. As before, copy the external package's files to a suitable place under the `resource` folder, e.g. `source/resource/ponycharts/ponycharts.js`
-3. Add an `@asset` hint in the project's main class
+#. Create a fresh %{qooxdoo} project using `create-application.py`.
+#. As in the approach above, copy the external package's files to a suitable place under the `resource` folder, e.g. `source/resource/ponycharts/ponycharts.js`.
+#. Likewise, add an `@asset` hint in the library's main class to include the external package as a resource (full example further below).
+#. Add code to this class that loads the external package, does necessary initialization and potentially adds a %{qooxdoo}-ish API to it.
 
-    ::
+   There is a framework class to help you with the loading part, `qx.util.DynamicScriptLoader <http://demo.qooxdoo.org/%{version}/apiviewer/#qx.util.DynamicScriptLoader>`_, which does most of the work to make the package available in the current browser context. Using this, here is how your wrapper class may look like:
+
+   ::
 
         /**
          * This is the main class of the PonyCharts wrapper.
          *
-         * @asset(ponycharts/ponycharts.js)
+         * @asset(ponycharts/*)
          */
         qx.Class.define("ponycharts.PonyCharts",
-            ...
+        {
+          extend: qx.core.Object,
 
-4. Add code this class that loads `ponycharts.js`, does necessary initialization, and adds a %{qooxdoo}-ish API to it.
+          construct: function() {
+            // initialize the script loading
+            var dynLoader = new qx.util.DynamicScriptLoader([
+                "ponycharts/PonyCharts.js"
+            ]);
 
-    ::
+            dynLoader.addListenerOnce('ready',function(e){
+              console.log("all scripts have been loaded!");
+            });
 
-        TBD
+            dynLoader.addListener('failed',function(e){
+              var data = e.getData();
+              console.log("failed to load " + data.script);
+            });
 
-5. In the using %{qooxdoo} application, call the correpsonding methods of the wrapper class.
+            dynLoader.start();
+          },
 
-    ::
+          members: {
+            paint: function() {
+              ThePonyChartsTopLevelSymbol.paint_demo();
+            }
+          }
+        }
 
-        TBD
+   See `qx.util.DynamicScriptLoader`_ for full details.
+
+#. Add the new %{qooxdoo} library to your main application's configuration. In its *config.json*, add under the *jobs* key
+
+   ::
+
+      "libraries" : {
+        "library" : [
+          "path" : "<path_to_ponycharts_lib>/Manifest.json"
+        ]
+      }
+
+#. In the using %{qooxdoo} application, call the correpsonding methods of the wrapper class.
+
+   ::
+
+        qx.Class.define("foo.Application",
+        {
+          extend: qx.core.Application,
+
+          construct: function() {
+            var myPonyCharts = new ponyCharts.PonyCharts();
+            myPonyCharts.paint();
+          }
+        }
  
+This should give you a basic outline how you can wrap an external package as a %{qooxdoo} library. You can now use the library for multiple projects, or even publish it as a contribution.

--- a/framework/source/class/qx/util/DynamicScriptLoader.js
+++ b/framework/source/class/qx/util/DynamicScriptLoader.js
@@ -27,7 +27,7 @@
  *
  * Usage example:
  *
- * <code>
+ * <pre>
  *  ... assets ...
  * /**
  *  * @asset(myapp/jquery/*)
@@ -66,7 +66,7 @@
  *
  *    dynLoader.start();
  *    
- * </code>
+ * </pre>
  */
 qx.Class.define("qx.util.DynamicScriptLoader", {
   extend: qx.core.Object,


### PR DESCRIPTION
This is the second half of the section about integrating external JS libs in the manual, namely creating a wrapping library using `qx.util.DynamicScriptLoader`, as discussed in PR #9181 . (I've also made a minor fix to the class documentation of DynamicScriptLoader.)

Please check for correctness and advise about any necessary corrections.
