### PR TITLE
Enhance Window: add autoDestroy and autoCenter properties

### DIFF
--- a/framework/source/class/qx/ui/window/Window.js
+++ b/framework/source/class/qx/ui/window/Window.js
@@ -91,6 +91,9 @@ qx.Class.define("qx.ui.window.Window",
     // Focusout listener
     this.addListener("focusout", this._onWindowFocusOut, this);
 
+    // Initialize the centerWhen property to its own empty array
+    this.setCenterWhen([]);
+
     // Automatically add to application root.
     qx.core.Init.getApplication().getRoot().add(this);
 
@@ -408,7 +411,7 @@ qx.Class.define("qx.ui.window.Window",
      */
     centerWhen :
     {
-      init : [],
+      init : null,              // initialized in constructor
       nullable : false,
       apply : "_applyCenterWhen",
       check : function(value)
@@ -1058,7 +1061,7 @@ qx.Class.define("qx.ui.window.Window",
     // overridden
     _applyCenterWhen : function(value, old)
     {
-      var             parent;
+      var             parent = this.getLayoutParent();
 
       // Remove prior listener for centering on appear
       if (this.__centeringAppearId !== null) {
@@ -1080,7 +1083,6 @@ qx.Class.define("qx.ui.window.Window",
 
       // If we are to center on resize, arrange to do so
       if (value.indexOf("resize") != -1) {
-        parent = this.getLayoutParent();
         if (parent) {
           this.__centeringResizeId =
             parent.addListener("resize", this.center, this);
@@ -1219,10 +1221,6 @@ qx.Class.define("qx.ui.window.Window",
 
     // Remove ourselves from the focus handler
     qx.ui.core.FocusHandler.getInstance().removeRoot(this);
-
-    // Remove the listener for appear, if there is one
-    id = this.__centeringAppearId;
-    id && this.removeListenerById(id);
 
     // If we haven't been removed from our parent, clean it up too.
     parent = this.getLayoutParent();

--- a/framework/source/class/qx/ui/window/Window.js
+++ b/framework/source/class/qx/ui/window/Window.js
@@ -1219,20 +1219,24 @@ qx.Class.define("qx.ui.window.Window",
   destruct : function()
   {
     var id;
-    var parent = this.getLayoutParent();
+    var parent;
+
+    // Remove ourselves from the focus handler
+    qx.ui.core.FocusHandler.getInstance().removeRoot(this);
 
     // Remove the listener for appear, if there is one
     id = this.__centeringAppearId;
     id && this.removeListenerById(id);
 
-    // Remove the listener for resize, if there is one
-    id = this.__centeringResizeId;
-    id && parent.removeListenerById(id);
+    // If we haven't been removed from our parent, clean it up too.
+    parent = this.getLayoutParent();
+    if (parent) {
+      // Remove the listener for resize, if there is one
+      id = this.__centeringResizeId;
+      id && parent.removeListenerById(id);
 
-    // Remove ourselves from the focus handler
-    qx.ui.core.FocusHandler.getInstance().removeRoot(this);
-
-    // Remove ourself from our parent
-    parent && parent.remove(this);
+      // Remove ourself from our parent
+      parent && parent.remove(this);
+    }
   }
 });

--- a/framework/source/class/qx/ui/window/Window.js
+++ b/framework/source/class/qx/ui/window/Window.js
@@ -125,7 +125,7 @@ qx.Class.define("qx.ui.window.Window",
 
   /*
   *****************************************************************************
-     PROPERTIES
+     EVENTS
   *****************************************************************************
   */
 
@@ -372,6 +372,50 @@ qx.Class.define("qx.ui.window.Window",
       check : "Boolean",
       init : false,
       apply : "_applyShowStatusbar"
+    },
+
+
+
+
+    /*
+    ---------------------------------------------------------------------------
+      OPEN BEHAVIOR
+    ---------------------------------------------------------------------------
+    */
+
+    /** Should the window be automatically centered when it is opened */
+    autoCenter :
+    {
+      check : "Boolean",
+      init : false
+    },
+
+
+
+
+    /*
+    ---------------------------------------------------------------------------
+      CLOSE BEHAVIOR
+    ---------------------------------------------------------------------------
+    */
+
+    /** 
+     * Should the window be automatically destroyed when it is closed.
+     *
+     * When false, closing the window behaves like hiding the window.
+     * 
+     * When true, the window is removed from its container (the root), all
+     * listeners are removed, the window's widgets are removed, and the window
+     * is destroyed.
+     *
+     * NOTE: If any widgets that were added to this window require special
+     * clean-up, you should listen on the 'close' event and remove and clean
+     * up those widgets there.
+     */
+    autoDestroy :
+    {
+      check : "Boolean",
+      init : false
     }
   },
 
@@ -618,12 +662,15 @@ qx.Class.define("qx.ui.window.Window",
     */
 
     /**
-     * Closes the current window instance.
-     * Technically calls the {@link qx.ui.core.Widget#hide} method.
+     * Close the current window instance.
+     *
+     * Simply calls the {@link qx.ui.core.Widget#hide} method if the
+     * {@link qx.ui.win.Window#autoDestroy} property is false; otherwise 
+     * removes and destroys the window.
      */
     close : function()
     {
-      if (!this.isVisible()) {
+      if (!this.getAutoDestroy() && !this.isVisible()) {
         return;
       }
 
@@ -632,17 +679,34 @@ qx.Class.define("qx.ui.window.Window",
         this.hide();
         this.fireEvent("close");
       }
+
+      // If automatically destroying the window upon close was requested, do
+      // so now. (Note that we explicitly re-obtain the autoDestroy property
+      // value, allowing the user's close handler to enable/disable it before
+      // here.)
+      if (this.getAutoDestroy()) {
+        this.removeAll();                                    // remove contents
+        qx.event.Registration.removeAllListeners(this);      // remove listeners
+        qx.core.Init.getApplication().getRoot().remove(this);// remove self
+        this.dispose();
+      }
     },
 
 
     /**
-     * Opens the window.
+     * Open the window. If the {@link qx.ui.win.Window#autoCenter} property is
+     * true, also center the window.
      */
     open : function()
     {
       this.show();
       this.setActive(true);
       this.focus();
+
+      // If autoCenter is true, then center the window
+      if (this.getAutoCenter()) {
+        this.center();
+      }
     },
 
 

--- a/framework/source/class/qx/ui/window/Window.js
+++ b/framework/source/class/qx/ui/window/Window.js
@@ -1022,8 +1022,6 @@ qx.Class.define("qx.ui.window.Window",
 
     _applyCenterOnAppear : function(value, old)
     {
-      var             parent = this.getLayoutParent();
-
       // Remove prior listener for centering on appear
       if (this.__centeringAppearId !== null) {
         this.removeListenerById(this.__centeringAppearId);

--- a/framework/source/class/qx/ui/window/Window.js
+++ b/framework/source/class/qx/ui/window/Window.js
@@ -522,6 +522,8 @@ qx.Class.define("qx.ui.window.Window",
     // overridden
     setLayoutParent : function(parent)
     {
+      var             oldParent;
+
       if (qx.core.Environment.get("qx.debug"))
       {
         parent && this.assertInterface(
@@ -530,7 +532,24 @@ qx.Class.define("qx.ui.window.Window",
           "qx.ui.window.IDesktop. All root widgets implement this interface."
         );
       }
+
+      // Before changing the parent, if there's a prior one, remove our resize
+      // listener
+      oldParent = this.getLayoutParent();
+      if (oldParent && this.__centeringResizeId) {
+        oldParent.removeListenerById(this.__centeringResizeId);
+        this.__centeringResizeId = null;
+      }
+
+      // Call the superclass
       this.base(arguments, parent);
+
+      // Re-add a listener for resize, if required
+      if (parent && this.getCenterWhen().indexOf("resize") != -1)
+      {
+        this.__centeringResizeId =
+          parent.addListener("resize", this.center, this);
+      }
     },
 
 
@@ -1070,29 +1089,6 @@ qx.Class.define("qx.ui.window.Window",
       }
     },
 
-    // overridden
-    setLayoutParent : function(parent)
-    {
-      var             oldParent;
-
-      // Before changing the parent, if there's a prior one, remove our resize
-      // listener
-      oldParent = this.getLayoutParent();
-      if (oldParent && this.__centeringResizeId) {
-        oldParent.removeListenerById(this.__centeringResizeId);
-        this.__centeringResizeId = null;
-      }
-
-      // Call the superclass
-      this.base(arguments, parent);
-
-      // Re-add a listener for resize, if required
-      if (parent && this.getCenterWhen().indexOf("resize") != -1)
-      {
-        this.__centeringResizeId =
-          parent.addListener("resize", this.center, this);
-      }
-    },
 
     /*
     ---------------------------------------------------------------------------

--- a/framework/source/class/qx/ui/window/Window.js
+++ b/framework/source/class/qx/ui/window/Window.js
@@ -389,33 +389,51 @@ qx.Class.define("qx.ui.window.Window",
      * This property value is formed from the following strings.
      *
      *   "appear" - Center the window when it appears (or reappears)
-     *   "resize" - Center the window when its containing app is resized
+     *   "resize" - Center the window when its parent container is resized
      * 
-     * An empty string or an empty array removes all automatic centering.
+     * An empty array removes all automatic centering.
      * 
-     * Otherwise, the property value should be either an array containing one
-     * or more of the above strings, or a string containing one or more of the
-     * above strings, whitespace-delimited.
+     * Otherwise, the property value should be an array containing one or more
+     * of the above strings.
      * 
      * Examples:
-     *   These two yield identical behavior, centering upon appear and resize:
+     *   Center upon appear and resize:
      *     win.setCenterWhen([ "appear", "resize" ]);
-     *     win.setCenterWhen("appear resize");
      * 
-     *   These two yield identical behavior, centering only upon appear:
-     *     win.setCenterWhen("appear");
+     *   Center only upon appear:
      *     win.setCenterWhen([ "appear" ]);
      * 
-     *   These two remove automatic centering:
-     *     win.setCenterWhen("");
+     *   Remove automatic centering:
      *     win.setCenterWhen([]);
      */
     centerWhen :
     {
       init : [],
       nullable : false,
-      transform : "_transformCenterWhen",
-      apply : "_applyCenterWhen"
+      apply : "_applyCenterWhen",
+      check : function(value)
+      {
+        var i;
+        var allowable = [ "appear", "resize" ];
+
+        // Value must be an array
+        if (! (value instanceof Array))
+        {
+          return false;
+        }
+
+        // The array must contain only allowable values
+        for (i = 0; i < value.length; i++)
+        {
+          if (allowable.indexOf(value[i]) == -1)
+          {
+            // Found a value that is not in our allowable list
+            return false;
+          }
+        }
+
+        return true;
+      }
     },
 
 
@@ -1016,55 +1034,6 @@ qx.Class.define("qx.ui.window.Window",
       if (qx.core.Environment.get("engine.name") !== "mshtml") {
         this.base(arguments, value, old);
       }
-    },
-
-    // overridden
-    _transformCenterWhen : function(value)
-    {
-      var             values = value;
-      
-      // Validate type of value
-      if (typeof value != "string" && ! (value instanceof Array))
-      {
-        throw new Error(
-          "centerWhen requires a string or an array of strings");
-      }
-
-      // Convert the value to an array if it was given as a string.
-      if (typeof value == "string")
-      {
-        if (value.trim() === "")
-        {
-          // We were given an empty string or array, requesting no automatic
-          // centering. Create an empty array of centering behaviors.
-          values = [];
-        }
-        else
-        {
-          // We were given a string. If they put multiple values into the
-          // string, separate them out into separate values, and place all into
-          // an array.
-          values = qx.lang.String.clean(value).split(/\s+/);
-        }
-      }
-
-      // Validate
-      values.forEach(
-        function(value)
-        {
-          switch(value)
-          {
-          case "appear" :
-          case "resize" :
-            // These are expected values
-            break;
-
-          default :
-            throw new Error("Unexpected centerWhen value: " + value);
-          }
-        });
-
-      return values;
     },
 
     // overridden

--- a/framework/source/class/qx/ui/window/Window.js
+++ b/framework/source/class/qx/ui/window/Window.js
@@ -1236,7 +1236,7 @@ qx.Class.define("qx.ui.window.Window",
       id && parent.removeListenerById(id);
 
       // Remove ourself from our parent
-      parent && parent.remove(this);
+      parent.remove(this);
     }
   }
 });


### PR DESCRIPTION
If the autoDestroy property is true, automatically remove a window from its root container, remove all listeners and contents, and dispose the window, when it is closed.

If the autoCenter property is true, automatically center the window when it is opened.

There is no change to prior behavior, by default, with this PR. Both autoDestroy and autoCenter default to false.
