### PR TITLE
Fixed crash in VirtualDropDownList#__getAvailableHeight when dropdown has no layout location

### DIFF
--- a/framework/source/class/qx/test/ui/form/VirtualSelectBox.js
+++ b/framework/source/class/qx/test/ui/form/VirtualSelectBox.js
@@ -58,6 +58,30 @@ qx.Class.define("qx.test.ui.form.VirtualSelectBox",
       }.bind(this));
 
       this.__simulateUiInteraction();
+    },
+
+    testChangeModelWhileNotVisible : function()
+    {
+      "use strict";
+      var selectBox = new qx.ui.form.VirtualSelectBox(); // We don't want to use a selectbox that has been added to a layout item.
+      selectBox.setLabelPath('b');
+      var items = qx.data.marshal.Json.createModel([{
+        a: 123,
+        b: 'item 1'
+      }, {
+        a: 456,
+        b: 'item 2'
+      }]);
+      items.setAutoDisposeItems(true);
+
+      selectBox.setModel(items);
+      try {
+        items.pop();
+      } catch (e) {
+        this.assertTrue(false, "Changing the model should not cause an exception in VirtualDropDownList#__getAvailableHeight");
+      }
+
+      items.dispose();
     }
   }
 });

--- a/framework/source/class/qx/ui/core/LayoutItem.js
+++ b/framework/source/class/qx/ui/core/LayoutItem.js
@@ -394,7 +394,7 @@ qx.Class.define("qx.ui.core.LayoutItem",
      * Get the computed location and dimension as computed by
      * the layout manager.
      *
-     * @return {Map} The location and dimensions in pixel
+     * @return {Map|null} The location and dimensions in pixel
      *    (if the layout is valid). Contains the keys
      *    <code>width</code>, <code>height</code>, <code>left</code> and
      *    <code>top</code>.

--- a/framework/source/class/qx/ui/core/MPlacement.js
+++ b/framework/source/class/qx/ui/core/MPlacement.js
@@ -220,7 +220,7 @@ qx.Mixin.define("qx.ui.core.MPlacement",
      * box.
      *
      * @param widget {qx.ui.core.Widget} Any widget
-     * @return {Map} Returns a map with <code>left</code>, <code>top</code>,
+     * @return {Map|null} Returns a map with <code>left</code>, <code>top</code>,
      *   <code>right</code> and <code>bottom</code> which contains the distance
      *   of the widget relative coords the document.
      */

--- a/framework/source/class/qx/ui/form/core/VirtualDropDownList.js
+++ b/framework/source/class/qx/ui/form/core/VirtualDropDownList.js
@@ -440,6 +440,10 @@ qx.Class.define("qx.ui.form.core.VirtualDropDownList",
     __adjustHeight : function()
     {
       var availableHeight = this.__getAvailableHeight();
+      if (availableHeight === null) {
+        return;
+      }
+
       var maxHeight = this._target.getMaxListHeight();
       var list = this.getChildControl("list");
       var itemsHeight = list.getPane().getRowConfig().getTotalSize();
@@ -464,13 +468,13 @@ qx.Class.define("qx.ui.form.core.VirtualDropDownList",
     /**
      * Calculates the available height in the viewport.
      *
-     * @return {Integer} Available height in the viewport.
+     * @return {Integer|null} Available height in the viewport.
      */
     __getAvailableHeight : function()
     {
       var distance = this.getLayoutLocation(this._target);
       if (!distance) {
-        return 0;
+        return null;
       }
 
       var viewPortHeight = qx.bom.Viewport.getHeight();

--- a/framework/source/class/qx/ui/form/core/VirtualDropDownList.js
+++ b/framework/source/class/qx/ui/form/core/VirtualDropDownList.js
@@ -469,6 +469,10 @@ qx.Class.define("qx.ui.form.core.VirtualDropDownList",
     __getAvailableHeight : function()
     {
       var distance = this.getLayoutLocation(this._target);
+      if (!distance) {
+        return 0;
+      }
+
       var viewPortHeight = qx.bom.Viewport.getHeight();
 
       // distance to the bottom and top borders of the viewport


### PR DESCRIPTION
When having set a model on a VirtualSelectBox that has not been rendered, and changing the length of the model array in any way, an exception gets thrown in `VirtualDropDownList#__getAvailableHeight`.

Reason:

`qx.ui.list.List` adds a `changeLength` listener to the model, when this gets fired, `qx.ui.list.List#_onModelChange` gets called which fires the `changeModelLength` event. The VirtualDropDownList listens to this event and calls `qx.ui.form.core.VirtualDropDownList#__adjustHeight` when this happens. This method in turn calls `__getAvailableHeight` which cannot deal with a `null` value for `distance`. `distance` will be null if the widget has no bounds.

I've also written a test for this situation, and I've fixed the docblocks on the relevant methods.