### PR TITLE
workaround for wrong event targets on touch devices

### DIFF
--- a/framework/source/class/qx/event/handler/DragDrop.js
+++ b/framework/source/class/qx/event/handler/DragDrop.js
@@ -615,13 +615,16 @@ qx.Class.define("qx.event.handler.DragDrop",
 
       // find current hovered droppable
       var el = e.getTarget();
+      if (this.__startConfig.target === el) {
+        el = document.elementFromPoint(e.getDocumentLeft(), e.getDocumentTop());
+      }
       var cursor = this.getCursor();
       if (!cursor) {
         cursor = qx.ui.core.DragDropCursor.getInstance();
       }
       var cursorEl = cursor.getContentElement().getDomElement();
 
-      if (el !== cursorEl) {
+      if (el !== cursorEl && !cursorEl.contains(el)) {
         var droppable = this.__findDroppable(el);
 
         // new drop target detected

--- a/framework/source/class/qx/event/handler/DragDrop.js
+++ b/framework/source/class/qx/event/handler/DragDrop.js
@@ -616,7 +616,7 @@ qx.Class.define("qx.event.handler.DragDrop",
       // find current hovered droppable
       var el = e.getTarget();
       if (this.__startConfig.target === el) {
-        el = document.elementFromPoint(e.getDocumentLeft(), e.getDocumentTop());
+        el = e.getNativeEvent().view.document.elementFromPoint(e.getDocumentLeft(), e.getDocumentTop());
       }
       var cursor = this.getCursor();
       if (!cursor) {

--- a/framework/source/class/qx/event/handler/DragDrop.js
+++ b/framework/source/class/qx/event/handler/DragDrop.js
@@ -624,7 +624,7 @@ qx.Class.define("qx.event.handler.DragDrop",
       }
       var cursorEl = cursor.getContentElement().getDomElement();
 
-      if (el !== cursorEl && !cursorEl.contains(el)) {
+      if (el !== cursorEl && (!cursorEl || !cursorEl.contains(el))) {
         var droppable = this.__findDroppable(el);
 
         // new drop target detected


### PR DESCRIPTION
Drag&Drop does not work on touch-enabled devices. To check that try to drag an element from one list to another in the qooxdoo demo browser DragDrop example (use a real tablet or the Chrome-Tablet-Simulation mode).

The problem is that the native event always return the element where the dragging started as target and not the one thats really under the cursor position.

This PR adds a workaround to get the real drop target by using `elementFromPoint`