### PR TITLE
'translation' generator job enhancement(s)

### DIFF
--- a/documentation/manual/source/pages/tool/generator/cheat_sheet.rst
+++ b/documentation/manual/source/pages/tool/generator/cheat_sheet.rst
@@ -486,10 +486,12 @@ Here are the configuration keys with their individual value syntax.
 
   "translate" :
   {
-    "namespaces"               : [ "qx.util" ],
-    "locales"                  : [ "en", "de" ],
-    "pofile-with-metadata"     : (true|false)
-    "poentry-with-occurrences" : (true|false)
+    "namespaces"                  : [ "qx.util" ],
+    "locales"                     : [ "en", "de" ],
+    "pofile-with-metadata"        : (true|false),
+    "poentry-with-occurrences"    : (true|false),
+    "occurrences-with-linenumber" : (true|false),
+    "eol-style"                   : "(LF|CR|CRLF)"
   }
 
   "use" :

--- a/documentation/manual/source/pages/tool/generator/generator_config_ref.rst
+++ b/documentation/manual/source/pages/tool/generator/generator_config_ref.rst
@@ -1302,10 +1302,12 @@ translate
 
   "translate" :
   {
-    "namespaces"               : [ "qx.util" ],
-    "locales"                  : [ "en", "de" ],
-    "pofile-with-metadata"     : (true|false)
-    "poentry-with-occurrences" : (true|false)
+    "namespaces"                  : [ "qx.util" ],
+    "locales"                     : [ "en", "de" ],
+    "pofile-with-metadata"        : (true|false)
+    "poentry-with-occurrences"    : (true|false)
+    "occurrences-with-linenumber" : (true|false),
+    "eol-style"                   : "(LF|CR|CRLF)"
   }
 
 .. note::
@@ -1316,6 +1318,8 @@ translate
 * **locales** :  List of locale identifiers to update.
 * **pofile-with-metadata** : Whether meta data is automatically added to a *new* .po file; on existing .po files the meta data is retained (default: *true*)
 * **poentry-with-occurrences** : Whether each PO entry is preceded by ``#:`` comments in the *.po* files, which indicate in which source file(s) and line number(s) this key is used (default: *true*)
+* **occurrences-with-linenumber** : Enables (or suppress) appending of line-numbers to every PO entry comment (default: *true*). Only effective when *poentry-with-occurrences* is enabled.
+* **eol-style** : Determines which line end character sequence to use (default: *LF*)
 
 .. _pages/tool/generator/generator_config_ref#use:
 

--- a/tool/data/config/config_schema.json
+++ b/tool/data/config/config_schema.json
@@ -698,7 +698,9 @@
           "items": { "type": "string" }
         },
         "profiles-with-metadata": { "type": "boolean" },
-        "poentry-with-occurrences": { "type": "boolean" }
+        "poentry-with-occurrences": { "type": "boolean" },
+        "occurrences-with-linenumber": { "type": "boolean" },
+        "eol-style": { "enum": ["LF", "CR", "CRLF"] }
       }
     },
     "use": {


### PR DESCRIPTION
Additional generator configuration possibilities regarding **translation** job:

- "**eol-style**": (Either "LF", "CR" or "CRLF")
  To generate OS-specific line-endings (default: "LF")

- "**occurrences-with-linenumber**": (Either true or false)
  To enable/supress line-numbers appended to the PO entry comments (default: True)

  - .po file entry with _"occurrences-with-linenumber" : true_
      ```
      #: application/ui/FooFile.js:11 application/ui/FooFile.js:22
      msgid "Foo"
      msgstr "Bar"
      ```
  - .po file entry with _"occurrences-with-linenumber" : false_
      ```
      #: application/ui/FooFile.js
      msgid "Foo"
      msgstr "Bar"
      ```



Example (config.json):
```
{
  "jobs" :
  {
    "translation" :
    {
      "translate" :
      {
        // Create Mac OS style .po files
        // with each PO entry preceded by `#:` comments only containing source file(s) in
        // which the key is used (no line-number)
        "eol-style" : "CR",
        "poentry-with-occurrences" : true,
        "occurrences-with-linenumber" : false
      }
    }
  }
}
```