### PR TITLE
Editors complain about missing arguments

### DIFF
--- a/framework/source/class/qx/core/Assert.js
+++ b/framework/source/class/qx/core/Assert.js
@@ -121,7 +121,7 @@ qx.Bootstrap.define("qx.core.Assert",
      *
      * @param condition {var} Condition to check for. Must evaluate to
      *    <code>true</code>.
-     * @param msg {String} Message to be shown if the assertion fails.
+     * @param msg {String?} Message to be shown if the assertion fails.
      */
     assert : function(condition, msg) {
       condition == true || this.__fail(msg || "", "Called assert with 'false'");
@@ -132,7 +132,7 @@ qx.Bootstrap.define("qx.core.Assert",
      * Raise an {@link AssertionError}.
      *
      * @param msg {String} Message to be shown if the assertion fails.
-     * @param compact {Boolean} Show less verbose message. Default: false.
+     * @param compact {Boolean?false} Show less verbose message. Default: false.
      */
     fail : function(msg, compact) {
       var msgvarargs = compact ? "" : "Called fail().";
@@ -145,7 +145,7 @@ qx.Bootstrap.define("qx.core.Assert",
      *
      * @param value {Boolean} Condition to check for. Must be identical to
      *    <code>true</code>.
-     * @param msg {String} Message to be shown if the assertion fails.
+     * @param msg {String?} Message to be shown if the assertion fails.
      */
     assertTrue : function(value, msg) {
       (value === true) || this.__fail(msg || "", "Called assertTrue with '", value, "'");
@@ -157,7 +157,7 @@ qx.Bootstrap.define("qx.core.Assert",
      *
      * @param value {Boolean} Condition to check for. Must be identical to
      *    <code>false</code>.
-     * @param msg {String} Message to be shown if the assertion fails.
+     * @param msg {String?} Message to be shown if the assertion fails.
      */
     assertFalse : function(value, msg) {
       (value === false) || this.__fail(msg || "", "Called assertFalse with '", value, "'");
@@ -170,7 +170,7 @@ qx.Bootstrap.define("qx.core.Assert",
      *
      * @param expected {var} Reference value
      * @param found {var} found value
-     * @param msg {String} Message to be shown if the assertion fails.
+     * @param msg {String?} Message to be shown if the assertion fails.
      */
     assertEquals : function(expected, found, msg)
     {
@@ -187,7 +187,7 @@ qx.Bootstrap.define("qx.core.Assert",
      *
      * @param expected {var} Reference value
      * @param found {var} found value
-     * @param msg {String} Message to be shown if the assertion fails.
+     * @param msg {String?} Message to be shown if the assertion fails.
      */
     assertNotEquals : function(expected, found, msg)
     {
@@ -204,7 +204,7 @@ qx.Bootstrap.define("qx.core.Assert",
      *
      * @param expected {Float} Reference value
      * @param found {Float} Found value
-     * @param msg {String} Message to be shown if the assertion fails.
+     * @param msg {String?} Message to be shown if the assertion fails.
      */
     assertEqualsFloat : function(expected, found, msg)
     {
@@ -223,7 +223,7 @@ qx.Bootstrap.define("qx.core.Assert",
      *
      * @param expected {Float} Reference value
      * @param found {Float} Found value
-     * @param msg {String} Message to be shown if the assertion fails.
+     * @param msg {String?} Message to be shown if the assertion fails.
      */
     assertNotEqualsFloat : function(expected, found, msg)
     {
@@ -242,7 +242,7 @@ qx.Bootstrap.define("qx.core.Assert",
      *
      * @param expected {var} Reference value
      * @param found {var} found value
-     * @param msg {String} Message to be shown if the assertion fails.
+     * @param msg {String?} Message to be shown if the assertion fails.
      */
     assertIdentical : function(expected, found, msg)
     {
@@ -260,7 +260,7 @@ qx.Bootstrap.define("qx.core.Assert",
      *
      * @param expected {var} Reference value
      * @param found {var} found value
-     * @param msg {String} Message to be shown if the assertion fails.
+     * @param msg {String?} Message to be shown if the assertion fails.
      */
     assertNotIdentical : function(expected, found, msg)
     {
@@ -276,7 +276,7 @@ qx.Bootstrap.define("qx.core.Assert",
      * Assert that the value is not <code>undefined</code>.
      *
      * @param value {var} Value to check
-     * @param msg {String} Message to be shown if the assertion fails.
+     * @param msg {String?} Message to be shown if the assertion fails.
      */
     assertNotUndefined : function(value, msg)
     {
@@ -291,7 +291,7 @@ qx.Bootstrap.define("qx.core.Assert",
      * Assert that the value is <code>undefined</code>.
      *
      * @param value {var} Value to check
-     * @param msg {String} Message to be shown if the assertion fails.
+     * @param msg {String?} Message to be shown if the assertion fails.
      */
     assertUndefined : function(value, msg)
     {
@@ -306,7 +306,7 @@ qx.Bootstrap.define("qx.core.Assert",
      * Assert that the value is not <code>null</code>.
      *
      * @param value {var} Value to check
-     * @param msg {String} Message to be shown if the assertion fails.
+     * @param msg {String?} Message to be shown if the assertion fails.
      */
     assertNotNull : function(value, msg)
     {
@@ -321,7 +321,7 @@ qx.Bootstrap.define("qx.core.Assert",
      * Assert that the value is <code>null</code>.
      *
      * @param value {var} Value to check
-     * @param msg {String} Message to be shown if the assertion fails.
+     * @param msg {String?} Message to be shown if the assertion fails.
      */
     assertNull : function(value, msg)
     {
@@ -338,7 +338,7 @@ qx.Bootstrap.define("qx.core.Assert",
      *
      * @param expected {var} The the expected value
      * @param found {var} The found value
-     * @param msg {String} Message to be shown if the assertion fails.
+     * @param msg {String?} Message to be shown if the assertion fails.
      */
     assertJsonEquals : function(expected, found, msg) {
       this.assertEquals(
@@ -354,7 +354,7 @@ qx.Bootstrap.define("qx.core.Assert",
      *
      * @param str {String} String, which should match the regular expression
      * @param re {String|RegExp} Regular expression to match
-     * @param msg {String} Message to be shown if the assertion fails.
+     * @param msg {String?} Message to be shown if the assertion fails.
      */
     assertMatch : function(str, re, msg)
     {
@@ -376,7 +376,7 @@ qx.Bootstrap.define("qx.core.Assert",
      * @param args {arguments} The <code>arguments<code> variable of a function
      * @param minCount {Integer} Minimal number of arguments
      * @param maxCount {Integer} Maximum number of arguments
-     * @param msg {String} Message to be shown if the assertion fails.
+     * @param msg {String?} Message to be shown if the assertion fails.
      */
     assertArgumentsCount : function(args, minCount, maxCount, msg)
     {
@@ -434,7 +434,7 @@ qx.Bootstrap.define("qx.core.Assert",
      * @param event {String} The event which should be fired.
      * @param invokeFunc {Function} The function which will be invoked and which
      *   should not fire the event.
-     * @param msg {String} Message to be shows if the assertion fails.
+     * @param msg {String?} Message to be shows if the assertion fails.
      */
     assertEventNotFired : function(obj, event, invokeFunc, msg)
     {
@@ -460,7 +460,7 @@ qx.Bootstrap.define("qx.core.Assert",
      *   parameter.
      * @param re {String|RegExp} The assertion fails if the error message does
      *   not match this parameter
-     * @param msg {String} Message to be shown if the assertion fails.
+     * @param msg {String?} Message to be shown if the assertion fails.
      */
     assertException : function(callback, exception, re, msg)
     {
@@ -495,7 +495,7 @@ qx.Bootstrap.define("qx.core.Assert",
      *
      * @param value {var} Value to check
      * @param array {Array} List of valid values
-     * @param msg {String} Message to be shown if the assertion fails.
+     * @param msg {String?} Message to be shown if the assertion fails.
      */
     assertInArray : function(value, array, msg)
     {
@@ -513,7 +513,7 @@ qx.Bootstrap.define("qx.core.Assert",
      *
      * @param value {var} Value to check
      * @param array {Array} List of values
-     * @param msg {String} Message to be shown if the assertion fails
+     * @param msg {String?} Message to be shown if the assertion fails
      */
     assertNotInArray : function(value, array, msg) {
       array.indexOf(value) === -1 || this.__fail(
@@ -531,7 +531,7 @@ qx.Bootstrap.define("qx.core.Assert",
      *
      * @param expected {Array} The expected array
      * @param found {Array} The found array
-     * @param msg {String} Message to be shown if the assertion fails.
+     * @param msg {String?} Message to be shown if the assertion fails.
      */
     assertArrayEquals : function(expected, found, msg)
     {
@@ -559,7 +559,7 @@ qx.Bootstrap.define("qx.core.Assert",
      *
      * @param value {var} Value to check
      * @param map {Map} Map, where the keys represent the valid values
-     * @param msg {String} Message to be shown if the assertion fails.
+     * @param msg {String?} Message to be shown if the assertion fails.
      */
     assertKeyInMap : function(value, map, msg)
     {
@@ -575,7 +575,7 @@ qx.Bootstrap.define("qx.core.Assert",
      * Assert that the value is a function.
      *
      * @param value {var} Value to check
-     * @param msg {String} Message to be shown if the assertion fails.
+     * @param msg {String?} Message to be shown if the assertion fails.
      */
     assertFunction : function(value, msg)
     {
@@ -589,7 +589,7 @@ qx.Bootstrap.define("qx.core.Assert",
      * Assert that the value is a function or an async function.
      *
      * @param value {var} Value to check
-     * @param msg {String} Message to be shown if the assertion fails.
+     * @param msg {String?} Message to be shown if the assertion fails.
      */
     assertFunctionOrAsyncFunction : function(value, msg)
     {
@@ -603,7 +603,7 @@ qx.Bootstrap.define("qx.core.Assert",
      * Assert that the value is a string.
      *
      * @param value {var} Value to check
-     * @param msg {String} Message to be shown if the assertion fails.
+     * @param msg {String?} Message to be shown if the assertion fails.
      */
     assertString : function(value, msg) {
       qx.lang.Type.isString(value) || this.__fail(
@@ -617,7 +617,7 @@ qx.Bootstrap.define("qx.core.Assert",
      * Assert that the value is a boolean.
      *
      * @param value {var} Value to check
-     * @param msg {String} Message to be shown if the assertion fails.
+     * @param msg {String?} Message to be shown if the assertion fails.
      */
     assertBoolean : function(value, msg)
     {
@@ -632,7 +632,7 @@ qx.Bootstrap.define("qx.core.Assert",
      * Assert that the value is a number.
      *
      * @param value {var} Value to check
-     * @param msg {String} Message to be shown if the assertion fails.
+     * @param msg {String?} Message to be shown if the assertion fails.
      */
     assertNumber : function(value, msg)
     {
@@ -647,7 +647,7 @@ qx.Bootstrap.define("qx.core.Assert",
      * Assert that the value is a number >= 0.
      *
      * @param value {var} Value to check
-     * @param msg {String} Message to be shown if the assertion fails.
+     * @param msg {String?} Message to be shown if the assertion fails.
      */
     assertPositiveNumber : function(value, msg)
     {
@@ -662,7 +662,7 @@ qx.Bootstrap.define("qx.core.Assert",
      * Assert that the value is an integer.
      *
      * @param value {var} Value to check
-     * @param msg {String} Message to be shown if the assertion fails.
+     * @param msg {String?} Message to be shown if the assertion fails.
      */
     assertInteger : function(value, msg)
     {
@@ -677,7 +677,7 @@ qx.Bootstrap.define("qx.core.Assert",
      * Assert that the value is an integer >= 0.
      *
      * @param value {var} Value to check
-     * @param msg {String} Message to be shown if the assertion fails.
+     * @param msg {String?} Message to be shown if the assertion fails.
      */
     assertPositiveInteger : function(value, msg)
     {
@@ -700,7 +700,7 @@ qx.Bootstrap.define("qx.core.Assert",
      * @param value {var} Value to check
      * @param min {Number} lower bound
      * @param max {Number} upper bound
-     * @param msg {String} Message to be shown if the assertion fails.
+     * @param msg {String?} Message to be shown if the assertion fails.
      */
     assertInRange : function(value, min, max, msg)
     {
@@ -715,7 +715,7 @@ qx.Bootstrap.define("qx.core.Assert",
      * Assert that the value is an object.
      *
      * @param value {var} Value to check
-     * @param msg {String} Message to be shown if the assertion fails.
+     * @param msg {String?} Message to be shown if the assertion fails.
      */
     assertObject : function(value, msg)
     {
@@ -732,7 +732,7 @@ qx.Bootstrap.define("qx.core.Assert",
      * Assert that the value is an array.
      *
      * @param value {var} Value to check
-     * @param msg {String} Message to be shown if the assertion fails.
+     * @param msg {String?} Message to be shown if the assertion fails.
      */
     assertArray : function(value, msg)
     {
@@ -748,7 +748,7 @@ qx.Bootstrap.define("qx.core.Assert",
      * or by using the object literal notation <code>{ ... }</code>.
      *
      * @param value {var} Value to check
-     * @param msg {String} Message to be shown if the assertion fails.
+     * @param msg {String?} Message to be shown if the assertion fails.
      */
     assertMap : function(value, msg)
     {
@@ -763,7 +763,7 @@ qx.Bootstrap.define("qx.core.Assert",
     * Assert that the value is a regular expression.
     *
     * @param value {var} Value to check
-    * @param msg {String} Message to be shown if the assertion fails.
+    * @param msg {String?} Message to be shown if the assertion fails.
     */
    assertRegExp : function(value, msg)
    {
@@ -782,7 +782,7 @@ qx.Bootstrap.define("qx.core.Assert",
      *
      * @param value {var} Value to check
      * @param type {String} expected type of the value
-     * @param msg {String} Message to be shown if the assertion fails.
+     * @param msg {String?} Message to be shown if the assertion fails.
      */
     assertType : function(value, type, msg)
     {
@@ -800,7 +800,7 @@ qx.Bootstrap.define("qx.core.Assert",
      *
      * @param value {var} Value to check
      * @param clazz {Class} The value must be an instance of this class
-     * @param msg {String} Message to be shown if the assertion fails.
+     * @param msg {String?} Message to be shown if the assertion fails.
      */
     assertInstance : function(value, clazz, msg)
     {
@@ -818,7 +818,7 @@ qx.Bootstrap.define("qx.core.Assert",
      *
      * @param value {var} Value to check
      * @param iface {Class} The value must implement this interface
-     * @param msg {String} Message to be shown if the assertion fails.
+     * @param msg {String?} Message to be shown if the assertion fails.
      */
     assertInterface : function(value, iface, msg) {
       qx.Class && qx.Class.implementsInterface(value, iface) || this.__fail(
@@ -835,7 +835,7 @@ qx.Bootstrap.define("qx.core.Assert",
      *
      *  @param expected {String} The expected color
      *  @param value {String} The value to check
-     *  @param msg {String} Message to be shown if the assertion fails.
+     *  @param msg {String?} Message to be shown if the assertion fails.
      */
     assertCssColor : function(expected, value, msg)
     {
@@ -874,7 +874,7 @@ qx.Bootstrap.define("qx.core.Assert",
      * Assert that the value is a DOM element.
      *
      * @param value {var} Value to check
-     * @param msg {String} Message to be shown if the assertion fails.
+     * @param msg {String?} Message to be shown if the assertion fails.
      */
     assertElement : function(value, msg)
     {
@@ -890,7 +890,7 @@ qx.Bootstrap.define("qx.core.Assert",
      * Assert that the value is an instance of {@link qx.core.Object}.
      *
      * @param value {var} Value to check
-     * @param msg {String} Message to be shown if the assertion fails.
+     * @param msg {String?} Message to be shown if the assertion fails.
      */
     assertQxObject : function(value, msg)
     {
@@ -905,7 +905,7 @@ qx.Bootstrap.define("qx.core.Assert",
      * Assert that the value is an instance of {@link qx.ui.core.Widget}.
      *
      * @param value {var} Value to check
-     * @param msg {String} Message to be shown if the assertion fails.
+     * @param msg {String?} Message to be shown if the assertion fails.
      */
     assertQxWidget : function(value, msg)
     {

--- a/framework/source/class/qx/core/MAssert.js
+++ b/framework/source/class/qx/core/MAssert.js
@@ -33,7 +33,7 @@ qx.Mixin.define("qx.core.MAssert",
    *
    * @param condition {var} Condition to check for. Must evaluate to
    *    <code>true</code>.
-   * @param msg {String} Message to be shown if the assertion fails.
+   * @param msg {String?} Message to be shown if the assertion fails.
    */
     assert : function(condition, msg) {
       qx.core.Assert.assert(condition, msg);
@@ -44,7 +44,7 @@ qx.Mixin.define("qx.core.MAssert",
      * Raise an {@link AssertionError}
      *
      * @param msg {String} Message to be shown if the assertion fails.
-     * @param compact {Boolean} Show less verbose message. Default: false.
+     * @param compact {Boolean?false} Show less verbose message. Default: false.
      */
     fail : function(msg, compact) {
       qx.core.Assert.fail(msg, compact);
@@ -56,7 +56,7 @@ qx.Mixin.define("qx.core.MAssert",
      *
      * @param value {Boolean} Condition to check for. Must be identical to
      *    <code>true</code>.
-     * @param msg {String} Message to be shown if the assertion fails.
+     * @param msg {String?} Message to be shown if the assertion fails.
      */
     assertTrue : function(value, msg) {
       qx.core.Assert.assertTrue(value, msg);
@@ -68,7 +68,7 @@ qx.Mixin.define("qx.core.MAssert",
      *
      * @param value {Boolean} Condition to check for. Must be identical to
      *    <code>false</code>.
-     * @param msg {String} Message to be shown if the assertion fails.
+     * @param msg {String?} Message to be shown if the assertion fails.
      */
     assertFalse : function(value, msg) {
       qx.core.Assert.assertFalse(value, msg);
@@ -81,7 +81,7 @@ qx.Mixin.define("qx.core.MAssert",
      *
      * @param expected {var} Reference value
      * @param found {var} found value
-     * @param msg {String} Message to be shown if the assertion fails.
+     * @param msg {String?} Message to be shown if the assertion fails.
      */
     assertEquals : function(expected, found, msg) {
       qx.core.Assert.assertEquals(expected, found, msg);
@@ -93,7 +93,7 @@ qx.Mixin.define("qx.core.MAssert",
      *
      * @param expected {var} Reference value
      * @param found {var} found value
-     * @param msg {String} Message to be shown if the assertion fails.
+     * @param msg {String?} Message to be shown if the assertion fails.
      */
     assertNotEquals : function(expected, found, msg) {
       qx.core.Assert.assertNotEquals(expected, found, msg);
@@ -106,7 +106,7 @@ qx.Mixin.define("qx.core.MAssert",
      *
      * @param expected {Float} Reference value
      * @param found {Float} Found value
-     * @param msg {String} Message to be shown if the assertion fails.
+     * @param msg {String?} Message to be shown if the assertion fails.
      */
     assertEqualsFloat : function(expected, found, msg) {
       qx.core.Assert.assertEqualsFloat(expected, found, msg);
@@ -119,7 +119,7 @@ qx.Mixin.define("qx.core.MAssert",
      *
      * @param expected {Float} Reference value
      * @param found {Float} Found value
-     * @param msg {String} Message to be shown if the assertion fails.
+     * @param msg {String?} Message to be shown if the assertion fails.
      */
     assertNotEqualsFloat : function(expected, found, msg) {
       qx.core.Assert.assertNotEqualsFloat(expected, found, msg);
@@ -132,7 +132,7 @@ qx.Mixin.define("qx.core.MAssert",
      *
      * @param expected {var} Reference value
      * @param found {var} found value
-     * @param msg {String} Message to be shown if the assertion fails.
+     * @param msg {String?} Message to be shown if the assertion fails.
      */
     assertIdentical : function(expected, found, msg) {
       qx.core.Assert.assertIdentical(expected, found, msg);
@@ -145,7 +145,7 @@ qx.Mixin.define("qx.core.MAssert",
      *
      * @param expected {var} Reference value
      * @param found {var} found value
-     * @param msg {String} Message to be shown if the assertion fails.
+     * @param msg {String?} Message to be shown if the assertion fails.
      */
     assertNotIdentical : function(expected, found, msg) {
       qx.core.Assert.assertNotIdentical(expected, found, msg);
@@ -156,7 +156,7 @@ qx.Mixin.define("qx.core.MAssert",
      * Assert that the value is not <code>undefined</code>.
      *
      * @param value {var} Value to check
-     * @param msg {String} Message to be shown if the assertion fails.
+     * @param msg {String?} Message to be shown if the assertion fails.
      */
     assertNotUndefined : function(value, msg) {
       qx.core.Assert.assertNotUndefined(value, msg);
@@ -167,7 +167,7 @@ qx.Mixin.define("qx.core.MAssert",
      * Assert that the value is <code>undefined</code>.
      *
      * @param value {var} Value to check
-     * @param msg {String} Message to be shown if the assertion fails.
+     * @param msg {String?} Message to be shown if the assertion fails.
      */
     assertUndefined : function(value, msg) {
       qx.core.Assert.assertUndefined(value, msg);
@@ -178,7 +178,7 @@ qx.Mixin.define("qx.core.MAssert",
      * Assert that the value is not <code>null</code>.
      *
      * @param value {var} Value to check
-     * @param msg {String} Message to be shown if the assertion fails.
+     * @param msg {String?} Message to be shown if the assertion fails.
      */
     assertNotNull : function(value, msg) {
       qx.core.Assert.assertNotNull(value, msg);
@@ -189,7 +189,7 @@ qx.Mixin.define("qx.core.MAssert",
      * Assert that the value is <code>null</code>.
      *
      * @param value {var} Value to check
-     * @param msg {String} Message to be shown if the assertion fails.
+     * @param msg {String?} Message to be shown if the assertion fails.
      */
     assertNull : function(value, msg) {
       qx.core.Assert.assertNull(value, msg);
@@ -202,7 +202,7 @@ qx.Mixin.define("qx.core.MAssert",
      *
      * @param expected {var} The expected value
      * @param found {var} The found value
-     * @param msg {String} Message to be shown if the assertion fails.
+     * @param msg {String?} Message to be shown if the assertion fails.
      */
     assertJsonEquals : function(expected, found, msg) {
       qx.core.Assert.assertJsonEquals(expected, found, msg);
@@ -214,7 +214,7 @@ qx.Mixin.define("qx.core.MAssert",
      *
      * @param str {String} String, which should match the regular expression
      * @param re {RegExp} Regular expression to match
-     * @param msg {String} Message to be shown if the assertion fails.
+     * @param msg {String?} Message to be shown if the assertion fails.
      */
     assertMatch : function(str, re, msg) {
       qx.core.Assert.assertMatch(str, re, msg);
@@ -227,7 +227,7 @@ qx.Mixin.define("qx.core.MAssert",
      * @param args {arguments} The <code>arguments<code> variable of a function
      * @param minCount {Integer} Minimal number of arguments
      * @param maxCount {Integer} Maximum number of arguments
-     * @param msg {String} Message to be shown if the assertion fails.
+     * @param msg {String?} Message to be shown if the assertion fails.
      */
     assertArgumentsCount : function(args, minCount, maxCount, msg) {
       qx.core.Assert.assertArgumentsCount(args, minCount, maxCount, msg);
@@ -257,7 +257,7 @@ qx.Mixin.define("qx.core.MAssert",
      * @param event {String} The event which should be fired.
      * @param invokeFunc {Function} The function which will be invoked and which
      *   should not fire the event.
-     * @param msg {String} Message to be shows if the assertion fails.
+     * @param msg {String?} Message to be shows if the assertion fails.
      */
     assertEventNotFired : function(obj, event, invokeFunc, msg) {
       qx.core.Assert.assertEventNotFired(obj, event, invokeFunc, msg);
@@ -273,7 +273,7 @@ qx.Mixin.define("qx.core.MAssert",
      *   parameter.
      * @param re {String|RegExp} The assertion fails if the error message does
      *   not match this parameter
-     * @param msg {String} Message to be shown if the assertion fails.
+     * @param msg {String?} Message to be shown if the assertion fails.
      */
     assertException : function(callback, exception, re, msg) {
       qx.core.Assert.assertException(callback, exception, re, msg);
@@ -285,7 +285,7 @@ qx.Mixin.define("qx.core.MAssert",
      *
      * @param value {var} Value to check
      * @param array {Array} List of valid values
-     * @param msg {String} Message to be shown if the assertion fails.
+     * @param msg {String?} Message to be shown if the assertion fails.
      */
     assertInArray : function(value, array, msg) {
       qx.core.Assert.assertInArray(value, array, msg);
@@ -297,7 +297,7 @@ qx.Mixin.define("qx.core.MAssert",
      *
      * @param value {var} Value to check
      * @param array {Array} List of values
-     * @param msg {String} Message to be shown if the assertion fails
+     * @param msg {String?} Message to be shown if the assertion fails
      */
     assertNotInArray : function(value, array, msg) {
       qx.core.Assert.assertNotInArray(value, array, msg);
@@ -309,7 +309,7 @@ qx.Mixin.define("qx.core.MAssert",
      *
      * @param expected {Array} The expected array
      * @param found {Array} The found array
-     * @param msg {String} Message to be shown if the assertion fails.
+     * @param msg {String?} Message to be shown if the assertion fails.
      */
     assertArrayEquals : function(expected, found, msg) {
       qx.core.Assert.assertArrayEquals(expected, found, msg);
@@ -321,7 +321,7 @@ qx.Mixin.define("qx.core.MAssert",
      *
      * @param value {var} Value to check
      * @param map {Map} Map, where the keys represent the valid values
-     * @param msg {String} Message to be shown if the assertion fails.
+     * @param msg {String?} Message to be shown if the assertion fails.
      */
     assertKeyInMap : function(value, map, msg) {
       qx.core.Assert.assertKeyInMap(value, map, msg);
@@ -332,7 +332,7 @@ qx.Mixin.define("qx.core.MAssert",
      * Assert that the value is a function.
      *
      * @param value {var} Value to check
-     * @param msg {String} Message to be shown if the assertion fails.
+     * @param msg {String?} Message to be shown if the assertion fails.
      */
     assertFunction : function(value, msg) {
       qx.core.Assert.assertFunction(value, msg);
@@ -343,7 +343,7 @@ qx.Mixin.define("qx.core.MAssert",
      * Assert that the value is a string.
      *
      * @param value {var} Value to check
-     * @param msg {String} Message to be shown if the assertion fails.
+     * @param msg {String?} Message to be shown if the assertion fails.
      */
     assertString : function(value, msg) {
       qx.core.Assert.assertString(value, msg);
@@ -354,7 +354,7 @@ qx.Mixin.define("qx.core.MAssert",
      * Assert that the value is a boolean.
      *
      * @param value {var} Value to check
-     * @param msg {String} Message to be shown if the assertion fails.
+     * @param msg {String?} Message to be shown if the assertion fails.
      */
     assertBoolean : function(value, msg) {
       qx.core.Assert.assertBoolean(value, msg);
@@ -365,7 +365,7 @@ qx.Mixin.define("qx.core.MAssert",
      * Assert that the value is a number.
      *
      * @param value {var} Value to check
-     * @param msg {String} Message to be shown if the assertion fails.
+     * @param msg {String?} Message to be shown if the assertion fails.
      */
     assertNumber : function(value, msg) {
       qx.core.Assert.assertNumber(value, msg);
@@ -376,7 +376,7 @@ qx.Mixin.define("qx.core.MAssert",
      * Assert that the value is a number >= 0.
      *
      * @param value {var} Value to check
-     * @param msg {String} Message to be shown if the assertion fails.
+     * @param msg {String?} Message to be shown if the assertion fails.
      */
     assertPositiveNumber : function(value, msg) {
       qx.core.Assert.assertPositiveNumber(value, msg);
@@ -387,7 +387,7 @@ qx.Mixin.define("qx.core.MAssert",
      * Assert that the value is an integer.
      *
      * @param value {var} Value to check
-     * @param msg {String} Message to be shown if the assertion fails.
+     * @param msg {String?} Message to be shown if the assertion fails.
      */
     assertInteger : function(value, msg) {
       qx.core.Assert.assertInteger(value, msg);
@@ -398,7 +398,7 @@ qx.Mixin.define("qx.core.MAssert",
      * Assert that the value is an integer >= 0.
      *
      * @param value {var} Value to check
-     * @param msg {String} Message to be shown if the assertion fails.
+     * @param msg {String?} Message to be shown if the assertion fails.
      */
     assertPositiveInteger : function(value, msg) {
       qx.core.Assert.assertPositiveInteger(value, msg);
@@ -411,7 +411,7 @@ qx.Mixin.define("qx.core.MAssert",
      * @param value {var} Value to check
      * @param min {Number} lower bound
      * @param max {Number} upper bound
-     * @param msg {String} Message to be shown if the assertion fails.
+     * @param msg {String?} Message to be shown if the assertion fails.
      */
     assertInRange : function(value, min, max, msg) {
       qx.core.Assert.assertInRange(value, min, max, msg);
@@ -422,7 +422,7 @@ qx.Mixin.define("qx.core.MAssert",
      * Assert that the value is an object.
      *
      * @param value {var} Value to check
-     * @param msg {String} Message to be shown if the assertion fails.
+     * @param msg {String?} Message to be shown if the assertion fails.
      */
     assertObject : function(value, msg) {
       qx.core.Assert.assertObject(value, msg);
@@ -433,7 +433,7 @@ qx.Mixin.define("qx.core.MAssert",
      * Assert that the value is an array.
      *
      * @param value {var} Value to check
-     * @param msg {String} Message to be shown if the assertion fails.
+     * @param msg {String?} Message to be shown if the assertion fails.
      */
     assertArray : function(value, msg) {
       qx.core.Assert.assertArray(value, msg);
@@ -445,7 +445,7 @@ qx.Mixin.define("qx.core.MAssert",
      * or by using the object literal notation <code>{ ... }</code>.
      *
      * @param value {var} Value to check
-     * @param msg {String} Message to be shown if the assertion fails.
+     * @param msg {String?} Message to be shown if the assertion fails.
      */
     assertMap : function(value, msg) {
       qx.core.Assert.assertMap(value, msg);
@@ -456,7 +456,7 @@ qx.Mixin.define("qx.core.MAssert",
      * Assert that the value is a regular expression.
      *
      * @param value {var} Value to check
-     * @param msg {String} Message to be shown if the assertion fails.
+     * @param msg {String?} Message to be shown if the assertion fails.
      */
     assertRegExp : function(value, msg) {
        qx.core.Assert.assertRegExp(value, msg);
@@ -471,7 +471,7 @@ qx.Mixin.define("qx.core.MAssert",
      *
      * @param value {var} Value to check
      * @param type {String} expected type of the value
-     * @param msg {String} Message to be shown if the assertion fails.
+     * @param msg {String?} Message to be shown if the assertion fails.
      */
     assertType : function(value, type, msg) {
       qx.core.Assert.assertType(value, type, msg);
@@ -483,7 +483,7 @@ qx.Mixin.define("qx.core.MAssert",
      *
      * @param value {var} Value to check
      * @param clazz {Class} The value must be an instance of this class
-     * @param msg {String} Message to be shown if the assertion fails.
+     * @param msg {String?} Message to be shown if the assertion fails.
      */
     assertInstance : function(value, clazz, msg) {
       qx.core.Assert.assertInstance(value, clazz, msg);
@@ -495,7 +495,7 @@ qx.Mixin.define("qx.core.MAssert",
      *
      * @param value {var} Value to check
      * @param iface {Class} The value must implement this interface
-     * @param msg {String} Message to be shown if the assertion fails.
+     * @param msg {String?} Message to be shown if the assertion fails.
      */
     assertInterface : function(value, iface, msg) {
       qx.core.Assert.assertInterface(value, iface, msg);
@@ -509,7 +509,7 @@ qx.Mixin.define("qx.core.MAssert",
      *
      *  @param expected {String} The expected color
      *  @param value {String} The value to check
-     *  @param msg {String} Message to be shown if the assertion fails.
+     *  @param msg {String?} Message to be shown if the assertion fails.
      */
     assertCssColor : function(expected, value, msg) {
       qx.core.Assert.assertCssColor(expected, value, msg);
@@ -520,7 +520,7 @@ qx.Mixin.define("qx.core.MAssert",
      * Assert that the value is a DOM element.
      *
      * @param value {var} Value to check
-     * @param msg {String} Message to be shown if the assertion fails.
+     * @param msg {String?} Message to be shown if the assertion fails.
      */
     assertElement : function(value, msg) {
       qx.core.Assert.assertElement(value, msg);
@@ -531,7 +531,7 @@ qx.Mixin.define("qx.core.MAssert",
      * Assert that the value is an instance of {@link qx.core.Object}.
      *
      * @param value {var} Value to check
-     * @param msg {String} Message to be shown if the assertion fails.
+     * @param msg {String?} Message to be shown if the assertion fails.
      */
     assertQxObject : function(value, msg) {
       qx.core.Assert.assertQxObject(value, msg);
@@ -542,7 +542,7 @@ qx.Mixin.define("qx.core.MAssert",
      * Assert that the value is an instance of {@link qx.ui.core.Widget}.
      *
      * @param value {var} Value to check
-     * @param msg {String} Message to be shown if the assertion fails.
+     * @param msg {String?} Message to be shown if the assertion fails.
      */
     assertQxWidget : function(value, msg) {
       qx.core.Assert.assertQxWidget(value, msg);


### PR DESCRIPTION
My editor (PHPStorm/WebStorm) is complaining about missing arguments for assert functions. This PR fixes that.