### PR TITLE
Removes the need for DateFormat instances to be manually disposed

### DIFF
--- a/framework/source/class/qx/util/format/DateFormat.js
+++ b/framework/source/class/qx/util/format/DateFormat.js
@@ -72,7 +72,7 @@
 qx.Class.define("qx.util.format.DateFormat",
 {
   extend : qx.core.Object,
-  implement : [ qx.util.format.IFormat, qx.core.IDisposable ],
+  implement : [ qx.util.format.IFormat ],
 
 
 
@@ -92,18 +92,7 @@ qx.Class.define("qx.util.format.DateFormat",
   {
     this.base(arguments);
 
-    if (!locale)
-    {
-      this.__locale = qx.locale.Manager.getInstance().getLocale();
-      this.__bindingId = qx.locale.Manager.getInstance().bind("locale", this, "locale");
-    }
-    else
-    {
-      this.__locale = locale;
-      this.setLocale(locale);
-    }
-
-    this.__initialLocale = this.__locale;
+    this.__initialLocale = this.__locale = locale;
 
     if (format != null)
     {
@@ -117,28 +106,10 @@ qx.Class.define("qx.util.format.DateFormat",
       }
     } else
     {
-      this.__format = qx.locale.Date.getDateFormat("long", this.__locale) + " " + qx.locale.Date.getDateTimeFormat("HHmmss", "HH:mm:ss", this.__locale);
+      this.__format = qx.locale.Date.getDateFormat("long", this.getLocale()) + " " + qx.locale.Date.getDateTimeFormat("HHmmss", "HH:mm:ss", this.getLocale());
     }
   },
 
-
-  /*
-  *****************************************************************************
-     PROPERTIES
-  *****************************************************************************
-  */
-
-  properties :
-  {
-
-    /** The locale used in this DateFormat instance*/
-    locale :
-    {
-      apply : "_applyLocale",
-      nullable : true,
-      check : "String"
-    }
-  },
 
   /*
   *****************************************************************************
@@ -233,7 +204,6 @@ qx.Class.define("qx.util.format.DateFormat",
 
   members :
   {
-    __bindingId : null,
     __locale : null,
     __initialLocale : null,
     __format : null,
@@ -426,14 +396,34 @@ qx.Class.define("qx.util.format.DateFormat",
     },
 
     /**
-     * Applies the new value for locale property
+     * Sets the new value for locale property
      * @param value {String} The new value.
-     * @param old {String} The old value.
      *
      */
-    _applyLocale : function(value, old)
+    setLocale : function(value)
     {
-      this.__locale = value === null ? this.setLocale(this.__initialLocale) : value;
+      if (value !== null && typeof value != "string") {
+        throw new Error("Cannot set locale to " + value + " - please provide a string");
+      }
+      this.__locale = value === null ? this.__initialLocale : value;
+    },
+    
+    /**
+     * Resets the Locale
+     */
+    resetLocale : function() {
+      this.setLocale(null);
+    },
+    
+    /**
+     * Returns the locale
+     */
+    getLocale : function() {
+      var locale = this.__locale;
+      if (locale === undefined) {
+        locale = qx.locale.Manager.getInstance().getLocale();
+      }
+      return locale;
     },
 
     /**
@@ -460,7 +450,7 @@ qx.Class.define("qx.util.format.DateFormat",
         date = new Date(date.getUTCFullYear(),date.getUTCMonth(),date.getUTCDate(),date.getUTCHours(),date.getUTCMinutes(),date.getUTCSeconds(),date.getUTCMilliseconds());
       }
 
-      var locale = this.__locale;
+      var locale = this.getLocale();
 
       var fullYear = date.getFullYear();
       var month = date.getMonth();
@@ -1150,9 +1140,9 @@ qx.Class.define("qx.util.format.DateFormat",
 
       var rules = this.__parseRules = [];
 
-      var amMarker = qx.locale.Date.getAmMarker(this.__locale).toString() || DateFormat.AM_MARKER;
-      var pmMarker = qx.locale.Date.getPmMarker(this.__locale).toString() || DateFormat.PM_MARKER;
-      var locale = this.__locale;
+      var amMarker = qx.locale.Date.getAmMarker(this.getLocale()).toString() || DateFormat.AM_MARKER;
+      var pmMarker = qx.locale.Date.getPmMarker(this.getLocale()).toString() || DateFormat.PM_MARKER;
+      var locale = this.getLocale();
 
       var yearManipulator = function(dateValues, value)
       {
@@ -1767,22 +1757,5 @@ qx.Class.define("qx.util.format.DateFormat",
         manipulator : ignoreManipulator
       });
     }
-  },
-
-
-
-
-  /*
-  *****************************************************************************
-     DESTRUCTOR
-  *****************************************************************************
-  */
-
-  destruct : function()
-  {
-    if (this.__bindingId != null) {
-      qx.locale.Manager.getInstance().removeBinding(this.__bindingId);
-    }
-    this.__formatTree = this.__parseFeed = this.__parseRules = null;
   }
 });


### PR DESCRIPTION
As a simple utility class, it is natural to instinctively expect `DateFormat` to not require manual disposal any more, this PR changes DateFormat to support that.

The reason why it was not automatically disposable before was because it had a binding to `qx.locale.Manager.locale` that was used only to cache the current locale; there is no need for caching so removing the binding was trivial, but this highlighted a potential bug or issue for backward compatibility: while the user is allowed to change the `DateFormat.locale`, `DateFormat` would behave differently depending on the initial locale given to the constructor.

The system locale is only used if no locale is provided to the constructor (see [DateFormat.js](https://github.com/qooxdoo/qooxdoo/blob/master/framework/source/class/qx/util/format/DateFormat.js#L97-L98) ), but this binding is *not* removed if the locale is explicitly set later; so if you set the locale explicitly in the constructor, it will always be that locale - but if you set it explicitly later on it could be silently changed by the browser (see [_applyLocale](https://github.com/qooxdoo/qooxdoo/blob/master/framework/source/class/qx/util/format/DateFormat.js#L434-L437) ).  There is no event handler for changes to `DateFormat.locale` so it cannot be detected by the user.

My guess is that the intention (and reasonable expectation for users) was that an explicitly set locale is *set* and always overrides the system; if it is not set, or is subsequently un-set, then it reverts to the system default.  

