### PR TITLE
Support for cooperative concurrency

### DIFF
--- a/framework/source/class/qx/bom/AnimationFrame.js
+++ b/framework/source/class/qx/bom/AnimationFrame.js
@@ -26,16 +26,16 @@
  *
  * Here is a sample usage:
  * <pre class='javascript'>var start = +(new Date());
- * var clb = function(time) {
+ * var cb = function(time) {
  *   if (time >= start + duration) {
  *     // ... do some last tasks
  *   } else {
  *     var timePassed = time - start;
  *     // ... calculate the current step and apply it
- *     qx.bom.AnimationFrame.request(clb, this);
+ *     qx.bom.AnimationFrame.request(cb, this);
  *   }
  * };
- * qx.bom.AnimationFrame.request(clb, this);
+ * qx.bom.AnimationFrame.request(cb, this);
  * </pre>
  *
  * Another way of using it is to use it as an instance emitting events.
@@ -81,7 +81,7 @@ qx.Bootstrap.define("qx.bom.AnimationFrame",
       this.__canceled = false;
 
       var start = +(new Date());
-      var clb = function(time) {
+      var cb = function(time) {
         if (this.__canceled) {
           this.id = null;
           return;
@@ -94,11 +94,11 @@ qx.Bootstrap.define("qx.bom.AnimationFrame",
         } else {
           var timePassed = Math.max(time - start, 0);
           this.emit("frame", timePassed);
-          this.id = qx.bom.AnimationFrame.request(clb, this);
+          this.id = qx.bom.AnimationFrame.request(cb, this);
         }
       };
 
-      this.id = qx.bom.AnimationFrame.request(clb, this);
+      this.id = qx.bom.AnimationFrame.request(cb, this);
     },
 
 
@@ -171,7 +171,7 @@ qx.Bootstrap.define("qx.bom.AnimationFrame",
     request : function(callback, context) {
       var req = qx.core.Environment.get("css.animation.requestframe");
 
-      var clb = function(time) {
+      var cb = function(time) {
         // check for high resolution time
         if (time < 1e10) {
           time = qx.bom.AnimationFrame.__start + time;
@@ -181,12 +181,12 @@ qx.Bootstrap.define("qx.bom.AnimationFrame",
         callback.call(context, time);
       };
       if (req) {
-        return window[req](clb);
+        return window[req](cb);
       } else {
         // make sure to use an indirection because setTimeout passes a
         // number as first argument as well
         return window.setTimeout(function() {
-          clb();
+          cb();
         }, qx.bom.AnimationFrame.TIMEOUT);
       }
     }

--- a/framework/source/class/qx/bom/IdleCallback.js
+++ b/framework/source/class/qx/bom/IdleCallback.js
@@ -60,16 +60,14 @@ qx.Bootstrap.define("qx.bom.IdleCallback",
      *   in case of the emulation.
      * @param context {var} The context of the callback.
      * @param timeout {Number} Timeout in milliseconds.
-     * @return {Number} The id of the request.
+     * @return {Number} Handle for that request
      */
     request : function(callback, context, timeout) {
-      var req = qx.core.Environment.get("client.idle");
-
       var clb = function(deadline) {
         return callback.call(context, deadline);
       };
 
-      if (req) {
+      if (qx.core.Environment.get("client.idle")) {
         return window.requestIdleCallback(clb, timeout);
       }
       else {
@@ -90,6 +88,21 @@ qx.Bootstrap.define("qx.bom.IdleCallback",
         return window.setTimeout(function() {
           clb(deadline);
         }, qx.bom.IdleCallback.TIMEOUT);
+      }
+    },
+
+    /**
+     * Cancel a requested IDLE callback.
+     *
+     * @param handle {Number} Handle acquired by <code>qx.bom.IdleCallback.request()</code>.
+     */
+    cancel : function(handle)
+    {
+      if (qx.core.Environment.get("client.idle")) {
+        window.cancelIdleCallback(handle);
+      }
+      else {
+        window.clearTimeout(handle);
       }
     }
   }

--- a/framework/source/class/qx/bom/IdleCallback.js
+++ b/framework/source/class/qx/bom/IdleCallback.js
@@ -1,0 +1,96 @@
+/* ************************************************************************
+
+   qooxdoo - the new era of web development
+
+   http://qooxdoo.org
+
+   Copyright:
+     2016 GONICUS GmbH, Germany, http://www.gonicus.de
+
+   License:
+     MIT: https://opensource.org/licenses/MIT
+     See the LICENSE file in the project's top-level directory for details.
+
+   Authors:
+     * Cajus Pollmeier (cajus)
+
+************************************************************************ */
+
+/**
+ * This is a cross browser wrapper for requestIdleCallback. For further
+ * information about the feature, take a look at spec:
+ * https://www.w3.org/TR/requestidlecallback/
+ *
+ * Here is a sample usage:
+ * <pre class='javascript'>var clb = function(deadline) {
+ *   while (deadline.timeRemaining() > 0) {
+ *     // ... do some last tasks
+ *   }
+ * };
+ *
+ * qx.bom.IdleCallback.request(clb, this);
+ * </pre>
+ */
+qx.Bootstrap.define("qx.bom.IdleCallback",
+{
+  extend : qx.core.Object,
+
+  statics :
+  {
+    /**
+     * The default time in ms the timeout fallback implementation uses.
+     */
+    TIMEOUT : 0,
+
+    /**
+     * The default remaining time in ms the timeout fallback implementation uses.
+     */
+    REMAINING : 250,
+
+    /**
+     * Request for an IDLE callback. If the native <code>requestIdleCallback</code>
+     * method is supported, it will be used. Otherwise, we use timeouts with a
+     * 30ms delay. The HighResolutionTime will be used if supported but the time given
+     * to the callback will still be a timestamp starting at 1 January 1970 00:00:00 UTC.
+     *
+     * @param callback {Function} The callback function which will get a deadline
+     *   object. It contains a <code>timeRemaining()</code> call which returns the
+     *   remaining milliseconds and the <code>didTimeout</code> flag which indicates
+     *   whether the callback was fired due to a timeout. The latter is always false
+     *   in case of the emulation.
+     * @param context {var} The context of the callback.
+     * @param timeout {Number} Timeout in milliseconds.
+     * @return {Number} The id of the request.
+     */
+    request : function(callback, context, timeout) {
+      var req = qx.core.Environment.get("client.idle");
+
+      var clb = function(deadline) {
+        return callback.call(context, deadline);
+      };
+
+      if (req) {
+        return window.requestIdleCallback(clb, timeout);
+      }
+      else {
+
+        var deadline = {
+          started : +(new Date()),
+
+          timeRemaining : function() {
+            var now = +new Date();
+            return Math.max(qx.bom.IdleCallback.REMAINING - (now - this.started), 0);
+          },
+
+          didTimeout : false
+        };
+
+        // make sure to use an indirection because setTimeout passes a
+        // number as first argument as well
+        return window.setTimeout(function() {
+          clb(deadline);
+        }, qx.bom.IdleCallback.TIMEOUT);
+      }
+    }
+  }
+});

--- a/framework/source/class/qx/bom/client/Idle.js
+++ b/framework/source/class/qx/bom/client/Idle.js
@@ -1,0 +1,45 @@
+/* ************************************************************************
+
+   qooxdoo - the new era of web development
+
+   http://qooxdoo.org
+
+   Copyright:
+     2016 GONICUS GmbH, Germany, http://www.gonicus.de
+
+   License:
+     MIT: https://opensource.org/licenses/MIT
+     See the LICENSE file in the project's top-level directory for details.
+
+   Authors:
+     * Cajus Pollmeier (cajus)
+
+************************************************************************ */
+
+/**
+ * Responsible for checking whether the browser supports cooperative
+ * scheduling.
+ *
+ * Spec: https://www.w3.org/TR/requestidlecallback/
+ *
+ * @internal
+ */
+qx.Bootstrap.define("qx.bom.client.Idle",
+{
+  statics :
+  {
+    /**
+     * Whether the client supports cooperative scheduling of background tasks.
+     *
+     * @internal
+     * @return {Boolean} <code>true</code> if API is supported
+     */
+    getSupport : function() {
+      return window.requestIdleCallback !== undefined;
+    }
+  },
+
+  defer : function(statics) {
+    qx.core.Environment.add("client.idle", statics.getSupport);
+  }
+});

--- a/framework/source/class/qx/test/bom/IdleCallback.js
+++ b/framework/source/class/qx/test/bom/IdleCallback.js
@@ -47,6 +47,19 @@ qx.Class.define("qx.test.bom.IdleCallback",
       }, this);
     },
 
+    "test: emulated cancelIdleCallback" : function() {
+      var setting = this.stub(qx.core.Environment, "get").withArgs("client.idle");
+      setting.returns(false);
+
+      var clb = this.spy();
+      var request = qx.bom.IdleCallback.request(clb);
+      qx.bom.IdleCallback.cancel(request);
+
+      this.wait(500, function() {
+        this.assertNotCalled(clb);
+      }, this);
+    },
+
 
     "test: native requestIdleCallback" : function() {
       if (!qx.core.Environment.get("client.idle")) {
@@ -60,6 +73,21 @@ qx.Class.define("qx.test.bom.IdleCallback",
         this.assertFalse(clb.args[0][0].didTimeout);
         this.assertFunction(clb.args[0][0].timeRemaining);
         this.assertNumber(clb.args[0][0].timeRemaining());
+      }, this);
+    },
+
+
+    "test: native cancelIdleCallback" : function() {
+      if (!qx.core.Environment.get("client.idle")) {
+        this.skip();
+      }
+
+      var clb = this.spy();
+      var request = qx.bom.IdleCallback.request(clb);
+      qx.bom.IdleCallback.cancel(request);
+
+      this.wait(500, function() {
+        this.assertNotCalled(clb);
       }, this);
     }
   }

--- a/framework/source/class/qx/test/bom/IdleCallback.js
+++ b/framework/source/class/qx/test/bom/IdleCallback.js
@@ -1,0 +1,66 @@
+/* ************************************************************************
+
+   qooxdoo - the new era of web development
+
+   http://qooxdoo.org
+
+   Copyright:
+     2016 GONICUS GmbH, Germany, http://www.gonicus.de
+
+   License:
+     MIT: https://opensource.org/licenses/MIT
+     See the LICENSE file in the project's top-level directory for details.
+
+   Authors:
+     * Cajus Pollmeier (cajus)
+
+************************************************************************ */
+
+
+qx.Class.define("qx.test.bom.IdleCallback",
+{
+  extend : qx.dev.unit.TestCase,
+  include : [
+    qx.dev.unit.MMock,
+    qx.dev.unit.MRequirements
+  ],
+
+  members :
+  {
+    tearDown: function() {
+      this.getSandbox().restore();
+    },
+
+
+    "test: emulated requestIdleCallback" : function() {
+      var setting = this.stub(qx.core.Environment, "get").withArgs("client.idle");
+      setting.returns(false);
+
+      var clb = this.spy();
+      qx.bom.IdleCallback.request(clb);
+      this.wait(500, function() {
+        this.assertCalledOnce(clb);
+        this.assertFalse(clb.args[0][0].didTimeout);
+        this.assertFunction(clb.args[0][0].timeRemaining);
+        this.assertNumber(clb.args[0][0].timeRemaining());
+        this.assertNumber(clb.args[0][0].timeRemaining(), 0);
+      }, this);
+    },
+
+
+    "test: native requestIdleCallback" : function() {
+      if (!qx.core.Environment.get("client.idle")) {
+        this.skip();
+      }
+
+      var clb = this.spy();
+      qx.bom.IdleCallback.request(clb);
+      this.wait(500, function() {
+        this.assertCalledOnce(clb);
+        this.assertFalse(clb.args[0][0].didTimeout);
+        this.assertFunction(clb.args[0][0].timeRemaining);
+        this.assertNumber(clb.args[0][0].timeRemaining());
+      }, this);
+    }
+  }
+});

--- a/framework/source/class/qx/test/bom/IdleCallback.js
+++ b/framework/source/class/qx/test/bom/IdleCallback.js
@@ -38,6 +38,8 @@ qx.Class.define("qx.test.bom.IdleCallback",
 
       var clb = this.spy();
       qx.bom.IdleCallback.request(clb);
+      this.getSandbox().restore();
+
       this.wait(500, function() {
         this.assertCalledOnce(clb);
         this.assertFalse(clb.args[0][0].didTimeout);
@@ -54,6 +56,7 @@ qx.Class.define("qx.test.bom.IdleCallback",
       var clb = this.spy();
       var request = qx.bom.IdleCallback.request(clb);
       qx.bom.IdleCallback.cancel(request);
+      this.getSandbox().restore();
 
       this.wait(500, function() {
         this.assertNotCalled(clb);


### PR DESCRIPTION
This pull requests implements the _cooperative concurrency_ (draft) detailed in https://w3c.github.io/requestidlecallback/. Please note that it is currently supported only in Chrome (>=47). Firefox support is on its way. The PR takes care about this fact and emulates the behaviour using traditional _setTimeout()_ calls and a pre-defined time bucket.

So - what is it good for? Think about a huge data model that needs some client side processing when read. Processing everything in a linear manner might lead to browser "page is not responsive" popups. So you'll end up splitting stuff into smaller chunks and process them in _setTimeout()_ calls.

That has the disadvantage that you cannot use the time where the browser is IDLE, because _setTimeout()_ has a granularity variing from browser to browser. That's what the W3C draft is good for.

Example:

```
var process = function(deadline) {
  while (deadline.timeRemaining() > 0 && stuffToDo()) {
    doChunkedStuff();  
  }

  if (stuffToDo()) {
    qx.bom.IdleCallback(process);  
  }
};

qx.bom.IdleCallback(process);
```

So the browser will tell you when there's time to do stuff without influencing the rendering. And - in opposite to _setTimeout()_ - it is called as soon as possible and gives you an estimated time frame to do as much as possible in that.
