### PR TITLE
Radio group specify property

### DIFF
--- a/framework/source/class/qx/test/ui/form/RadioGroup.js
+++ b/framework/source/class/qx/test/ui/form/RadioGroup.js
@@ -79,6 +79,9 @@ qx.Class.define("qx.test.ui.form.RadioGroup",
       composite.destroy();
     },
 
+    /**
+     * @ignore(qx.test.ui.form.RadioGroupTest)
+     */
     testAlteredGroupProperty : function()
     {
       qx.Class.define("qx.test.ui.form.RadioGroupTest",

--- a/framework/source/class/qx/test/ui/form/RadioGroup.js
+++ b/framework/source/class/qx/test/ui/form/RadioGroup.js
@@ -77,6 +77,73 @@ qx.Class.define("qx.test.ui.form.RadioGroup",
       this.assertEquals(this.__radioButtons[0].getModel(), this.__radioGroup.getModelSelection().getItem(0), "Model selection does not work correctly!");
       this.assertTrue(this.__radioGroup.isSelected(this.__radioButtons[0]), "Hidden radio button not selected!");
       composite.destroy();
+    },
+
+    testAlteredGroupProperty : function()
+    {
+      qx.Class.define("qx.test.ui.form.RadioGroupTest",
+      {
+        extend : qx.core.Object,
+
+        properties :
+        {
+          locked :
+          {
+            init     : false,
+            check    : "Boolean",
+            event    : "changeLocked",
+            nullable : false
+          },
+
+          // set by the RadioGroup
+          lockedGroup :
+          {
+            init     : null,
+            check    : "qx.ui.form.RadioGroup",
+            nullable : true
+          }
+        }
+      });
+
+      var rg;
+      var testObj1, testObj2, testObj3
+
+      rg = new qx.ui.form.RadioGroup();
+      rg.set(
+        {
+          groupedProperty     : "locked",
+          groupProperty       : "lockedGroup"
+        });
+
+      testObj1 = new qx.test.ui.form.RadioGroupTest();
+      testObj2 = new qx.test.ui.form.RadioGroupTest();
+      testObj3 = new qx.test.ui.form.RadioGroupTest();
+
+      // Add the test objects to the radio group. This should automatically
+      // select the first one.
+      rg.add(testObj1, testObj2, testObj3);
+
+      // Ensure it did and the other ones are off
+      this.assertTrue(testObj1.getLocked());
+      this.assertFalse(testObj2.getLocked());
+      this.assertFalse(testObj3.getLocked());
+
+      // Select the second one.
+      rg.setSelection( [ testObj2 ] );
+
+      // Ensure it's now on and the other ones are off
+      this.assertTrue(testObj2.getLocked());
+      this.assertFalse(testObj1.getLocked());
+      this.assertFalse(testObj3.getLocked());
+
+      // Also ensure that the selection is as we expect
+      this.assertEquals(rg.getSelection()[0], testObj2);
+
+      // Clean up
+      testObj1.dispose();
+      testObj2.dispose();
+      testObj3.dispose();
+      qx.Class.undefine("qx.test.ui.form.RadioGroupTest");
     }
   }
 });

