### PR TITLE
Fixed disposing of deferred call object

### DIFF
--- a/framework/source/class/qx/ui/list/List.js
+++ b/framework/source/class/qx/ui/list/List.js
@@ -923,7 +923,7 @@ qx.Class.define("qx.ui.list.List",
 
   destruct : function()
   {
-    this.__deferredLayerUpdate = null;
+    this._disposeObjects("__deferredLayerUpdate");
     
     var model = this.getModel();
     if (model != null) {


### PR DESCRIPTION
In `qx.ui.list.List` there might survive a deferred call when the list is disposed. Thus the callback of the deferred call will be invoked on a disposed object which can cause errors.