### PR TITLE
Fix copyright in footer

### DIFF
--- a/documentation/manual/source/_theme.indigo/layout.html
+++ b/documentation/manual/source/_theme.indigo/layout.html
@@ -227,6 +227,7 @@
           <img src="http://resources.qooxdoo.org/images/feed.png">
         </a>
       </div>
+<!--
       <div class="notice">
         <p class="source">
           {%- if show_source and has_source and sourcename %}
@@ -251,6 +252,7 @@
           {%- endif %}
         </p>
       </div>
+-->	  
     </div>
   </footer>
 </div>


### PR DESCRIPTION
In the current documentation the footer shows the old copyright notice of 1&1. This should be also merged into the 5.0.2 version!