### PR TITLE
Fix Textarea autosize calculation in special case

### DIFF
--- a/framework/source/class/qx/ui/form/TextArea.js
+++ b/framework/source/class/qx/ui/form/TextArea.js
@@ -8,8 +8,7 @@
      2004-2008 1&1 Internet AG, Germany, http://www.1und1.de
 
    License:
-     LGPL: http://www.gnu.org/licenses/lgpl.html
-     EPL: http://www.eclipse.org/org/documents/epl-v10.php
+     MIT: https://opensource.org/licenses/MIT
      See the LICENSE file in the project's top-level directory for details.
 
    Authors:
@@ -152,7 +151,8 @@ qx.Class.define("qx.ui.form.TextArea",
         e.stop();
       }
     },
-
+	
+	
     /**
      * When the element resizes we throw away the clone and trigger autosize again, otherwise the clone would have
      * another width and the autosize calculation would be faulty.
@@ -179,10 +179,8 @@ qx.Class.define("qx.ui.form.TextArea",
     */
     __autoSize: function() {
       if (this.isAutoSize()) {
-        // make sure to only create the clone when the bounds of this element are calculated. Otherwise clone will have
-        // no width and the autoSize calculation is wrong due to much smaller clone (creates a lot of whitespace at the
-        // end of the textbox)
         var clone = this.__getAreaClone();
+
         if (clone && this.getBounds()) {
 
           // Remember original area height

--- a/framework/source/class/qx/ui/form/TextArea.js
+++ b/framework/source/class/qx/ui/form/TextArea.js
@@ -8,7 +8,8 @@
      2004-2008 1&1 Internet AG, Germany, http://www.1und1.de
 
    License:
-     MIT: https://opensource.org/licenses/MIT
+     LGPL: http://www.gnu.org/licenses/lgpl.html
+     EPL: http://www.eclipse.org/org/documents/epl-v10.php
      See the LICENSE file in the project's top-level directory for details.
 
    Authors:
@@ -43,6 +44,7 @@ qx.Class.define("qx.ui.form.TextArea",
     this.initWrap();
 
     this.addListener("roll", this._onRoll, this);
+    this.addListener("resize", this._onResize, this);
   },
 
 
@@ -151,6 +153,20 @@ qx.Class.define("qx.ui.form.TextArea",
       }
     },
 
+    /**
+     * When the element resizes we throw away the clone and trigger autosize again, otherwise the clone would have
+     * another width and the autosize calculation would be faulty.
+     * 
+     * @param e {qx.event.type.Data} resize event.
+     */
+    _onResize : function(e) {
+      if (this.__areaClone) {
+        this.__areaClone.dispose();
+        this.__areaClone = null;
+        this.__autoSize();
+      }
+    },
+
     /*
     ---------------------------------------------------------------------------
       AUTO SIZE
@@ -163,11 +179,11 @@ qx.Class.define("qx.ui.form.TextArea",
     */
     __autoSize: function() {
       if (this.isAutoSize()) {
-        
-        // make sure to only create the clone when the bounds of this element are calculated. Otherwise in special cases
-        // clone will have no width set and the autoSize calculation is wrong due to much smaller clone (creates a lot 
-        // of whitespace at the end of the textbox)
-        if (this.getBounds() && this.__getAreaClone()) {
+        // make sure to only create the clone when the bounds of this element are calculated. Otherwise clone will have
+        // no width and the autoSize calculation is wrong due to much smaller clone (creates a lot of whitespace at the
+        // end of the textbox)
+        var clone = this.__getAreaClone();
+        if (clone && this.getBounds()) {
 
           // Remember original area height
           this.__originalAreaHeight = this.__originalAreaHeight || this._getAreaHeight();

--- a/framework/source/class/qx/ui/form/TextArea.js
+++ b/framework/source/class/qx/ui/form/TextArea.js
@@ -163,9 +163,11 @@ qx.Class.define("qx.ui.form.TextArea",
     */
     __autoSize: function() {
       if (this.isAutoSize()) {
-        var clone = this.__getAreaClone();
-
-        if (clone && this.getBounds()) {
+        
+        // make sure to only create the clone when the bounds of this element are calculated. Otherwise in special cases
+        // clone will have no width set and the autoSize calculation is wrong due to much smaller clone (creates a lot 
+        // of whitespace at the end of the textbox)
+        if (this.getBounds() && this.__getAreaClone()) {
 
           // Remember original area height
           this.__originalAreaHeight = this.__originalAreaHeight || this._getAreaHeight();


### PR DESCRIPTION
In some cases the textarea's autosize method was called before the textarea had proper bounds applied. In this case a clone of the textarea was created without a width set and the width was also not updated later. This lead to a wrong calculation of textarea height, because the clone used for calculation had a very small width, while the real textarea could be much bigger, which produced a lot of whitespace the longer the text got.

This fix delays the creation of the clone until the bounds are available. Fixed the issue in our project.