### PR TITLE
Avoid exception on getting the focus target of compound widgets

### DIFF
--- a/framework/source/class/qx/event/handler/Focus.js
+++ b/framework/source/class/qx/event/handler/Focus.js
@@ -1058,7 +1058,7 @@ qx.Class.define("qx.event.handler.Focus",
         // Check compound widgets
         var widget = qx.ui.core.Widget.getWidgetByElement(focusedElement);
         if(widget) {
-          var textField = widget.getChildControl && widget.hasChildControl("textfield") && widget.getChildControl("textfield", true);
+          var textField = widget.hasChildControl("textfield") && widget.getChildControl("textfield", true);
           if (textField) {
             return textField.getContentElement().getDomElement();
           }

--- a/framework/source/class/qx/event/handler/Focus.js
+++ b/framework/source/class/qx/event/handler/Focus.js
@@ -1056,11 +1056,12 @@ qx.Class.define("qx.event.handler.Focus",
           return focusedElement;
         }
         // Check compound widgets
-        var widget = qx.ui.core.Widget.getWidgetByElement(focusedElement),
-          textField = widget && widget.getChildControl && widget.getChildControl("textfield", true);
-
-        if (textField) {
-          return textField.getContentElement().getDomElement();
+        var widget = qx.ui.core.Widget.getWidgetByElement(focusedElement);
+        if(widget) {
+          var textField = widget.getChildControl && widget.hasChildControl("textfield") && widget.getChildControl("textfield", true);
+          if (textField) {
+            return textField.getContentElement().getDomElement();
+          }
         }
       }
       return target;


### PR DESCRIPTION
Focus able widgets may not have a "textfield" child control resulting in an exception calling getChildControl("textfield"). To avoid this we first have to check if a child control named "textfield" exists.