### PR TITLE
stop momentum scrolling when the window object is gone

### DIFF
--- a/framework/source/class/qx/event/handler/Gesture.js
+++ b/framework/source/class/qx/event/handler/Gesture.js
@@ -90,6 +90,13 @@ qx.Class.define("qx.event.handler.Gesture",
     __onDblClickWrapped : null,
     __fireRollWrapped : null,
 
+    /**
+     * Getter for the internal __window object
+     * @return {Window} DOM window instance
+     */
+    getWindow: function() {
+      return this.__window;
+    },
 
     // interface implementation
     canHandleEvent : function(target, type) {},

--- a/framework/source/class/qx/event/handler/GestureCore.js
+++ b/framework/source/class/qx/event/handler/GestureCore.js
@@ -422,7 +422,7 @@ qx.Bootstrap.define("qx.event.handler.GestureCore", {
         this.stopMomentum(this.__momentum[domEvent.pointerId]);
       }
       // do nothing if we don't need to scroll
-      if ((Math.abs(deltaY) < 1 && Math.abs(deltaX) < 1) || this.__stopMomentum[oldTimeoutId] || !this.__window) {
+      if ((Math.abs(deltaY) < 1 && Math.abs(deltaX) < 1) || this.__stopMomentum[oldTimeoutId] || !this.getWindow()) {
         delete this.__stopMomentum[oldTimeoutId];
         delete this.__momentum[domEvent.pointerId];
         return;

--- a/framework/source/class/qx/event/handler/GestureCore.js
+++ b/framework/source/class/qx/event/handler/GestureCore.js
@@ -422,7 +422,7 @@ qx.Bootstrap.define("qx.event.handler.GestureCore", {
         this.stopMomentum(this.__momentum[domEvent.pointerId]);
       }
       // do nothing if we don't need to scroll
-      if ((Math.abs(deltaY) < 1 && Math.abs(deltaX) < 1) || this.__stopMomentum[oldTimeoutId]) {
+      if ((Math.abs(deltaY) < 1 && Math.abs(deltaX) < 1) || this.__stopMomentum[oldTimeoutId] || !this.__window) {
         delete this.__stopMomentum[oldTimeoutId];
         delete this.__momentum[domEvent.pointerId];
         return;


### PR DESCRIPTION
when you close e.g. a dialog while its content is scrollign with a momentum, the roll event gets fired on an non existing element, which leads to an error.

This fix stops the momentum scrolling when the internal `__window` object is gone.