### PR TITLE
Proposed fix for #9393

### DIFF
--- a/framework/source/class/qx/event/handler/Focus.js
+++ b/framework/source/class/qx/event/handler/Focus.js
@@ -251,9 +251,15 @@ qx.Class.define("qx.event.handler.Focus",
       }
       else
       {
-        try {
-          element.focus();
-        } catch(ex) {}
+        // Fix re-focusing on mousup event
+        // See https://github.com/qooxdoo/qooxdoo/issues/9393 and
+        // discussion in https://github.com/qooxdoo/qooxdoo/pull/9394
+        window.setTimeout(function()
+        {
+          try {
+            element.focus();
+          } catch(ex) {}
+        }, 0);
       }
 
       this.setFocus(element);


### PR DESCRIPTION
The focus handler receives the "native mouse up" event delayed. As a
result the blocker already passed the focus to the application root.
Then the chrome event drops in and puts the focus back on the button.

closes #9393