### PR TITLE
take a look underneath the cursor element to fix the dragover event f…

### DIFF
--- a/framework/source/class/qx/event/handler/DragDrop.js
+++ b/framework/source/class/qx/event/handler/DragDrop.js
@@ -616,6 +616,7 @@ qx.Class.define("qx.event.handler.DragDrop",
       // find current hovered droppable
       var el = e.getTarget();
       if (this.__startConfig.target === el) {
+        // on touch devices the native events return wrong elements as target (its always the element where the dragging started)
         el = e.getNativeEvent().view.document.elementFromPoint(e.getDocumentLeft(), e.getDocumentTop());
       }
       var cursor = this.getCursor();
@@ -623,8 +624,15 @@ qx.Class.define("qx.event.handler.DragDrop",
         cursor = qx.ui.core.DragDropCursor.getInstance();
       }
       var cursorEl = cursor.getContentElement().getDomElement();
+      if (cursorEl && (el === cursorEl || cursorEl.contains(el))) {
+        var display = qx.bom.element.Style.get(cursorEl, "display");
+        // get the cursor out of the way
+        qx.bom.element.Style.set(cursorEl, "display", "none");
+        el = e.getNativeEvent().view.document.elementFromPoint(e.getDocumentLeft(), e.getDocumentTop());
+        qx.bom.element.Style.set(cursorEl, "display", display);
+      }
 
-      if (el !== cursorEl && (!cursorEl || !cursorEl.contains(el))) {
+      if (el !== cursorEl) {
         var droppable = this.__findDroppable(el);
 
         // new drop target detected


### PR DESCRIPTION
…iring

This is follow up to #9327 : The problem is that, depending how fast you drag in the direction where the drag-cursor is positioned it is possible the you do not receive the dragover event.

This fix checks if the cursor is returned as drop target and if so, it hides the cursor to see whats underneath it for a short period of time. As this only happens while your dragging the cursor hiding is not visible to the human eye.