### PR TITLE
Polyfill for Object.is which is missing in IE11

### DIFF
--- a/framework/source/class/qx/bom/client/EcmaScript.js
+++ b/framework/source/class/qx/bom/client/EcmaScript.js
@@ -240,6 +240,15 @@ qx.Bootstrap.define("qx.bom.client.EcmaScript",
     },
 
     /**
+     * Checks if 'is' is supported on the Object object.
+     * @internal
+     * @return {Boolean} <code>true</code>, if the method is available.
+     */
+    getObjectIs : function() {
+      return !!Object.is;
+    },
+
+    /**
      * Checks if 'now' is supported on the Date object.
      * @internal
      * @return {Boolean} <code>true</code>, if the method is available.
@@ -341,6 +350,7 @@ qx.Bootstrap.define("qx.bom.client.EcmaScript",
     // object polyfill
     qx.core.Environment.add("ecmascript.object.keys", statics.getObjectKeys);
     qx.core.Environment.add("ecmascript.object.values", statics.getObjectValues);
+    qx.core.Environment.add("ecmascript.object.is", statics.getObjectIs);
 
     // number polyfill
     qx.core.Environment.add("ecmascript.number.EPSILON", statics.getEpsilon);

--- a/framework/source/class/qx/lang/normalize/Object.js
+++ b/framework/source/class/qx/lang/normalize/Object.js
@@ -58,6 +58,27 @@ qx.Bootstrap.define("qx.lang.normalize.Object", {
       }
 
       return arr;
+    },
+
+
+    /**
+     * Determines whether two values are the same value.
+     *
+     * <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/is">MDN web docs: Object.is()</a>
+     *
+     * @signature function(value1,value2)
+     * @param value1 {Object} the first value to compare
+     * @param value2 {Object} the second value to compare
+     * @return {Boolean} indicating whether or not the two arguments are the same value.
+     */
+    is : function(v1, v2) {
+      if (v1 === 0 && v2 === 0) {
+        return 1 / v1 === 1 / v2;
+      }
+      if (v1 !== v1) {
+        return v2 !== v2;
+      }
+      return v1 === v2;
     }
   },
 
@@ -70,6 +91,11 @@ qx.Bootstrap.define("qx.lang.normalize.Object", {
     // values
     if (!qx.core.Environment.get("ecmascript.object.values")) {
       Object.values = statics.values;
+    }
+
+    // is
+    if (!qx.core.Environment.get("ecmascript.object.is")) {
+      Object.is = statics.is;
     }
   }
 });

--- a/framework/source/class/qx/lang/normalize/Object.js
+++ b/framework/source/class/qx/lang/normalize/Object.js
@@ -66,19 +66,20 @@ qx.Bootstrap.define("qx.lang.normalize.Object", {
      *
      * <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/is">MDN web docs: Object.is()</a>
      *
-     * @signature function(value1,value2)
-     * @param value1 {Object} the first value to compare
-     * @param value2 {Object} the second value to compare
+     * @signature function(x,y)
+     * @param x {Object} the first value to compare
+     * @param y {Object} the second value to compare
      * @return {Boolean} indicating whether or not the two arguments are the same value.
      */
-    is : function(v1, v2) {
-      if (v1 === 0 && v2 === 0) {
-        return 1 / v1 === 1 / v2;
+    is : function(x, y) {
+      // SameValue algorithm
+      if (x === y) { // Steps 1-5, 7-10
+        // Steps 6.b-6.e: +0 != -0
+        return x !== 0 || 1 / x === 1 / y;
+      } else {
+       // Step 6.a: NaN == NaN
+       return x !== x && y !== y;
       }
-      if (v1 !== v1) {
-        return v2 !== v2;
-      }
-      return v1 === v2;
     }
   },
 


### PR DESCRIPTION
IE11 and maybe other clients not fully supporting ECMAScript 2015 do not offer `Object.is`. This polyfill is implemented as recommended in https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/is

This is the reason why three tests failed for IE11 in https://github.com/qooxdoo/qooxdoo/blob/master/framework/source/class/qx/test/core/Property.js