### PR TITLE
Added assertEqualsFloat to qx.core.Assert and qx.core.MAssert

### DIFF
--- a/framework/source/class/qx/Class.js
+++ b/framework/source/class/qx/Class.js
@@ -72,6 +72,7 @@
  * @require(qx.lang.normalize.Function)
  * @require(qx.lang.normalize.String)
  * @require(qx.lang.normalize.Object)
+ * @require(qx.lang.normalize.Number)
  */
 qx.Bootstrap.define("qx.Class",
 {

--- a/framework/source/class/qx/bom/client/EcmaScript.js
+++ b/framework/source/class/qx/bom/client/EcmaScript.js
@@ -291,6 +291,13 @@ qx.Bootstrap.define("qx.bom.client.EcmaScript",
      */
     getPromiseNative: function() {
       return typeof window.Promise !== "undefined" && window.Promise.toString().indexOf("[native code]") !== -1;
+    },
+
+    /**
+     * Checks whether Native promises are available
+     */
+    getEpsilon: function() {
+      return typeof Number.prototype.EPSILON !== "undefined";
     }
   },
 
@@ -323,6 +330,9 @@ qx.Bootstrap.define("qx.bom.client.EcmaScript",
     // object polyfill
     qx.core.Environment.add("ecmascript.object.keys", statics.getObjectKeys);
     qx.core.Environment.add("ecmascript.object.values", statics.getObjectValues);
+
+    // number polyfill
+    qx.core.Environment.add("ecmascript.number.EPSILON", statics.getEpsilon);
 
     // string polyfill
     qx.core.Environment.add("ecmascript.string.startsWith", statics.getStringStartsWith);

--- a/framework/source/class/qx/core/Assert.js
+++ b/framework/source/class/qx/core/Assert.js
@@ -199,9 +199,8 @@ qx.Bootstrap.define("qx.core.Assert",
     },
 
     /**
-     * Assert that both float values are equal within the given tolerance. This
-     * might be needed because of the natural floating point inaccuracy of
-     * computers.
+     * Assert that both float values are equal. This might be needed because
+     * of the natural floating point inaccuracy of computers.
      *
      * @param expected {Float} Reference value
      * @param found {Float} Found value
@@ -215,6 +214,25 @@ qx.Bootstrap.define("qx.core.Assert",
       qx.lang.Number.equals(expected, found) ||
         this.__fail(msg || "", "Expected '", expected, "' to be equal with '",
         found, "'!"
+      );
+    },
+
+    /**
+     * Assert that both float values are not equal. This might be needed
+     * because of the natural floating point inaccuracy of computers.
+     *
+     * @param expected {Float} Reference value
+     * @param found {Float} Found value
+     * @param msg {String} Message to be shown if the assertion fails.
+     */
+    assertNotEqualsFloat : function(expected, found, msg)
+    {
+      this.assertNumber(expected);
+      this.assertNumber(found);
+
+      !qx.lang.Number.equals(expected, found) ||
+        this.__fail(msg || "", "Expected '", expected,
+        "' to be not equal with '", found, "'!"
       );
     },
 

--- a/framework/source/class/qx/core/Assert.js
+++ b/framework/source/class/qx/core/Assert.js
@@ -199,6 +199,33 @@ qx.Bootstrap.define("qx.core.Assert",
     },
 
     /**
+     * Assert that both float values are equal within the given tolerance. This
+     * might be needed because of the natural floating point inaccuracy of
+     * computers.
+     *
+     * @param expected {Float} Reference value
+     * @param found {Float} Found value
+     * @param precision {Float ? 0.01} Value by which expected and found may
+     *   differ
+     * @param msg {String} Message to be shown if the assertion fails.
+     */
+    assertEqualsFloat : function(expected, found, precision, msg)
+    {
+      this.assertNumber(expected);
+      this.assertNumber(found);
+      if (!qx.lang.Type.isNumber(precision)) {
+        precision = 0.01;
+      }
+
+      Math.abs(expected - found) < precision || this.__fail(
+        msg || "",
+        "Expected '", expected,
+        "' to be equal with '", found, "' within the precision of '",
+        precision, "'!"
+      );
+    },
+
+    /**
      * Assert that both values are identical. (Uses the identity operator
      * <code>===</code>.)
      *

--- a/framework/source/class/qx/core/Assert.js
+++ b/framework/source/class/qx/core/Assert.js
@@ -205,23 +205,20 @@ qx.Bootstrap.define("qx.core.Assert",
      *
      * @param expected {Float} Reference value
      * @param found {Float} Found value
-     * @param precision {Float ? 0.01} Value by which expected and found may
-     *   differ
      * @param msg {String} Message to be shown if the assertion fails.
      */
-    assertEqualsFloat : function(expected, found, precision, msg)
+    assertEqualsFloat : function(expected, found, msg)
     {
       this.assertNumber(expected);
       this.assertNumber(found);
-      if (!qx.lang.Type.isNumber(precision)) {
-        precision = 0.01;
-      }
 
-      Math.abs(expected - found) < precision || this.__fail(
-        msg || "",
-        "Expected '", expected,
-        "' to be equal with '", found, "' within the precision of '",
-        precision, "'!"
+      var diff = Math.abs(expected - found);
+
+      // The maximum of both numbers multiplied by 1e-14 is the relative difference
+      diff < Number.EPSILON ||
+        diff <= Math.max(Math.abs(expected), Math.abs(found)) * 1e-14 ||
+        this.__fail(msg || "", "Expected '", expected, "' to be equal with '",
+        found, "' regarding the precision inefficiencies of floats!"
       );
     },
 

--- a/framework/source/class/qx/core/Assert.js
+++ b/framework/source/class/qx/core/Assert.js
@@ -212,13 +212,9 @@ qx.Bootstrap.define("qx.core.Assert",
       this.assertNumber(expected);
       this.assertNumber(found);
 
-      var diff = Math.abs(expected - found);
-
-      // The maximum of both numbers multiplied by 1e-14 is the relative difference
-      diff < Number.EPSILON ||
-        diff <= Math.max(Math.abs(expected), Math.abs(found)) * 1e-14 ||
+      qx.lang.Number.equals(expected, found) ||
         this.__fail(msg || "", "Expected '", expected, "' to be equal with '",
-        found, "' regarding the precision inefficiencies of floats!"
+        found, "'!"
       );
     },
 

--- a/framework/source/class/qx/core/MAssert.js
+++ b/framework/source/class/qx/core/MAssert.js
@@ -106,11 +106,10 @@ qx.Mixin.define("qx.core.MAssert",
      *
      * @param expected {Float} Reference value
      * @param found {Float} Found value
-     * @param precision {Float ? 0.01} Value by which expected and found may differ
      * @param msg {String} Message to be shown if the assertion fails.
      */
-    assertEqualsFloat : function(expected, found, precision, msg) {
-      qx.core.Assert.assertEqualsFloat(expected, found, precision, msg);
+    assertEqualsFloat : function(expected, found, msg) {
+      qx.core.Assert.assertEqualsFloat(expected, found, msg);
     },
 
 

--- a/framework/source/class/qx/core/MAssert.js
+++ b/framework/source/class/qx/core/MAssert.js
@@ -99,6 +99,21 @@ qx.Mixin.define("qx.core.MAssert",
       qx.core.Assert.assertNotEquals(expected, found, msg);
     },
 
+
+    /**
+     * Assert that both float values are equal within the given tolerance. This might be needed because of the natural
+     * floating point inaccuracy of computers.
+     *
+     * @param expected {Float} Reference value
+     * @param found {Float} Found value
+     * @param precision {Float ? 0.01} Value by which expected and found may differ
+     * @param msg {String} Message to be shown if the assertion fails.
+     */
+    assertEqualsFloat : function(expected, found, precision, msg) {
+      qx.core.Assert.assertEqualsFloat(expected, found, precision, msg);
+    },
+
+
     /**
      * Assert that both values are identical. (Uses the identity operator
      * <code>===</code>.)

--- a/framework/source/class/qx/core/MAssert.js
+++ b/framework/source/class/qx/core/MAssert.js
@@ -101,8 +101,8 @@ qx.Mixin.define("qx.core.MAssert",
 
 
     /**
-     * Assert that both float values are equal within the given tolerance. This might be needed because of the natural
-     * floating point inaccuracy of computers.
+     * Assert that both float values are equal. This might be needed because
+     * of the natural floating point inaccuracy of computers.
      *
      * @param expected {Float} Reference value
      * @param found {Float} Found value
@@ -110,6 +110,19 @@ qx.Mixin.define("qx.core.MAssert",
      */
     assertEqualsFloat : function(expected, found, msg) {
       qx.core.Assert.assertEqualsFloat(expected, found, msg);
+    },
+
+
+    /**
+     * Assert that both float values are not equal. This might be needed
+     * because of the natural floating point inaccuracy of computers.
+     *
+     * @param expected {Float} Reference value
+     * @param found {Float} Found value
+     * @param msg {String} Message to be shown if the assertion fails.
+     */
+    assertNotEqualsFloat : function(expected, found, msg) {
+      qx.core.Assert.assertNotEqualsFloat(expected, found, msg);
     },
 
 

--- a/framework/source/class/qx/lang/Number.js
+++ b/framework/source/class/qx/lang/Number.js
@@ -91,12 +91,14 @@ qx.Class.define("qx.lang.Number",
         qx.core.Assert.assertNumber(y);
       }
 
-      // 2e-52 is the difference between 1 and the smallest floating point
-      // number greater than 1, like Number.EPSILON, but that is not supported
-      // by all browsers.
+      // Number.EPSILON (which is 2e-52) is the difference between 1 and the
+      // smallest floating point number greater than 1. Unfortunately, it is
+      // not supported by all browsers.
+      var epsilon = Number.EPSILON !== undefined ? Number.EPSILON : 2e-52;
+
       // 1e-14 is the relative difference.
       return x === y ||
-             Math.abs(x - y) < 2e-52 ||
+             Math.abs(x - y) < epsilon ||
              Math.abs(x - y) <= Math.max(Math.abs(x), Math.abs(y)) * 1e-14;
     }
   }

--- a/framework/source/class/qx/lang/Number.js
+++ b/framework/source/class/qx/lang/Number.js
@@ -91,9 +91,12 @@ qx.Class.define("qx.lang.Number",
         qx.core.Assert.assertNumber(y);
       }
 
-      // 1e-14 is the relative difference
+      // 2e-52 is the difference between 1 and the smallest floating point
+      // number greater than 1, like Number.EPSILON, but that is not supported
+      // by all browsers.
+      // 1e-14 is the relative difference.
       return x === y ||
-             Math.abs(x - y) < Number.EPSILON ||
+             Math.abs(x - y) < 2e-52 ||
              Math.abs(x - y) <= Math.max(Math.abs(x), Math.abs(y)) * 1e-14;
     }
   }

--- a/framework/source/class/qx/lang/Number.js
+++ b/framework/source/class/qx/lang/Number.js
@@ -91,14 +91,9 @@ qx.Class.define("qx.lang.Number",
         qx.core.Assert.assertNumber(y);
       }
 
-      // Number.EPSILON (which is 2e-52) is the difference between 1 and the
-      // smallest floating point number greater than 1. Unfortunately, it is
-      // not supported by all browsers.
-      var epsilon = Number.EPSILON !== undefined ? Number.EPSILON : 2e-52;
-
       // 1e-14 is the relative difference.
       return x === y ||
-             Math.abs(x - y) < epsilon ||
+             Math.abs(x - y) < Number.EPSILON ||
              Math.abs(x - y) <= Math.max(Math.abs(x), Math.abs(y)) * 1e-14;
     }
   }

