### PR TITLE
Fix for #9310. Don't use locale workaround for Android >= 4.4.x

### DIFF
--- a/framework/source/class/qx/bom/client/Locale.js
+++ b/framework/source/class/qx/bom/client/Locale.js
@@ -85,18 +85,24 @@ qx.Bootstrap.define("qx.bom.client.Locale",
       var locale = (navigator.userLanguage || navigator.language || "");
 
       // Android Bug: Android does not return the system language from the
-      // navigator language. Try to parse the language from the userAgent.
+      // navigator language before version 4.4.x. Try to parse the language
+      // from the userAgent.
       // See http://code.google.com/p/android/issues/detail?id=4641
-      if (qx.bom.client.OperatingSystem.getName() == "android")
-      {
-        var match = /(\w{2})-(\w{2})/i.exec(navigator.userAgent);
-        if (match) {
-          locale = match[0];
+      if (qx.bom.client.OperatingSystem.getName() == "android") {
+        var version = /^(\d+)\.(\d+)(\..+)?/i.exec(qx.bom.client.OperatingSystem.getVersion());
+        if (qx.lang.Type.isArray(version) && version.length >= 3) {
+          if (parseInt(version[1]) < 4 || (parseInt(version[1]) === 4 && parseInt(version[2]) < 4)) {
+            var match = /(\w{2})-(\w{2})/i.exec(navigator.userAgent);
+            if (match) {
+              locale = match[0];
+            }
+          }
         }
       }
 
       return locale.toLowerCase();
     }
+
   },
 
   defer : function(statics) {


### PR DESCRIPTION
Use navigator.language for Android 4.4.x and greater. Use workaround
only for lower versions.