### PR TITLE
#9331 fix focus should return textfield child control

### DIFF
--- a/framework/source/class/qx/event/handler/Focus.js
+++ b/framework/source/class/qx/event/handler/Focus.js
@@ -1075,15 +1075,9 @@ qx.Class.define("qx.event.handler.Focus",
      */
     __fixFocus : qx.event.GlobalError.observeMethod(qx.core.Environment.select("engine.name",
       {
-        "mshtml" : function(target)
-        {
-          return this.__getCorrectFocusTarget(target);
-        },
+        "mshtml" : this.__getCorrectFocusTarget,
 
-        "webkit" : function(target)
-        {
-          return this.__getCorrectFocusTarget(target);
-        },
+        "webkit" : this.__getCorrectFocusTarget,
 
         "default" : function(target) {
           return target;

--- a/framework/source/class/qx/event/handler/Focus.js
+++ b/framework/source/class/qx/event/handler/Focus.js
@@ -39,7 +39,7 @@ qx.Class.define("qx.event.handler.Focus",
 {
   extend : qx.core.Object,
   implement : [ qx.event.IEventHandler, qx.core.IDisposable ],
-  
+
   /*
   *****************************************************************************
      CONSTRUCTOR
@@ -439,7 +439,7 @@ qx.Class.define("qx.event.handler.Focus",
         qx.bom.Event.addNativeListener(this._document, "selectstart", this.__onNativeSelectStartWrapper);
       },
 
-      "webkit" : qx.core.Environment.select("browser.name", 
+      "webkit" : qx.core.Environment.select("browser.name",
       {
         // fix for [ISSUE #9174]
         // distinguish bettween MS Edge, which is reported
@@ -535,7 +535,7 @@ qx.Class.define("qx.event.handler.Focus",
         qx.bom.Event.removeNativeListener(this._document, "selectstart", this.__onNativeSelectStartWrapper);
       },
 
-      "webkit" : qx.core.Environment.select("browser.name", 
+      "webkit" : qx.core.Environment.select("browser.name",
       {
         // fix for [ISSUE #9174]
         // distinguish bettween MS Edge, which is reported
@@ -554,9 +554,9 @@ qx.Class.define("qx.event.handler.Focus",
           qx.bom.Event.removeNativeListener(this._document, "mousedown", this.__onNativeMouseDownWrapper, true);
           qx.bom.Event.removeNativeListener(this._document, "mouseup", this.__onNativeMouseUpWrapper, true);
           qx.bom.Event.removeNativeListener(this._document, "selectstart", this.__onNativeSelectStartWrapper, false);
-  
+
           qx.bom.Event.removeNativeListener(this._window, "DOMFocusOut", this.__onNativeFocusOutWrapper, true);
-  
+
           qx.bom.Event.removeNativeListener(this._window, "focus", this.__onNativeFocusWrapper, true);
           qx.bom.Event.removeNativeListener(this._window, "blur", this.__onNativeBlurWrapper, true);
         }
@@ -628,7 +628,7 @@ qx.Class.define("qx.event.handler.Focus",
         this.tryActivate(target);
       },
 
-      "webkit" : qx.core.Environment.select("browser.name", 
+      "webkit" : qx.core.Environment.select("browser.name",
       {
         // fix for [ISSUE #9174]
         // distinguish bettween MS Edge, which is reported
@@ -716,7 +716,7 @@ qx.Class.define("qx.event.handler.Focus",
         }
       },
 
-      "webkit" : qx.core.Environment.select("browser.name", 
+      "webkit" : qx.core.Environment.select("browser.name",
       {
         // fix for [ISSUE #9174]
         // distinguish bettween MS Edge, which is reported
@@ -1041,6 +1041,32 @@ qx.Class.define("qx.event.handler.Focus",
     })),
 
     /**
+     * Fix for bug #9331.
+     *
+     * @signature function(target)
+     * @param target {Element} element to check
+     * @return {Element} return correct target (in case of compound input controls should always return textfield);
+     */
+    __getCorrectFocusTarget: function(target)
+    {
+      var focusedElement = this.getFocus();
+      if (focusedElement && target != focusedElement) {
+        if (focusedElement.nodeName.toLowerCase() === "input" ||
+          focusedElement.nodeName.toLowerCase() === "textarea") {
+          return focusedElement;
+        }
+        // Check compound widgets
+        var widget = qx.ui.core.Widget.getWidgetByElement(focusedElement),
+          textField = widget && widget.getChildControl && widget.getChildControl("textfield", true);
+
+        if (textField) {
+          return textField.getContentElement().getDomElement();
+        }
+      }
+      return target;
+    },
+
+    /**
      * Fix for bug #2602.
      *
      * @signature function(target)
@@ -1048,35 +1074,21 @@ qx.Class.define("qx.event.handler.Focus",
      * @return {Element} Element to activate;
      */
     __fixFocus : qx.event.GlobalError.observeMethod(qx.core.Environment.select("engine.name",
-    {
-      "mshtml" : function(target)
       {
-        var focusedElement = this.getFocus();
-        if (focusedElement && target != focusedElement &&
-            (focusedElement.nodeName.toLowerCase() === "input" ||
-            focusedElement.nodeName.toLowerCase() === "textarea")) {
-          target = focusedElement;
+        "mshtml" : function(target)
+        {
+          return this.__getCorrectFocusTarget(target);
+        },
+
+        "webkit" : function(target)
+        {
+          return this.__getCorrectFocusTarget(target);
+        },
+
+        "default" : function(target) {
+          return target;
         }
-
-        return target;
-      },
-
-      "webkit" : function(target)
-      {
-        var focusedElement = this.getFocus();
-        if (focusedElement && target != focusedElement &&
-            (focusedElement.nodeName.toLowerCase() === "input" ||
-            focusedElement.nodeName.toLowerCase() === "textarea")) {
-          target = focusedElement;
-        }
-
-        return target;
-      },
-
-      "default" : function(target) {
-        return target;
-      }
-    })),
+      })),
 
     /**
      * Native event listener for <code>selectstart</code>.


### PR DESCRIPTION
Method __fixFocus should return textfield child control for Combo, Spinner and DateField.

This way compound input control still stays active after mouse up happens outside of it (same as simple text and textarea controls), and keypress is fired correctly.