### PR TITLE
Fix for issue #9135

### DIFF
--- a/framework/source/class/qx/locale/LocalizedString.js
+++ b/framework/source/class/qx/locale/LocalizedString.js
@@ -28,12 +28,14 @@ qx.Class.define("qx.locale.LocalizedString",
    * @param translation {String} The translated message
    * @param messageId {String} The messageId to translate
    * @param args {Array} list of arguments passed used as values for format strings
+   * @param localized {Boolean} True if the string uses localize instead of translate
    */
-  construct : function(translation, messageId, args)
+  construct : function(translation, messageId, args, localized)
   {
     this.base(arguments, translation);
 
     this.__messageId = messageId;
+    this.__localized = !!localized;
     this.__args = args;
   },
 
@@ -50,6 +52,10 @@ qx.Class.define("qx.locale.LocalizedString",
      *    locale.
      */
     translate : function() {
+      if (this.__localized) {
+        return qx.locale.Manager.getInstance().localize(this.__messageId, this.__args);
+      }
+
       return qx.locale.Manager.getInstance().translate(this.__messageId, this.__args);
     },
 

--- a/framework/source/class/qx/locale/LocalizedString.js
+++ b/framework/source/class/qx/locale/LocalizedString.js
@@ -41,7 +41,7 @@ qx.Class.define("qx.locale.LocalizedString",
 
   members :
   {
-
+    __localized : null,
     __messageId : null,
     __args : null,
 

--- a/framework/source/class/qx/locale/Manager.js
+++ b/framework/source/class/qx/locale/Manager.js
@@ -466,7 +466,7 @@ qx.Class.define("qx.locale.Manager",
       }
 
       if (qx.core.Environment.get("qx.dynlocale")) {
-        txt = new qx.locale.LocalizedString(txt, messageId, args);
+        txt = new qx.locale.LocalizedString(txt, messageId, args, catalog === this.__locales);
       }
 
       return txt;

--- a/framework/source/class/qx/test/locale/LocalizedString.js
+++ b/framework/source/class/qx/test/locale/LocalizedString.js
@@ -29,6 +29,13 @@ qx.Class.define("qx.test.locale.LocalizedString",
         var ls  = new qx.locale.LocalizedString("foo", "id", "xyz");
         ls.translate();
       });
+    },
+
+    testLocalizeVsTranslate : function() {
+      this.assertEquals(
+        qx.locale.Date.getMonthName("wide", new Date().getMonth()).toString(),
+        qx.locale.Date.getMonthName("wide", new Date().getMonth()).translate().toString()
+      );
     }
   }
 });


### PR DESCRIPTION
This PR adds a flag to distinguish between the two possible message catalogues, in order to make the translation of CLDR provided objects possible.

See #9135