### PR TITLE
Improved error messages when databinding fails on missing target setter

### DIFF
--- a/framework/source/class/qx/data/SingleValueBinding.js
+++ b/framework/source/class/qx/data/SingleValueBinding.js
@@ -658,12 +658,10 @@ qx.Class.define("qx.data.SingleValueBinding",
           target["reset" + qx.lang.String.firstUp(lastProperty)]();
         } else {
           // fallback if no resetter is given (see bug #2456)
-          try{
-            target["set" + qx.lang.String.firstUp(lastProperty)](null);
-          } catch (e) {
-            throw new Error("Binding '" + lastProperty + "' on target " + target + " failed: " + e);
+          if( typeof target["set" + qx.lang.String.firstUp(lastProperty)] != "function") {
+            throw new qx.core.AssertionError("No setter for '" + lastProperty + "' on target " + target + ".");
           }
-          
+          target["set" + qx.lang.String.firstUp(lastProperty)](null);
         }
       }
     },
@@ -697,11 +695,10 @@ qx.Class.define("qx.data.SingleValueBinding",
           }
           target.setItem(index, value);
         } else {
-          try {
-            return target["set" + qx.lang.String.firstUp(lastProperty)](value);
-          } catch (e) { 
-            throw new Error("Binding '" + lastProperty + "' on target " + target + " failed: " + e);
+          if( typeof target["set" + qx.lang.String.firstUp(lastProperty)] != "function" ){
+            throw new qx.core.AssertionError("No setter for '" + lastProperty + "' on target " + target + ".");
           }
+          return target["set" + qx.lang.String.firstUp(lastProperty)](value);
         }
       }
     },

--- a/framework/source/class/qx/data/SingleValueBinding.js
+++ b/framework/source/class/qx/data/SingleValueBinding.js
@@ -658,7 +658,12 @@ qx.Class.define("qx.data.SingleValueBinding",
           target["reset" + qx.lang.String.firstUp(lastProperty)]();
         } else {
           // fallback if no resetter is given (see bug #2456)
-          target["set" + qx.lang.String.firstUp(lastProperty)](null);
+          try{
+            target["set" + qx.lang.String.firstUp(lastProperty)](null);
+          } catch (e) {
+            throw new Error("Databinding failed as target " + target + " does not have a setter for " + lastProperty );
+          }
+          
         }
       }
     },
@@ -692,7 +697,11 @@ qx.Class.define("qx.data.SingleValueBinding",
           }
           target.setItem(index, value);
         } else {
-          return target["set" + qx.lang.String.firstUp(lastProperty)](value);
+          try {
+            return target["set" + qx.lang.String.firstUp(lastProperty)](value);
+          } catch (e) { 
+            throw new Error("Databinding failed as target " + target + " does not have a setter for " + lastProperty );
+          }
         }
       }
     },

--- a/framework/source/class/qx/data/SingleValueBinding.js
+++ b/framework/source/class/qx/data/SingleValueBinding.js
@@ -661,7 +661,7 @@ qx.Class.define("qx.data.SingleValueBinding",
           try{
             target["set" + qx.lang.String.firstUp(lastProperty)](null);
           } catch (e) {
-            throw new Error("Databinding failed as target " + target + " does not have a setter for " + lastProperty );
+            throw new Error("Binding '" + lastProperty + "' on target " + target + " failed: " + e);
           }
           
         }
@@ -700,7 +700,7 @@ qx.Class.define("qx.data.SingleValueBinding",
           try {
             return target["set" + qx.lang.String.firstUp(lastProperty)](value);
           } catch (e) { 
-            throw new Error("Databinding failed as target " + target + " does not have a setter for " + lastProperty );
+            throw new Error("Binding '" + lastProperty + "' on target " + target + " failed: " + e);
           }
         }
       }


### PR DESCRIPTION
This has bugged me for years, but I never got around fixing it. During a binding, if a target setter method is missing, it will throw a cryptic error message (`target["set" + qx.lang.String.firstUp(lastProperty)] is not a function`), with no indication where and why this error was thrown. This PR provides a more descriptive error message which allows to search the code for databinding involving the target object and property. 