### PR TITLE
Explicit default for enabled property of qx.event.Timer 

### DIFF
--- a/framework/source/class/qx/event/Timer.js
+++ b/framework/source/class/qx/event/Timer.js
@@ -49,8 +49,6 @@ qx.Class.define("qx.event.Timer",
   {
     this.base(arguments);
 
-    this.setEnabled(false);
-
     if (interval != null) {
       this.setInterval(interval);
     }
@@ -153,7 +151,7 @@ qx.Class.define("qx.event.Timer",
      */
     enabled :
     {
-      init : true,
+      init : false,
       check : "Boolean",
       apply : "_applyEnabled"
     },

--- a/framework/source/class/qx/test/event/Timer.js
+++ b/framework/source/class/qx/test/event/Timer.js
@@ -38,6 +38,69 @@ qx.Class.define("qx.test.event.Timer",
 
       qx.event.Timer.once(fail, this, 0);
       this.wait(100);
+    },
+
+
+    /**
+     * Test if timer can be started and stopped.
+     */
+    testStartStop : function()
+    {
+      var runCount = 0;
+
+      var timer = new qx.event.Timer(50);
+      timer.addListener('interval', function() {
+        runCount++;
+        if (runCount === 2) {
+          timer.stop();
+        }
+      })
+      timer.start();
+
+      // 250ms should be sufficient for exactly two runs of an 50ms timer. We
+      // don't want to use a shorter interval, because cancellation of the timer
+      // via stop() could then become unreliable (timer could fire a third time)
+      this.wait(250, function() {
+          this.assertFalse(runCount === 0, 'Timer did not fire interval event');
+          this.assertFalse(runCount === 1, 'Timer did not fire interval event repeatedly, fired only once');
+          this.assertIdentical(2, runCount, 'Timer fired more interval events than expected (could not be stopped after second run)');
+        }.bind(this));
+    },
+
+
+    /**
+     * Test if newly created timers don't start by default.
+     */
+    testNoStartByDefault : function()
+    {
+      var runCount = 0;
+
+      var timer = new qx.event.Timer(1);
+      timer.addListener('interval', function() {
+        runCount++;
+      });
+
+      this.wait(250, function() { // 250ms should be sufficient to detect an (unwanted) start of an 1ms timer
+        this.assertIdentical(0, runCount, 'New timer did fire interval event without explicitly being started by calling start() or by setting enabled property to true');
+      }.bind(this));
+    },
+
+
+    /**
+     * Timer using static method once() should start automatically and fire
+     * exactly a single time.
+     */
+    testStaticOnce : function()
+    {
+      var runCount = 0;
+
+      qx.event.Timer.once(function() {
+        runCount++;
+      }, this, 1)
+
+      this.wait(250, function() {
+          this.assertIdentical(1, runCount, 'Static method once() is expected to start automatically and to run exactly once');
+        }.bind(this));
     }
   }
 });


### PR DESCRIPTION
See discussion in #9407 

- 'enabled' property: made implicit default of 'true' (set in constructor) explicit via property definition.
- add some unit tests for qx.event.Timer

