### PR TITLE
Add a controller for synchronizing model open property with VirtualTree state

### DIFF
--- a/framework/source/class/qx/test/ui/tree/virtual/OpenCloseController.js
+++ b/framework/source/class/qx/test/ui/tree/virtual/OpenCloseController.js
@@ -1,0 +1,257 @@
+/* ************************************************************************
+
+   qooxdoo - the new era of web development
+
+   http://qooxdoo.org
+
+   Copyright:
+     2017 Derrell Lipman
+
+   License:
+     MIT: https://opensource.org/licenses/MIT
+     See the LICENSE file in the project's top-level directory for details.
+
+   Authors:
+     * Derrell Lipman (derrell)
+
+************************************************************************ */
+
+qx.Class.define("qx.test.ui.tree.virtual.OpenCloseController",
+{
+  extend : qx.dev.unit.TestCase,
+  implement : qx.ui.tree.core.IVirtualTree,
+  include : qx.dev.unit.MMock,
+
+  events :
+  {
+    open : "qx.event.type.Data",
+    close : "qx.event.type.Data"
+  },
+
+  properties :
+  {
+    openProperty : {
+      check : "String",
+      init : null
+    }
+  },
+
+  members :
+  {
+    model : null,
+    controller : null,
+    nodesOpen : null,
+
+    setUp : function()
+    {
+      if (! this.spyOpenNode)
+      {
+        this.spyOpenNode = this.spy(this, "openNode");
+        this.spyCloseNode = this.spy(this, "closeNode");
+      }
+
+      var rawData = 
+      [
+        {
+          name : "Root",
+          open : false,
+          kids :
+          [
+            {
+              name : "Branch 1",
+              open : false,
+              kids :
+              [
+                {
+                  name : "Leaf 1.1"
+                },
+                {
+                  name : "Leaf 1.2"
+                },
+                {
+                  name : "Branch 1.3",
+                  open : false,
+                  kids :
+                  [
+                    {
+                      name : "Branch 1.3.1",
+                      open : false,
+                      kids :
+                      [
+                        {
+                          name : "Leaf 1.3.1.1"
+                        }
+                      ]
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        }
+      ];
+
+      this.model = qx.data.marshal.Json.createModel(rawData, true);
+      this.setOpenProperty("open");
+      this.controller =
+        new qx.ui.tree.core.OpenCloseController(this, this.model, "open");
+
+      this.nodesOpen = {};
+    },
+
+
+    tearDown : function()
+    {
+      this.controller.dispose();
+      this.controller = null;
+
+      this.model.dispose();
+      this.model = null;
+    },
+
+
+    testModelToTree : function()
+    {
+      var node;
+      var openNodeNames;
+
+      // Reset the spies
+      this.spyOpenNode.reset();
+      this.spyCloseNode.reset();
+
+      // get the Branch 1 node
+      node = this.model.getItem(0).getKids().getItem(0);
+
+      // open Branch 1
+      node.setOpen(true);
+
+      // openNode should have been called exactly once
+      this.assertCalledOnce(this.spyOpenNode);
+
+      // there should be only one node open
+      openNodeNames = Object.keys(this.nodesOpen);
+      this.assertEquals(openNodeNames.length, 1);
+
+      // the name of the open node should be "Branch 1"
+      this.assertEquals(openNodeNames[0], "Branch 1");
+
+      // close Branch 1
+      this.model.getItem(0).getKids().getItem(0).setOpen(false);
+
+      // closeNode should have been called exactly once
+      this.assertCalledOnce(this.spyCloseNode);
+
+      // there should be no nodes open
+      openNodeNames = Object.keys(this.nodesOpen);
+      this.assertEquals(openNodeNames.length, 0);
+    },
+
+
+    testTreeToModel : function()
+    {
+      var node;
+      var openNodeNames;
+
+      // Reset the spies
+      this.spyOpenNode.reset();
+      this.spyCloseNode.reset();
+
+      // get the Branch 1 node
+      node = this.model.getItem(0).getKids().getItem(0);
+
+      // send an open event to the controller as if the open button were clicked
+      this.fireDataEvent("open", node);
+
+      // openNode should have been called exactly once
+      this.assertCalledOnce(this.spyOpenNode);
+
+      // there should be only one node open
+      openNodeNames = Object.keys(this.nodesOpen);
+      this.assertEquals(openNodeNames.length, 1);
+
+      // the name of the open node should be "Branch 1"
+      this.assertEquals(openNodeNames[0], "Branch 1");
+
+      // the model value should now be true
+      this.assertTrue(node.getOpen())
+
+      // send a close event to the controller as if the open button were clicked
+      this.fireDataEvent("close", node);
+
+      // closeNode should have been called exactly once
+      this.assertCalledOnce(this.spyCloseNode);
+
+      // there should be no nodes open
+      openNodeNames = Object.keys(this.nodesOpen);
+      this.assertEquals(openNodeNames.length, 0);
+
+      // the model value should now be false
+      this.assertFalse(node.getOpen())
+    },
+
+
+    /*
+    ---------------------------------------------------------------------------
+      MOCK API
+    ---------------------------------------------------------------------------
+    */
+
+    isShowTopLevelOpenCloseIcons : function() {
+      return true;
+    },
+
+
+    isShowLeafs : function() {
+      return true;
+    },
+
+
+    getSelection : function()
+    {
+      throw new Error("getSelection called unexpectedly");
+    },
+
+
+    getLookupTable : function()
+    {
+      throw new Error("getLookupTable called unexpectedly");
+    },
+
+
+    isNode : function(item)
+    {
+      throw new Error("isNode called unexpectedly");
+    },
+
+
+    isNodeOpen : function(node)
+    {
+      return this.nodesOpen[node.getName()];
+    },
+
+
+    getLevel : function(row)
+    {
+      throw new Error("getLevel called unexpectedly");
+    },
+
+
+    hasChildren : function(node)
+    {
+      throw new Error("hasChildren called unexpectedly");
+    },
+
+    openNode : function(node)
+    {
+      this.nodesOpen[node.getName()] = true;
+    },
+    
+    closeNode : function(node)
+    {
+      delete this.nodesOpen[node.getName()];
+    },
+
+    openNodeWithoutScrolling : function(node) {},
+    closeNodeWithoutScrolling : function(node) {}
+  }
+});

--- a/framework/source/class/qx/test/ui/tree/virtual/WidgetProvider.js
+++ b/framework/source/class/qx/test/ui/tree/virtual/WidgetProvider.js
@@ -22,6 +22,14 @@ qx.Class.define("qx.test.ui.tree.virtual.WidgetProvider",
   implement : qx.ui.tree.core.IVirtualTree,
   include : qx.dev.unit.MMock,
 
+  properties :
+  {
+    openProperty : {
+      check : "String",
+      init : null
+    }
+  },
+
   members :
   {
     model : null,

--- a/framework/source/class/qx/ui/tree/VirtualTree.js
+++ b/framework/source/class/qx/ui/tree/VirtualTree.js
@@ -787,8 +787,6 @@ qx.Class.define("qx.ui.tree.VirtualTree",
     // property apply
     _applyModel : function(value, old)
     {
-      var openProperty;
-
       this.__openNodes = [];
 
       if (value != null)

--- a/framework/source/class/qx/ui/tree/VirtualTree.js
+++ b/framework/source/class/qx/ui/tree/VirtualTree.js
@@ -148,14 +148,14 @@ qx.Class.define("qx.ui.tree.VirtualTree",
    * @param childProperty {String?null} The name of the child property, for
    *   more details have a look at the 'childProperty' property.
    * @param openProperty {String|null} the name of the model property which
-   *   represents the open state of a branch.
-   * @param fullModel {qx.data.Array}?
+   *   represents the open state of a branch. If this value is provided, so, 
+   *   too, must be fullModel.
+   * @param fullModel {qx.data.Array?}
    *   The model which represents the tree. This is not the same value as
    *   rootModel. rootModel is the model of the root item of the tree. What's
    *   required here is the full data array which is the model of the whole
    *   tree. Often, rootItem provided as model.getItem(0), where as fullModel
    *   would be provided as model.
-
    */
   construct : function(
     rootModel, labelPath, childProperty, openProperty, fullModel)

--- a/framework/source/class/qx/ui/tree/VirtualTree.js
+++ b/framework/source/class/qx/ui/tree/VirtualTree.js
@@ -16,7 +16,7 @@
 
 ************************************************************************ */
 
-/**
+/*
  * Virtual tree implementation.
  *
  * The virtual tree can be used to render node and leafs. Nodes and leafs are
@@ -26,40 +26,108 @@
  * With the {@link qx.ui.tree.core.IVirtualTreeDelegate} interface it is possible
  * to configure the tree's behavior (item renderer configuration, etc.).
  *
- * Here's an example of how to use the widget:
+ * Here's an example of how to use the widget, including using a model
+ * property to open/close branches. See the two timers at the end. The first
+ * one opens all branches after two seconds; the second cleans up the tree
+ * after five seconds.
+ *
  * <pre class="javascript">
- * //create the model data
- * var nodes = [];
- * for (var i = 0; i < 2500; i++)
- * {
- *   nodes[i] = {name : "Item " + i};
- *
- *   // if its not the root node
- *   if (i !== 0)
- *   {
- *     // add the children in some random order
- *     var node = nodes[parseInt(Math.random() * i)];
- *
- *     if(node.children == null) {
- *       node.children = [];
+ *   var nodes = 
+ *   [
+ *     {
+ *       name : "Root",
+ *       open : false,
+ *       children :
+ *       [
+ *         {
+ *           name : "Branch 1",
+ *           open : false,
+ *           children :
+ *           [
+ *             {
+ *               name : "Leaf 1.1"
+ *             },
+ *             {
+ *               name : "Leaf 1.2"
+ *             },
+ *             {
+ *               name : "Branch 1.3",
+ *               open : false,
+ *               children :
+ *               [
+ *                 {
+ *                   name : "Branch 1.3.1",
+ *                   open : false,
+ *                   children :
+ *                   [
+ *                     {
+ *                       name : "Leaf 1.3.1.1"
+ *                     }
+ *                   ]
+ *                 }
+ *               ]
+ *             }
+ *           ]
+ *         }
+ *       ]
  *     }
- *     node.children.push(nodes[i]);
- *   }
- * }
+ *   ];
  *
- * // converts the raw nodes to qooxdoo objects
- * nodes = qx.data.marshal.Json.createModel(nodes, true);
+ *   // convert the raw nodes to qooxdoo objects
+ *   nodes = qx.data.marshal.Json.createModel(nodes, true);
  *
- * // creates the tree
- * var tree = new qx.ui.tree.VirtualTree(nodes.getItem(0), "name", "children").set({
- *   width : 200,
- *   height : 400
- * });
+ *   // create the tree and synchronize the model property 'open'
+ *   // to nodes being open
+ *   var tree =
+ *     new qx.ui.tree.VirtualTree(
+ *       nodes.getItem(0), "name", "children", "open", nodes).set({
+ *         width : 200,
+ *         height : 400
+ *       });
  *
- * //log selection changes
- * tree.getSelection().addListener("change", function(e) {
- *   this.debug("Selection: " + tree.getSelection().getItem(0).getName());
- * }, this);
+ *   //log selection changes
+ *   tree.getSelection().addListener("change", function(e) {
+ *     this.debug("Selection: " + tree.getSelection().getItem(0).getName());
+ *   }, this);
+ *
+ *   tree.set(
+ *     {
+ *       width : 200,
+ *       height : 400,
+ *       showTopLevelOpenCloseIcons : true
+ *     });
+ *
+ *   var doc = this.getRoot();
+ *   doc.add(tree,
+ *   {
+ *     left : 100,
+ *     top  : 50
+ *   });
+ *
+ *   // After two seconds, open up all branches by setting their open
+ *   // property to true.
+ *   qx.event.Timer.once(
+ *     function()
+ *     {
+ *       ;(function allOpen(root)
+ *         {
+ *           if (root.setOpen)     root.setOpen(true);
+ *           if (root.getChildren) root.getChildren().forEach(allOpen);
+ *         })(nodes.getItem(0));
+ *     },
+ *     this,
+ *     2000);
+ *
+ *   // After five seconds, remove and dispose the tree.
+ *   qx.event.Timer.once(
+ *     function()
+ *     {
+ *       doc.remove(tree);
+ *       tree.dispose();
+ *       console.warn("All cleaned up.");
+ *     },
+ *     this,
+ *     5000);
  * </pre>
  */
 qx.Class.define("qx.ui.tree.VirtualTree",
@@ -72,14 +140,25 @@ qx.Class.define("qx.ui.tree.VirtualTree",
   ],
 
   /**
-   * @param model {qx.core.Object?null} The model structure for the tree, for
-   *   more details have a look at the 'model' property.
+   * @param rootModel {qx.core.Object?null} The model structure representing
+   *   the root of the tree, for more details have a look at the 'model'
+   *   property.
    * @param labelPath {String?null} The name of the label property, for more
    *   details have a look at the 'labelPath' property.
    * @param childProperty {String?null} The name of the child property, for
    *   more details have a look at the 'childProperty' property.
+   * @param openProperty {String|null} the name of the model property which
+   *   represents the open state of a branch.
+   * @param fullModel {qx.data.Array}?
+   *   The model which represents the tree. This is not the same value as
+   *   rootModel. rootModel is the model of the root item of the tree. What's
+   *   required here is the full data array which is the model of the whole
+   *   tree. Often, rootItem provided as model.getItem(0), where as fullModel
+   *   would be provided as model.
+
    */
-  construct : function(model, labelPath, childProperty)
+  construct : function(
+    rootModel, labelPath, childProperty, openProperty, fullModel)
   {
     this.base(arguments, 0, 1, 20, 100);
 
@@ -93,14 +172,20 @@ qx.Class.define("qx.ui.tree.VirtualTree",
       this.setChildProperty(childProperty);
     }
 
-    if(model != null) {
-      this.initModel(model);
+    if(rootModel != null) {
+      this.initModel(rootModel);
     }
 
     this.initItemHeight();
     this.initOpenMode();
 
     this.addListener("keypress", this._onKeyPress, this);
+
+    // If an open property and full model are provided, start up the
+    // open-close controller.
+    if (openProperty && fullModel) {
+      this.openViaModelChanges(openProperty, fullModel);
+    }
   },
 
   events :
@@ -162,7 +247,7 @@ qx.Class.define("qx.ui.tree.VirtualTree",
     },
 
 
-    /**
+     /**
      * Control whether tap or double tap should open or close the tapped
      * item.
      */
@@ -175,7 +260,7 @@ qx.Class.define("qx.ui.tree.VirtualTree",
       themeable: true
     },
 
-
+    
     /**
      * Hides *only* the root node, not the node's children when the property is
      * set to <code>true</code>.
@@ -342,6 +427,11 @@ qx.Class.define("qx.ui.tree.VirtualTree",
     /** @type {Array} internal parent chain form the last selected node */
     __parentChain : null,
 
+    /** 
+     * @type {String|null} the name of the model property which represents the
+     *   open state of a branch.
+     */
+    __openProperty : null,
 
     /*
     ---------------------------------------------------------------------------
@@ -441,6 +531,50 @@ qx.Class.define("qx.ui.tree.VirtualTree",
     // Interface implementation
     isNodeOpen : function(node) {
       return qx.lang.Array.contains(this.__openNodes, node);
+    },
+
+
+    /**
+     * Open and close branches via changes to a property in the model.
+     * 
+     * @param openProperty {String|null} 
+     *   The name of the open property, which determines the open state of a
+     *   branch in the tree. If null, turn off opening and closing branches
+     *   via changes to the model.
+     * 
+     * @param fullModel {qx.data.Array?}
+     *   The model which represents the tree. (Note that this is not the same
+     *   value which was passed to the constructor or to setModel(). That is
+     *   the model of the root item of the tree. What's required here is the
+     *   full data array which is the model of the whole tree.) If
+     *   openProperty is non-null, this model must be provided.
+     */
+    openViaModelChanges : function(openProperty, fullModel) {
+      // Save the open property
+      this.__openProperty = openProperty;
+
+      // if no name is provided, just remove any prior open-close controller
+      if (! openProperty) {
+        if (this._openCloseController) {
+          this._openCloseController.dispose();
+          this._openCloseController = null;
+        }
+
+        return;
+      }
+
+      // we have a property name, so create controller
+      this._openCloseController =
+        new qx.ui.tree.core.OpenCloseController(this, fullModel, openProperty);
+    },
+
+
+    /**
+     * Getter for the open property
+     */
+    getOpenProperty : function()
+    {
+      return this.__openProperty;
     },
 
 
@@ -653,6 +787,8 @@ qx.Class.define("qx.ui.tree.VirtualTree",
     // property apply
     _applyModel : function(value, old)
     {
+      var openProperty;
+
       this.__openNodes = [];
 
       if (value != null)
@@ -669,6 +805,13 @@ qx.Class.define("qx.ui.tree.VirtualTree",
         }
         value.addListener("changeBubble", this._onChangeBubble, this);
         this.__openNode(value);
+      }
+
+      // If the model changes, an existing OpenCloseController is no longer
+      // valid, so dispose it. The user should call openViaModelChanges again.
+      if (this._openCloseController) {
+        this._openCloseController.dispose();
+        this._openCloseController = null;
       }
 
       if (old != null) {
@@ -1158,6 +1301,10 @@ qx.Class.define("qx.ui.tree.VirtualTree",
 
   destruct : function()
   {
+    if (this._openCloseController) {
+      this._openCloseController.dispose();
+    }
+
     var pane = this.getPane();
     if (pane != null)
     {

--- a/framework/source/class/qx/ui/tree/core/OpenCloseController.js
+++ b/framework/source/class/qx/ui/tree/core/OpenCloseController.js
@@ -1,0 +1,128 @@
+/* ************************************************************************
+
+   qooxdoo - the new era of web development
+
+   http://qooxdoo.org
+
+   Copyright:
+     2017 Cajus Pollmeier
+
+   License:
+     MIT: https://opensource.org/licenses/MIT
+     See the LICENSE file in the project's top-level directory for details.
+
+   Authors:
+     * Cajus Pollmeier
+     * Derrell Lipman
+
+************************************************************************ */
+
+/**
+ * Because of the virtual nature of the VirtualTree, and the fact that
+ * rendering occurs asynchronously, it is not a simple matter to bind a
+ * property in the model that will open or close branches in the
+ * tree. Instead, this controller listens to both the model and the tree, and
+ * synchronizes the openness of branches in the tree.
+ * 
+ * To use this controller, simply instantiate it with the requisite
+ * constructor arguments.
+ */
+qx.Class.define("qx.ui.tree.core.OpenCloseController",
+{
+  extend: qx.core.Object,
+  
+  /**
+   * @param tree {qx.ui.tree.VirtualTree}
+   *   The tree whose branch open or closed state is to be synchronized to a
+   *   model property.
+   * 
+   * @param rootModel {qx.data.Array}
+   *   The tree root model wherein a property is to be synchronized to the
+   *   tree branches' open or closed states
+   */
+  construct: function(tree, rootModel)
+  {
+    var             openProperty = tree.getOpenProperty();
+
+    this.base(arguments);
+    
+    // Save the tree and initialize storage of listener IDs
+    this._tree = tree;
+    this._lids = [];
+    
+    // Sync tree nodes
+    var sync = function(node) {
+      if (qx.Class.hasProperty(node.constructor, "children")) {
+        node.getChildren().forEach(sync);
+      }
+      
+      if (qx.Class.hasProperty(node.constructor, openProperty)) {
+        if (node.get(openProperty)) {
+          tree.openNode(node);
+        }
+        else {
+          tree.closeNode(node);
+        }
+      }
+    }.bind(this);
+    sync(rootModel);
+    
+    // Wire change listeners
+    var lid = tree.addListener("open", this._onOpen, this);
+    this._lids.push([tree, lid]);
+    lid = tree.addListener("close", this._onClose, this);
+    this._lids.push([tree, lid]);
+    lid = rootModel.addListener("changeBubble", this._onChangeBubble, this);
+    this._lids.push([rootModel, lid]);
+  },
+  
+  members:
+  {
+    /** The tree which is synced to the model */
+    _tree: null,
+
+    /** Listener IDs that we manage */
+    _lids: null,
+    
+    // event listener for "open" on the tree
+    _onOpen: function(ev)
+    {
+      ev.getData().set(this._tree.getOpenProperty(), true);
+    },
+    
+    // event listener for "close" on the tree
+    _onClose: function(ev)
+    {
+      ev.getData().set(this._tree.getOpenProperty(), false);
+    },
+    
+    // event listener for model changes
+    _onChangeBubble: function(ev)
+    {
+      var bubble = ev.getData();
+      var modelPropRe;
+
+      // generate a regular expression that identifies model changes that
+      // pertain to the open state of a branch in the tree.
+      modelPropRe = new RegExp("\\." + this._tree.getOpenProperty() + "$");
+      
+      // open related? sync it back to the node item.
+      if (modelPropRe.test(bubble.name)) {
+        if (bubble.value && !this._tree.isNodeOpen(bubble.item)) {
+          this._tree.openNode(bubble.item);
+        }
+        else if (!bubble.value && this._tree.isNodeOpen(bubble.item)) {
+          this._tree.closeNode(bubble.item);
+        }
+      }
+    }
+  },
+  
+  destruct: function()
+  {
+    this._tree = null;
+    this._lids.forEach(function(data) {
+      data[0].removeListenerById(data[1]);
+    });
+  }
+});

--- a/framework/source/class/qx/ui/tree/provider/WidgetProvider.js
+++ b/framework/source/class/qx/ui/tree/provider/WidgetProvider.js
@@ -82,9 +82,6 @@ qx.Class.define("qx.ui.tree.provider.WidgetProvider",
       widget.setUserData("cell.childProperty", this.getChildProperty());
       widget.setUserData("cell.showLeafs", this._tree.isShowLeafs());
 
-      var openProperty = this._tree.getOpenProperty();
-      widget.setUserData("cell.openProperty", openProperty);
-
       if(this._tree.getSelection().contains(item)) {
         this._styleSelectabled(widget);
       } else {
@@ -103,7 +100,7 @@ qx.Class.define("qx.ui.tree.provider.WidgetProvider",
         widget.setOpenSymbolMode("auto");
       }
 
-      if (openProperty) {
+      if (this._tree.getOpenProperty()) {
         widget.setModel(item);
       }
 

--- a/framework/source/class/qx/ui/tree/provider/WidgetProvider.js
+++ b/framework/source/class/qx/ui/tree/provider/WidgetProvider.js
@@ -82,6 +82,9 @@ qx.Class.define("qx.ui.tree.provider.WidgetProvider",
       widget.setUserData("cell.childProperty", this.getChildProperty());
       widget.setUserData("cell.showLeafs", this._tree.isShowLeafs());
 
+      var openProperty = this._tree.getOpenProperty();
+      widget.setUserData("cell.openProperty", openProperty);
+
       if(this._tree.getSelection().contains(item)) {
         this._styleSelectabled(widget);
       } else {
@@ -98,6 +101,10 @@ qx.Class.define("qx.ui.tree.provider.WidgetProvider",
         widget.setOpenSymbolMode("never");
       } else {
         widget.setOpenSymbolMode("auto");
+      }
+
+      if (openProperty) {
+        widget.setModel(item);
       }
 
       this._bindItem(widget, row);


### PR DESCRIPTION
See #9395 (and #9396) for the history of this PR. #9395 became a mess following a merge from upstream. This version fixes the WidgetProvider test that required a new mock, and adds tests for OpenCloseController.
