### PR TITLE
Issue #9128: force rebuild of the qx.ui.tree.VirtualTree lookup table on changes of properties showLeafs and showTopLevelOpenCloseIcons

### DIFF
--- a/framework/source/class/qx/ui/tree/VirtualTree.js
+++ b/framework/source/class/qx/ui/tree/VirtualTree.js
@@ -598,12 +598,18 @@ qx.Class.define("qx.ui.tree.VirtualTree",
 
     // property apply
     _applyShowTopLevelOpenCloseIcons : function(value, old) {
+      // force rebuild of the lookup table
+      // fixes https://github.com/qooxdoo/qooxdoo/issues/9128
+      this.getLookupTable().removeAll();
       this.buildLookupTable();
     },
 
 
     // property apply
     _applyShowLeafs : function(value, old) {
+      // force rebuild of the lookup table
+      // fixes https://github.com/qooxdoo/qooxdoo/issues/9128
+      this.getLookupTable().removeAll();
       this.buildLookupTable();
     },
 


### PR DESCRIPTION
Fixes #9128