--- a/framework/source/class/qx/lang/Number.js
+++ b/framework/source/class/qx/lang/Number.js
@@ -74,6 +74,27 @@ qx.Class.define("qx.lang.Number",
       } else {
         return nr;
       }
+    },
+
+
+    /**
+     * Checks the equality of two numbers regarding the imprecision of floats.
+     *
+     * @param x {Number}
+     * @param y {Number}
+     * @return {Boolean}
+     */
+    equals : function(x, y)
+    {
+      if (qx.core.Environment.get("qx.debug")) {
+        qx.core.Assert.assertNumber(x);
+        qx.core.Assert.assertNumber(y);
+      }
+
+      // 1e-14 is the relative difference
+      return x === y ||
+             Math.abs(x - y) < Number.EPSILON ||
+             Math.abs(x - y) <= Math.max(Math.abs(x), Math.abs(y)) * 1e-14;
     }
   }
 });

--- a/framework/source/class/qx/lang/normalize/Number.js
+++ b/framework/source/class/qx/lang/normalize/Number.js
@@ -1,0 +1,38 @@
+/* ************************************************************************
+
+   qooxdoo - the new era of web development
+
+   http://qooxdoo.org
+
+   Copyright:
+     2017 The Qooxdoo Project
+
+   License:
+     MIT: https://opensource.org/licenses/MIT
+     See the LICENSE file in the project's top-level directory for details.
+
+   Authors:
+     * Cajus Pollmeier (cajus)
+
+************************************************************************ */
+/**
+ * This class is responsible for the normalization of the native 'String' object.
+ * It checks if these methods are available and, if not, appends them to
+ * ensure compatibility in all browsers.
+ * For usage samples, check out the attached links.
+ *
+ * @group (Polyfill)
+ */
+qx.Bootstrap.define("qx.lang.normalize.Number", {
+
+  statics : {
+    EPSILON : 2e-52
+  },
+
+  defer : function(statics)
+  {
+    if (!qx.core.Environment.get("ecmascript.number.EPSILON")) {
+      Number.prototype.EPSILON = statics.EPSILON;
+    }
+  }
+});

