### PR TITLE
Make qx.util.ResourceManager.toDataUri more robust

### DIFF
--- a/framework/source/class/qx/util/ResourceManager.js
+++ b/framework/source/class/qx/util/ResourceManager.js
@@ -232,7 +232,7 @@ qx.Class.define("qx.util.ResourceManager",
     toDataUri : function (resid)
     {
       var resentry = this.constructor.__registry[resid];
-      var combined = this.constructor.__registry[resentry[4]];
+      var combined = resentry?this.constructor.__registry[resentry[4]]:null;
       var uri;
       if (combined) {
         var resstruct = combined[4][resid];

--- a/framework/source/class/qx/util/ResourceManager.js
+++ b/framework/source/class/qx/util/ResourceManager.js
@@ -232,7 +232,7 @@ qx.Class.define("qx.util.ResourceManager",
     toDataUri : function (resid)
     {
       var resentry = this.constructor.__registry[resid];
-      var combined = resentry?this.constructor.__registry[resentry[4]]:null;
+      var combined = resentry ? this.constructor.__registry[resentry[4]] : null;
       var uri;
       if (combined) {
         var resstruct = combined[4][resid];


### PR DESCRIPTION
avoids exception if the resid is not loaded yet and passes it to toUri