### PR TITLE
Open close messagebus

### DIFF
--- a/framework/source/class/qx/test/ui/tree/virtual/WidgetProvider.js
+++ b/framework/source/class/qx/test/ui/tree/virtual/WidgetProvider.js
@@ -463,6 +463,8 @@ qx.Class.define("qx.test.ui.tree.virtual.WidgetProvider",
 
 
     closeNode : function(node) {},
-    closeNodeWithoutScrolling : function(node) {}
+    closeNodeWithoutScrolling : function(node) {},
+
+    getOpenPropertyName : function() { return null; }
   }
 });

--- a/framework/source/class/qx/ui/tree/VirtualTree.js
+++ b/framework/source/class/qx/ui/tree/VirtualTree.js
@@ -16,7 +16,7 @@
 
 ************************************************************************ */
 
-/**
+/*
  * Virtual tree implementation.
  *
  * The virtual tree can be used to render node and leafs. Nodes and leafs are
@@ -26,13 +26,15 @@
  * With the {@link qx.ui.tree.core.IVirtualTreeDelegate} interface it is possible
  * to configure the tree's behavior (item renderer configuration, etc.).
  *
- * Here's an example of how to use the widget:
+ * Here's an example of how to use the widget, including binding a model
+ * property to open/close branches:
+ *
  * <pre class="javascript">
  * //create the model data
  * var nodes = [];
  * for (var i = 0; i < 2500; i++)
  * {
- *   nodes[i] = {name : "Item " + i};
+ *   nodes[i] = {name : "Item " + i, item : i};
  *
  *   // if its not the root node
  *   if (i !== 0)
@@ -42,24 +44,55 @@
  *
  *     if(node.children == null) {
  *       node.children = [];
+ *       node.opened = node.item <= 10;
  *     }
  *     node.children.push(nodes[i]);
  *   }
  * }
  *
+ * // initialize the root node to closed
+ * nodes[0].opened = false;
+ *
  * // converts the raw nodes to qooxdoo objects
  * nodes = qx.data.marshal.Json.createModel(nodes, true);
  *
- * // creates the tree
- * var tree = new qx.ui.tree.VirtualTree(nodes.getItem(0), "name", "children").set({
- *   width : 200,
- *   height : 400
- * });
+ * // create the tree
+ * var tree =
+ *   new qx.ui.tree.VirtualTree(nodes.getItem(0), "name", "children").set({
+ *       width : 200,
+ *       height : 400
+ *     });
+ *
+ * // synchronize the model property 'opened' to nodes being open
+ * new qx.ui.tree.core.OpenCloseController(tree, nodes, "opened");
  *
  * //log selection changes
  * tree.getSelection().addListener("change", function(e) {
  *   this.debug("Selection: " + tree.getSelection().getItem(0).getName());
  * }, this);
+ *
+ * tree.set(
+ *   {
+ *     width : 200,
+ *     height : 400,
+ *     showTopLevelOpenCloseIcons : true
+ *   });
+ *
+ * var doc = this.getRoot();
+ * doc.add(tree,
+ * {
+ *   left : 100,
+ *   top  : 50
+ * });
+ *
+ * // in two seconds, open the root node
+ * qx.event.Timer.once(
+ *   function()
+ *   {
+ *     nodes.getItem(0).setOpened(true);
+ *   },
+ *   this,
+ *   2000);      
  * </pre>
  */
 qx.Class.define("qx.ui.tree.VirtualTree",

--- a/framework/source/class/qx/ui/tree/VirtualTree.js
+++ b/framework/source/class/qx/ui/tree/VirtualTree.js
@@ -329,6 +329,17 @@ qx.Class.define("qx.ui.tree.VirtualTree",
       apply: "_applyDelegate",
       init: null,
       nullable: true
+    },
+
+    /**
+     * For internal use for and by {@link qx.ui.tree.core.OpenCloseController}
+     * and {@link qx.ui.tree.provider.WidgetProvider} only.
+     */
+    openPropertyName :
+    {
+      check : "String",
+      nullable : true,
+      init : null
     }
   },
 

