### PR TITLE
fix warning " Unresolved use of symbol _wrap.$$original" with new qxcompiler

### DIFF
--- a/framework/source/class/qx/Class.js
+++ b/framework/source/class/qx/Class.js
@@ -1745,7 +1745,7 @@ qx.Bootstrap.define("qx.Class",
      */
     __wrapConstructor : function(construct, name, type)
     {
-      var wrapper = function()
+      var wrapper = function wrapFunc()
       {
         var clazz = wrapper;
 


### PR DESCRIPTION
With the new qxcompiler we get an error message:

 qx.Class: [1803,8] Unresolved use of symbol _wrap.$$original

The compiler transpiled the wrapper function into a named function wrapper and changed the variable wrapper to _wrapper.
In this solution i named the wrapper function so that the compiler did not change the names.