### PR TITLE
Fix 3 testrunner tests for ie and edge

### DIFF
--- a/framework/source/class/qx/dev/unit/MRequirements.js
+++ b/framework/source/class/qx/dev/unit/MRequirements.js
@@ -257,6 +257,18 @@ qx.Mixin.define("qx.dev.unit.MRequirements", {
 
 
     /**
+     * Checks if the application is running on Windows 10
+     *
+     * @return {Boolean} <code>false</code> if operating system is Windows 10
+     */
+    hasNoWin10 : function()
+    {
+      var isWin10 = (qx.core.Environment.get("os.name") === "win" && qx.core.Environment.get("os.version") === "10");
+      return (isWin10 ? false : true);
+    },
+
+
+    /**
      * Checks if the application is not running in a Google Chrome browser on Linux
      *
      * @return {Boolean} <code>true</code> if the browser is not Google Chrome on Linux

--- a/framework/source/class/qx/test/Browser.js
+++ b/framework/source/class/qx/test/Browser.js
@@ -34,6 +34,7 @@ qx.Class.define("qx.test.Browser",
       // google chrome, opera 10.5, Safari 7 and ie 9
       if (
         qx.core.Environment.get("browser.name").indexOf("chrome") != -1 ||
+        qx.core.Environment.get("browser.name") == "edge" ||
         (qx.core.Environment.get("browser.name") == "opera" &&
          qx.core.Environment.get("browser.version") >= 10.5) ||
         (qx.core.Environment.get("browser.name") == "ie" &&

--- a/framework/source/class/qx/test/io/request/XhrWithRemote.js
+++ b/framework/source/class/qx/test/io/request/XhrWithRemote.js
@@ -121,7 +121,8 @@ qx.Class.define("qx.test.io.request.XhrWithRemote",
       // Note:
       //   * Breaks on Windows 7 and OS X in every browser because the loading phase
       //     is never entered
-      this.require(["noIe", "noWin7", "noOsx"]);
+      //   * Also breaks on Windows 10 in every browser
+      this.require(["noIe", "noWin7", "noOsx", "noWin10"]);
 
       var req = this.req,
           phases = [],

--- a/framework/source/class/qx/test/ui/embed/Iframe.js
+++ b/framework/source/class/qx/test/ui/embed/Iframe.js
@@ -117,9 +117,19 @@ qx.Class.define("qx.test.ui.embed.Iframe",
       window.setTimeout(function ()
       {
         this.resume(function() {
+          var innerText = iframe.getWindow().document.body.innerText;
+
+          // IE and edge deliver an extra blank at the end of 
+          // body.innerText
+          if(typeof innerText == "string" &&
+             (qx.core.Environment.get("browser.name") == "edge" ||
+              qx.core.Environment.get("browser.name") == "ie" )) 
+          {
+            innerText = innerText.replace(/\s$/gm,'');
+          }
           this.assertEquals(
             "Hello World!",
-            iframe.getWindow().document.body.innerText
+            innerText
           );
         });
       }.bind(this), 4000);

--- a/framework/source/class/qx/test/util/DateFormat.js
+++ b/framework/source/class/qx/test/util/DateFormat.js
@@ -20,6 +20,8 @@ qx.Class.define("qx.test.util.DateFormat",
 {
   extend : qx.dev.unit.TestCase,
 
+  include: qx.dev.unit.MRequirements,
+
   members :
   {
 
@@ -122,6 +124,13 @@ qx.Class.define("qx.test.util.DateFormat",
 
     testInvalidDate : function()
     {
+      // Note:
+      //   * Edge parses even invalid dates and calculates
+      //     from the "overflowing" days and months the
+      //     next "logical" date. In the example below
+      //     the date parsed is "2011-12-02".
+      this.require(["noEdge"]);
+
       var invalidDate = new Date("2011-11-32");
       var dateFmt = new qx.util.format.DateFormat();
       this.assertNull(dateFmt.format(invalidDate));
@@ -849,6 +858,10 @@ qx.Class.define("qx.test.util.DateFormat",
     dfDE.dispose();
     dfUS.dispose();
 
+  },
+  
+  hasNoEdge: function() {
+    return !(qx.core.Environment.get("browser.name") == "edge");
   }
 
   }


### PR DESCRIPTION
1. qx.test.Browser.testForIn for edge: This tests the hash map element order where it seems that edge has the same behavior as all other modern browsers have: sort by hash key.
2. qx.test.ui.embed.Iframe.testSyncSourceAfterDOMMove for IE and edge: IE and edge deliver an extra blank at the end of body.innerText which made the test fail. The extra blank is now deleted specifically for edge and ie.
3. qx.test.io.request.XhrWithRemote."test: progress phases when abort after loading": breaks on win 10 for edge, ie, chrome and firefox. Disabled this test by the added detection for not having win 10 ("noWin10") 
4. qx.test.util.DateForma.testInvalidDate for edge: edge parses even invalid dates and calculates  from the "overflowing" days and months the next "logical" date. In the test the invalid date "2011-11-32" is parsed as "2011-12-02". Disabled this test for edge.