### PR TITLE
Adds get/setTimeout to qx.io.remote.transport.XmlHttp

### DIFF
--- a/framework/source/class/qx/io/remote/transport/XmlHttp.js
+++ b/framework/source/class/qx/io/remote/transport/XmlHttp.js
@@ -105,6 +105,10 @@ qx.Class.define("qx.io.remote.transport.XmlHttp",
     
     /**
      * Sets the timeout for requests
+     * @deprecated {6.0} This method is deprecated from the start because synchronous I/O itself is deprecated
+     *  in the W3C spec {@link https://xhr.spec.whatwg.org/} and timeouts are indicative of synchronous I/O and/or
+     *  other server issues.  However, this API is still supported by many browsers and this API is useful
+     *  for code which has not made the transition to asynchronous I/O   
      */
     setTimeout: function(timeout) {
       this.__timeout = timeout;

--- a/framework/source/class/qx/io/remote/transport/XmlHttp.js
+++ b/framework/source/class/qx/io/remote/transport/XmlHttp.js
@@ -96,6 +96,26 @@ qx.Class.define("qx.io.remote.transport.XmlHttp",
      */
     isSupported : function() {
       return !!this.createRequestObject();
+    },
+    
+    
+    /** The timeout for Xhr requests */
+    __timeout: 0,
+    
+    
+    /**
+     * Sets the timeout for requests
+     */
+    setTimeout: function(timeout) {
+      this.__timeout = timeout;
+    },
+    
+    
+    /**
+     * Returns the timeout for requests
+     */
+    getTimeout: function() {
+      return this.__timeout;
     }
   },
 
@@ -306,6 +326,12 @@ qx.Class.define("qx.io.remote.transport.XmlHttp",
         this.error("Failed with exception: " + ex);
         this.failed();
         return;
+      }
+
+      // Apply timeout
+      var timeout = qx.io.remote.transport.XmlHttp.getTimeout();
+      if (timeout && vAsynchronous) {
+        vRequest.timeout = timeout;
       }
 
       // --------------------------------------


### PR DESCRIPTION
It is sometimes useful to change the timeout when using XML; this can only be done by directly manipulating the XMLHttpRequest before the request is opened, and this API allows the timeouts to be specified.

This method is deprecated from the start because synchronous I/O itself is deprecated in the W3C spec https://xhr.spec.whatwg.org/ and timeouts are indicative of synchronous I/O and/or other server issues.  However, the timeouts API is still supported by many browsers and this API is useful for code which has not made the transition to asynchronous I/O - which is typically a non-trivial task.

By nature this is platform specific, and therefore it is only added to the `XmlHttp` transport; it is arguably only likely to be used in specific applications or low level libraries (such as ServerObjects contrib 😊  ). 

I have also found this useful in resolving ERR_NETWORK_IO_SUSPENDED in Chrome, which appears to be related to sleep mode.
