### PR TITLE
Remove 'generate test' warnings

### DIFF
--- a/framework/source/class/qx/test/core/Object.js
+++ b/framework/source/class/qx/test/core/Object.js
@@ -366,6 +366,9 @@ qx.Class.define("qx.test.core.Object",
     },
 
 
+    /**
+     * @ignore(qx.test.MyClass)
+     */
     testIsPropertyInitialized : function()
     {
       qx.Class.define("qx.test.MyClass", {

--- a/framework/source/class/qx/test/data/controller/FormWithArrayAndModel.js
+++ b/framework/source/class/qx/test/data/controller/FormWithArrayAndModel.js
@@ -57,7 +57,6 @@ qx.Class.define("qx.test.data.controller.FormWithArrayAndModel",
 
           /**
            * @param value {qx.data.Array|null}
-           * @return void
            */
           setValue : function(value) {
             var oldValue = this.__value;
@@ -70,9 +69,6 @@ qx.Class.define("qx.test.data.controller.FormWithArrayAndModel",
            */
           getValue : function() {return this.__value;},
 
-          /**
-           * @return void
-           */
           resetValue : function() {this.__value = null;}
         }
       });
@@ -97,7 +93,6 @@ qx.Class.define("qx.test.data.controller.FormWithArrayAndModel",
 
           /**
            * @param value {qx.core.Object|null}
-           * @return void
            */
           setValue : function(value) {
             this.setModel(value);
@@ -108,9 +103,6 @@ qx.Class.define("qx.test.data.controller.FormWithArrayAndModel",
            */
           getValue : function() {return this.getModel();},
 
-          /**
-           * @return void
-           */
           resetValue : function() { this.resetModel(); },
 
           // overwritten

--- a/framework/source/class/qx/test/log/Logger.js
+++ b/framework/source/class/qx/test/log/Logger.js
@@ -82,6 +82,9 @@ qx.Class.define("qx.test.log.Logger",
     },
 
 
+    /**
+     * @ignore(test.DisposableObject)
+     */
     testContextObject : function() {
       var appender = new qx.log.appender.RingBuffer();
 

--- a/framework/source/class/qx/test/ui/basic/Image.js
+++ b/framework/source/class/qx/test/ui/basic/Image.js
@@ -508,6 +508,9 @@ qx.Class.define("qx.test.ui.basic.Image",
       return qx.core.Environment.get("engine.name") === "gecko";
     },
 
+    /**
+     * @ignore(qx.theme.icon.Font)
+     */
     _initWebFont : function()
     {
       qx.$$resources["@FontAwesome/heart"] = [40, 40, 61444];


### PR DESCRIPTION
Following warnings -popped up during 'generate test'- removed:
- Warning: framework\source/class\qx\test\data\controller\FormWithArrayAndModel.js (61): Unable to parse JSDoc entry: @return void
- Warning: framework\source/class\qx\test\data\controller\FormWithArrayAndModel.js (75): Unable to parse JSDoc entry: @return void
- Warning: framework\source/class\qx\test\data\controller\FormWithArrayAndModel.js (101): Unable to parse JSDoc entry: @return void
- Warning: framework\source/class\qx\test\data\controller\FormWithArrayAndModel.js (113): Unable to parse JSDoc entry: @return void
- Warning: qx.test.core.Object (379): Unknown global symbol used: qx.test.MyClass
- Warning: qx.test.ui.basic.Image (539): Unknown global symbol used: qx.theme.icon.Font
- Warning: qx.test.log.Logger (98): Unknown global symbol used: test.DisposableObject