### PR TITLE
Fix load time dependency

### DIFF
--- a/framework/source/class/qx/event/handler/Pointer.js
+++ b/framework/source/class/qx/event/handler/Pointer.js
@@ -21,6 +21,7 @@
  * Unified pointer event handler.
  * @require(qx.event.dispatch.DomBubbling)
  * @require(qx.event.type.Pointer) // load-time dependency for early native events
+ * @require(qx.event.type.dom.Pointer)
  */
 qx.Class.define("qx.event.handler.Pointer",
 {


### PR DESCRIPTION
Using the new compiler rises at least this dependency problem
which is really anoying. You just need to move the mouse while
loading the application and you're bugged into the developer
console.

Maybe there are others, but this one seems to be a must have.