### PR TITLE
[Fixed] keyboard handling of virtual drop down list

### DIFF
--- a/framework/source/class/qx/ui/form/core/VirtualDropDownList.js
+++ b/framework/source/class/qx/ui/form/core/VirtualDropDownList.js
@@ -179,6 +179,7 @@ qx.Class.define("qx.ui.form.core.VirtualDropDownList",
           control = new qx.ui.list.List().set({
             focusable: false,
             keepFocus: true,
+            keepActive: true,
             height: null,
             width: null,
             maxHeight: this._target.getMaxListHeight(),


### PR DESCRIPTION
So this one is relative hard to reproduce, although it doesn't involve timing.

This is how you can reproduce:
1. make a new qx app (e.g.: create-application.py -n test .)
2. insert this in your main function:
```
var vsb = new qx.ui.form.VirtualSelectBox();
vsb.setModel(qx.data.marshal.Json.createModel(['a', 'b']));
this.getRoot().add(vsb, {left: 50, top: 50});
```
_I've placed it above the ```var button1 = ... ``` declaration and replace the ```doc.add(button1, {left: 100, top: 50});``` line with ```doc.add(vsb, {left: 100, top: 50});```_

3. Now change the QXTHEME variable in the config.json file to "qx.theme.Modern".
4. Run the generator (I used the default job).
5. Now open the app in your browser window (opened mine through a web server) (hit F5 for a clean slate).
6. Use only the mouse to select 'b' (make sure the popup is closed).
7. Now use the keyboard and tap twice on arrow up to select 'a'.
8. Now hit enter and see what happens.

Expected: the popup should close and the value 'a' should be in the box.
Actual: nothing happens.

You can also notice a small white bar below 'b' when the popup is open after first clicking it.

Is there anyone who knows why this isn't occurring in the indigo theme?