### PR TITLE
fix assertions used in qx.ui.basic.Image font icon code in app built with qx.debug set to false

### DIFF
--- a/framework/source/class/qx/ui/basic/Image.js
+++ b/framework/source/class/qx/ui/basic/Image.js
@@ -918,7 +918,9 @@ qx.Class.define("qx.ui.basic.Image",
         }
         else {
           var charCode = parseInt(qx.theme.manager.Font.getInstance().resolve(source.match(/@([^/]+)\/(.*)$/)[2]), 16);
-          this.assertNumber(charCode, "Font source needs either a glyph name or the unicode number in hex");
+          if (qx.core.Environment.get("qx.debug")) {
+            this.assertNumber(charCode, "Font source needs either a glyph name or the unicode number in hex");
+          }
           el.setValue(String.fromCharCode(charCode));
         }
 


### PR DESCRIPTION
assertions should be guarded with ```qx.core.Environment.get("qx.debug")```.

Building with ```qx.debug``` set to false, assertion functions are not available. Calling ```this.assertXxxx``` then leads to an exception because the function is missing.

See https://github.com/qooxdoo/qooxdoo/blob/master/framework/source/class/qx/core/Object.js#L42