### PR TITLE
Demobrowser generator fix

### DIFF
--- a/application/demobrowser/tool/lib/DataGenerator.js
+++ b/application/demobrowser/tool/lib/DataGenerator.js
@@ -492,7 +492,7 @@
 
       return {
         category: fileNameParts[0],
-        name: path.basename(fileNameParts[1], '.html')
+        name: fileNameParts[1] ? path.basename(fileNameParts[1], '.html') : undefined
       };
     },
 


### PR DESCRIPTION
The API of `path.basename` changed in a way that the input of _undefined_ doesn't return _undefined_ anymore. Instead it raises an exception. If the inspected path just contains one */*, it fails here:

```path.basename(fileNameParts[1], '.html')```