### PR TITLE
Avoid usage of qx.bom.Selector by replacing it with native document.getElementsByTagName

### DIFF
--- a/framework/source/class/qx/util/ResourceManager.js
+++ b/framework/source/class/qx/util/ResourceManager.js
@@ -285,7 +285,7 @@ qx.Class.define("qx.util.ResourceManager",
 
           var href;
           //first check if there is base url set
-          var baseElements = qx.bom.Selector.query("base", document);
+          var baseElements = document.getElementsByTagName("base");
           if (baseElements.length > 0) {
             href = baseElements[0].href;
           }


### PR DESCRIPTION
This avoids gui dependencies in non gui runtime environments