### PR TITLE
revert 7e40ccb. It brings in qx.bom.Selector which disallows non-GUI use

### DIFF
--- a/framework/source/class/qx/util/ResourceManager.js
+++ b/framework/source/class/qx/util/ResourceManager.js
@@ -71,7 +71,7 @@ qx.Class.define("qx.util.ResourceManager",
       if(!registry) {
         return null;
       }
- 
+  
       var ids = [];
       for (var id in registry) {
         if (registry.hasOwnProperty(id)) {
@@ -81,7 +81,7 @@ qx.Class.define("qx.util.ResourceManager",
           ids.push(id);
         }
       }
- 
+  
       return ids;
     },
 
@@ -283,13 +283,6 @@ qx.Class.define("qx.util.ResourceManager",
             continue;
           }
 
-          var href;
-          //first check if there is base url set
-          var baseElements = qx.bom.Selector.query("base", document);
-          if (baseElements.length > 0) {
-            href = baseElements[0].href;
-          }
-
           // It is valid to to begin a URL with "//" so this case has to
           // be considered. If the to resolved URL begins with "//" the
           // manager prefixes it with "https:" to avoid any problems for IE
@@ -298,16 +291,8 @@ qx.Class.define("qx.util.ResourceManager",
           }
           // If the resourceUri begins with a single slash, include the current
           // hostname
-          else if (resourceUri.match(/^\//) != null)
-          {
-            if (href)
-            {
-              statics.__urlPrefix[lib] = href;
-            }
-            else
-            {
-              statics.__urlPrefix[lib] = window.location.protocol + "//" + window.location.host;
-            }
+          else if (resourceUri.match(/^\//) != null) {
+            statics.__urlPrefix[lib] = window.location.protocol + "//" + window.location.host;
           }
           // If the resolved URL begins with "./" the final URL has to be
           // put together using the document.URL property.
@@ -322,19 +307,13 @@ qx.Class.define("qx.util.ResourceManager",
           }
           else
           {
-            if (!href)
-            {
-              // check for parameters with URLs as value
-              var index = window.location.href.indexOf("?");
-
-              if (index == -1)
-              {
-                href = window.location.href;
-              }
-              else
-              {
-                href = window.location.href.substring(0, index);
-              }
+            // check for parameters with URLs as value
+            var index = window.location.href.indexOf("?");
+            var href;
+            if (index == -1) {
+              href = window.location.href;
+            } else {
+              href = window.location.href.substring(0, index);
             }
 
             statics.__urlPrefix[lib] = href.substring(0, href.lastIndexOf("/") + 1);


### PR DESCRIPTION
I've reopened #9353 because the commit is not backward compatible and prevents non-GUI code from using the ResourceManager. This reverts 7e40ccb to allow non-GUI use, and we need to find a different way of solving the IE problem that #9353 was intending to solve.