### PR TITLE
Fix tree open-close controller to handle / properly render model changes with 'open' via push()

### DIFF
--- a/framework/source/class/qx/test/ui/tree/virtual/OpenCloseController.js
+++ b/framework/source/class/qx/test/ui/tree/virtual/OpenCloseController.js
@@ -92,11 +92,36 @@ qx.Class.define("qx.test.ui.tree.virtual.OpenCloseController",
       ];
 
       this.model = qx.data.marshal.Json.createModel(rawData, true);
-      this.setOpenProperty("open");
-      this.controller =
-        new qx.ui.tree.core.OpenCloseController(this, this.model, "open");
+
+      // Ensure that pushing onto the model works as well
+      var parentItem = qx.data.marshal.Json.createModel(
+        {
+          Name  : "New parent",
+          kids  : [],
+          open  : true
+        },
+        true);
+      this.model.getItem(0).getKids().push(parentItem);
+
+      var childItem = qx.data.marshal.Json.createModel(
+        {
+          Name  : "Child of new parent"
+        },
+        true);
+      parentItem.getKids().push(childItem);
+
+      childItem = qx.data.marshal.Json.createModel(
+        {
+          Name  : "Child of Root"
+        },
+        true);
+      this.model.getItem(0).getKids().push(childItem);
 
       this.nodesOpen = {};
+
+      this.setOpenProperty("open");
+      this.controller =
+        new qx.ui.tree.core.OpenCloseController(this, this.model.getItem(0));
     },
 
 
@@ -252,6 +277,11 @@ qx.Class.define("qx.test.ui.tree.virtual.OpenCloseController",
     },
 
     openNodeWithoutScrolling : function(node) {},
-    closeNodeWithoutScrolling : function(node) {}
+    closeNodeWithoutScrolling : function(node) {},
+
+    refresh : function()
+    {
+      // nothing to do
+    }
   }
 });

--- a/framework/source/class/qx/ui/tree/VirtualTree.js
+++ b/framework/source/class/qx/ui/tree/VirtualTree.js
@@ -80,7 +80,7 @@
  *   // to nodes being open
  *   var tree =
  *     new qx.ui.tree.VirtualTree(
- *       nodes.getItem(0), "name", "children", "open", nodes).set({
+ *       nodes.getItem(0), "name", "children", "open").set({
  *         width : 200,
  *         height : 400
  *       });
@@ -149,16 +149,10 @@ qx.Class.define("qx.ui.tree.VirtualTree",
    *   more details have a look at the 'childProperty' property.
    * @param openProperty {String|null} the name of the model property which
    *   represents the open state of a branch. If this value is provided, so, 
-   *   too, must be fullModel.
-   * @param fullModel {qx.data.Array?}
-   *   The model which represents the tree. This is not the same value as
-   *   rootModel. rootModel is the model of the root item of the tree. What's
-   *   required here is the full data array which is the model of the whole
-   *   tree. Often, rootItem provided as model.getItem(0), where as fullModel
-   *   would be provided as model.
+   *   too, must be rootModel.
    */
   construct : function(
-    rootModel, labelPath, childProperty, openProperty, fullModel)
+    rootModel, labelPath, childProperty, openProperty)
   {
     this.base(arguments, 0, 1, 20, 100);
 
@@ -181,10 +175,9 @@ qx.Class.define("qx.ui.tree.VirtualTree",
 
     this.addListener("keypress", this._onKeyPress, this);
 
-    // If an open property and full model are provided, start up the
-    // open-close controller.
-    if (openProperty && fullModel) {
-      this.openViaModelChanges(openProperty, fullModel);
+    // If an open property and root model are provided, start up the open-close controller.
+    if (openProperty && rootModel) {
+      this.openViaModelChanges(openProperty);
     }
   },
 
@@ -541,15 +534,8 @@ qx.Class.define("qx.ui.tree.VirtualTree",
      *   The name of the open property, which determines the open state of a
      *   branch in the tree. If null, turn off opening and closing branches
      *   via changes to the model.
-     * 
-     * @param fullModel {qx.data.Array?}
-     *   The model which represents the tree. (Note that this is not the same
-     *   value which was passed to the constructor or to setModel(). That is
-     *   the model of the root item of the tree. What's required here is the
-     *   full data array which is the model of the whole tree.) If
-     *   openProperty is non-null, this model must be provided.
      */
-    openViaModelChanges : function(openProperty, fullModel) {
+    openViaModelChanges : function(openProperty) {
       // Save the open property
       this.__openProperty = openProperty;
 
@@ -565,7 +551,7 @@ qx.Class.define("qx.ui.tree.VirtualTree",
 
       // we have a property name, so create controller
       this._openCloseController =
-        new qx.ui.tree.core.OpenCloseController(this, fullModel, openProperty);
+        new qx.ui.tree.core.OpenCloseController(this, this.getModel(), openProperty);
     },
 
 

--- a/framework/source/class/qx/ui/tree/core/OpenCloseController.js
+++ b/framework/source/class/qx/ui/tree/core/OpenCloseController.js
@@ -99,22 +99,33 @@ qx.Class.define("qx.ui.tree.core.OpenCloseController",
     // event listener for model changes
     _onChangeBubble: function(ev)
     {
+      var index;
+      var item;
+      var isOpen;
       var bubble = ev.getData();
-      var modelPropRe;
 
-      // generate a regular expression that identifies model changes that
-      // pertain to the open state of a branch in the tree.
-      modelPropRe = new RegExp("\\." + this._tree.getOpenProperty() + "$");
-      
-      // open related? sync it back to the node item.
-      if (modelPropRe.test(bubble.name)) {
-        if (bubble.value && !this._tree.isNodeOpen(bubble.item)) {
-          this._tree.openNode(bubble.item);
+      // Extract the index of the current item
+      index = bubble.name.replace(/.*\[([0-9]+)\]$/, "$1");
+
+      // Retrieve that indexed array item if it's an array; otherwise the item itself
+      item = bubble.item.getItem ? bubble.item.getItem(index) : bubble.item;
+
+      // If this item isn't being deleted and has an open property...
+      if (item && qx.Class.hasProperty(item.constructor, this._tree.getOpenProperty())) {
+        // ... then find out if this branch is open
+        isOpen = item.get(this._tree.getOpenProperty());
+
+        // Open or close the tree branch as necessary
+        if (isOpen && !this._tree.isNodeOpen(item)) {
+          this._tree.openNode(item);
         }
-        else if (!bubble.value && this._tree.isNodeOpen(bubble.item)) {
-          this._tree.closeNode(bubble.item);
+        else if (! isOpen && this._tree.isNodeOpen(item)) {
+          this._tree.closeNode(item);
         }
       }
+
+      // Rebuild the internal lookup table
+      this._tree.refresh();
     }
   },
   


### PR DESCRIPTION
When the model was changed by using the `push()` method after the initial creation of the model, rather than initially creating the entire tree model, open/close didn't work because the controller's changeBubble handler was only looking at changes to the `open` property, but in this case the changes are to the `children` property.

This implementation feels inefficient for large trees, as it's inspecting all changes instead of only changes to a single property. I don't see a better way to do it, however, and this has the major advantage of actually working. :-) Suggestions welcome!