--- a/framework/source/class/qx/ui/form/RadioGroup.js
+++ b/framework/source/class/qx/ui/form/RadioGroup.js
@@ -82,6 +82,28 @@ qx.Class.define("qx.ui.form.RadioGroup",
   properties :
   {
     /**
+     * The property name in each of the added widgets that is grouped
+     */
+    groupedProperty :
+    {
+      check : "String",
+      apply : "_applyGroupedProperty",
+      event : "changeGroupedProperty",
+      init  : "value"
+    },
+
+    /**
+     * The property name in each of the added widgets that is informed of the
+     * RadioGroup object it is a member of
+     */
+    groupProperty :
+    {
+      check : "String",
+      event : "changeGroupProperty",
+      init  : "group"
+    },
+
+    /**
      * Whether the radio group is enabled
      */
     enabled :
@@ -202,6 +224,8 @@ qx.Class.define("qx.ui.form.RadioGroup",
     {
       var items = this.__items;
       var item;
+      var groupedProperty = this.getGroupedProperty();
+      var groupedPropertyUp = qx.lang.String.firstUp(groupedProperty);
 
       for (var i=0, l=arguments.length; i<l; i++)
       {
@@ -212,16 +236,17 @@ qx.Class.define("qx.ui.form.RadioGroup",
         }
 
         // Register listeners
-        item.addListener("changeValue", this._onItemChangeChecked, this);
+        item.addListener(
+          "change" + groupedPropertyUp, this._onItemChangeChecked, this);
 
         // Push RadioButton to array
         items.push(item);
 
         // Inform radio button about new group
-        item.setGroup(this);
+        item.set(this.getGroupProperty(), this);
 
         // Need to update internal value?
-        if (item.getValue()) {
+        if (item.get(groupedProperty)) {
           this.setSelection([item]);
         }
       }
@@ -240,21 +265,25 @@ qx.Class.define("qx.ui.form.RadioGroup",
     remove : function(item)
     {
       var items = this.__items;
+      var groupedProperty = this.getGroupedProperty();
+      var groupedPropertyUp = qx.lang.String.firstUp(groupedProperty);
+
       if (qx.lang.Array.contains(items, item))
       {
         // Remove RadioButton from array
         qx.lang.Array.remove(items, item);
 
         // Inform radio button about new group
-        if (item.getGroup() === this) {
-          item.resetGroup();
+        if (item.get(this.getGroupProperty()) === this) {
+          item.reset(this.getGroupProperty());
         }
 
         // Deregister listeners
-        item.removeListener("changeValue", this._onItemChangeChecked, this);
+        item.removeListener(
+          "change" + groupedPropertyUp, this._onItemChangeChecked, this);
 
         // if the radio was checked, set internal selection to null
-        if (item.getValue()) {
+        if (item.get(groupedProperty)) {
           this.resetSelection();
         }
       }
@@ -287,7 +316,9 @@ qx.Class.define("qx.ui.form.RadioGroup",
     _onItemChangeChecked : function(e)
     {
       var item = e.getTarget();
-      if (item.getValue()) {
+      var groupedProperty = this.getGroupedProperty();
+
+      if (item.get(groupedProperty)) {
         this.setSelection([item]);
       } else if (this.getSelection()[0] == item) {
         this.resetSelection();
@@ -300,6 +331,26 @@ qx.Class.define("qx.ui.form.RadioGroup",
       APPLY ROUTINES
     ---------------------------------------------------------------------------
     */
+
+    // property apply
+    _applyGroupedProperty : function(value, old) {
+      var item;
+      var oldFirstUp = qx.lang.String.firstUp(old);
+      var newFirstUp = qx.lang.String.firstUp(value);
+
+      for (var i = 0; i < this.__items.length; i++) {
+        item = this.__items[i];
+
+        // remove the listener for the old change event
+        item.removeListener(
+          "change" + oldFirstUp, this._onItemChangeChecked, this);
+
+        // add the listener for the new change event
+        item.removeListener(
+          "change" + newFirstUp, this._onItemChangeChecked, this);
+      }
+    },
+
     // property apply
     _applyInvalidMessage : function(value, old) {
       for (var i = 0; i < this.__items.length; i++) {
@@ -462,13 +513,14 @@ qx.Class.define("qx.ui.form.RadioGroup",
     {
       var value = e.getData()[0];
       var old = e.getOldData()[0];
+      var groupedProperty = this.getGroupedProperty();
 
       if (old) {
-        old.setValue(false);
+        old.set(groupedProperty, false);
       }
 
       if (value) {
-        value.setValue(true);
+        value.set(groupedProperty, true);
       }
     }
   },


### PR DESCRIPTION
Allow RadioGroup to group by other than the 'value' property.

Prior to this change, widgets to be grouped in a RadioGroup had to have a
'value' property which was monitored for changes to ensure that no more than
one of the grouped widgets was active at any one time; and a 'group'property,
which was set to the RadioGroup object to which the widget was added.

With this change, the two property names can be specified. The RadioGroup
object has two new properties:

- The property groupedProperty, which defaults to 'value', is the property on
  which widgets are grouped.

- The property groupProperty, which defaults to 'group', is the property in
  the widgets which is set by RadioGroup to tell a widget what RadioGroup
  object it is associated with.

It is now possible for a set of widgets to have multiple properties that are
independently maintained as mutually exclusive via multiple RadioGroups, each
responsible for the mutual exclusivity of a particular property. For example,
if a group of widgets can have only one of them with their 'locked' property
set to true, and the same set of widgets can have only one of them with their
'ready' property set to true, then the widgets would be defined with
properties:

    locked :
    {
      init     : null,
      check    : "Boolean",
      apply    : "_applyLocked",
      event    : "changeLocked",
      nullable : false
    },

    // set by the RadioGroup
    lockedGroup :
    {
      init     : null,
      check    : "qx.ui.form.RadioGroup",
      nullable : true
    },

    ready :
    {
      init     : false,
      check    : "Boolean",
      apply    : "_applyReady",
      event    : "changeReady",
      nullable : false
    },

    // set by the RadioGroup
    readyGroup :
    {
      init     : null,
      check    : "qx.ui.form.RadioGroup",
      nullable : true
    },

Then two radio groups can be defined:

    var rgLocked = new qx.ui.form.RadioGroup();
    var rgReady = new qx.ui.form.RadioGroup();

    rgLocked.set(
      {
        groupedProperty     : "locked",
        groupProperty       : "lockedGroup"
      });

    rgReady.set(
      {
        groupedProperty     : "ready",
        groupProperty       : "readyGroup"
      });

Then, widgets which define the 'locked', 'lockedGroup', 'ready', and
'readyGroup' properties can be added to rgLocked and rgReady.
