### PR TITLE
allow qx.test.io.remote.transport.XmlHttp:testSetHeader to be run under php-fpm

### DIFF
--- a/framework/source/resource/qx/test/xmlhttp/echo_header.php
+++ b/framework/source/resource/qx/test/xmlhttp/echo_header.php
@@ -1,4 +1,56 @@
 <?php
+/**
+ * polyfill for getallheaders from https://github.com/ralouphie/getallheaders
+ * published under the MIT license
+ *
+ * needed if the test is run under php-fpm
+ *
+ * See https://bugs.php.net/bug.php?id=62596
+ */
+if (!function_exists('getallheaders')) {
+    
+    /**
+     * Get all HTTP header key/values as an associative array for the current request.
+     *
+     * @return string[string] The HTTP header key/value pairs.
+     */
+    function getallheaders()
+    {
+        $headers = array();
+        
+        $copy_server = array(
+            'CONTENT_TYPE'   => 'Content-Type',
+            'CONTENT_LENGTH' => 'Content-Length',
+            'CONTENT_MD5'    => 'Content-Md5',
+        );
+        
+        foreach ($_SERVER as $key => $value) {
+            if (substr($key, 0, 5) === 'HTTP_') {
+                $key = substr($key, 5);
+                if (!isset($copy_server[$key]) || !isset($_SERVER[$key])) {
+                    $key = str_replace(' ', '-', ucwords(strtolower(str_replace('_', ' ', $key))));
+                    $headers[$key] = $value;
+                }
+            } elseif (isset($copy_server[$key])) {
+                $headers[$copy_server[$key]] = $value;
+            }
+        }
+        
+        if (!isset($headers['Authorization'])) {
+            if (isset($_SERVER['REDIRECT_HTTP_AUTHORIZATION'])) {
+                $headers['Authorization'] = $_SERVER['REDIRECT_HTTP_AUTHORIZATION'];
+            } elseif (isset($_SERVER['PHP_AUTH_USER'])) {
+                $basic_pass = isset($_SERVER['PHP_AUTH_PW']) ? $_SERVER['PHP_AUTH_PW'] : '';
+                $headers['Authorization'] = 'Basic ' . base64_encode($_SERVER['PHP_AUTH_USER'] . ':' . $basic_pass);
+            } elseif (isset($_SERVER['PHP_AUTH_DIGEST'])) {
+                $headers['Authorization'] = $_SERVER['PHP_AUTH_DIGEST'];
+            }
+        }
+        
+        return $headers;
+    }
+}
+
 $a = getallheaders();
 if (isset($a['COOKIE'])) unset($a['COOKIE']);
 echo json_encode($a);

--- a/framework/source/resource/qx/test/xmlhttp/echo_header.php
+++ b/framework/source/resource/qx/test/xmlhttp/echo_header.php
@@ -54,4 +54,4 @@ if (!function_exists('getallheaders')) {
 $a = getallheaders();
 if (isset($a['COOKIE'])) unset($a['COOKIE']);
 echo json_encode($a);
-?>
+


### PR DESCRIPTION
polyfill for getallheaders from https://github.com/ralouphie/getallheaders
published under the MIT license
needed if the test is run under php-fpm
See https://bugs.php.net/bug.php?id=62596