### PR TITLE
Migrate to array includes

### DIFF
--- a/application/demobrowser/source/class/demobrowser/DemoBrowser.js
+++ b/application/demobrowser/source/class/demobrowser/DemoBrowser.js
@@ -347,7 +347,7 @@ qx.Class.define("demobrowser.DemoBrowser",
 
       var currentTags = this._tree.getSelection()[0].getUserData("tags");
       if (currentTags) {
-        playable = playable && !qx.lang.Array.contains(currentTags, "noPlayground");
+        playable = playable && !currentTags.includes("noPlayground");
       }
 
       this.__playgroundButton.setEnabled(playable);
@@ -1089,7 +1089,7 @@ qx.Class.define("demobrowser.DemoBrowser",
         }
         var currentTags = treeNode.getUserData("tags");
         if (currentTags) {
-          this.__playgroundButton.setEnabled(!qx.lang.Array.contains(currentTags, "noPlayground"));
+          this.__playgroundButton.setEnabled(!currentTags.includes("noPlayground"));
         }
       }
       else

--- a/component/testrunner/source/class/testrunner/runner/TestRunnerBasic.js
+++ b/component/testrunner/source/class/testrunner/runner/TestRunnerBasic.js
@@ -502,7 +502,7 @@ qx.Class.define("testrunner.runner.TestRunnerBasic", {
           }
         }
 
