### PR TITLE
raise timeout for test qx.test.ui.embed Iframe:testSyncSourceAfterDOMMove to make travis happy

### DIFF
--- a/framework/source/class/qx/test/ui/embed/Iframe.js
+++ b/framework/source/class/qx/test/ui/embed/Iframe.js
@@ -122,7 +122,7 @@ qx.Class.define("qx.test.ui.embed.Iframe",
             iframe.getWindow().document.body.innerText
           );
         });
-      }.bind(this), 1000);
+      }.bind(this), 4000);
 
       this.wait(10000);
     }


### PR DESCRIPTION
recently the test fails on firefox frequently which seems related to travis now running ubuntu trusty containers, which seem to run slower than ubuntu precise.

See https://travis-ci.org/qooxdoo/qooxdoo/jobs/262861133