### PR TITLE
avoid exceptions in qx.ui.window.Manager if the desktop was reset

### DIFF
--- a/framework/source/class/qx/ui/window/Manager.js
+++ b/framework/source/class/qx/ui/window/Manager.js
@@ -41,7 +41,16 @@ qx.Class.define("qx.ui.window.Manager",
     setDesktop : function(desktop)
     {
       this.__desktop = desktop;
-      this.updateStack();
+      
+      if(desktop) {
+        this.updateStack();
+      }
+      else {
+         // the window manager should be removed
+         // from the widget queue if the desktop
+         // was set to null
+         qx.ui.core.queue.Widget.remove(this);
+      }
     },
 
 
@@ -86,12 +95,6 @@ qx.Class.define("qx.ui.window.Manager",
      */
     syncWidget : function()
     {
-      // it may occur that the manager was added to the widget queue
-      // and the desktop was removed meanwhile
-      if(!this.__desktop) {
-        return;
-      }
-      
       this.__desktop.forceUnblock();
 
       var windows = this.__desktop.getWindows();

--- a/framework/source/class/qx/ui/window/Manager.js
+++ b/framework/source/class/qx/ui/window/Manager.js
@@ -86,6 +86,12 @@ qx.Class.define("qx.ui.window.Manager",
      */
     syncWidget : function()
     {
+      // it may occur that the manager was added to the widget queue
+      // and the desktop was removed meanwhile
+      if(!this.__desktop) {
+        return;
+      }
+      
       this.__desktop.forceUnblock();
 
       var windows = this.__desktop.getWindows();


### PR DESCRIPTION
A bit more description:

I'm trying to replace the window manager of a standalone desktop application ```qx.application.Standalone``` with the following code in the ```main``` method:
```javascript
    main : function() {
      this.base(arguments);

      var desktop = this.getRoot().getWindowManager().getDesktop();
      var windowManager = new qx.ui.window.MyManager();
      windowManager.setDesktop(desktop);
      this.getRoot().setWindowManager(windowManager);
```
which is essentially successfull, but the widget queue throws an exception as it seems that with ```this.getRoot().setWindowManager(windowManager);``` the private ```__desktop``` member is set to null while the old window manager is still queued in the widget queue.

As a result an exception is thrown when the widget queue tries to run ```syncWidget```.

This PR _solves_ this by leaving the ```syncWidget``` method if the desktop is not set.