### PR TITLE
Strict mode compliance

### DIFF
--- a/framework/source/class/qx/bom/Window.js
+++ b/framework/source/class/qx/bom/Window.js
@@ -189,12 +189,11 @@ qx.Class.define("qx.bom.Window",
       if(newWindow && listener && (listener instanceof Function)){
         var context = self || newWindow;
         var onLoadFunction = qx.lang.Function.bind(listener, context);
-        qx.bom.Event.addNativeListener(
-          newWindow, 'load', function(){
-            onLoadFunction();
-            qx.bom.Event.removeNativeListener(newWindow, 'load', arguments.callee);
-          }
-        );
+        var onNativeLoad = function(){
+          onLoadFunction();
+          qx.bom.Event.removeNativeListener(newWindow, 'load', onNativeLoad);
+        }
+        qx.bom.Event.addNativeListener(newWindow, 'load', onNativeLoad);
       }
       return newWindow;
     },

--- a/framework/source/class/qx/event/Manager.js
+++ b/framework/source/class/qx/event/Manager.js
@@ -52,7 +52,7 @@ qx.Class.define("qx.event.Manager",
     {
       var self = this;
       var method = function () {
-        qx.bom.Event.removeNativeListener(win, "unload", arguments.callee);
+        qx.bom.Event.removeNativeListener(win, "unload", method);
         self.dispose();
       };
       if (qx.core.Environment.get("qx.globalErrorHandling")) {

--- a/framework/source/class/qx/event/dispatch/MouseCapture.js
+++ b/framework/source/class/qx/event/dispatch/MouseCapture.js
@@ -169,11 +169,12 @@ qx.Class.define("qx.event.dispatch.MouseCapture",
       if (this.hasNativeCapture) {
         this.nativeSetCapture(element, containerCapture);
         var self = this;
-        qx.bom.Event.addNativeListener(element, "losecapture", function()
+        var onNativeListener = function()
         {
-          qx.bom.Event.removeNativeListener(element, "losecapture", arguments.callee);
+          qx.bom.Event.removeNativeListener(element, "losecapture", onNativeListener);
           self.releaseCapture();
-        });
+        };
+        qx.bom.Event.addNativeListener(element, "losecapture", onNativeListener);
       }
 
       this.__containerCapture = containerCapture;

--- a/framework/source/class/qx/test/Bootstrap.js
+++ b/framework/source/class/qx/test/Bootstrap.js
@@ -292,7 +292,7 @@ qx.Class.define("qx.test.Bootstrap",
 
           stopEngine : function()
           {
-            var ret = arguments.callee.base.call();
+            var ret = qx.test.Bmw.prototype.stopEngine.base.call();
             return "brrr " + ret;
           },
 

--- a/framework/source/class/qx/test/Bootstrap.js
+++ b/framework/source/class/qx/test/Bootstrap.js
@@ -292,7 +292,7 @@ qx.Class.define("qx.test.Bootstrap",
 
           stopEngine : function()
           {
-            var ret = qx.test.Bmw.prototype.stopEngine.base.call();
+            var ret = this.base(arguments);
             return "brrr " + ret;
           },
 

--- a/framework/source/class/qx/test/Class.js
+++ b/framework/source/class/qx/test/Class.js
@@ -139,7 +139,7 @@ qx.Class.define("qx.test.Class",
 
           stopEngine : function()
           {
-            var ret = this.base.call();
+            var ret = this.base(arguments);
             return "brrr " + ret;
           },
 
@@ -176,7 +176,7 @@ qx.Class.define("qx.test.Class",
     {
       qx.Class.define("qx.AbstractCar",
       {
-        extend : Object,
+        extend : qx.core.Object,
         type : "abstract",
 
         construct : function(color) {
@@ -202,7 +202,7 @@ qx.Class.define("qx.test.Class",
         extend : qx.AbstractCar,
 
         construct : function(color) {
-          this.base.apply(this, arguments);
+          this.base(arguments, color);
         }
       });
 

--- a/framework/source/class/qx/test/Class.js
+++ b/framework/source/class/qx/test/Class.js
@@ -139,7 +139,7 @@ qx.Class.define("qx.test.Class",
 
           stopEngine : function()
           {
-            var ret = arguments.callee.base.call();
+            var ret = this.base.call();
             return "brrr " + ret;
           },
 
@@ -202,7 +202,7 @@ qx.Class.define("qx.test.Class",
         extend : qx.AbstractCar,
 
         construct : function(color) {
-          arguments.callee.base.apply(this, arguments);
+          this.base.apply(this, arguments);
         }
       });
 
@@ -295,49 +295,6 @@ qx.Class.define("qx.test.Class",
       defer.setColor("red");
       this.assertEquals("red", defer.getColor());
       defer.dispose();
-    },
-
-
-    testGetFunctionName : function()
-    {
-      var self = this;
-
-      qx.Class.define("qx.FuncName",
-      {
-        extend : qx.core.Object,
-
-        construct : function()
-        {
-          this.base(arguments);
-          self.assertEquals("construct", qx.dev.Debug.getFunctionName(arguments.callee));
-        },
-
-        members :
-        {
-          __foo : function()
-          {
-            if (self.isDebugOn()) {
-              self.assertEquals("__foo", qx.dev.Debug.getFunctionName(arguments.callee));
-            };
-          },
-
-          _bar : function() {
-            self.assertEquals("_bar", qx.dev.Debug.getFunctionName(arguments.callee));
-          },
-
-          sayFooBar : function()
-          {
-            self.assertEquals("sayFooBar", qx.dev.Debug.getFunctionName(arguments.callee));
-            this.__foo();
-            this._bar();
-          }
-        }
-      });
-
-      var funcName = new qx.FuncName();
-      funcName.sayFooBar();
-      this.assertNull(qx.dev.Debug.getFunctionName(function() {}));
-      funcName.dispose();
     },
 
 

--- a/framework/source/class/qx/test/lang/Function.js
+++ b/framework/source/class/qx/test/lang/Function.js
@@ -39,24 +39,6 @@ qx.Class.define("qx.test.lang.Function",
     },
 
 
-    testGetCaller : function()
-    {
-      var self = this;
-      var fcn = arguments.callee;
-
-      function f1(caller) {
-        self.assertIdentical(caller, qx.lang.Function.getCaller(arguments), "Wrong caller.");
-      }
-
-      function f2() {
-        f1(f2);
-      }
-
-      f2();
-      f1(fcn);
-    },
-
-
     testFunctionWrap : function()
     {
       var context = null;

--- a/framework/source/class/qx/test/lang/Type.js
+++ b/framework/source/class/qx/test/lang/Type.js
@@ -163,7 +163,6 @@ qx.Class.define("qx.test.lang.Type",
       var Type = qx.lang.Type;
 
       this.assertTrue(Type.isFunction(function() {}));
-      this.assertTrue(Type.isFunction(arguments.callee));
       this.assertTrue(Type.isFunction(Object));
 
       this.assertFalse(Type.isFunction());

--- a/framework/source/class/qx/ui/table/pane/Pane.js
+++ b/framework/source/class/qx/ui/table/pane/Pane.js
@@ -665,7 +665,7 @@ qx.Class.define("qx.ui.table.pane.Pane",
       var elem = this.getContentElement().getDomElement();
       if (!elem) {
         // pane has not yet been rendered
-        this.addListenerOnce("appear", arguments.callee, this);
+        this.addListenerOnce("appear", this._updateAllRows, this);
         return;
       }
 

--- a/framework/source/class/qx/util/Function.js
+++ b/framework/source/class/qx/util/Function.js
@@ -50,54 +50,44 @@ qx.Bootstrap.define("qx.util.Function", {
      * @return {Function} a wrapper function which <em>shields</em> the given callback function
      */
     debounce: function (callback, delay, immediate) {
+      var fired = false;
+      var intervalId = null;
       var wrapperFunction = function () {
-        arguments.callee.immediate = !!(immediate);
-
         // store the current arguments at the function object
         // to have access inside the interval method
-        arguments.callee.args = qx.lang.Array.fromArguments(arguments);
+        var args = qx.lang.Array.fromArguments(arguments);
 
         // it's necessary to store the context to be able to call
         // the callback within the right scope
         var context = this;
 
-        // arguments.callee is the wrapper function itself
-        // use this function object to store the 'intervalId' and the 'fired' state
-        var id = arguments.callee.intervalId;
-        if (typeof id === "undefined") {
+        if (intervalId === null) {
           // setup the interval for the first run
-          var intervalId = window.setInterval((function () {
+          intervalId = window.setInterval(function () {
 
             // if the 'wrapperFunction' was *not* called during the last
             // interval then can call the provided callback and clear the interval
-            // except for 'immediate' mode
-            if (!this.fired) {
-              window.clearInterval(this.intervalId);
-              delete this.intervalId;
+            if (!fired) {
+              window.clearInterval(intervalId);
+              intervalId = null;
 
-              if (this.immediate === false) {
-                if (context && context.isDisposed && context.isDisposed()) {
-                  qx.log.Logger.warn(
-                    "The context object '" + context + "' of the debounced call '" +
-                    this + "'is already disposed.");
-                }
-                else {
-                  callback.apply(context, this.args);
-                }
+              if (context && context.isDisposed && context.isDisposed()) {
+                qx.log.Logger.warn("The context object '" + context + "' of the debounced call is already disposed.");
+              }
+              else {
+                callback.apply(context, args);
               }
             }
-            this.fired = false;
-          }).bind(arguments.callee), delay);
+            fired = false;
+          }, delay);
 
-          arguments.callee.intervalId = intervalId;
-
-          if (arguments.callee.immediate) {
-            callback.apply(context, arguments.callee.args);
+          if (immediate) {
+            callback.apply(context, args);
           }
         }
 
         // This prevents the logic to clear the interval
-        arguments.callee.fired = true;
+        fired = true;
       };
 
       return wrapperFunction;

--- a/framework/source/class/qx/util/Function.js
+++ b/framework/source/class/qx/util/Function.js
@@ -53,8 +53,7 @@ qx.Bootstrap.define("qx.util.Function", {
       var fired = false;
       var intervalId = null;
       var wrapperFunction = function () {
-        // store the current arguments at the function object
-        // to have access inside the interval method
+        // store the current arguments to have access inside the interval method
         var args = qx.lang.Array.fromArguments(arguments);
 
         // it's necessary to store the context to be able to call


### PR DESCRIPTION
Various minor fixes for strict mode compliance, IE remove references to `arguments.callee` and `arguments.caller`