--- a/framework/source/class/qx/module/Polyfill.js
+++ b/framework/source/class/qx/module/Polyfill.js
@@ -26,6 +26,7 @@
  * @require(qx.lang.normalize.Array)
  * @require(qx.lang.normalize.Error)
  * @require(qx.lang.normalize.Object)
+ * @require(qx.lang.normalize.Number)
  *
  * @group (Polyfill)
  */

--- a/framework/source/class/qx/test/core/Assert.js
+++ b/framework/source/class/qx/test/core/Assert.js
@@ -158,29 +158,22 @@ qx.Class.define("qx.test.core.Assert",
     testAssertEqualsFloat : function()
     {
       this.assertEqualsFloat(1.0, 1.0);
-      this.assertEqualsFloat(1.0, 1.009);
-      this.assertEqualsFloat(1.0, 0.991);
+      this.assertEqualsFloat(0.3, 0.1 + 0.2);
 
       this.assertException(function() {
-        qx.core.Assert.assertEqualsFloat(1.0, 1.01);
+        qx.core.Assert.assertEqualsFloat(1.0, 1.0000001);
       }, qx.core.AssertionError);
 
       this.assertException(function() {
-        qx.core.Assert.assertEqualsFloat(1.0, 0.09);
+        qx.core.Assert.assertEqualsFloat(1.0, 0.0000009);
       }, qx.core.AssertionError);
 
-      // custom precision
-      this.assertEqualsFloat(-5.5, -5.5, 0.2);
-      this.assertEqualsFloat(-5.5, -5.69, 0.2);
-      this.assertEqualsFloat(-5.5, -5.31, 0.2);
-
+      // test error message
       this.assertException(function() {
-        qx.core.Assert.assertEqualsFloat(-5.5, -5.7);
-      }, qx.core.AssertionError);
-
-      this.assertException(function() {
-        qx.core.Assert.assertEqualsFloat(-5.5, -5.3);
-      }, qx.core.AssertionError);
+          qx.core.Assert.assertEqualsFloat(1.5, 1.6);
+        }, qx.core.AssertionError,
+        "Expected '1.5' to be equal with '1.6' regarding the precision inefficiencies of floats!"
+      );
     }
   }
 });

