### PR TITLE
Replace qx.lang.Object.getValues() by Object.values()

### DIFF
--- a/framework/source/class/qx/bom/client/EcmaScript.js
+++ b/framework/source/class/qx/bom/client/EcmaScript.js
@@ -220,6 +220,14 @@ qx.Bootstrap.define("qx.bom.client.EcmaScript",
       return !!Object.keys;
     },
 
+    /**
+     * Checks if 'values' is supported on the Object object.
+     * @internal
+     * @return {Boolean} <code>true</code>, if the method is available.
+     */
+    getObjectValues : function() {
+      return !!Object.values;
+    },
 
     /**
      * Checks if 'now' is supported on the Date object.
@@ -314,6 +322,7 @@ qx.Bootstrap.define("qx.bom.client.EcmaScript",
 
     // object polyfill
     qx.core.Environment.add("ecmascript.object.keys", statics.getObjectKeys);
+    qx.core.Environment.add("ecmascript.object.values", statics.getObjectValues);
 
     // string polyfill
     qx.core.Environment.add("ecmascript.string.startsWith", statics.getStringStartsWith);

--- a/framework/source/class/qx/dev/Profile.js
+++ b/framework/source/class/qx/dev/Profile.js
@@ -137,7 +137,7 @@ qx.Bootstrap.define("qx.dev.Profile",
       this.stop();
       this.normalizeProfileData();
 
-      var data = qx.lang.Object.getValues(this.__profileData);
+      var data = Object.values(this.__profileData);
       data = data.sort(function(a,b) {
         return a.calibratedOwnTime<b.calibratedOwnTime ? 1: -1;
       });

--- a/framework/source/class/qx/lang/Object.js
+++ b/framework/source/class/qx/lang/Object.js
@@ -95,23 +95,14 @@ qx.Bootstrap.define("qx.lang.Object",
     /**
      * Get the values of a map as array
      *
+     * @deprecated {6.0} Please use Object instance values method instead
+     *
      * @param map {Object} the map
      * @return {Array} array of the values of the map
      */
     getValues : function(map)
     {
-      if (qx.core.Environment.get("qx.debug")) {
-        qx.core.Assert && qx.core.Assert.assertMap(map, "Invalid argument 'map'");
-      }
-
-      var arr = [];
-      var keys = Object.keys(map);
-
-      for (var i=0, l=keys.length; i<l; i++) {
-        arr.push(map[keys[i]]);
-      }
-
-      return arr;
+      return Object.values(map); 
     },
 
 

--- a/framework/source/class/qx/lang/normalize/Object.js
+++ b/framework/source/class/qx/lang/normalize/Object.js
@@ -37,13 +37,39 @@ qx.Bootstrap.define("qx.lang.normalize.Object", {
      * @param map {Object} the map
      * @return {Array} array of the keys of the map
      */
-    keys : qx.Bootstrap.keys
+    keys : qx.Bootstrap.keys,
+
+    /**
+     * Get the values of a map as array
+     *
+     * @param map {Object} the map
+     * @return {Array} array of the values of the map
+     */
+    values : function(map) {
+      if (qx.core.Environment.get("qx.debug")) {
+        qx.core.Assert && qx.core.Assert.assertMap(map, "Invalid argument 'map'");
+      }
+
+      var arr = [];
+      var keys = Object.keys(map);
+
+      for (var i=0, l=keys.length; i<l; i++) {
+        arr.push(map[keys[i]]);
+      }
+
+      return arr;
+    }
   },
 
   defer : function(statics) {
     // keys
     if (!qx.core.Environment.get("ecmascript.object.keys")) {
       Object.keys = statics.keys;
+    }
+
+    // values
+    if (!qx.core.Environment.get("ecmascript.object.values")) {
+      Object.values = statics.values;
     }
   }
 });

--- a/framework/source/class/qx/test/lang/normalize/Object.js
+++ b/framework/source/class/qx/test/lang/normalize/Object.js
@@ -68,6 +68,37 @@ qx.Class.define("qx.test.lang.normalize.Object",
       this.assertTrue(qx.lang.Array.contains(keys, "valueOf"), "Test valueOf");
       this.assertTrue(qx.lang.Array.contains(keys, "constructor"), "Test constructor");
       this.assertTrue(qx.lang.Array.contains(keys, "prototype"), "Test prototype");
+    },
+
+    testGetValues : function()
+    {
+      var object = {
+        a: undefined,
+        b: null,
+        c: 1
+      };
+      this.assertArrayEquals(
+        [undefined, null, 1].sort(),
+        Object.values(object).sort()
+      );
+
+      var object = {};
+      this.assertArrayEquals(
+        [],
+        Object.values(object)
+      );
+
+      var object = {
+        "isPrototypeOf": 1,
+        "hasOwnProperty": 2,
+        "toLocaleString": 3,
+        "toString": 4,
+        "valueOf": 5
+      };
+      this.assertArrayEquals(
+        [1, 2, 3, 4, 5].sort(),
+        Object.values(object).sort()
+      );
     }
   }
 });

--- a/framework/source/class/qx/ui/core/selection/Abstract.js
+++ b/framework/source/class/qx/ui/core/selection/Abstract.js
@@ -381,7 +381,7 @@ qx.Class.define("qx.ui.core.selection.Abstract",
      * @return {Object[]} List of items.
      */
     getSelection : function() {
-      return qx.lang.Object.getValues(this.__selection);
+      return Object.values(this.__selection);
     },
 
 
@@ -394,7 +394,7 @@ qx.Class.define("qx.ui.core.selection.Abstract",
     getSortedSelection : function()
     {
       var children = this.getSelectables();
-      var sel = qx.lang.Object.getValues(this.__selection);
+      var sel = Object.values(this.__selection);
 
       sel.sort(function(a, b) {
         return children.indexOf(a) - children.indexOf(b);

--- a/framework/source/class/qx/ui/virtual/cell/Cell.js
+++ b/framework/source/class/qx/ui/virtual/cell/Cell.js
@@ -487,7 +487,7 @@ qx.Class.define("qx.ui.virtual.cell.Cell",
      */
     __computeCssClassForStates : function()
     {
-      var styleString = qx.lang.Object.getValues(this.__themeStyles).join(";");
+      var styleString = Object.values(this.__themeStyles).join(";");
       this.__stylesheet.computeClassForStyles(this.__statesKey, styleString);
     },
 
@@ -528,7 +528,7 @@ qx.Class.define("qx.ui.virtual.cell.Cell",
 
     // overridden
     getStyles: function(value, states) {
-      return qx.lang.Object.getValues(this.__userStyles).join(";");
+      return Object.values(this.__userStyles).join(";");
     },
 
 

--- a/framework/source/class/qx/ui/virtual/layer/CellSpanManager.js
+++ b/framework/source/class/qx/ui/virtual/layer/CellSpanManager.js
@@ -119,7 +119,7 @@ qx.Class.define("qx.ui.virtual.layer.CellSpanManager",
       if (this._sorted[key]) {
         return this._sorted[key];
       }
-      var sorted = this._sorted[key] = qx.lang.Object.getValues(this._cells);
+      var sorted = this._sorted[key] = Object.values(this._cells);
       sorted.sort(function(a, b) {
         return a[key] < b[key] ? -1 : 1;
       });


### PR DESCRIPTION
There's a native `Object.values()` now in modern browsers, so I'd install a polyfill for that and deprecate the use of `qx.lang.Object.getValues()`.