### PR TITLE
add resetSource method to qx.html.Label as it is used by qx.ui.basic.Image when using font icons.

### DIFF
--- a/framework/source/class/qx/html/Label.js
+++ b/framework/source/class/qx/html/Label.js
@@ -131,6 +131,15 @@ qx.Class.define("qx.html.Label",
      */
     getValue : function() {
       return this._getProperty("value");
+    },
+
+    /**
+     * Reset the current content
+     *
+     * @return {qx.html.Label} This instance for for chaining support.
+     */
+    resetValue: function() {
+      return this._removeProperty("value");
     }
   }
 });

--- a/framework/source/class/qx/test/ui/basic/Image.js
+++ b/framework/source/class/qx/test/ui/basic/Image.js
@@ -56,7 +56,7 @@ qx.Class.define("qx.test.ui.basic.Image",
       } else {
         this.assertTrue(tagNameAfter == "img");
       }
-      
+
       image.destroy();
     },
 
@@ -412,6 +412,10 @@ qx.Class.define("qx.test.ui.basic.Image",
       image.setSource("@FontAwesome/f004");
       this.assertEquals("", el.getValue());
 
+      // reset source
+      image.resetSource();
+      this.assertEquals(null, el.getValue());
+
       image.destroy();
     },
 
@@ -436,7 +440,7 @@ qx.Class.define("qx.test.ui.basic.Image",
       this.assertEquals("qx/static/drawer@2x.png", image.getContentElement().getSource());
 
       image.destroy();
-      
+
       devicePixelRatioStub.restore();
     },
 
@@ -465,7 +469,7 @@ qx.Class.define("qx.test.ui.basic.Image",
       this.assertTrue(backgroundImage.indexOf("toolbar-part.gif") > -1);
 
       image.destroy();
-      
+
       devicePixelRatioStub.restore();
     },
 
@@ -495,7 +499,7 @@ qx.Class.define("qx.test.ui.basic.Image",
       this.assertTrue(backgroundImage.indexOf("toolbar-part.gif") > -1);
 
       image.destroy();
-      
+
       devicePixelRatioStub.restore();
     },
 


### PR DESCRIPTION
This PR adds the missing method which is used here:
https://github.com/qooxdoo/qooxdoo/blob/0bcb969/framework/source/class/qx/ui/basic/Image.js#L877

