### PR TITLE
Enable API users to know about parser errors

### DIFF
--- a/framework/source/class/qx/data/store/Json.js
+++ b/framework/source/class/qx/data/store/Json.js
@@ -79,6 +79,13 @@ qx.Class.define("qx.data.store.Json",
     "loaded" : "qx.event.type.Data",
 
     /**
+     * Fired when a parse error (i.e. broken JSON) occurred
+     * during the load. The data contains a hash of the original
+     * response and the parser error (exception object).
+     */
+    "parseError" : "qx.event.type.Data",
+
+    /**
      * Fired when an error (aborted, timeout or failed) occurred
      * during the load. The data contains the response of the request.
      * If you want more details, use the {@link #changeState} event.
@@ -190,6 +197,7 @@ qx.Class.define("qx.data.store.Json",
       // register the internal event before the user has the change to
       // register its own event in the delegate
       req.addListener("success", this._onSuccess, this);
+      req.addListener("parseError", this._onParseError, this);
 
       // check for the request configuration hook
       var del = this._delegate;
@@ -244,6 +252,18 @@ qx.Class.define("qx.data.store.Json",
     _onFail : function(ev) {
       var req = ev.getTarget();
       this.fireDataEvent("error", req);
+    },
+
+
+    /**
+     * Handler called when not completing the request successfully because
+     * of parse errors.
+     *
+     * @param ev {qx.event.type.Data} Hash map containing the original 'request'
+     *                                and the original parser 'error' exception object.
+     */
+    _onParseError : function(ev) {
+      this.fireDataEvent("parseError", ev.getData());
     },
 
 

--- a/framework/source/class/qx/io/request/AbstractRequest.js
+++ b/framework/source/class/qx/io/request/AbstractRequest.js
@@ -114,6 +114,11 @@ qx.Class.define("qx.io.request.AbstractRequest",
     "statusError": "qx.event.type.Event",
 
     /**
+     * Fired when the configured parser runs into an unrecoverable error.
+     */
+    "parseError": "qx.event.type.Data",
+
+    /**
      * Fired on timeout, error or remote error.
      *
      * This event is fired for convenience. Usually, it is recommended
@@ -262,6 +267,11 @@ qx.Class.define("qx.io.request.AbstractRequest",
      * Holds transport.
      */
     _transport: null,
+
+    /**
+     * Holds information about the parser status for the last request.
+     */
+    _parserFailed: false,
 
     /*
     ---------------------------------------------------------------------------
@@ -745,7 +755,11 @@ qx.Class.define("qx.io.request.AbstractRequest",
 
         this._setResponse(this._getParsedResponse());
 
-        this._fireStatefulEvent("success");
+        if (this._parserFailed) {
+          this.fireEvent("fail");
+        } else {
+          this._fireStatefulEvent("success");
+        }
 
       // Erroneous HTTP status
       } else {

--- a/framework/source/class/qx/io/request/Xhr.js
+++ b/framework/source/class/qx/io/request/Xhr.js
@@ -301,9 +301,21 @@ qx.Class.define("qx.io.request.Xhr",
      */
     _getParsedResponse: function() {
       var response = this._transport.responseText,
-          contentType = this.getResponseContentType() || "";
+          contentType = this.getResponseContentType() || "",
+          parsedResponse = "";
 
-      return this._parser.parse(response, contentType);
+      try {
+        parsedResponse = this._parser.parse(response, contentType);
+        this._parserFailed = false
+      } catch(e) {
+        this._parserFailed = true
+        this.fireDataEvent("parseError", {
+          error: e,
+          response: response
+        });
+      }
+
+      return parsedResponse;
     },
 
     /**

--- a/framework/source/class/qx/test/data/store/Json.js
+++ b/framework/source/class/qx/test/data/store/Json.js
@@ -149,6 +149,21 @@ qx.Class.define("qx.test.data.store.Json",
     },
 
 
+    testParseErrorForResource : function() {
+      this.__store.addListener("parseError", function(ev) {
+        this.resume(function() {
+          this.assertString(ev.getData().response, "Parse error object does not contain response!");
+          this.assertObject(ev.getData().error, "Parse error object does not contain parser exception!");
+        }, this);
+      }, this);
+
+      var resource = "qx/test/failing.json";
+      this.__store.setUrl(resource);
+
+      this.wait();
+    },
+
+
     testLoadAlias : function() {
       this.__store.addListener("loaded", function() {
         this.resume(function() {

--- a/framework/source/resource/qx/test/failing.json
+++ b/framework/source/resource/qx/test/failing.json
@@ -1,0 +1,6 @@
+{
+  "string": String,
+  "number": 12,
+  "boolean": true,
+  "null": null
+}


### PR DESCRIPTION
If the data source is providing an invalid JSON file (for whatever
reason), you'll run into a deadlock when waiting for some kind of
response from the data store / Xhr request.

It will neither fire 'loaded', nor 'fail', nor 'error'. You can
just see an error on the browser console. The error itself is not
catchable.

Adding a 'parseError' event lets you react on such problems.