### PR TITLE
fix debounce function to always use the arguments from the latest cal…

### DIFF
--- a/framework/source/class/qx/test/util/Function.js
+++ b/framework/source/class/qx/test/util/Function.js
@@ -1,0 +1,60 @@
+/* ************************************************************************
+
+   qooxdoo - the new era of web development
+
+   http://qooxdoo.org
+
+   Copyright:
+     2007-2008 1&1 Internet AG, Germany, http://www.1und1.de
+
+   License:
+     MIT: https://opensource.org/licenses/MIT
+     See the LICENSE file in the project's top-level directory for details.
+
+   Authors:
+     * Fabian Jakobs (fjakobs)
+
+************************************************************************ */
+
+qx.Class.define("qx.test.util.Function",
+{
+  extend : qx.dev.unit.TestCase,
+  include: qx.dev.unit.MMock,
+
+  members :
+  {
+    testDebounce : function()
+    {
+      var test = this.stub();
+
+      var debouncedTest = qx.util.Function.debounce(test, 10);
+
+      debouncedTest(true);
+      this.assertNotCalled(test);
+      debouncedTest(false);
+      this.wait(50, function() {
+        this.assertCalledOnce(test);
+        this.assertCalledWith(test, false);
+      }, this);
+    },
+
+    testImmediateDebounce : function()
+    {
+      var test = this.stub();
+
+      var debouncedTest = qx.util.Function.debounce(test, 10, true);
+
+      debouncedTest(true);
+      this.assertCalled(test);
+      this.assertCalledWith(test, true);
+
+      debouncedTest(false);
+      debouncedTest(true);
+      debouncedTest(false);
+      this.wait(50, function() {
+        this.assertCalledTwice(test);
+        this.assertCalledWith(test, false);
+      }, this);
+    }
+  }
+});

--- a/framework/source/class/qx/util/Function.js
+++ b/framework/source/class/qx/util/Function.js
@@ -52,9 +52,10 @@ qx.Bootstrap.define("qx.util.Function", {
     debounce: function (callback, delay, immediate) {
       var fired = false;
       var intervalId = null;
+      var args = null;
       var wrapperFunction = function () {
         // store the current arguments to have access inside the interval method
-        var args = qx.lang.Array.fromArguments(arguments);
+        args = qx.lang.Array.fromArguments(arguments);
 
         // it's necessary to store the context to be able to call
         // the callback within the right scope


### PR DESCRIPTION
…l instead of the initial ones + test for that case.

The fix is simple, just move the `args` declaration outside of the wrapper function.

The `testDebounce` TestCase tests that behaviour, without the fix the debounced function would have been called with the initial `true`argument instead of the last calls `false` argument.