### PR TITLE
Fix webfont rule removal for IE and edge

### DIFF
--- a/framework/source/class/qx/bom/webfonts/Manager.js
+++ b/framework/source/class/qx/bom/webfonts/Manager.js
@@ -498,9 +498,19 @@ qx.Class.define("qx.bom.webfonts.Manager", {
      */
     __removeRule : function(familyName, fontWeight, fontStyle)
     {
-      var reg = new RegExp("@font-face.*?" + familyName + ".*font-style: *"
-      + (fontStyle ? fontStyle : "normal") + ".*font-weight: *"
-      + (fontWeight ? fontWeight : "normal"), "m");
+      // In IE and edge even if the rule was added with font-style first
+      // and font-weight second, it is not guaranteed that the attributes
+      // remain in that order. Therefore we check for both version,
+      // style first, weight second and weight first, style second.
+      // Without this fix the rule isn't found and removed reliable. 
+      var regtext = 
+        "@font-face.*?" + familyName + 
+        "(.*font-style: *" + (fontStyle ? fontStyle : "normal") + 
+        ".*font-weight: *" + (fontWeight ? fontWeight : "normal")+")|" +
+        "(.*font-weight: *" + (fontWeight ? fontWeight : "normal") + 
+        ".*font-style: *" + (fontStyle ? fontStyle : "normal")+")"
+        ;
+      var reg = new RegExp(regtext, "m");
       for (var i=0,l=document.styleSheets.length; i<l; i++) {
         var sheet = document.styleSheets[i];
         if (sheet.cssText) {


### PR DESCRIPTION
In IE and edge even if the rule was added with font-style first and font-weight second, it is not guaranteed that the attributes remain in that order. Therefore we check for both versions, style first, weight second and weight first, style second.
Without this fix the rule isn't found and removed reliable. 

This also makes the test qx.test.bom.webfonts.Manager."test: do not create rule for invalid font" succeed again on IE and edge