### PR TITLE
avoid exceptions in qx.ui.window.Manager if the desktop was reset - attempt 2

### DIFF
--- a/framework/source/class/qx/ui/window/Manager.js
+++ b/framework/source/class/qx/ui/window/Manager.js
@@ -41,7 +41,16 @@ qx.Class.define("qx.ui.window.Manager",
     setDesktop : function(desktop)
     {
       this.__desktop = desktop;
-      this.updateStack();
+        
+      if(desktop) {
+        this.updateStack();
+      }
+      else {
+         // the window manager should be removed
+         // from the widget queue if the desktop
+         // was set to null
+         qx.ui.core.queue.Widget.remove(this);
+      }
     },
 
 


### PR DESCRIPTION
A bit more description:

I'm trying to replace the window manager of a standalone desktop application ```qx.application.Standalone``` with the following code in the ```main``` method:
```javascript
    main : function() {
      this.base(arguments);

      var desktop = this.getRoot().getWindowManager().getDesktop();
      var windowManager = new qx.ui.window.MyManager();
      windowManager.setDesktop(desktop);
      this.getRoot().setWindowManager(windowManager);
```
which is essentially successfull, but the widget queue throws an exception as it seems that with ```this.getRoot().setWindowManager(windowManager);``` the private ```__desktop``` member is set to null while the old window manager is still queued in the widget queue.

As a result an exception is thrown when the widget queue tries to run ```syncWidget```.

This is the second PR which now attempts to solve this by removing the window manager from the widget queue if a null desktop was set.

Closing PR #9255 in favour of this one.