### PR TITLE
bug fix for complex regex

### DIFF
--- a/framework/source/class/qx/test/ui/form/TextField.js
+++ b/framework/source/class/qx/test/ui/form/TextField.js
@@ -53,6 +53,28 @@ qx.Class.define("qx.test.ui.form.TextField",
       this.assertEquals(Infinity, l);
     },
 	
+    "test: validate input with filter": function() {
+      this.__field.setFilter(/[0-9]/);
+      var s = this.__field._validateInput("a");
+      this.assertEquals("", s);
+      var s = this.__field._validateInput("111");
+      this.assertEquals("111", s);
+    },
+    "test: validate input with complex filter": function() {
+      this.__field.setFilter(/^(\+|-)?\d*$/);
+      var s = this.__field._validateInput("a");
+      this.assertEquals("", s);
+      var s = this.__field._validateInput("1");
+      this.assertEquals("1", s);
+      var s = this.__field._validateInput("-");
+      this.assertEquals("-", s);
+      var s = this.__field._validateInput("111");
+      this.assertEquals("111", s);
+      var s = this.__field._validateInput("-111");
+      this.assertEquals("-111", s);
+      var s = this.__field._validateInput("-11-1");
+      this.assertEquals("", s);
+    },
 
     __field: null
   }

--- a/framework/source/class/qx/test/ui/form/TextField.js
+++ b/framework/source/class/qx/test/ui/form/TextField.js
@@ -15,7 +15,6 @@
      * Henner Kollmann
 
 ************************************************************************ */
-
 qx.Class.define("qx.test.ui.form.TextField",
 {
   extend: qx.test.ui.LayoutTestCase,

--- a/framework/source/class/qx/test/ui/form/TextField.js
+++ b/framework/source/class/qx/test/ui/form/TextField.js
@@ -74,6 +74,11 @@ qx.Class.define("qx.test.ui.form.TextField",
       var s = this.__field._validateInput("-11-1");
       this.assertEquals("", s);
     },
+  "test: validate input with complex filter 2": function() {
+      this.__field.setFilter(/^xy$/);
+      var s = this.__field._validateInput("x? y?");
+      this.assertEquals("", s);
+    },
 
     __field: null
   }

--- a/framework/source/class/qx/ui/form/AbstractField.js
+++ b/framework/source/class/qx/ui/form/AbstractField.js
@@ -560,20 +560,9 @@ qx.Class.define("qx.ui.form.AbstractField",
       if (this.__oldInputValue && this.__oldInputValue === value) {
         fireEvents = false;
       }
-
-      // check for the filter
-      if (this.getFilter() != null)
+      if (fireEvents)
       {
-        var filteredValue = "";
-        var index = value.search(this.getFilter());
-        var processedValue = value;
-        while(index >= 0)
-        {
-          filteredValue = filteredValue + (processedValue.charAt(index));
-          processedValue = processedValue.substring(index + 1, processedValue.length);
-          index = processedValue.search(this.getFilter());
-        }
-
+        var filteredValue = this._validateInput(value);
         if (filteredValue != value)
         {
           fireEvents = false;
@@ -581,7 +570,6 @@ qx.Class.define("qx.ui.form.AbstractField",
           this.getContentElement().setValue(value);
         }
       }
-
       // fire the events, if necessary
       if (fireEvents)
       {
@@ -942,8 +930,31 @@ qx.Class.define("qx.ui.form.AbstractField",
         qx.ui.form.AbstractField.__addPlaceholderRules();
       }
     },
-
-
+    /**
+     * validates the the input value
+     * 
+     * @param {type} value: the value to check
+     * @returns the checked value
+     */
+    _validateInput : function(value) {
+      // if no filter is set return just the value
+      var filteredValue = value;
+      // check for the filter
+      var filter = this.getFilter();
+      if (filter != null)
+      {
+        filteredValue = "";
+        var index = value.search(filter);
+        var processedValue = value;
+        while((index >= 0) && (processedValue.length > 0))
+        {
+          filteredValue = filteredValue + (processedValue.charAt(index));
+          processedValue = processedValue.substring(index + 1, processedValue.length);
+          index = processedValue.search(filter);
+        }
+      }
+      return filteredValue;
+    },
     /*
     ---------------------------------------------------------------------------
       PROPERTY APPLY ROUTINES

--- a/framework/source/class/qx/ui/form/AbstractField.js
+++ b/framework/source/class/qx/ui/form/AbstractField.js
@@ -231,8 +231,8 @@ qx.Class.define("qx.ui.form.AbstractField",
      * RegExp responsible for filtering the value of the textfield. the RegExp
      * gives the range of valid values.
      * Note: The regexp specified is applied to each character in turn, 
-	   * NOT to the entire string. So only regular expressions matching a 
-	   * single character make sense in the context.	 
+     * NOT to the entire string. So only regular expressions matching a 
+     * single character make sense in the context.
      * The following example only allows digits in the textfield.
      * <pre class='javascript'>field.setFilter(/[0-9]/);</pre>
      */

--- a/framework/source/class/qx/ui/form/AbstractField.js
+++ b/framework/source/class/qx/ui/form/AbstractField.js
@@ -230,6 +230,9 @@ qx.Class.define("qx.ui.form.AbstractField",
     /**
      * RegExp responsible for filtering the value of the textfield. the RegExp
      * gives the range of valid values.
+     * Note: The regexp specified is applied to each character in turn, 
+	 *       NOT to the entire string. So only regular expressions matching a 
+	 *       single character make sense in the context.	 
      * The following example only allows digits in the textfield.
      * <pre class='javascript'>field.setFilter(/[0-9]/);</pre>
      */

--- a/framework/source/class/qx/ui/form/AbstractField.js
+++ b/framework/source/class/qx/ui/form/AbstractField.js
@@ -560,7 +560,9 @@ qx.Class.define("qx.ui.form.AbstractField",
       if (this.__oldInputValue && this.__oldInputValue === value) {
         fireEvents = false;
       }
-      if (fireEvents)
+
+      // check for the filter
+      if (this.getFilter() != null)
       {
         var filteredValue = this._validateInput(value);
         if (filteredValue != value)

--- a/framework/source/class/qx/ui/form/AbstractField.js
+++ b/framework/source/class/qx/ui/form/AbstractField.js
@@ -231,8 +231,8 @@ qx.Class.define("qx.ui.form.AbstractField",
      * RegExp responsible for filtering the value of the textfield. the RegExp
      * gives the range of valid values.
      * Note: The regexp specified is applied to each character in turn, 
-	 *       NOT to the entire string. So only regular expressions matching a 
-	 *       single character make sense in the context.	 
+	   * NOT to the entire string. So only regular expressions matching a 
+	   * single character make sense in the context.	 
      * The following example only allows digits in the textfield.
      * <pre class='javascript'>field.setFilter(/[0-9]/);</pre>
      */


### PR DESCRIPTION
if you set the filter to an complex regex like `^(\+|-)?\d*$` validating never stops.
This commit fixes this issue and adds some test cases.

I seperated the the code for validating in `_onHtmlInput` to an own function `_validateInput`. This function could be tested easily.