### PR TITLE
Fix test qx.test.bom.Attribute for safari/webkit

### DIFF
--- a/framework/source/class/qx/test/bom/Attribute.js
+++ b/framework/source/class/qx/test/bom/Attribute.js
@@ -55,7 +55,6 @@ qx.Class.define("qx.test.bom.Attribute",
 
       this.__maxLengthValues = {
         "mshtml": 2147483647,
-        "webkit": 524288,
         "default": -1
       };
     },
@@ -109,7 +108,8 @@ qx.Class.define("qx.test.bom.Attribute",
       if (qx.core.Environment.get("browser.name") == "edge") {
         this.assertEquals(Attribute.get(this._input, "maxLength"), this.__maxLengthValues.mshtml);
       }
-      else if (qx.core.Environment.get("browser.name") == "chrome") {
+      else if (qx.core.Environment.get("browser.name") == "chrome" || 
+               qx.core.Environment.get("browser.name") == "safari") {
         this.assertEquals(Attribute.get(this._input, "maxLength"), this.__maxLengthValues["default"]);
       } else {
         this.assertNull(Attribute.get(this._input, "maxLength"));
@@ -165,7 +165,8 @@ qx.Class.define("qx.test.bom.Attribute",
       if (qx.core.Environment.get("browser.name") == "edge") {
         maxLengthValue = this.__maxLengthValues.mshtml;
       }
-      else if (qx.core.Environment.get("browser.name") == "chrome") {
+      else if (qx.core.Environment.get("browser.name") == "chrome" ||
+               qx.core.Environment.get("browser.name") == "safari") {
         maxLengthValue = this.__maxLengthValues["default"];
       }
 
@@ -173,7 +174,8 @@ qx.Class.define("qx.test.bom.Attribute",
       if (qx.core.Environment.get("browser.name") == "edge") {
         this.assertEquals(Attribute.get(this._input, "maxLength"), this.__maxLengthValues.mshtml);
       }
-      else if (qx.core.Environment.get("browser.name") == "chrome") {
+      else if (qx.core.Environment.get("browser.name") == "chrome" ||
+               qx.core.Environment.get("browser.name") == "safari") {
         this.assertEquals(Attribute.get(this._input, "maxLength"), this.__maxLengthValues["default"]);
       } else {
         this.assertNull(Attribute.get(this._input, "maxLength"));
@@ -197,7 +199,8 @@ qx.Class.define("qx.test.bom.Attribute",
       if (qx.core.Environment.get("browser.name") == "edge") {
         this.assertEquals(Attribute.get(this._input, "maxLength"), this.__maxLengthValues.mshtml);
       }
-      else if (qx.core.Environment.get("browser.name") == "chrome") {
+      else if (qx.core.Environment.get("browser.name") == "chrome" ||
+               qx.core.Environment.get("browser.name") == "safari") {
         this.assertEquals(Attribute.get(this._input, "maxLength"), this.__maxLengthValues["default"]);
       } else {
         this.assertNull(Attribute.get(this._input, "maxLength"));


### PR DESCRIPTION
Current Safari does not report the maximum value for `maxlength` for input elements anymore which was til some point 524288. Instead it reports, in compliance with W3C [1], the value of -1 as a default for the case that there is no default value for the attribute. The current W3C tests [2] also expect this behaviour.

See 
[1] https://html.spec.whatwg.org/multipage/common-dom-interfaces.html#limited-to-only-non-negative-numbers
[2] http://w3c-test.org/html/semantics/forms/the-input-element/maxlength.html