### PR TITLE
Document how to retrieve the list ITEM that was dragged and dropped

### DIFF
--- a/documentation/manual/source/pages/desktop/ui_dragdrop.rst
+++ b/documentation/manual/source/pages/desktop/ui_dragdrop.rst
@@ -44,6 +44,20 @@ The drop target can then add a listener to react for the ``drop`` event.
 
 The listener now shows an alert box which should present the identification ID (classname + hash code) of the drag target. Theoretically this could already be used to transfer data from A to B.
 
+A common need is to retrieve information from the model of the specific list
+item which was dragged from ``dragTarget`` which is an instance of
+``qx.ui.form.List``. This can be easily accomplished in the ``drop`` event
+handler, using the event argument which provides a manager which provides the
+actual drag target (the List item).
+
+::
+
+  dropTarget.addListener("drop", function(e) {
+    var list = e.getManager().getDragTarget();
+    var model = list.getModel();
+    ...
+  });
+
 .. _pages/desktop/ui_dragdrop#data_handling:
 
 Data Handling

--- a/documentation/manual/source/pages/desktop/ui_dragdrop.rst
+++ b/documentation/manual/source/pages/desktop/ui_dragdrop.rst
@@ -48,13 +48,13 @@ A common need is to retrieve information from the model of the specific list
 item which was dragged from ``dragTarget`` which is an instance of
 ``qx.ui.form.List``. This can be easily accomplished in the ``drop`` event
 handler, using the event argument which provides a manager which provides the
-actual drag target (the List item).
+actual drag target (the ``qx.ui.form.ListItem``).
 
 ::
 
   dropTarget.addListener("drop", function(e) {
-    var list = e.getManager().getDragTarget();
-    var model = list.getModel();
+    var listItem = e.getManager().getDragTarget();
+    var model = listItem.getModel();
     ...
   });
 


### PR DESCRIPTION
I must not be the only one who needs to go search for old code, or spend a half hour in Developer Tools each time I need to figure out which list _item_ was dragged and dropped. This PR adds a bit of documentation describing how to do it, for easy reference.