--- a/framework/source/class/qx/test/core/Assert.js
+++ b/framework/source/class/qx/test/core/Assert.js
@@ -172,7 +172,7 @@ qx.Class.define("qx.test.core.Assert",
       this.assertException(function() {
           qx.core.Assert.assertEqualsFloat(1.5, 1.6);
         }, qx.core.AssertionError,
-        "Expected '1.5' to be equal with '1.6' regarding the precision inefficiencies of floats!"
+        "Expected '1.5' to be equal with '1.6'!"
       );
     }
   }

--- a/framework/source/class/qx/test/core/Assert.js
+++ b/framework/source/class/qx/test/core/Assert.js
@@ -153,6 +153,34 @@ qx.Class.define("qx.test.core.Assert",
           this.fireEvent("xyz1");
         });
       }, qx.core.AssertionError);
+    },
+
+    testAssertEqualsFloat : function()
+    {
+      this.assertEqualsFloat(1.0, 1.0);
+      this.assertEqualsFloat(1.0, 1.009);
+      this.assertEqualsFloat(1.0, 0.991);
+
+      this.assertException(function() {
+        qx.core.Assert.assertEqualsFloat(1.0, 1.01);
+      }, qx.core.AssertionError);
+
+      this.assertException(function() {
+        qx.core.Assert.assertEqualsFloat(1.0, 0.09);
+      }, qx.core.AssertionError);
+
+      // custom precision
+      this.assertEqualsFloat(-5.5, -5.5, 0.2);
+      this.assertEqualsFloat(-5.5, -5.69, 0.2);
+      this.assertEqualsFloat(-5.5, -5.31, 0.2);
+
+      this.assertException(function() {
+        qx.core.Assert.assertEqualsFloat(-5.5, -5.7);
+      }, qx.core.AssertionError);
+
+      this.assertException(function() {
+        qx.core.Assert.assertEqualsFloat(-5.5, -5.3);
+      }, qx.core.AssertionError);
     }
   }
 });

