### PR TITLE
Transform property

### DIFF
--- a/documentation/manual/source/pages/core/defining_properties.rst
+++ b/documentation/manual/source/pages/core/defining_properties.rst
@@ -396,7 +396,7 @@ Here we define both a check and transform method for the width property. Though 
 
     members :
     {
-       _transformWidth : function(value)
+       _transformWidth : function(value, oldValue)
        {
           if ( qx.lang.Type.isString(value) )
           {
@@ -407,6 +407,7 @@ Here we define both a check and transform method for the width property. Though 
        }
     }
 
+The transform function is passed a second parameter which is the value previously set - note that the first time that transform is called, the oldValue parameter will be undefined
 
 .. _pages/defining_properties#validation_incoming_values:
 

--- a/framework/source/class/qx/core/Property.js
+++ b/framework/source/class/qx/core/Property.js
@@ -84,8 +84,10 @@
  *   </td></tr>
  *   <tr><th>transform</th><td>String</td><td>
  *     On setting of the property value the method of the specified name will
- *     be called. The signature of the method is <code>function(value)</code>.
- *     The parameter <code>value</code> is the value passed to the setter.
+ *     be called. The signature of the method is <code>function(value, oldValue)</code>.
+ *     The parameter <code>value</code> is the value passed to the setter, the
+ *     parameter <code>oldValue</code> is the current value, or undefined if no value
+ *     has been set previously.
  *     The function must return the modified or unmodified value.
  *     Transformation occurs before the check function, so both may be
  *     specified if desired.  Alternatively, the transform function may throw

--- a/framework/source/class/qx/core/Property.js
+++ b/framework/source/class/qx/core/Property.js
@@ -944,8 +944,9 @@ qx.Bootstrap.define("qx.core.Property",
 
       this.__emitSetterPreConditions(code, config, name, variant, incomingValue);
       
-      if (incomingValue || hasCallback)
+      if (incomingValue || hasCallback) {
         this.__emitOldValue(code, config, name);
+      }
 
       if (incomingValue) {
         this.__emitIncomingValueTransformation(code, clazz, config, name);

--- a/framework/source/class/qx/test/core/Property.js
+++ b/framework/source/class/qx/test/core/Property.js
@@ -892,6 +892,66 @@ qx.Class.define("qx.test.core.Property",
       this.assertIdentical(object, context);
 
       object.dispose();
+    },
+    
+    
+    testTransform : function ()
+    {
+      qx.Class.define("qx.TestProperty", {
+        extend : qx.core.Object,
+        construct: function() {
+          this.base(arguments);
+          this.initPropTwo(new qx.data.Array());
+        },
+        properties : {
+          prop : {
+            check : "qx.data.Array",
+            nullable : true,
+            event : "changeProp",
+            transform : "__transform"
+          },
+          propTwo : {
+            check : "qx.data.Array",
+            nullable : true,
+            event : "changePropTwo",
+            transform : "__transform",
+            deferredInit: true
+          }
+        },
+        members : {
+          __transform : function (value, oldValue) {
+            if (oldValue === undefined)
+              return value;
+            if (!value)
+              oldValue.removeAll();
+            else
+              oldValue.replace(value)
+            return oldValue;
+          }
+        }
+      });
+
+      var object = new qx.TestProperty();
+      var arr = new qx.data.Array();
+      object.setProp(arr);
+      this.assertIdentical(arr, object.getProp());
+      arr.push("1");
+
+      var arr2 = new qx.data.Array();
+      arr2.push("2");
+      arr2.push("3");
+
+      object.setProp(arr2);
+      this.assertIdentical(arr, object.getProp());
+      this.assertArrayEquals([ "2", "3" ], arr.toArray());
+
+
+      var savePropTwo = object.getPropTwo();
+      object.setPropTwo(arr2);
+      this.assertIdentical(savePropTwo, object.getPropTwo());
+      this.assertArrayEquals([ "2", "3" ], savePropTwo.toArray());
     }
+
+
   }
 });


### PR DESCRIPTION
This PR extends the property definition so that the `transform` method also receives the value currently assigned to the property (or undefined) as well as the new value.

This makes `transform` analogous to the `apply` method, and provides information which is not otherwise available; note that it is not ideal to call the property’s `getXxx` method because this can throw exceptions if the property has not yet been initialised, and adding try/catch handlers complicates property implementation unnecessarily (especially when the property system has the existing value to hand)

This is a non-breaking change.