### PR TITLE
New feature: transaction mechanism

### DIFF
--- a/framework/source/class/qx/core/Transaction.js
+++ b/framework/source/class/qx/core/Transaction.js
@@ -1,0 +1,55 @@
+/* ************************************************************************
+
+   qooxdoo - the new era of web development
+
+   http://qooxdoo.org
+
+   Copyright:
+     2017 Martijn Evers, The Netherlands
+
+   License:
+     MIT: https://opensource.org/licenses/MIT
+     See the LICENSE file in the project's top-level directory for details.
+
+   Authors:
+     * Martijn Evers (mever)
+
+************************************************************************ */
+
+/**
+ * Within a transaction, property changes can be applied atomically.
+ */
+qx.Class.define("qx.core.Transaction", {
+  extend : qx.core.Object,
+  members : {
+
+    /**
+     * Sets the property value of given subject.
+     *
+     * Note that any exceptions caused by property constrains are caught in the commit phase
+     * and returned as error object(s).
+     *
+     * @param subject {qx.core.Object} Object to change withing the transaction.
+     * @param property {string} Name of the property to set.
+     * @param value {var} Any value accepted by the property.
+     */
+    setPropertyValue : function(subject, property, value) {
+    },
+
+    /**
+     * Commits the transaction.
+     *
+     * When returned array of errors is not empty the transaction is rolled back.
+     *
+     * @return {Error[]} Empty array on success; otherwise an array of error are returned.
+     */
+    commit : function() {
+    },
+
+    /**
+     * Rollback the transaction.
+     */
+    rollback : function () {
+    }
+  }
+});


### PR DESCRIPTION
Dear Qooxdoo members,

For issue #9430 I am changing the `set` implementation to solve a fundamental problem when setting properties in bulk. The PR I am going to release will probably solve an issue raised by PR #9377.

It occurred to me that Qooxdoo's property system can be very useful to hold integrity constraints between objects. It at least provides facilities for supporting this. Usually property value changes are hard-coded changes in order, in which the programmer is aware of state and the changes to this state.

Features like setting properties in bulk currently are not transactional. Therefore constraint checks can not involve constraints between objects or properties.

For example, when a component has an initial minHeight of 40. Then a programmer, trying to set the component to a min- and maxHeight of 20, will first lower minHeight to 20 and then maxHeight. Doing this in the wrong order may cause a constraint violation (the problem with min- and max height is illustrative, reverting PR #9377 will solve this particular problem at once). Thus, applying properties depend on the initial state (before the bulk operation) of the object(s) in question.

The reason why I created this PR is because I think PR #9377 is part of a bigger problem. In a sense, before PR #9377 the commit was implemented in the render layer of the UI system (not very intuitive, also see the fail fast principle).

This PR allows us to use the property system to keep our object model in a consistent state while still applying changing in bulk without knowing the initial state. Also it would be a nice addition to Qooxdoo :)

This PR isn't ready yet. I made it to receive feedback early on. So let's hear it!