--- a/framework/source/class/qx/ui/tree/VirtualTreeItem.js
+++ b/framework/source/class/qx/ui/tree/VirtualTreeItem.js
@@ -91,6 +91,7 @@ qx.Class.define("qx.ui.tree.VirtualTreeItem",
     {
       var childProperty = this.getUserData("cell.childProperty");
       var showLeafs = this.getUserData("cell.showLeafs");
+      var openProperty = this.getUserData("cell.openProperty");
 
       if (value != null && qx.ui.tree.core.Util.isNode(value, childProperty))
       {
@@ -110,6 +111,18 @@ qx.Class.define("qx.ui.tree.VirtualTreeItem",
         }
       }
 
+      // If the OpenCloseController is in use, an openProperty will have been
+      // set. If so, and this item has that poperty, add a listener for it.
+      if (value != null &&
+          openProperty &&
+          qx.ui.tree.core.Util.isNode(value, openProperty))
+      {
+        var eventType = "change" + qx.lang.String.firstUp(openProperty);
+        // listen to children property changes
+        if (qx.Class.hasProperty(value.constructor, openProperty)) {
+          value.addListener(eventType, this._onChangeOpenProperty, this);
+        }
+      }
 
       if (old != null && qx.ui.tree.core.Util.isNode(old, childProperty))
       {
@@ -150,6 +163,26 @@ qx.Class.define("qx.ui.tree.VirtualTreeItem",
       if (old) {
         old.removeListener("changeLength", this._onChangeLength, this);
       }
+    },
+
+    /**
+     * Handler to issue model change to OpenCloseController
+     */
+    _onChangeOpenProperty : function(e)
+    {
+      var value = e.getData();
+      var model = e.getTarget();
+      var eventType = this.getUserData("cell.treeId") + ".open";
+      var messageBus = qx.event.message.Bus.getInstance();
+
+      // Dispatch this model change to all listeners for this tree's open
+      // property's model changes
+      messageBus.dispatchByName(
+        eventType,
+        {
+          item  : model,
+          value : value
+        });
     }
   }
 });

--- a/framework/source/class/qx/ui/tree/core/OpenCloseController.js
+++ b/framework/source/class/qx/ui/tree/core/OpenCloseController.js
@@ -26,6 +26,12 @@
  * 
  * To use this controller, simply instantiate it with the requisite
  * constructor arguments.
