### PR TITLE
replace context parameter

### DIFF
--- a/framework/source/class/qx/event/handler/Gesture.js
+++ b/framework/source/class/qx/event/handler/Gesture.js
@@ -129,7 +129,7 @@ qx.Class.define("qx.event.handler.Gesture",
       // list to wheel events
       var data = qx.bom.client.Event.getMouseWheel(this.__window);
       this.__fireRollWrapped = qx.lang.Function.listener(this._fireRoll, this);
-      qx.bom.Event.addNativeListener(data.target, data.type, this.__fireRollWrapped, this);
+      qx.bom.Event.addNativeListener(data.target, data.type, this.__fireRollWrapped);
     },
 
     /**

--- a/framework/source/class/qx/event/handler/Gesture.js
+++ b/framework/source/class/qx/event/handler/Gesture.js
@@ -129,7 +129,7 @@ qx.Class.define("qx.event.handler.Gesture",
       // list to wheel events
       var data = qx.bom.client.Event.getMouseWheel(this.__window);
       this.__fireRollWrapped = qx.lang.Function.listener(this._fireRoll, this);
-      qx.bom.Event.addNativeListener(data.target, data.type, this.__fireRollWrapped);
+      qx.bom.Event.addNativeListener(data.target, data.type, this.__fireRollWrapped, true);
     },
 
     /**

--- a/framework/source/class/qx/event/handler/Gesture.js
+++ b/framework/source/class/qx/event/handler/Gesture.js
@@ -129,6 +129,8 @@ qx.Class.define("qx.event.handler.Gesture",
       // list to wheel events
       var data = qx.bom.client.Event.getMouseWheel(this.__window);
       this.__fireRollWrapped = qx.lang.Function.listener(this._fireRoll, this);
+      // replaced the useCapture (4th parameter) from this to true
+      // see https://github.com/qooxdoo/qooxdoo/pull/9292
       qx.bom.Event.addNativeListener(data.target, data.type, this.__fireRollWrapped, true);
     },
 


### PR DESCRIPTION
Something I just stumbled upon: I think this is some kind of copy & paste error which causes the native event listener to be added in the capturing phase. If this is a wanted behaviour, we should change the last parameter from `this` to `true`. Otherwise remove it as suggest in this PR.

I don't really know how much impact this change would have on existing applications, so this change needs to be discussed first.