-        if (!qx.lang.Array.contains(this.__testsInView, this.currentTestData.fullName)) {
+        if (!this.__testsInView.includes(this.currentTestData.fullName)) {
           this.view.addTestResult(this.currentTestData);
           this.__testsInView.push(this.currentTestData.fullName);
         }

--- a/component/testrunner/source/class/testrunner/view/Reporter.js
+++ b/component/testrunner/source/class/testrunner/view/Reporter.js
@@ -131,13 +131,13 @@ qx.Class.define("testrunner.view.Reporter", {
         for (var i=0,l=packages.length; i<l; i++) {
           var pkg = packages.getItem(i);
           var packageName = pkg.fullName;
-          if (qx.lang.Array.contains(this.__ignoredPackages, packageName)) {
+          if (this.__ignoredPackages.includes(packageName)) {
             continue;
           }
           if (packageName == "qx.test.ui") {
             for (var j=0,m=pkg.getChildren().length; j<m; j++) {
               packageName = pkg.getChildren().getItem(j).getFullName();
-              if (!qx.lang.Array.contains(this.__ignoredPackages, packageName)) {
+              if (!this.__ignoredPackages.includes(packageName)) {
                 this.__testPackages.push(packageName);
               }
             }

--- a/framework/source/class/qx/Annotation.js
+++ b/framework/source/class/qx/Annotation.js
@@ -255,7 +255,7 @@ qx.Bootstrap.define("qx.Annotation", {
       var properties = [];
 
       qx.Class.getProperties(clazz).forEach(function(property) {
-        if (qx.lang.Array.contains(qx.Annotation.getProperty(clazz, property), annotation)) {
+        if (qx.Annotation.getProperty(clazz, property).includes(annotation)) {
           properties.push(property);
         }
       });

--- a/framework/source/class/qx/bom/Input.js
+++ b/framework/source/class/qx/bom/Input.js
@@ -33,8 +33,6 @@
 
 /**
  * Cross browser abstractions to work with input elements.
- *
- * @require(qx.lang.Array#contains)
  */
 qx.Bootstrap.define("qx.bom.Input",
 {
@@ -125,7 +123,6 @@ qx.Bootstrap.define("qx.bom.Input",
     {
       var tag = element.nodeName.toLowerCase();
       var type = element.type;
-      var Array = qx.lang.Array;
       var Type = qx.lang.Type;
 
       if (typeof value === "number") {
@@ -135,7 +132,7 @@ qx.Bootstrap.define("qx.bom.Input",
       if ((type === "checkbox" || type === "radio"))
       {
         if (Type.isArray(value)) {
-          element.checked = Array.contains(value, element.value);
+          element.checked = value.includes(element.value);
         } else {
           element.checked = element.value == value;
         }
@@ -155,7 +152,7 @@ qx.Bootstrap.define("qx.bom.Input",
           }
 
           subel.selected = isArray ?
-             Array.contains(value, subval) : value == subval;
+            value.includes(subval) : value == subval;
         }
 
         if (isArray && value.length == 0) {

--- a/framework/source/class/qx/bom/client/EcmaScript.js
+++ b/framework/source/class/qx/bom/client/EcmaScript.js
@@ -177,6 +177,16 @@ qx.Bootstrap.define("qx.bom.client.EcmaScript",
 
 
     /**
+     * Checks if 'includes' is supported on the Array object.
+     * @internal
+     * @return {Boolean} <code>true</code>, if the method is available.
+     */
+    getArrayIncludes : function() {
+      return !!Array.prototype.includes;
+    },
+
+
+    /**
      * Checks if 'toString' is supported on the Error object and
      * its working as expected.
      * @internal
@@ -308,6 +318,7 @@ qx.Bootstrap.define("qx.bom.client.EcmaScript",
     qx.core.Environment.add("ecmascript.array.every", statics.getArrayEvery);
     qx.core.Environment.add("ecmascript.array.reduce", statics.getArrayReduce);
     qx.core.Environment.add("ecmascript.array.reduceright", statics.getArrayReduceRight);
+    qx.core.Environment.add("ecmascript.array.includes", statics.getArrayIncludes);
 
     // date polyfill
     qx.core.Environment.add("ecmascript.date.now", statics.getDateNow);

--- a/framework/source/class/qx/bom/webfonts/Manager.js
+++ b/framework/source/class/qx/bom/webfonts/Manager.js
@@ -303,7 +303,7 @@ qx.Class.define("qx.bom.webfonts.Manager", {
     __require : function(familyName, sources, fontWeight, fontStyle, comparisonString, version, callback, context)
     {
       var fontLookupKey = this.__createFontLookupKey(familyName, fontWeight, fontStyle);
-      if (!qx.lang.Array.contains(this.__createdStyles, fontLookupKey)) {
+      if (!this.__createdStyles.includes(fontLookupKey)) {
         var sourcesMap = this.__getSourcesMap(sources);
         var rule = this.__getRule(familyName, fontWeight, fontStyle, sourcesMap, version);
 

--- a/framework/source/class/qx/data/Array.js
+++ b/framework/source/class/qx/data/Array.js
@@ -647,10 +647,22 @@ qx.Class.define("qx.data.Array",
     /**
      * Check if the given item is in the current array.
      *
+     * @deprecated {6.0} Please use the include method instead
+     *
      * @param item {var} The item which is possibly in the array.
      * @return {Boolean} true, if the array contains the given item.
      */
     contains: function(item) {
+      return this.includes(item);
+    },
+
+    /**
+     * Check if the given item is in the current array.
+     *
+     * @param item {var} The item which is possibly in the array.
+     * @return {Boolean} true, if the array contains the given item.
+     */
+    includes: function(item) {
       return this.__array.indexOf(item) !== -1;
     },
 

--- a/framework/source/class/qx/data/controller/List.js
+++ b/framework/source/class/qx/data/controller/List.js
@@ -683,7 +683,7 @@ qx.Class.define("qx.data.controller.List",
       targetWidget.setUserData(targetProperty + "BindingId", id);
 
       // save the bound property
-      if (!qx.lang.Array.contains(this.__boundProperties, targetProperty)) {
+      if (!this.__boundProperties.includes(targetProperty)) {
         this.__boundProperties.push(targetProperty);
       }
     },
@@ -716,7 +716,7 @@ qx.Class.define("qx.data.controller.List",
       sourceWidget.setUserData(targetPath + "ReverseBindingId", id);
 
       // save the bound property
-      if (!qx.lang.Array.contains(this.__boundPropertiesReverse, targetPath)) {
+      if (!this.__boundPropertiesReverse.includes(targetPath)) {
         this.__boundPropertiesReverse.push(targetPath);
       }
     },

--- a/framework/source/class/qx/data/controller/MSelection.js
+++ b/framework/source/class/qx/data/controller/MSelection.js
@@ -300,9 +300,7 @@ qx.Mixin.define("qx.data.controller.MSelection",
         // go through the controller selection
         for (var i = this.getSelection().length - 1; i >= 0; i--) {
           // if the item in the controller selection is not selected in the list
-          if (!qx.lang.Array.contains(
-            targetSelectionItems, this.getSelection().getItem(i)
-          )) {
+          if (!targetSelectionItems.includes(this.getSelection().getItem(i))) {
             // remove the current element and get rid of the return array
             this.getSelection().splice(i, 1).dispose();
           }

--- a/framework/source/class/qx/data/controller/Tree.js
+++ b/framework/source/class/qx/data/controller/Tree.js
@@ -693,7 +693,7 @@ qx.Class.define("qx.data.controller.Tree",
       }
 
       // save the bound property
-      if (!qx.lang.Array.contains(this.__boundProperties, targetPath)) {
+      if (!this.__boundProperties.includes(targetPath)) {
         this.__boundProperties.push(targetPath);
       }
     },
@@ -744,7 +744,7 @@ qx.Class.define("qx.data.controller.Tree",
       }
 
       // save the bound property
-      if (!qx.lang.Array.contains(this.__boundProperties, sourcePath)) {
+      if (!this.__boundProperties.includes(sourcePath)) {
         this.__boundProperties.push(sourcePath);
       }
     },

--- a/framework/source/class/qx/dom/Hierarchy.js
+++ b/framework/source/class/qx/dom/Hierarchy.js
@@ -271,7 +271,7 @@ qx.Bootstrap.define("qx.dom.Hierarchy",
         {
           if (element1)
           {
-            if (qx.lang.Array.contains(known, element1)) {
+            if (known.includes(element1)) {
               return element1;
             }
 
@@ -281,7 +281,7 @@ qx.Bootstrap.define("qx.dom.Hierarchy",
 
           if (element2)
           {
-            if (qx.lang.Array.contains(known, element2)) {
+            if (known.includes(element2)) {
               return element2;
             }
 

--- a/framework/source/class/qx/io/remote/Exchange.js
+++ b/framework/source/class/qx/io/remote/Exchange.js
@@ -189,7 +189,7 @@ qx.Class.define("qx.io.remote.Exchange",
      */
     canHandle : function(vImpl, vNeeds, vResponseType)
     {
-      if (!qx.lang.Array.contains(vImpl.handles.responseTypes, vResponseType)) {
+      if (!vImpl.handles.responseTypes.includes(vResponseType)) {
         return false;
       }
 

--- a/framework/source/class/qx/io/remote/RequestQueue.js
+++ b/framework/source/class/qx/io/remote/RequestQueue.js
@@ -496,7 +496,7 @@ qx.Class.define("qx.io.remote.RequestQueue",
 
       if (vTransport) {
         vTransport.abort();
-      } else if (qx.lang.Array.contains(this.__queue, vRequest)) {
+      } else if (this.__queue.includes(vRequest)) {
         qx.lang.Array.remove(this.__queue, vRequest);
       }
     }

--- a/framework/source/class/qx/lang/Array.js
+++ b/framework/source/class/qx/lang/Array.js
@@ -363,18 +363,18 @@ qx.Bootstrap.define("qx.lang.Array",
       }
     },
 
-
     /**
      * Whether the array contains the given element
+     *
+     * @deprecated {6.0} Please use Array instance include method instead
      *
      * @param arr {Array} the array
      * @param obj {var} object to look for
      * @return {Boolean} whether the arr contains the element
      */
     contains : function(arr, obj) {
-      return arr.indexOf(obj) !== -1;
+      return arr.includes(obj);
     },
-
 
     /**
      * Check whether the two arrays have the same content. Checks only the

--- a/framework/source/class/qx/lang/normalize/Array.js
+++ b/framework/source/class/qx/lang/normalize/Array.js
@@ -382,6 +382,63 @@ qx.Bootstrap.define("qx.lang.normalize.Array", {
       }
 
       return ret;
+    },
+
+    /**
+     * The includes() method determines whether an array includes a certain element, returning
+     * true or false as appropriate.
+     *
+     * <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/includes">MDN documentation</a> |
+     *
+     * @param searchElement {var} Element which is checked for.
+     * @param fromIndex {Number} Index to start search from
+     * @return {bool} true if element is included
+     */
+    includes : function(searchElement, fromIndex)
+    {
+      if (this == null) {
+        throw new TypeError('"this" is null or not defined');
+      }
+
+      // 1. Let O be ? ToObject(this value).
+      var o = Object(this);
+
+      // 2. Let len be ? ToLength(? Get(O, "length")).
+      var len = o.length >>> 0;
+
+      // 3. If len is 0, return false.
+      if (len === 0) {
+        return false;
+      }
+
+      // 4. Let n be ? ToInteger(fromIndex).
+      //    (If fromIndex is undefined, this step produces the value 0.)
+      var n = fromIndex | 0;
+
+      // 5. If n ≥ 0, then
+      //  a. Let k be n.
+      // 6. Else n < 0,
+      //  a. Let k be len + n.
+      //  b. If k < 0, let k be 0.
+      var k = Math.max(n >= 0 ? n : len - Math.abs(n), 0);
+
+      function sameValueZero(x, y) {
+        return x === y || (typeof x === 'number' && typeof y === 'number' && isNaN(x) && isNaN(y));
+      }
+
+      // 7. Repeat, while k < len
+      while (k < len) {
+        // a. Let elementK be the result of ? Get(O, ! ToString(k)).
+        // b. If SameValueZero(searchElement, elementK) is true, return true.
+        if (sameValueZero(o[k], searchElement)) {
+          return true;
+        }
+        // c. Increase k by 1. 
+        k++;
+      }
+
+      // 8. Return false
+      return false;
     }
   },
 
@@ -409,5 +466,6 @@ qx.Bootstrap.define("qx.lang.normalize.Array", {
     install("ecmascript.array.every", "every");
     install("ecmascript.array.reduce", "reduce");
     install("ecmascript.array.reduceright", "reduceRight");
+    install("ecmascript.array.includes", "includes");
   }
 });

--- a/framework/source/class/qx/test/bom/element/BoxSizing.js
+++ b/framework/source/class/qx/test/bom/element/BoxSizing.js
@@ -67,7 +67,7 @@ qx.Class.define("qx.test.bom.element.BoxSizing",
       var supported = this.__support[qx.core.Environment.get("engine.name")] || [];
       for (var i=0, l=allValues.length; i<l; i++) {
         qx.bom.element.BoxSizing.set(this.__el, allValues[i]);
-        if (qx.lang.Array.contains(supported, allValues[i])) {
+        if (supported.includes(allValues[i])) {
           this.assertEquals(supported[i], qx.bom.element.BoxSizing.get(this.__el),
             "supported boxSizing value was not applied!");
         }

--- a/framework/source/class/qx/test/lang/Array.js
+++ b/framework/source/class/qx/test/lang/Array.js
@@ -172,10 +172,10 @@ qx.Class.define("qx.test.lang.Array",
       var a = [ -3, -2, -1, 0, 1, 2, 3 ];
       var da = new qx.data.Array(a);
 
-      this.assertTrue(qx.lang.Array.contains(a, -2));
-      this.assertFalse(qx.lang.Array.contains(a, -10));
-      this.assertTrue(qx.lang.Array.contains(da, -2));
-      this.assertFalse(qx.lang.Array.contains(da, -10));
+      this.assertTrue(a.includes(-2));
+      this.assertFalse(a.includes(-10));
+      this.assertTrue(da.includes(-2));
+      this.assertFalse(da.includes(-10));
       
       da.dispose();
     },

--- a/framework/source/class/qx/test/lang/normalize/Array.js
+++ b/framework/source/class/qx/test/lang/normalize/Array.js
@@ -234,6 +234,20 @@ qx.Class.define("qx.test.lang.normalize.Array",
       this.assertArrayEquals([0, 3,4,1,2], [[1,2], [3,4]].reduceRight(
         function(a, b) {return a.concat(b);}, [0]
       ));
+    },
+
+    testIncludes : function() {
+      var arr = ['one', 'two', 'three'];
+      this.assertTrue(arr.includes("one"), "includes does not work!");
+      this.assertTrue(arr.includes("two"), "includes does not work!");
+      this.assertTrue(arr.includes("three"), "includes does not work!");
+      this.assertFalse(arr.includes("four"), "includes does not work!");
+
+      arr = [NaN];
+      this.assertTrue(arr.includes(NaN), "includes does not work!");
+
+      arr = [];
+      this.assertFalse(arr.includes("one"), "includes does not work!");
     }
   }
 });

--- a/framework/source/class/qx/test/lang/normalize/Object.js
+++ b/framework/source/class/qx/test/lang/normalize/Object.js
@@ -45,8 +45,8 @@ qx.Class.define("qx.test.lang.normalize.Object",
 
       var keys = Object.keys(objB);
       this.assertEquals(1, keys.length, "Expected length wrong!");
-      this.assertFalse(qx.lang.Array.contains(keys, "A"), "Test property A!");
-      this.assertTrue(qx.lang.Array.contains(keys, "B"), "Test property B!");
+      this.assertFalse(keys.includes("A"), "Test property A!");
+      this.assertTrue(keys.includes("B"), "Test property B!");
     },
 
 
@@ -61,13 +61,13 @@ qx.Class.define("qx.test.lang.normalize.Object",
       obj.prototype = function() {};
 
       var keys = Object.keys(obj);
-      this.assertTrue(qx.lang.Array.contains(keys, "isPrototypeOf"), "Test isPrototypeOf");
-      this.assertTrue(qx.lang.Array.contains(keys, "hasOwnProperty"), "Test hasOwnProperty");
-      this.assertTrue(qx.lang.Array.contains(keys, "toLocaleString"), "Test toLocaleString");
-      this.assertTrue(qx.lang.Array.contains(keys, "toString"), "Test toString");
-      this.assertTrue(qx.lang.Array.contains(keys, "valueOf"), "Test valueOf");
-      this.assertTrue(qx.lang.Array.contains(keys, "constructor"), "Test constructor");
-      this.assertTrue(qx.lang.Array.contains(keys, "prototype"), "Test prototype");
+      this.assertTrue(keys.includes("isPrototypeOf"), "Test isPrototypeOf");
+      this.assertTrue(keys.includes("hasOwnProperty"), "Test hasOwnProperty");
+      this.assertTrue(keys.includes("toLocaleString"), "Test toLocaleString");
+      this.assertTrue(keys.includes("toString"), "Test toString");
+      this.assertTrue(keys.includes("valueOf"), "Test valueOf");
+      this.assertTrue(keys.includes("constructor"), "Test constructor");
+      this.assertTrue(keys.includes("prototype"), "Test prototype");
     },
 
     testGetValues : function()

--- a/framework/source/class/qx/test/ui/form/ModelSelection.js
+++ b/framework/source/class/qx/test/ui/form/ModelSelection.js
@@ -76,8 +76,8 @@ qx.Class.define("qx.test.ui.form.ModelSelection",
       // check the set selection again
       widget.setModelSelection([2, 3]);
       this.assertEquals(2, widget.getSelection().length);
-      this.assertTrue(qx.lang.Array.contains(widget.getSelection(), children[1]));
-      this.assertTrue(qx.lang.Array.contains(widget.getSelection(), children[2]));
+      this.assertTrue(widget.getSelection().includes(children[1]));
+      this.assertTrue(widget.getSelection().includes(children[2]));
     },
 
 

--- a/framework/source/class/qx/test/ui/tree/virtual/Tree.js
+++ b/framework/source/class/qx/test/ui/tree/virtual/Tree.js
@@ -401,7 +401,7 @@ qx.Class.define("qx.test.ui.tree.virtual.Tree",
       var openNodes = this.tree.getOpenNodes();
       this.assertEquals(expectedOpen.length, openNodes.length);
       for (var i = 0; i < expectedOpen.length; i++) {
-        this.assertTrue(qx.lang.Array.contains(openNodes, expectedOpen[i]));
+        this.assertTrue(openNodes.includes(expectedOpen[i]));
       }
     },
 

--- a/framework/source/class/qx/ui/command/GroupManager.js
+++ b/framework/source/class/qx/ui/command/GroupManager.js
@@ -43,7 +43,7 @@ qx.Class.define("qx.ui.command.GroupManager",
         this.assertInstance(group, qx.ui.command.Group, "Given group is not an instance of qx.ui.command.Group");
       }
 
-      if (qx.lang.Array.contains(this.__groups, group)){
+      if (this.__groups.includes(group)){
         if (qx.core.Environment.get("qx.debug")) {
           this.debug("Group is already added!");
         }

--- a/framework/source/class/qx/ui/core/queue/Dispose.js
+++ b/framework/source/class/qx/ui/core/queue/Dispose.js
@@ -40,7 +40,7 @@ qx.Class.define("qx.ui.core.queue.Dispose",
     add : function(widget)
     {
       var queue = this.__queue;
-      if (qx.lang.Array.contains(queue, widget)) {
+      if (queue.includes(widget)) {
         return;
       }
 

--- a/framework/source/class/qx/ui/core/queue/Widget.js
+++ b/framework/source/class/qx/ui/core/queue/Widget.js
@@ -54,7 +54,7 @@ qx.Class.define("qx.ui.core.queue.Widget",
     {
       var queue = this.__queue;
 
-      if (!qx.lang.Array.contains(queue, widget)) {
+      if (!queue.includes(widget)) {
         return;
       }
 
@@ -91,7 +91,7 @@ qx.Class.define("qx.ui.core.queue.Widget",
     {
       var queue = this.__queue;
       //add widget if not containing
-      if (!qx.lang.Array.contains(queue, widget)){
+      if (!queue.includes(widget)){
         queue.unshift(widget);
       }
 

--- a/framework/source/class/qx/ui/form/RadioGroup.js
+++ b/framework/source/class/qx/ui/form/RadioGroup.js
@@ -232,7 +232,7 @@ qx.Class.define("qx.ui.form.RadioGroup",
       {
         item = arguments[i];
 
-        if (qx.lang.Array.contains(items, item)) {
+        if (items.includes(item)) {
           continue;
         }
 
@@ -269,7 +269,7 @@ qx.Class.define("qx.ui.form.RadioGroup",
       var groupedProperty = this.getGroupedProperty();
       var groupedPropertyUp = qx.lang.String.firstUp(groupedProperty);
 
-      if (qx.lang.Array.contains(items, item))
+      if (items.includes(item))
       {
         // Remove RadioButton from array
         qx.lang.Array.remove(items, item);

--- a/framework/source/class/qx/ui/list/core/MWidgetController.js
+++ b/framework/source/class/qx/ui/list/core/MWidgetController.js
@@ -307,7 +307,7 @@ qx.Mixin.define("qx.ui.list.core.MWidgetController",
         }
       }
 
-      if (qx.lang.Array.contains(this.__boundItems, item)) {
+      if (this.__boundItems.includes(item)) {
         qx.lang.Array.remove(this.__boundItems, item);
       }
     },
@@ -346,11 +346,11 @@ qx.Mixin.define("qx.ui.list.core.MWidgetController",
     {
       var bindings = this.__getBindings(widget);
 
-      if (!qx.lang.Array.contains(bindings, id)) {
+      if (!bindings.includes(id)) {
         bindings.push(id);
       }
 
-      if (!qx.lang.Array.contains(this.__boundItems, widget)) {
+      if (!this.__boundItems.includes(widget)) {
         this.__boundItems.push(widget);
       }
     },

--- a/framework/source/class/qx/ui/progressive/renderer/table/cell/Conditional.js
+++ b/framework/source/class/qx/ui/progressive/renderer/table/cell/Conditional.js
@@ -152,7 +152,7 @@ qx.Class.define("qx.ui.progressive.renderer.table.cell.Conditional",
     addNumericCondition : function(condition, value1, align,
                                    color, style, weight, target)
     {
-      if (! qx.lang.Array.contains(this.__numericAllowed, condition) ||
+      if (!this.__numericAllowed.includes(condition) ||
           value1 == null)
       {
         throw new Error("Condition not recognized or value is null!");
@@ -214,7 +214,7 @@ qx.Class.define("qx.ui.progressive.renderer.table.cell.Conditional",
     addBetweenCondition : function(condition, value1, value2, align,
                                    color, style, weight, target)
     {
-      if (! qx.lang.Array.contains(this.__betweenAllowed, condition) ||
+      if (!this.__betweenAllowed.includes(condition) ||
           value1 == null ||
           value2 == null)
       {
@@ -325,7 +325,7 @@ qx.Class.define("qx.ui.progressive.renderer.table.cell.Conditional",
 
         bTestPassed = false;
 
-        if (qx.lang.Array.contains(this.__numericAllowed, test.condition))
+        if (this.__numericAllowed.includes(test.condition))
         {
           if (test.target == null)
           {
@@ -387,8 +387,7 @@ qx.Class.define("qx.ui.progressive.renderer.table.cell.Conditional",
             break;
           }
         }
-        else if (qx.lang.Array.contains(this.__betweenAllowed,
-                                        test.condition))
+        else if (this.__betweenAllowed.includes(test.condition))
         {
           if (test.target == null)
           {

--- a/framework/source/class/qx/ui/table/cellrenderer/AbstractImage.js
+++ b/framework/source/class/qx/ui/table/cellrenderer/AbstractImage.js
@@ -85,7 +85,7 @@ qx.Class.define("qx.ui.table.cellrenderer.AbstractImage",
             "repeat-y",
             "no-repeat"
           ];
-        return qx.lang.Array.contains(valid, value);
+        return valid.includes(value);
       },
       init  : "no-repeat"
     }

--- a/framework/source/class/qx/ui/table/cellrenderer/Conditional.js
+++ b/framework/source/class/qx/ui/table/cellrenderer/Conditional.js
@@ -128,7 +128,7 @@ qx.Class.define("qx.ui.table.cellrenderer.Conditional",
     {
       var temp = null;
 
-      if (qx.lang.Array.contains(this.numericAllowed, condition))
+      if (this.numericAllowed.includes(condition))
       {
         if (value1 != null) {
           temp = [condition, align, color, style, weight, value1, target];
@@ -166,7 +166,7 @@ qx.Class.define("qx.ui.table.cellrenderer.Conditional",
      */
     addBetweenCondition : function(condition, value1, value2, align, color, style, weight, target)
     {
-      if (qx.lang.Array.contains(this.betweenAllowed, condition))
+      if (this.betweenAllowed.includes(condition))
       {
         if (value1 != null && value2 != null) {
           var temp = [condition, align, color, style, weight, value1, value2, target];
@@ -244,7 +244,7 @@ qx.Class.define("qx.ui.table.cellrenderer.Conditional",
       {
         cond_test = false;
 
-        if (qx.lang.Array.contains(this.numericAllowed, this.conditions[i][0]))
+        if (this.numericAllowed.includes(this.conditions[i][0]))
         {
           if (this.conditions[i][6] == null) {
             compareValue = cellInfo.value;
@@ -297,7 +297,7 @@ qx.Class.define("qx.ui.table.cellrenderer.Conditional",
               break;
           }
         }
-        else if (qx.lang.Array.contains(this.betweenAllowed, this.conditions[i][0]))
+        else if (this.betweenAllowed.includes(this.conditions[i][0]))
         {
           if (this.conditions[i][7] == null) {
             compareValue = cellInfo.value;

--- a/framework/source/class/qx/ui/table/model/Filtered.js
+++ b/framework/source/class/qx/ui/table/model/Filtered.js
@@ -396,7 +396,7 @@ qx.Class.define("qx.ui.table.model.Filtered",
       }
 
       rowArr = rowArr.filter(function(row, index) {
-        return !qx.lang.Array.contains(rowsToHide, index);
+        return !rowsToHide.includes(index);
       });
 
       this._rowArr = rowArr;

--- a/framework/source/class/qx/ui/tree/VirtualTree.js
+++ b/framework/source/class/qx/ui/tree/VirtualTree.js
@@ -505,7 +505,7 @@ qx.Class.define("qx.ui.tree.VirtualTree",
     // Interface implementation
     closeNode : function(node)
     {
-      if (qx.lang.Array.contains(this.__openNodes, node))
+      if (this.__openNodes.includes(node))
       {
         qx.lang.Array.remove(this.__openNodes, node);
         this.fireDataEvent("close", node);
@@ -530,7 +530,7 @@ qx.Class.define("qx.ui.tree.VirtualTree",
 
     // Interface implementation
     isNodeOpen : function(node) {
-      return qx.lang.Array.contains(this.__openNodes, node);
+      return this.__openNodes.includes(node);
     },
 
 
@@ -1163,7 +1163,7 @@ qx.Class.define("qx.ui.tree.VirtualTree",
      */
     __openNode : function(node)
     {
-      if (!qx.lang.Array.contains(this.__openNodes, node)) {
+      if (!this.__openNodes.includes(node)) {
         this.__openNodes.push(node);
         this.fireDataEvent("open", node);
       }

--- a/framework/source/class/qx/ui/tree/core/MWidgetController.js
+++ b/framework/source/class/qx/ui/tree/core/MWidgetController.js
@@ -248,7 +248,7 @@ qx.Mixin.define("qx.ui.tree.core.MWidgetController",
         }
       }
 
-      if (qx.lang.Array.contains(this.__boundItems, item)) {
+      if (this.__boundItems.includes(item)) {
         qx.lang.Array.remove(this.__boundItems, item);
       }
     },
@@ -281,11 +281,11 @@ qx.Mixin.define("qx.ui.tree.core.MWidgetController",
     {
       var bindings = this.__getBindings(widget);
 
-      if (!qx.lang.Array.contains(bindings, id)) {
+      if (!bindings.includes(id)) {
         bindings.push(id);
       }
 
-      if (!qx.lang.Array.contains(this.__boundItems, widget)) {
+      if (!this.__boundItems.includes(widget)) {
         this.__boundItems.push(widget);
       }
     },

--- a/framework/source/class/qx/ui/window/MDesktop.js
+++ b/framework/source/class/qx/ui/window/MDesktop.js
@@ -177,7 +177,7 @@ qx.Mixin.define("qx.ui.window.MDesktop",
      */
     _addWindow : function(win)
     {
-      if (!qx.lang.Array.contains(this.getWindows(), win))
+      if (!this.getWindows().includes(win))
       {
         this.getWindows().push(win);
 
@@ -216,7 +216,7 @@ qx.Mixin.define("qx.ui.window.MDesktop",
      */
     _removeWindow : function(win)
     {
-      if (qx.lang.Array.contains(this.getWindows(), win))
+      if (this.getWindows().includes(win))
       {
         qx.lang.Array.remove(this.getWindows(), win);
 


### PR DESCRIPTION
ES6 defined *Array.prototype.includes* which was choosen over the *contains* variant. This PR moves to *includes*.