### PR TITLE
fix logger to not use the $$hash value when this object has not bee…

### DIFF
--- a/framework/source/class/qx/log/Logger.js
+++ b/framework/source/class/qx/log/Logger.js
@@ -582,7 +582,8 @@ qx.Bootstrap.define("qx.log.Logger",
         // to introduce an unwanted load-time dependency
         if (object.$$hash !== undefined) {
           entry.object = object.$$hash;
-        } else if (object.$$type) {
+        }
+        if (object.$$type) {
           entry.clazz = object;
         } else if (object.constructor) {
           entry.clazz = object.constructor;

--- a/framework/source/class/qx/log/appender/Util.js
+++ b/framework/source/class/qx/log/appender/Util.js
@@ -174,7 +174,6 @@ qx.Bootstrap.define("qx.log.appender.Util",
 
       output.push(this.formatOffset(entry.offset, 6));
 
-      var hash = entry.object;
       if (entry.object)
       {
         if (entry.clazz) {

--- a/framework/source/class/qx/log/appender/Util.js
+++ b/framework/source/class/qx/log/appender/Util.js
@@ -38,9 +38,13 @@ qx.Bootstrap.define("qx.log.appender.Util",
 
       if (entry.object)
       {
-        var obj = entry.win.qx.core.ObjectRegistry.fromHashCode(entry.object, true);
-        if (obj) {
-          output.push("<span class='object' title='Object instance with hash code: " + obj.$$hash + "'>", obj.classname, "[" , obj.$$hash, "]</span>: ");
+        if (entry.clazz) {
+          output.push("<span class='object' title='Object instance with hash code: " + entry.object + "'>", entry.clazz.classname, "[", entry.object, "]</span>: ");
+        } else {
+          var obj = entry.win.qx.core.ObjectRegistry.fromHashCode(entry.object, true);
+          if (obj) {
+            output.push("<span class='object' title='Object instance with hash code: " + obj.$$hash + "'>", obj.classname, "[", obj.$$hash, "]</span>: ");
+          }
         }
       }
       else if (entry.clazz)
@@ -170,11 +174,16 @@ qx.Bootstrap.define("qx.log.appender.Util",
 
       output.push(this.formatOffset(entry.offset, 6));
 
+      var hash = entry.object;
       if (entry.object)
       {
-        var obj = entry.win.qx.core.ObjectRegistry.fromHashCode(entry.object, true);
-        if (obj) {
-          output.push(obj.classname + "[" + obj.$$hash + "]:");
+        if (entry.clazz) {
+          output.push(entry.clazz.classname + "[" + entry.object + "]:");
+        } else {
+          var obj = entry.win.qx.core.ObjectRegistry.fromHashCode(entry.object, true);
+          if (obj) {
+            output.push(obj.classname + "[" + obj.$$hash + "]:");
+          }
         }
       }
       else if (entry.clazz) {

--- a/framework/source/class/qx/test/log/Logger.js
+++ b/framework/source/class/qx/test/log/Logger.js
@@ -89,18 +89,28 @@ qx.Class.define("qx.test.log.Logger",
       qx.log.Logger.clear();
       qx.log.Logger.register(appender);
 
+      qx.Class.define("test.DisposableObject", {
+        extend: qx.core.Object,
+        implement: qx.core.IDisposable
+      });
+
       var obj = new qx.core.Object();
-      qx.core.ObjectRegistry.register(obj);
+      var dispObj = new test.DisposableObject();
       qx.log.Logger.debug(qx.core.Object, "m1");
       qx.log.Logger.debug(obj, "m2");
       qx.log.Logger.debug(qxWeb(), "m3");
+      qx.log.Logger.debug(dispObj, "m4");
+
 
       var events = appender.getAllLogEvents();
       this.assertEquals(qx.core.Object, events[0].clazz);
-      this.assertEquals(obj.toHashCode(), events[1].object);
+      this.assertEquals(qx.core.Object, events[1].clazz);
       this.assertEquals(qxWeb, events[2].clazz);
+      this.assertEquals(dispObj.toHashCode(), events[3].object);
 
       qx.log.Logger.unregister(appender);
+      dispObj.dispose();
+      qx.Class.undefine("test.DisposableObject");
     },
 
 


### PR DESCRIPTION
…n registered in the Registry.

This fixes the problem, that the logging object was not shown in the log string since the new automatic memory management feature has been introduced.