### PR TITLE
Remove texlive and introduce 'git fetch' limit

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,14 +19,11 @@ env:
 cache:
   directories:
   - "/tmp/qx*"
-  - "`pwd`/texlive"
 
 before_install:
 - gem install sass -v 3.4.20
-- curl -L https://github.com/raphink/travis-texlive/releases/download/2015-07-14_05/texlive.tar.xz  | tar xJC `pwd`
 
 install:
-- export PATH=`pwd`/texlive/bin/x86_64-linux:$PATH
 - .travis/prepare_npm
 - cd framework
 

--- a/.travis/build-site
+++ b/.travis/build-site
@@ -107,8 +107,6 @@ function build_manual {
   (
     cd documentation/manual
     make html && cp -r build/html/* "$TARGET"
-    make latexpdf && cp build/latex/qooxdoo.pdf "$TARGET"
-    #make epub && cp build/epub/qooxdoo.epub "$TARGET"
   )
 }
 

--- a/.travis/deploy
+++ b/.travis/deploy
@@ -74,7 +74,7 @@ git commit -m "Refresh site at ${rev}"
 git push -q upstream HEAD:master
 
 # Do a regular checkout and make a dummy commit
-git clone -q git@github.com:qooxdoo/qooxdoo.github.io.git tmp
+git clone --depth 10 -q git@github.com:qooxdoo/qooxdoo.github.io.git tmp
 cd tmp
 echo $rev > revision
 git add revision

--- a/.travis/deploy
+++ b/.travis/deploy
@@ -32,7 +32,7 @@ git config --global user.email "no-reply@qooxdoo.org"
 git config --global push.default simple
 
 git remote add upstream "git@github.com:qooxdoo/qooxdoo.github.io.git"
-git fetch upstream
+git fetch --depth 10 upstream
 git merge upstream/master
 
 # Adjust settings for TAG build

--- a/.travis/make-release-sdk
+++ b/.travis/make-release-sdk
@@ -100,7 +100,6 @@ function make-release-sdk()
     rm -rf $RELEASE_SDK/documentation/tech_manual/
     mkdir -p $RELEASE_SDK/documentation/manual/
     $SYNC $BASE_DIR/documentation/manual/build/html/* $RELEASE_SDK/documentation/manual/
-    $SYNC $BASE_DIR/documentation/manual/build/latex/qooxdoo.pdf $RELEASE_SDK/documentation/manual/
 
     rm -rf $RELEASE_SDK/.travis*
     rm -rf $RELEASE_SDK/.editorconfig
@@ -146,10 +145,6 @@ function build-docs()
     echo "  * building HTML..."
     (cd $MANUAL && QOOXDOO_RELEASE=1 make html)
     (cd $BASE_DIR/documentation/tech_manual && make html &> /dev/null)
-
-    echo "  * building PDF..."
-    (cd $MANUAL && QOOXDOO_RELEASE=1 make latex &> /dev/null)
-    (cd $MANUAL/build/latex && make all-pdf &> /dev/null)
 }
 
 


### PR DESCRIPTION
This is an attempt to reduce the required *travis* disk space on the deploy job.