### PR TITLE
Allows promises to be disabled and eliminated from the build

### DIFF
--- a/framework/source/class/qx/Promise.js
+++ b/framework/source/class/qx/Promise.js
@@ -776,6 +776,9 @@ qx.Class.define("qx.Promise", {
       }
       this.__initialized = true;
       qx.bom.Event.addNativeListener(window, "unhandledrejection", this.__onUnhandledRejection.bind(this));
+      if (!qx.core.Environment.get("qx.promise")) {
+        qx.log.Logger.error(this, "Promises are installed and initialised but disabled from properties because qx.promise==false; this may cause unexpected behaviour");
+      }
     },
     
     /**

--- a/framework/source/class/qx/core/Environment.js
+++ b/framework/source/class/qx/core/Environment.js
@@ -889,7 +889,8 @@ qx.Bootstrap.define("qx.core.Environment",
       "module.property": true,
       "module.events": true,
       "qx.nativeScrollBars": false,
-      "qx.automaticMemoryManagement": true
+      "qx.automaticMemoryManagement": true,
+      "qx.promise": true
     },
 
     /**

--- a/framework/source/class/qx/data/MBinding.js
+++ b/framework/source/class/qx/data/MBinding.js
@@ -87,20 +87,24 @@ qx.Mixin.define("qx.data.MBinding",
      *   there is no property definition for object and property (source and
      *   target).
      */
-    bindAsync : function(sourcePropertyChain, targetObject, targetProperty, options)
-    {
-      var id = qx.data.SingleValueBinding.bind(
-        this, sourcePropertyChain, targetObject, targetProperty, options
-      );
-      if (id.initialPromise) {
-      	return id.initialPromise.then(function() {
-      		id.initialPromise = null;
-      		return id;
-      	});
-      } else {
-      	return qx.Promise.resolve(id);
+    bindAsync : qx.core.Environment.select("qx.promise", {
+      "true": function(sourcePropertyChain, targetObject, targetProperty, options) {
+        var id = qx.data.SingleValueBinding.bind(
+          this, sourcePropertyChain, targetObject, targetProperty, options
+        );
+        if (id.initialPromise) {
+          return id.initialPromise.then(function() {
+            id.initialPromise = null;
+            return id;
+          });
+        } else {
+          return qx.Promise.resolve(id);
+        }
+      },
+      "false": function(sourcePropertyChain, targetObject, targetProperty, options) {
+        return this.bind(sourcePropertyChain, targetObject, targetProperty, options);
       }
-    },
+    }),
 
 
     /**

--- a/framework/source/class/qx/event/Registration.js
+++ b/framework/source/class/qx/event/Registration.js
@@ -413,14 +413,18 @@ qx.Class.define("qx.event.Registration",
      * 	if the default was prevented, the promise is rejected
      * @see #createEvent
      */
-    fireNonBubblingEventAsync : function(target, type, clazz, args)
-    {
-      var evt = this.__fireNonBubblingEvent.apply(this, arguments);
-      if (evt === null) {
-      	return qx.Promise.resolve(true);
+    fireNonBubblingEventAsync : qx.core.Environment.select("qx.promise", {
+      "true": function(target, type, clazz, args) {
+        var evt = this.__fireNonBubblingEvent.apply(this, arguments);
+        if (evt === null) {
+          return qx.Promise.resolve(true);
+        }
+        return evt.promise();
+      },
+      "false": function() {
+        throw new Error(this.classname + ".fireNonBubblingEventAsync not supported because qx.promise==false");
       }
-      return evt.promise();
-    },
+    }),
 
 
 

--- a/framework/source/class/qx/event/dispatch/Direct.js
+++ b/framework/source/class/qx/event/dispatch/Direct.js
@@ -133,8 +133,10 @@ qx.Class.define("qx.event.dispatch.Direct",
             }
           }
           var promise = listeners[i].handler.call(context, event);
-          if (promise instanceof qx.Promise) {
-          	event.addPromise(promise);
+          if (qx.core.Environment.get("qx.promise")) {
+            if (promise instanceof qx.Promise) {
+            	event.addPromise(promise);
+            }
           }
         }
       }

--- a/framework/source/class/qx/event/type/Event.js
+++ b/framework/source/class/qx/event/type/Event.js
@@ -212,22 +212,32 @@ qx.Class.define("qx.event.type.Event",
      * Adds a promise to the list of promises returned by event handlers
      * @param promise {qx.Promise} the promise to add
      */
-    addPromise: function(promise) {
-    	if (this._promises === null) {
-    		this._promises = [promise];
-    	} else {
-    		this._promises.push(promise);
-    	}
-    },
+    addPromise: qx.core.Environment.select("qx.promise", {
+      "true": function(promise) {
+          if (this._promises === null) {
+            this._promises = [promise];
+          } else {
+            this._promises.push(promise);
+          }
+        },
+      "false": function() {
+        throw new Error(this.classname + ".addPromise not supported because qx.promise==false");
+      }
+    }),
     
     
     /**
      * Returns the array of promises, or null if there are no promises
      * @return {qx.Promise[]?}
      */
-    getPromises: function() {
-    	return this._promises;
-    },
+    getPromises: qx.core.Environment.select("qx.promise", {
+      "true": function() {
+        return this._promises;
+      },
+      "false": function() {
+        throw new Error(this.classname + ".getPromises not supported because qx.promise==false");
+      }
+    }),
     
     
     /**
@@ -235,15 +245,20 @@ qx.Class.define("qx.event.type.Event",
      * is a rejected promise, otherwise it is fulfilled.  The promise returned will only
      * be fulfilled when the promises added via {@link addPromise} are also fulfilled
      */
-    promise: function() {
-    	if (this.getDefaultPrevented()) {
-    		return qx.Promise.reject();
-    	}
-    	if (this._promises === null) {
-    		return qx.Promise.resolve(true);
-    	}
-    	return qx.Promise.all(this._promises);
-    },
+    promise: qx.core.Environment.select("qx.promise", {
+      "true": function() {
+        if (this.getDefaultPrevented()) {
+          return qx.Promise.reject();
+        }
+        if (this._promises === null) {
+          return qx.Promise.resolve(true);
+        }
+        return qx.Promise.all(this._promises);
+      },
+      "false": function() {
+        throw new Error(this.classname + ".promise not supported because qx.promise==false");
+      }
+    }),
 
 
     /**


### PR DESCRIPTION
Please see issue https://github.com/qooxdoo/qooxdoo/issues/9294, this patch allows an environment key called `qx.promise` to turn off the `qx.Promise` from the main body of the Qooxdoo framework.  

This means that properties and events will no longer support promises, and will mean that provided you do not use `qx.Promise` yourself, it will be eliminated from the `build` target.  The `source` target will still include `qx.Promise` (use the `exclude` key of config.json to force exclusion completely)

Note that this does not force `qx.Promise` to be excluded from the build, it merely makes sure that Qooxdoo framework itself does not require it to be included.  

If `qx.promise == false` and your code (or contribs etc) reference `qx.Promise`, the class will still be included and will work, but will not be integrated into the properties or events; a warning will be output in this case.

