### PR TITLE
Remove use of qx.bom.Selector in qx.util.ResourceManager

### DIFF
--- a/framework/source/class/qx/util/ResourceManager.js
+++ b/framework/source/class/qx/util/ResourceManager.js
@@ -285,9 +285,10 @@ qx.Class.define("qx.util.ResourceManager",
 
           var href;
           //first check if there is base url set
-          var baseElements = qx.bom.Selector.query("base", document);
-          if (baseElements.length > 0) {
-            href = baseElements[0].href;
+          if (typeof window == "object" &&
+              window.document &&
+              window.document.getElementsByTagName("base").length > 0) {
+            href = window.document.getElementsByTagName("base"[0]).href;
           }
 
           // It is valid to to begin a URL with "//" so this case has to


### PR DESCRIPTION
ResourceManager is used in non-GUI code. qx.bom.Selector
brings in the Sizzle library, which does a whole bunch of
initialization that requires a GUI environment (expects
'document' to exist).

This patch replaces the use of qx.bom.Selector with explicit
tests for existence of 'window' and 'window.document' and
use of the element API.