### PR TITLE
Fix for issue #9334

### DIFF
--- a/framework/source/class/qx/ui/table/pane/Scroller.js
+++ b/framework/source/class/qx/ui/table/pane/Scroller.js
@@ -390,6 +390,8 @@ qx.Class.define("qx.ui.table.pane.Scroller",
     __top : null,
 
     __timer : null,
+		
+		__focusIndicatorPointerDownListener: null,
 
 
     /**
@@ -1887,7 +1889,7 @@ qx.Class.define("qx.ui.table.pane.Scroller",
           this._cellEditor.setUserBounds(0, 0, size.width, size.height);
 
           // prevent tap event from bubbling up to the table
-          this.__focusIndicator.addListener("pointerdown", function(e)
+          this.__focusIndicatorPointerDownListener = this.__focusIndicator.addListener("pointerdown", function(e)
           {
             this.__lastPointerDownCell = {
               row : this.__focusedRow,
@@ -1967,6 +1969,11 @@ qx.Class.define("qx.ui.table.pane.Scroller",
         {
           this.__focusIndicator.removeState("editing");
           this.__focusIndicator.setKeepActive(true);
+
+					if (this.__focusIndicatorPointerDownListener !== null) {
+						this.__focusIndicator.removeListenerById(this.__focusIndicatorPointerDownListener);
+						this.__focusIndicatorPointerDownListener = null;
+					}
         }
         this._cellEditor.destroy();
         this._cellEditor = null;


### PR DESCRIPTION
In startEditing() a pointerdown listener is attached to the focus indicator to prevent events from propagation. This listener is not removed anymore in cancelEditing(). This causes dragging of items to fail afterwards. This fix saves the event listener id to remove the listener in cancelEditing().