### PR TITLE
Fixes a bug where an exception is raised if there is no contentElement

### DIFF
--- a/framework/source/class/qx/ui/embed/Iframe.js
+++ b/framework/source/class/qx/ui/embed/Iframe.js
@@ -370,7 +370,10 @@ qx.Class.define("qx.ui.embed.Iframe",
      */
     _syncSourceAfterDOMMove : function()
     {
-      var iframeDomElement = this.getContentElement().getDomElement();
+      var iframeDomElement = this.getContentElement() && this.getContentElement().getDomElement();
+      if (!iframeDomElement) {
+        return;
+      }
       var iframeSource = iframeDomElement.src;
 
       // remove trailing "/"


### PR DESCRIPTION
The exception is a side effect of changing the iframe's source