--- a/framework/source/class/qx/test/core/Assert.js
+++ b/framework/source/class/qx/test/core/Assert.js
@@ -174,6 +174,28 @@ qx.Class.define("qx.test.core.Assert",
         }, qx.core.AssertionError,
         "Expected '1.5' to be equal with '1.6'!"
       );
+    },
+
+    testAssertNotEqualsFloat : function()
+    {
+      this.assertNotEqualsFloat(1.0, 1.0000001);
+      this.assertNotEqualsFloat(1.5, 1.6);
+      this.assertNotEqualsFloat(1.0, 0.0000009);
+
+      this.assertException(function() {
+        qx.core.Assert.assertNotEqualsFloat(1.0, 1.0);
+      }, qx.core.AssertionError);
+
+      this.assertException(function() {
+        qx.core.Assert.assertNotEqualsFloat(0.3, 0.1 + 0.2);
+      }, qx.core.AssertionError);
+
+      // test error message
+      this.assertException(function() {
+        qx.core.Assert.assertNotEqualsFloat(1.5, 1.5);
+        }, qx.core.AssertionError,
+        "Expected '1.5' to be not equal with '1.5'!"
+      );
     }
   }
 });

--- a/framework/source/class/qx/test/lang/Number.js
+++ b/framework/source/class/qx/test/lang/Number.js
@@ -1,0 +1,39 @@
+/* ************************************************************************
+
+   qooxdoo - the new era of web development
+
+   http://qooxdoo.org
+
+   Copyright:
+     2007-2008 1&1 Internet AG, Germany, http://www.1und1.de
+
+   License:
+     MIT: https://opensource.org/licenses/MIT
+     See the LICENSE file in the project's top-level directory for details.
+
+   Authors:
+     * Markus Bader (mbgonicus)
+
+************************************************************************ */
+
+qx.Class.define("qx.test.lang.Number",
+{
+  extend : qx.dev.unit.TestCase,
+
+  members :
+  {
+    testEquals : function() {
+      this.assertNotUndefined(qx.lang.Number);
+      this.assertFunction(qx.lang.Number.equals);
+
+      // Check integers
+      this.assertTrue(qx.lang.Number.equals(1, 1));
+      this.assertFalse(qx.lang.Number.equals(1, 0));
+
+      // Check floats
+      this.assertTrue(qx.lang.Number.equals(1.5, 1.5));
+      this.assertTrue(qx.lang.Number.equals(0.1 + 0.2, 0.3));
+      this.assertFalse(qx.lang.Number.equals(1.5, 1.500000001));
+    }
+  }
+});


### PR DESCRIPTION
One thing I really dislike about computers is that their memory and calculation precision is naturally finite. Of course I dropped that brick when I recently wanted to assert that two floats are equal. Couldn't find a function in the qooxdoo framework that allows an assertion of the equality of two floats respecting a precision, thus I wrote it on my own. Hope you like it.