### PR TITLE
Enable size shortcut for font icons

### DIFF
--- a/documentation/manual/source/pages/development/icon_fonts.rst
+++ b/documentation/manual/source/pages/development/icon_fonts.rst
@@ -15,7 +15,14 @@ assign the font icon to virtual image names. If you for example include the
 
 	var image = new qx.ui.basic.Image('@Ligature/print');
 
-to show the 'print' symbol.
+to show the 'print' symbol. Additionally, you have a shortcut for a different size than
+the font's default size:
+
+::
+
+	var image = new qx.ui.basic.Image('@Ligature/print/16');
+
+The latter makes the icon 16px in size.
 
 This mechanism heavily depends on how good the font glyph names are maintained. In some
 cases (i.e. `Font Awesome <http://fontawesome.io/icons/>`_), the glyph information is either
@@ -24,7 +31,9 @@ address all the glyphs by their name/alias.
 
 The itegration is generic, so that it does not collide with the frameworks :doc:`appearance themes
 </pages/desktop/ui_theming>`. Font icons can be addressed using ``@FontName/GlyphName`` or
-``@FontName/HexUnicode`` in the source property of your ``qx.ui.basic.Image``.
+``@FontName/HexUnicode`` in the source property of your ``qx.ui.basic.Image``. To override the
+default size, you can also use ``@FontName/GlyphName/size`` or ``@FontName/HexUnicode/size`` to scale it
+to the given number of pixels.
 
 
 Defining an icon font

--- a/documentation/manual/source/pages/development/icon_fonts.rst
+++ b/documentation/manual/source/pages/development/icon_fonts.rst
@@ -29,7 +29,7 @@ cases (i.e. `Font Awesome <http://fontawesome.io/icons/>`_), the glyph informati
 incomplete or missing. You need to use a custom font map in this case to be able to
 address all the glyphs by their name/alias.
 
-The itegration is generic, so that it does not collide with the frameworks :doc:`appearance themes
+The integration is generic, so that it does not collide with the framework's :doc:`appearance themes
 </pages/desktop/ui_theming>`. Font icons can be addressed using ``@FontName/GlyphName`` or
 ``@FontName/HexUnicode`` in the source property of your ``qx.ui.basic.Image``. To override the
 default size, you can also use ``@FontName/GlyphName/size`` or ``@FontName/HexUnicode/size`` to scale it

--- a/framework/source/class/qx/test/ui/basic/Image.js
+++ b/framework/source/class/qx/test/ui/basic/Image.js
@@ -397,6 +397,15 @@ qx.Class.define("qx.test.ui.basic.Image",
 
       // Back to no scale
       image.setScale(false);
+      image.setWidth(40);
+      this.assertEquals("40px", el.getStyle("fontSize"));
+
+      // Set size via name postfix
+      image.setSource("@FontAwesome/heart/55");
+      this.assertEquals("55px", el.getStyle("fontSize"));
+
+      // Check revert to default size
+      image.setSource("@FontAwesome/heart");
       this.assertEquals("40px", el.getStyle("fontSize"));
 
       // Change content element

--- a/framework/source/class/qx/ui/basic/Image.js
+++ b/framework/source/class/qx/ui/basic/Image.js
@@ -753,6 +753,11 @@ qx.Class.define("qx.ui.basic.Image",
       if (isFont) {
         var size;
 
+        // Don't use scale if size is set via postfix
+        if (this.getScale() && parseInt(source.split("/")[2], 10)) {
+          this.setScale(false);
+        }
+
         // Adjust size if scaling is applied
         if (this.getScale()) {
           var width = this.getWidth() || this.getHeight() || 40;
@@ -764,7 +769,7 @@ qx.Class.define("qx.ui.basic.Image",
           if (qx.core.Environment.get("qx.debug")) {
             this.assertObject(font, "Virtual image source contains unkown font descriptor");
           }
-          size = font.getSize();
+          size = parseInt(source.split("/")[2] || font.getSize(), 10);
         }
 
         // Default to something definitively numeric if nothing set
@@ -898,6 +903,13 @@ qx.Class.define("qx.ui.basic.Image",
       var isFont = source && qx.lang.String.startsWith(source, "@");
 
       if (isFont) {
+        var sparts = source.split("/");
+        var fontSource = source;
+        if (sparts.length > 2) {
+          fontSource = sparts[0] + "/" + sparts[1];
+        }
+
+
         var ResourceManager = qx.util.ResourceManager.getInstance();
         var font = qx.theme.manager.Font.getInstance().resolve(source.match(/@([^/]+)/)[1]);
         var fontStyles = qx.lang.Object.clone(font.getStyles());
@@ -912,10 +924,11 @@ qx.Class.define("qx.ui.basic.Image",
           el.setStyle("fontSize", (this.__width > this.__height ? this.__height : this.__width) + "px");
         }
         else {
-          el.setStyle("fontSize", font.getSize() + "px");
+          var size = parseInt(sparts[2] || qx.theme.manager.Font.getInstance().resolve(source.match(/@([^/]+)/)[1]).getSize());
+          el.setStyle("fontSize", size + "px");
         }
 
-        var resource = ResourceManager.getData(source);
+        var resource = ResourceManager.getData(fontSource);
         if (resource) {
           el.setValue(String.fromCharCode(resource[2]));
         }


### PR DESCRIPTION
This PR enables size shortcuts for the source property when using icon fonts like this:
```
  var icon = new qx.ui.form.Button(this.tr("Home sweet home"), "@Ligature/home/22");
```