### PR TITLE
use the correct start time for animation sequences

### DIFF
--- a/framework/source/class/qx/bom/AnimationFrame.js
+++ b/framework/source/class/qx/bom/AnimationFrame.js
@@ -82,7 +82,7 @@ qx.Bootstrap.define("qx.bom.AnimationFrame",
     startSequence : function(duration) {
       this.__canceled = false;
 
-      var start = (window.performance && window.performance.now) ? (performance.now() + qx.bom.AnimationFrame.__start) : Date.now();
+      var start = (window.performance && performance.now) ? (performance.now() + qx.bom.AnimationFrame.__start) : Date.now();
       var cb = function(time) {
         if (this.__canceled) {
           this.id = null;

--- a/framework/source/class/qx/bom/AnimationFrame.js
+++ b/framework/source/class/qx/bom/AnimationFrame.js
@@ -25,7 +25,7 @@
  * API the spec describes.
  *
  * Here is a sample usage:
- * <pre class='javascript'>var start = +(new Date());
+ * <pre class='javascript'>var start = Date.now();
  * var cb = function(time) {
  *   if (time >= start + duration) {
  *     // ... do some last tasks
@@ -76,11 +76,13 @@ qx.Bootstrap.define("qx.bom.AnimationFrame",
      * soon as the given duration is over.
      *
      * @param duration {Number} The duration the sequence should take.
+     *
+     * @ignore(performance.*)
      */
     startSequence : function(duration) {
       this.__canceled = false;
 
-      var start = +(new Date());
+      var start = (window.performance && window.performance.now) ? (performance.now() + qx.bom.AnimationFrame.__start) : Date.now();
       var cb = function(time) {
         if (this.__canceled) {
           this.id = null;
@@ -177,7 +179,7 @@ qx.Bootstrap.define("qx.bom.AnimationFrame",
           time = qx.bom.AnimationFrame.__start + time;
         }
 
-        time = time || +(new Date());
+        time = time || Date.now();
         callback.call(context, time);
       };
       if (req) {


### PR DESCRIPTION
The start time for an animation sequence should be based on `performance.timing.navigationStart + performance.now()` and not `Date.now()` (if the performance API is available).

As the performance API says `performance.now()` is constantly increasing (independent from changes to system tiime), while the browser is active. It does *not* increase while the browse is suspended. So e.g. after the browser has been suspended for 10s, `Date.now()` would be 10s ahead `performance.timing.navigationStart + performance.now()` and the animation sequence will start with a 10s delay with the current implementation.

And: I replaced `+(new Date())` with `Date.now()` within this fix, because it's more intuitive.