### PR TITLE
Fix regression in focus handler introduced with PR #9333

### DIFF
--- a/framework/source/class/qx/event/handler/Focus.js
+++ b/framework/source/class/qx/event/handler/Focus.js
@@ -1075,9 +1075,13 @@ qx.Class.define("qx.event.handler.Focus",
      */
     __fixFocus : qx.event.GlobalError.observeMethod(qx.core.Environment.select("engine.name",
       {
-        "mshtml" : this.__getCorrectFocusTarget,
+        "mshtml" : function(target) {
+          return this.__getCorrectFocusTarget(target);
+        },
 
-        "webkit" : this.__getCorrectFocusTarget,
+        "webkit" : function(target) {
+          return this.__getCorrectFocusTarget(target);
+        },
 
         "default" : function(target) {
           return target;


### PR DESCRIPTION
Assigning the method via `this` does not work here as we are in the class construction phase.

Bug reported by @valette:

```
Uncaught TypeError: Cannot read property 'apply' of undefined
    at wrapper.__fixFocus (GlobalError.js:131)
    at wrapper.webkit (Focus.js:1031)
    at wrapper.__onNativeMouseUp (GlobalError.js:131)
    at HTMLDocument.<anonymous> (Function.js:337)
qx.event.handler.Focus.prototype.__fixFocus() @ GlobalError.js:131
webkit @ Focus.js:1031
qx.event.handler.Focus.prototype.__onNativeMouseUp() @ GlobalError.js:131
(anonymous) @ Function.js:337
```