### PR TITLE
Trap error from RPC callback rather than calling callback with its own error

### DIFF
--- a/framework/source/class/qx/io/remote/Rpc.js
+++ b/framework/source/class/qx/io/remote/Rpc.js
@@ -528,7 +528,6 @@ qx.Class.define("qx.io.remote.Rpc",
       var argsArray = [];
       var eventTarget = this;
       var protocol = this.getProtocol();
-      var _this = this;
 
       for (var i=offset+1; i<args.length; ++i)
       {
@@ -575,7 +574,7 @@ qx.Class.define("qx.io.remote.Rpc",
             }
             catch(e)
             {
-              _this.error(
+              eventTarget.error(
                 "rpc handler threw an error:" +
                   " id=" + id +
                   " result=" + JSON.stringify(result) +

--- a/framework/source/class/qx/io/remote/Rpc.js
+++ b/framework/source/class/qx/io/remote/Rpc.js
@@ -568,7 +568,18 @@ qx.Class.define("qx.io.remote.Rpc",
             break;
 
           case 1: // async with handler function
-            handler(result, ex, id);
+            try
+            {
+              handler(result, ex, id);
+            }
+            catch(e)
+            {
+              console.error(
+                "rpc handler threw an error:" +
+                  " id=" + id +
+                  " result=" + JSON.stringify(result) +
+                  " ex=" + JSON.stringify(ex));
+            }
             break;
 
           case 2: // async with event listeners

--- a/framework/source/class/qx/io/remote/Rpc.js
+++ b/framework/source/class/qx/io/remote/Rpc.js
@@ -578,7 +578,8 @@ qx.Class.define("qx.io.remote.Rpc",
                 "rpc handler threw an error:" +
                   " id=" + id +
                   " result=" + JSON.stringify(result) +
-                  " ex=" + JSON.stringify(ex));
+                  " ex=" + JSON.stringify(ex),
+                e);
             }
             break;
 

--- a/framework/source/class/qx/io/remote/Rpc.js
+++ b/framework/source/class/qx/io/remote/Rpc.js
@@ -528,6 +528,7 @@ qx.Class.define("qx.io.remote.Rpc",
       var argsArray = [];
       var eventTarget = this;
       var protocol = this.getProtocol();
+      var _this = this;
 
       for (var i=offset+1; i<args.length; ++i)
       {
@@ -574,7 +575,7 @@ qx.Class.define("qx.io.remote.Rpc",
             }
             catch(e)
             {
-              console.error(
+              _this.error(
                 "rpc handler threw an error:" +
                   " id=" + id +
                   " result=" + JSON.stringify(result) +

--- a/framework/source/class/qx/io/remote/Rpc.js
+++ b/framework/source/class/qx/io/remote/Rpc.js
@@ -577,8 +577,8 @@ qx.Class.define("qx.io.remote.Rpc",
               eventTarget.error(
                 "rpc handler threw an error:" +
                   " id=" + id +
-                  " result=" + JSON.stringify(result) +
-                  " ex=" + JSON.stringify(ex),
+                  " result=" + qx.lang.Json.stringify(result) +
+                  " ex=" + qx.lang.Json.stringify(ex),
                 e);
             }
             break;


### PR DESCRIPTION
This should fix the problem that @oetiker identified, where the RPC callback function threw an error, which caused that callback function to be called again.