+ * 
+ * NOTE: This uses {@link qx.event.message.Bus} to send messages between tree
+ * items and this controller. The 'name' of the messages is created to be
+ * unique among trees. It uses the hash code of the tree, with ".open"
+ * appended to it. A message 'name' might therefore be something like
+ * "37422-0.open".
  */
 qx.Class.define("qx.ui.tree.core.OpenCloseController",
 {
@@ -51,7 +57,7 @@ qx.Class.define("qx.ui.tree.core.OpenCloseController",
     // If a property name was specified, use it instead of the default
     if (openPropertyName)
     {
-      this.setOpenPropertyName(openPropertyName);
+      tree.setOpenPropertyName(openPropertyName);
     }
     
     // Save the tree and initialize storage of listener IDs
@@ -60,7 +66,7 @@ qx.Class.define("qx.ui.tree.core.OpenCloseController",
     
     // Sync tree nodes
     var sync = function(node) {
-      var openPropertyName = this.getOpenPropertyName();
+      var openPropertyName = this._tree.getOpenPropertyName();
 
       if (qx.Class.hasProperty(node.constructor, "children")) {
         node.getChildren().forEach(sync);
@@ -82,8 +88,13 @@ qx.Class.define("qx.ui.tree.core.OpenCloseController",
     this._lids.push([tree, lid]);
     lid = tree.addListener("close", this._onClose, this);
     this._lids.push([tree, lid]);
-    lid = model.addListener("changeBubble", this._onChangeBubble, this);
-    this._lids.push([model, lid]);
+
+    // Await messages from VirtualTreeItem indicating a model change. (This is
+    // more efficient that requiring change bubbles for open changes on the
+    // model.)
+    var messageBus = qx.event.message.Bus.getInstance();
+    var eventType = tree.toHashCode() + ".open";
+    messageBus.subscribe(eventType, this._onBusMessage, this);
   },
   
   properties :
@@ -111,13 +122,19 @@ qx.Class.define("qx.ui.tree.core.OpenCloseController",
     // event listener for "open" on the tree
     _onOpen: function(ev)
     {
-      ev.getData().set(this.getOpenPropertyName(), true);
+      var model = ev.getData();
+      var openPropertyName = this._tree.getOpenPropertyName();
+
+      model.set(openPropertyName, true);
     },
     
     // event listener for "close" on the tree
     _onClose: function(ev)
     {
-      ev.getData().set(this.getOpenPropertyName(), false);
+      var model = ev.getData();
+      var openPropertyName = this._tree.getOpenPropertyName();
+
+      model.set(openPropertyName, false);
     },
     
     // event listener for model changes
@@ -138,6 +155,20 @@ qx.Class.define("qx.ui.tree.core.OpenCloseController",
         else if (!bubble.value && this._tree.isNodeOpen(bubble.item)) {
           this._tree.closeNode(bubble.item);
         }
+      }
+    },
+
+    // event listener for messages from VirtualTreeItems indicating that a
+    // model change is intended to cause a branch to open or close
+    _onBusMessage : function(busMessage)
+    {
+      var change = busMessage.getData();
+
+      if (change.value && !this._tree.isNodeOpen(change.item)) {
+        this._tree.openNode(change.item);
+      }
+      else if (!change.value && this._tree.isNodeOpen(change.item)) {
+        this._tree.closeNode(change.item);
       }
     }
   },

--- a/framework/source/class/qx/ui/tree/core/OpenCloseController.js
+++ b/framework/source/class/qx/ui/tree/core/OpenCloseController.js
@@ -1,0 +1,152 @@
+/* ************************************************************************
+
+   qooxdoo - the new era of web development
+
+   http://qooxdoo.org
+
+   Copyright:
+     2017 Cajus Pollmeier
+
+   License:
+     MIT: https://opensource.org/licenses/MIT
+     See the LICENSE file in the project's top-level directory for details.
+
+   Authors:
+     * Cajus Pollmeier
+     * Derrell Lipman
+
+************************************************************************ */
+
+/**
+ * Because of the virtual nature of the VirtualTree, and the fact that
+ * rendering occurs asynchronously, it is not a simple matter to bind a
+ * property in the model that will open or close branches in the
+ * tree. Instead, this controller listens to both the model and the tree, and
+ * synchronizes the openness of branches in the tree.
+ * 
+ * To use this controller, simply instantiate it with the requisite
+ * constructor arguments.
+ */
+qx.Class.define("qx.ui.tree.core.OpenCloseController",
+{
+  extend: qx.core.Object,
+  
+  /**
+   * @param tree {qx.ui.tree.VirtualTree}
+   *   The tree whose branch open or closed state is to be synchronized to a
+   *   model property.
+   * 
+   * @param model {qx.data.Array}
+   *   The model wherein a property is to be synchronized to the tree
+   *   branches' open or closed states
+   * 
+   * @param openPropertyName {String?"open"}
+   *   The name of the boolean property in the model which controls whether a
+   *   branch in the tree is open or closed. Defaults to "open".
+   */
+  construct: function(tree, model, openPropertyName)
+  {
+    this.base(arguments);
+    
+    // If a property name was specified, use it instead of the default
+    if (openPropertyName)
+    {
+      this.setOpenPropertyName(openPropertyName);
+    }
+    
+    // Save the tree and initialize storage of listener IDs
+    this._tree = tree;
+    this._lids = [];
+    
+    // Sync tree nodes
+    var sync = function(node) {
+      var openPropertyName = this.getOpenPropertyName();
+
+      if (qx.Class.hasProperty(node.constructor, "children")) {
+        node.getChildren().forEach(sync);
+      }
+      
+      if (qx.Class.hasProperty(node.constructor, openPropertyName)) {
+        if (node.get(openPropertyName)) {
+          tree.openNode(node);
+        }
+        else {
+          tree.closeNode(node);
+        }
+      }
+    }.bind(this);
+    sync(model.getItem(0));
+    
+    // Wire change listeners
+    var lid = tree.addListener("open", this._onOpen, this);
+    this._lids.push([tree, lid]);
+    lid = tree.addListener("close", this._onClose, this);
+    this._lids.push([tree, lid]);
+    lid = model.addListener("changeBubble", this._onChangeBubble, this);
+    this._lids.push([model, lid]);
+  },
+  
+  properties :
+  {
+    /**
+     * Name of the property whose value determines whether a branch is open or
+     * not
+     */
+    openPropertyName :
+    {
+      check : "String",
+      nullable : false,
+      init : "open"
+    }
+  },
+  
+  members:
+  {
+    /** The tree which is synced to the model */
+    _tree: null,
+
+    /** Listener IDs that we manage */
+    _lids: null,
+    
+    // event listener for "open" on the tree
+    _onOpen: function(ev)
+    {
+      ev.getData().set(this.getOpenPropertyName(), true);
+    },
+    
+    // event listener for "close" on the tree
+    _onClose: function(ev)
+    {
+      ev.getData().set(this.getOpenPropertyName(), false);
+    },
+    
+    // event listener for model changes
+    _onChangeBubble: function(ev)
+    {
+      var bubble = ev.getData();
+      var modelPropRe;
+
+      // generate a regular expression that identifies model changes that
+      // pertain to the open state of a branch in the tree.
+      modelPropRe = new RegExp("\\." + this.getOpenPropertyName() + "$");
+      
+      // open related? sync it back to the node item.
+      if (modelPropRe.test(bubble.name)) {
+        if (bubble.value && !this._tree.isNodeOpen(bubble.item)) {
+          this._tree.openNode(bubble.item);
+        }
+        else if (!bubble.value && this._tree.isNodeOpen(bubble.item)) {
+          this._tree.closeNode(bubble.item);
+        }
+      }
+    }
+  },
+  
+  destruct: function()
+  {
+    this._tree = null;
+    this._lids.forEach(function(data) {
+      data[0].removeListenerById(data[1]);
+    });
+  }
+});

--- a/framework/source/class/qx/ui/tree/provider/WidgetProvider.js
+++ b/framework/source/class/qx/ui/tree/provider/WidgetProvider.js
@@ -81,6 +81,8 @@ qx.Class.define("qx.ui.tree.provider.WidgetProvider",
       widget.addListener("changeOpen", this.__onOpenChanged, this);
       widget.setUserData("cell.childProperty", this.getChildProperty());
       widget.setUserData("cell.showLeafs", this._tree.isShowLeafs());
+      widget.setUserData("cell.openProperty", this._tree.getOpenPropertyName());
+      widget.setUserData("cell.treeId", this._tree.toHashCode());
 
       if(this._tree.getSelection().contains(item)) {
         this._styleSelectabled(widget);


### PR DESCRIPTION
This is an alternate implementation of #9395 which uses the message bus instead of change bubbles to communicate changes of the model pertaining to opening/closing branches. See #9395 for usage details.

I was able to avoid the downside described by @cajus, of the user having to provide a configureItem delegate. The message name is determined internally, and the open property name is communicated via a property of the tree, as set by the OpenCloseController.
