### PR TITLE
Drop down bugfix and consistency check

### DIFF
--- a/framework/source/class/qx/test/ui/core/SizeHint.js
+++ b/framework/source/class/qx/test/ui/core/SizeHint.js
@@ -179,12 +179,11 @@ qx.Class.define("qx.test.ui.core.SizeHint",
     testMinLargerThanMax : function()
     {
       this.setStretching(true, true);
-      this.setSize(200, 100, 150);
       if (this.isDebugOn())
       {
         var that = this;
         this.assertException(function() {
-          that.getHint();
+          that.setSize(200, 100, 150);
         }, qx.core.AssertionError);
       }
     },

--- a/framework/source/class/qx/ui/core/LayoutItem.js
+++ b/framework/source/class/qx/ui/core/LayoutItem.js
@@ -748,6 +748,20 @@ qx.Class.define("qx.ui.core.LayoutItem",
 
     // property apply
     _applyDimension : function() {
+      if (qx.core.Environment.get("qx.debug")) {
+        var minWidth = this.getMinWidth();
+        var maxWidth = this.getMaxWidth();
+        if (minWidth !== null && maxWidth !== null) {
+          this.assert(minWidth <= maxWidth, "minWidth is larger than maxWidth!");
+        }
+
+        var minHeight = this.getMinHeight();
+        var maxHeight = this.getMaxHeight();
+        if (minHeight !== null && maxHeight !== null) {
+          this.assert(minHeight <= maxHeight, "minHeight is larger than maxHeight!");
+        }
+      }
+
       qx.ui.core.queue.Layout.add(this);
     },
 

--- a/framework/source/class/qx/ui/core/Widget.js
+++ b/framework/source/class/qx/ui/core/Widget.js
@@ -1195,16 +1195,6 @@ qx.Class.define("qx.ui.core.Widget",
       var minHeight = this.getMinHeight();
       var maxHeight = this.getMaxHeight();
 
-      if (qx.core.Environment.get("qx.debug"))
-      {
-        if (minWidth !== null && maxWidth !== null) {
-          this.assert(minWidth <= maxWidth, "minWidth is larger than maxWidth!");
-        }
-        if (minHeight !== null && maxHeight !== null) {
-          this.assert(minHeight <= maxHeight, "minHeight is larger than maxHeight!");
-        }
-      }
-
       // Ask content
       var contentHint = this._getContentHint();
 

--- a/framework/source/class/qx/ui/form/core/AbstractVirtualBox.js
+++ b/framework/source/class/qx/ui/form/core/AbstractVirtualBox.js
@@ -291,7 +291,7 @@ qx.Class.define("qx.ui.form.core.AbstractVirtualBox",
       var isModifierPressed = this._isModifierPressed(event);
 
       if (
-        !isOpen && !isModifierPressed &&
+        !isOpen && !isModifierPressed && this.__hasVisibleItems() &&
         (keyIdentifier === "Down" || keyIdentifier === "Up")
       ) {
         return "open";
@@ -302,6 +302,19 @@ qx.Class.define("qx.ui.form.core.AbstractVirtualBox",
       } else {
         return null;
       }
+    },
+
+
+    /**
+     * Return if this virtual box has any visible items.
+     *
+     * @returns {boolean} True when it has at least one visible item.
+     * @private
+     */
+    __hasVisibleItems : function() {
+      var list = this.getChildControl("dropdown").getChildControl("list");
+      var totalSize = list.getPane().getRowConfig().getTotalSize();
+      return totalSize > 0;
     },
 
 

--- a/framework/source/class/qx/ui/form/core/VirtualDropDownList.js
+++ b/framework/source/class/qx/ui/form/core/VirtualDropDownList.js
@@ -439,19 +439,24 @@ qx.Class.define("qx.ui.form.core.VirtualDropDownList",
     __adjustHeight : function()
     {
       var availableHeigth = this.__getAvailableHeigth();
-      var maxListHeight = this._target.getMaxListHeight();
+      var maxHeight = this._target.getMaxListHeight();
       var list = this.getChildControl("list");
       var itemsHeight = list.getPane().getRowConfig().getTotalSize();
 
-      if (maxListHeight == null || itemsHeight < maxListHeight) {
-        maxListHeight = itemsHeight;
+      if (maxHeight == null || itemsHeight < maxHeight) {
+        maxHeight = itemsHeight;
       }
 
-      if (maxListHeight > availableHeigth) {
-        list.setMaxHeight(availableHeigth);
-      } else if (maxListHeight < availableHeigth) {
-        list.setMaxHeight(maxListHeight);
+      if (maxHeight > availableHeigth) {
+        maxHeight = availableHeigth;
       }
+
+      var minHeight = list.getMinHeight();
+      if (null !== minHeight && minHeight > maxHeight) {
+        maxHeight = minHeight;
+      }
+
+      list.setMaxHeight(maxHeight);
     },
 
 


### PR DESCRIPTION
In order to solve the following error:
```
qx.ui.core.queue.Layout: Error in the 'Layout' queue:minHeight is larger than maxHeight!: Called assert with 'false' minHeight is larger than maxHeight!: Called assert with 'false'
```
I had to improve a dimension consistency check **844ae28**. By trowing the exception earlier (when setting the dimensions) it produces a more useful trace. Also the model (layout item in this case) should keep its own state consistent.

I also made a change in the abstract virtual box. Previously, you could press the down or up arrow key to open the list when it was closed. This change prevents the list from opening on key down or up when no visible items are present.