### PR TITLE
Added workaround for broken qx site

### DIFF
--- a/.travis/deploy.sh
+++ b/.travis/deploy.sh
@@ -38,12 +38,17 @@ if [ $CURRENT = 1 ]; then
   ln -s "$TARGET" current
 fi
 
-#TODO: When we've some more control over the qx DNS records, we can add a CNAME here...
-#echo "qooxdoo.org" > CNAME
-
 touch .nojekyll
 touch .
 
 git add -A .
 git commit -m "Refresh site at ${rev}"
 git push -q upstream HEAD:master
+
+# Do a regular checkout and make a dummy commit
+git clone -q git@github.com:qooxdoo/qooxdoo.github.io.git tmp
+cd tmp
+echo $rev > revision
+git add revision
+git commit -m "Dummy commit to fix github site sync"
+git push -q


### PR DESCRIPTION
Proposal to work around the github issues. Maybe there's a more elegant way to do an _ordinary_ push to the repository in order to trigger a proper sync.

Just choosen the _clone/push_ approach. Additionally we may wait if the github engineers find a reason. 

Any comments? 
