### PR TITLE
Promise support in Events

### DIFF
--- a/application/uitests/.gitignore
+++ b/application/uitests/.gitignore
@@ -1,0 +1,13 @@
+# .gitignore template for skeleton-based apps
+/api/
+/build/
+/test/
+/source/script/
+source-output/
+build-output/
+db.json
+resource-db.json
+
+# node-related files
+/node_modules
+npm-debug.log

--- a/application/uitests/Manifest.json
+++ b/application/uitests/Manifest.json
@@ -1,0 +1,34 @@
+{
+  "info" : 
+  {
+    "name" : "dragndrop",
+
+    "summary" : "Custom Application",
+    "description" : "This is a skeleton for a custom application with qooxdoo.",
+    
+    "homepage" : "http://some.homepage.url/",
+
+    "license" : "SomeLicense",
+    "authors" : 
+    [
+      {
+        "name" : "First Author (uid)",
+        "email" : "first.author@some.domain"
+      }
+    ],
+
+    "version" : "master",
+    "qooxdoo-versions": ["6.0.0-alpha"]
+  },
+  
+  "provides" : 
+  {
+    "namespace"   : "dragndrop",
+    "encoding"    : "utf-8",
+    "class"       : "source/class",
+    "resource"    : "source/resource",
+    "translation" : "source/translation",
+    "type"        : "application"
+  }
+}
+

--- a/application/uitests/compile.json
+++ b/application/uitests/compile.json
@@ -1,0 +1,32 @@
+{
+  "targets": [
+    {
+      "type": "source",
+      "outputPath": "source-output"
+    },
+    {
+      "type": "hybrid",
+      "outputPath": "hybrid-output"
+    },
+    {
+      "type": "build",
+      "outputPath": "build-output",
+      "addCreatedAt": true
+    }
+  ],
+  "defaultTarget": "source",
+  "locales": [ "en" ],
+
+  "applications": [
+    {
+      "class": "uitests.DragAndDropApplication",
+      "theme": "qx.theme.Simple",
+      "name": "dragndrop"
+    }
+  ],
+
+  "libraries": [
+    "../../framework",
+    "."
+  ]
+}

--- a/application/uitests/readme.md
+++ b/application/uitests/readme.md
@@ -1,0 +1,15 @@
+# UI Tests
+
+Until we have a working Selenium install, the tests you need to make are by compiling these apps and following instructions for each application below.  To compile and run the apps, just do:
+
+```
+$ qx serve
+```
+
+and open http://localhost:8080 
+
+
+## Drag and Drop demo app (dragndrop/index.html)
+
+Drag and drop items from Simple Source into Simple Target; make sure that when you switch on the checkboxes, you are able to prevent the drag and drop from happening
+

--- a/application/uitests/source/class/uitests/DragAndDropApplication.js
+++ b/application/uitests/source/class/uitests/DragAndDropApplication.js
@@ -54,8 +54,10 @@ qx.Class.define("uitests.DragAndDropApplication", {
         return new qx.Promise((resolve, reject) => {
           if (cbxCancelDragstart.getValue())
             e.preventDefault();
-          if (cbxRejectDragstart.getValue())
-            return reject();
+          if (cbxRejectDragstart.getValue()) {
+            reject();
+            return;
+          }
           
           if (!e.getDefaultPrevented()) {
             // Register supported types

--- a/application/uitests/source/class/uitests/DragAndDropApplication.js
+++ b/application/uitests/source/class/uitests/DragAndDropApplication.js
@@ -1,0 +1,156 @@
+/* ************************************************************************
+
+   Copyright:
+
+   License:
+
+   Authors:
+
+ ************************************************************************ */
+
+/**
+ * This is the main application class of your custom application "dragndrop"
+ * 
+ * @asset(qx/icon/Tango/16/actions/document-print.png)
+ */
+qx.Class.define("uitests.DragAndDropApplication", {
+  extend: qx.application.Standalone,
+
+  members: {
+    main: function() {
+      this.base(arguments);
+
+      if (qx.core.Environment.get("qx.debug")) {
+        qx.log.appender.Native;
+        qx.log.appender.Console;
+      }
+
+      var doc = this.getRoot();
+      var tb = new qx.ui.toolbar.ToolBar();
+      var btn = new qx.ui.toolbar.Button("Click Me", "qx/icon/Tango/16/actions/document-print.png");
+      tb.add(btn);
+      doc.add(tb, { left: 10, top: 10, right: 10 });
+      
+      var root = new qx.ui.container.Composite(new qx.ui.layout.HBox(10));
+      doc.add(root, { left: 10, top: 100, right: 10, bottom: 10 });
+
+      var compSource = new qx.ui.container.Composite(new qx.ui.layout.VBox(6));
+      root.add(compSource);
+      compSource.add(new qx.ui.basic.Label("Simple Source"));
+      var lstSource = new qx.ui.form.List().set({ draggable: true, selectionMode: "multi" });
+      compSource.add(lstSource);
+
+      for (var i = 0; i < 20; i++)
+        lstSource.add(new qx.ui.form.ListItem("Item " + i, "icon/16/places/folder.png"));
+
+      var cbxCancelDragstart = new qx.ui.form.CheckBox("Cancel dragstart").set({ value: false });
+      compSource.add(cbxCancelDragstart);
+      
+      var cbxRejectDragstart = new qx.ui.form.CheckBox("Reject dragstart").set({ value: false });
+      compSource.add(cbxRejectDragstart);
+      
+      lstSource.addListener("dragstart", function(e) {
+        this.debug("lstSource: dragstart");
+        return new qx.Promise((resolve, reject) => {
+          if (cbxCancelDragstart.getValue())
+            e.preventDefault();
+          if (cbxRejectDragstart.getValue())
+            return reject();
+          
+          if (!e.getDefaultPrevented()) {
+            // Register supported types
+            e.addType("value");
+            e.addType("items");
+  
+            // Register supported actions
+            e.addAction("copy");
+            e.addAction("move");
+          }
+          
+          resolve();
+        });
+      });
+
+      lstSource.addListener("droprequest", function(e) {
+        this.debug("lstSource: droprequest");
+        return new qx.Promise((resolve, reject) => {
+          this.debug("Related of droprequest: " + e.getRelatedTarget());
+
+          var action = e.getCurrentAction();
+          var type = e.getCurrentType();
+          var result;
+          var selection = this.getSelection();
+          var dragTarget = e.getDragTarget();
+          if (selection.length === 0) {
+            selection.push(dragTarget);
+          } else if (selection.indexOf(dragTarget) == -1) {
+            selection = [ dragTarget ];
+          }
+
+          switch (type) {
+          case "items":
+            result = selection;
+
+            if (action == "copy") {
+              var copy = [];
+              for (var i = 0, l = result.length; i < l; i++) {
+                copy[i] = result[i].clone();
+              }
+              result = copy;
+            }
+            break;
+
+          case "value":
+            result = selection[0].getLabel();
+            break;
+          }
+
+          // Remove selected items on move
+          if (action == "move") {
+            for (var i = 0, l = selection.length; i < l; i++) {
+              this.remove(selection[i]);
+            }
+          }
+
+          // Add data to manager
+          e.addData(type, result);
+          resolve();
+        });
+      });
+
+      var compTarget = new qx.ui.container.Composite(new qx.ui.layout.VBox(10));
+      root.add(compTarget);
+      compTarget.add(new qx.ui.basic.Label("Simple Target"));
+
+      var lstTargetSimple = new qx.ui.form.List().set({ droppable: true, selectionMode: "multi" });
+      compTarget.add(lstTargetSimple);
+
+      lstTargetSimple.addListener("drop", function(e) {
+        this.debug("lstTargetSimple: drop");
+        return new qx.Promise((resolve, reject) => {
+          this.debug("Related of drop: " + e.getRelatedTarget());
+
+          // Move items from lstSource to target
+          var items = e.getData("items");
+          for (var i=0, l=items.length; i<l; i++) {
+            this.add(items[i]);
+          }
+          resolve();
+        });
+      });
+
+      lstTargetSimple.addListener("dragover", function(e) {
+        this.debug("lstTargetSimple: dragover");
+        return new qx.Promise((resolve, reject) => {
+          if (!e.supportsType("items") || cbxCancelDragover.getValue()) {
+            e.preventDefault();
+          }
+          resolve();
+        });
+      });
+
+      var cbxCancelDragover = new qx.ui.form.CheckBox("Cancel dragover").set({ value: false });
+      compSource.add(cbxCancelDragover);
+    }
+  }
+});

--- a/application/uitests/source/translation/readme.txt
+++ b/application/uitests/source/translation/readme.txt
@@ -1,0 +1,3 @@
+This directory will contain translation (.po) files once you run the
+'translation' job in your project.
+

--- a/documentation/manual/source/pages/desktop/ui_interaction.rst
+++ b/documentation/manual/source/pages/desktop/ui_interaction.rst
@@ -77,6 +77,17 @@ If a widget is a capturing widget, all pointer events will be dispatched on this
 
 Internally, qooxdoo uses capturing in menus, split panes or sliders for example.
 
+
+.. _pages/desktop/ui_interaction#promises:
+
+Promise Support
+===============
+
+Event handlers are called in sequence, but if an event handler returns a ``qx.Promise`` then the event handling chain will be suspended until the promise is resolved; if the promise is rejected, then the event's ``stopPropagation()`` method will be called and the usual behaviour for handling aborted events will apply.  
+
+Note that this is not able to stop different physical events - for example, "mousedown" and "mouseup" are two completely separate events sent by the browser in response to physical user events, and if you return a promise from a "mousedown" handler this will not prevent "mouseup" being sent a few milliseconds later; of course, because these events are technically unrelated there is no guarantee that just because a widget sees a "mousedown" event it would see a "mouseup" in the first place, or vice versa.
+
+
 .. _pages/desktop/ui_interaction#keyboard_support:
 
 Keyboard Support

--- a/framework/source/class/qx/Promise.js
+++ b/framework/source/class/qx/Promise.js
@@ -13,9 +13,9 @@
      See the LICENSE file in the project's top-level directory for details.
 
    Authors:
-     * John Spackman (john.spackman@zenesis.com)
+ * John Spackman (john.spackman@zenesis.com)
 
-************************************************************************ */
+ ************************************************************************ */
 
 /**
  * This class adds Promise/A+ support to Qooxdoo, as specified at 
@@ -58,7 +58,7 @@
  */
 qx.Class.define("qx.Promise", {
   extend: qx.core.Object,
-  
+
   /**
    * Constructor.
    * 
@@ -79,9 +79,25 @@ qx.Class.define("qx.Promise", {
       if (context !== undefined && context !== null) {
         fn = fn.bind(context);
       }
+      if (qx.core.Environment.get("qx.debug")) {
+        var origFn = fn;
+        var self = this;
+        fn = function(resolve, reject) {
+          return origFn(resolve, function(reason) {
+            var args = qx.lang.Array.fromArguments(arguments);
+            if (reason === undefined) {
+              args.shift();
+              args.unshift(qx.Promise.__DEFAULT_ERROR);
+            } else if (reason && !(reason instanceof Error)) {
+              self.error("Calling reject with non-error object, createdAt=" + JSON.stringify(self.$$createdAt || null));
+            }
+            reject.apply(this, args)
+          });
+        };
+      }
       this.__p = new qx.Promise.Bluebird(fn);
     } else {
-    	this.__p = new qx.Promise.Bluebird(this.__externalPromise.bind(this));
+      this.__p = new qx.Promise.Bluebird(this.__externalPromise.bind(this));
     }
     qx.core.Assert.assertTrue(!this.__p.$$qxPromise);
     this.__p.$$qxPromise = this;
@@ -89,7 +105,7 @@ qx.Class.define("qx.Promise", {
       this.__p = this.__p.bind(context);
     }
   },
-  
+
   /**
    * Destructor
    */
@@ -97,22 +113,22 @@ qx.Class.define("qx.Promise", {
     delete this.__p.$$qxPromise;
     delete this.__p;
   },
-  
+
   members: {
     /** The Promise */
     __p: null,
-    
+
     /** Stores data for completing the promise externally */
     __external: null,
-    
 
-    
+
+
     /* *********************************************************************************
      * 
      * Promise API methods
      * 
      */
-    
+
     /**
      * Returns a promise which is determined by the functions <code>onFulfilled</code>
      * and <code>onRejected</code>.
@@ -126,7 +142,7 @@ qx.Class.define("qx.Promise", {
     then: function(onFulfilled, onRejected) {
       return this._callMethod('then', arguments);
     },
-    
+
     /**
      * Appends a rejection handler callback to the promise, and returns a new promise 
      * resolving to the return value of the callback if it is called, or to its original 
@@ -140,15 +156,15 @@ qx.Class.define("qx.Promise", {
     "catch": function(onRejected) {
       return this._callMethod('catch', arguments);
     },
-    
-    
-    
+
+
+
     /* *********************************************************************************
      * 
      * Extension Promise methods
      * 
      */
-    
+
     /**
      * Creates a new qx.Promise with the 'this' set to a different context
      * 
@@ -158,7 +174,7 @@ qx.Class.define("qx.Promise", {
     bind: function(context) {
       return qx.Promise.__wrap(this.__p.bind(context));
     },
-    
+
     /**
      * Like calling <code>.then</code>, but the fulfillment value must be an array, which is flattened 
      * to the formal parameters of the fulfillment handler.
@@ -184,7 +200,7 @@ qx.Class.define("qx.Promise", {
     spread: function(fulfilledHandler) {
       return this._callMethod('spread', arguments);
     },
-    
+
     /**
      * Appends a handler that will be called regardless of this promise's fate. The handler
      * is not allowed to modify the value of the promise
@@ -196,14 +212,14 @@ qx.Class.define("qx.Promise", {
     "finally": function(onRejected) {
       return this._callMethod('finally', arguments);
     },
-    
+
     /**
      * Cancel this promise. Will not do anything if this promise is already settled.
      */
     cancel: function() {
       return this._callMethod('cancel', arguments);
     },
-    
+
     /**
      * Same as {@link qx.Promise.all} except that it iterates over the value of this promise, when
      * it is fulfilled; for example, if this Promise resolves to an Iterable (eg an Array), 
@@ -215,7 +231,7 @@ qx.Class.define("qx.Promise", {
     all: function() {
       return this._callIterableMethod('all', arguments);
     },
-    
+
     /**
      * Same as {@link qx.Promise.race} except that it iterates over the value of this promise, when
      * it is fulfilled; for example, if this Promise resolves to an Iterable (eg an Array), 
@@ -227,7 +243,7 @@ qx.Class.define("qx.Promise", {
     race: function(iterable) {
       return this._callIterableMethod('race', arguments);
     },
-    
+
     /**
      * Same as {@link qx.Promise.some} except that it iterates over the value of this promise, when
      * it is fulfilled.  Like <code>some</code>, with 1 as count. However, if the promise fulfills, 
@@ -238,7 +254,7 @@ qx.Class.define("qx.Promise", {
     any: function(iterable) {
       return this._callIterableMethod('any', arguments);
     },
-    
+
     /**
      * Same as {@link qx.Promise.some} except that it iterates over the value of this promise, when
      * it is fulfilled; return a promise that is fulfilled as soon as count promises are fulfilled 
@@ -251,7 +267,7 @@ qx.Class.define("qx.Promise", {
     some: function(iterable, count) {
       return this._callIterableMethod('some', arguments);
     },
-    
+
     /**
      * Same as {@link qx.Promise.forEach} except that it iterates over the value of this promise, when
      * it is fulfilled; iterates over the values with the given <code>iterator</code> function with the signature 
@@ -269,7 +285,7 @@ qx.Class.define("qx.Promise", {
     forEach: function(iterable, iterator) {
       return this._callIterableMethod('each', arguments);
     },
-    
+
     /**
      * Same as {@link qx.Promise.filter} except that it iterates over the value of this promise, when it is fulfilled; 
      * iterates over all the values into an array and filter the array to another using the given filterer function.
@@ -283,7 +299,7 @@ qx.Class.define("qx.Promise", {
     filter: function(iterable, iterator, options) {
       return this._callIterableMethod('filter', arguments);
     },
-    
+
     /**
      * Same as {@link qx.Promise.map} except that it iterates over the value of this promise, when it is fulfilled; 
      * iterates over all the values into an array and map the array to another using the given mapper function.
@@ -306,7 +322,7 @@ qx.Class.define("qx.Promise", {
     map: function(iterable, iterator, options) {
       return this._callIterableMethod('map', arguments);
     },
-    
+
     /**
      * Same as {@link qx.Promise.mapSeries} except that it iterates over the value of this promise, when
      * it is fulfilled; iterates over all the values into an array and iterate over the array serially, 
@@ -327,7 +343,7 @@ qx.Class.define("qx.Promise", {
     mapSeries: function(iterable, iterator) {
       return this._callIterableMethod('mapSeries', arguments);
     },
-    
+
     /**
      * Same as {@link qx.Promise.reduce} except that it iterates over the value of this promise, when
      * it is fulfilled; iterates over all the values in the <code>Iterable</code> into an array and 
@@ -358,47 +374,47 @@ qx.Class.define("qx.Promise", {
      * External promise handler
      */
     __externalPromise: function(resolve, reject) {
-    	this.__external = { resolve: resolve, reject: reject, complete: false };
+      this.__external = { resolve: resolve, reject: reject, complete: false };
     },
-    
+
     /**
      * Returns the data stored by __externalPromise, throws an exception once processed
      */
     __getPendingExternal: function() {
-    	if (!this.__external) {
-    		throw new Error("Promise cannot be resolved externally");
-    	}
-    	if (this.__external.complete) {
-    		throw new Error("Promise has already been resolved or rejected");
-    	}
-    	this.__external.complete = true;
-    	return this.__external;
+      if (!this.__external) {
+        throw new Error("Promise cannot be resolved externally");
+      }
+      if (this.__external.complete) {
+        throw new Error("Promise has already been resolved or rejected");
+      }
+      this.__external.complete = true;
+      return this.__external;
     },
-    
+
     /**
      * Resolves an external promise
      */
     resolve: function(value) {
-    	this.__getPendingExternal().resolve(value);
+      this.__getPendingExternal().resolve(value);
     },
 
     /**
      * Rejects an external promise
      */
     reject: function(reason) {
-    	this.__getPendingExternal().reject(reason);
+      this.__getPendingExternal().reject(reason);
     },
 
-    
-    
-    
-    
+
+
+
+
     /* *********************************************************************************
      * 
      * Utility methods
      * 
      */
-    
+
     /**
      * Helper method used to call Promise methods which iterate over an array
      */
@@ -409,7 +425,7 @@ qx.Class.define("qx.Promise", {
         return qx.Promise.__wrap(newP[methodName].apply(newP, args));
       }));
     },
-    
+
     /**
      * Helper method used to call a Promise method
      */
@@ -417,7 +433,7 @@ qx.Class.define("qx.Promise", {
       args = qx.Promise.__bindArgs(args);
       return qx.Promise.__wrap(this.__p[methodName].apply(this.__p, args));
     },
-    
+
     /**
      * Returns the actual Promise implementation.
      * 
@@ -432,25 +448,30 @@ qx.Class.define("qx.Promise", {
       return this.__p;
     }
   },
-  
+
   statics: {
-  	
+
     /** Bluebird Promise library; always available */
     Bluebird: null,
-    
+
     /** Native Promise library; only available if the browser supports it */
     Native: null,
-    
+
     /** Promise library, either the Native one or a Polyfill; reliable choice for native Promises */
     Promise: null,
     
-    
+    /** This is used to suppress warnings about rejections without an Error object, only used if
+     * the reason is undefined
+     */
+    __DEFAULT_ERROR: new Error("Default Error"),
+
+
     /* *********************************************************************************
      * 
      * Promise API methods
      * 
      */
-     
+
     /**
      * Returns a Promise object that is resolved with the given value. If the value is a thenable (i.e. 
      * has a then method), the returned promise will "follow" that thenable, adopting its eventual 
@@ -474,7 +495,7 @@ qx.Class.define("qx.Promise", {
       }
       return promise;
     },
-    
+
     /**
      * Returns a Promise object that is rejected with the given reason.
      * @param reason {Object} Reason why this Promise rejected.
@@ -482,13 +503,20 @@ qx.Class.define("qx.Promise", {
      * @return {qx.Promise}
      */
     reject: function(reason, context) {
-      var promise = this.__callStaticMethod('reject', arguments, 0);
+      var args = qx.lang.Array.fromArguments(arguments);
+      if (reason === undefined) {
+        args.shift();
+        args.unshift(qx.Promise.__DEFAULT_ERROR);
+      } else if (!(reason instanceof Error)) {
+        this.error("Rejecting a promise with a non-Error value");
+      }
+      var promise = this.__callStaticMethod('reject', args, 0);
       if (context !== undefined) {
         promise = promise.bind(context);
       }
       return promise;
     },
-    
+
     /**
      * Returns a promise that resolves when all of the promises in the iterable argument have resolved, 
      * or rejects with the reason of the first passed promise that rejects.
@@ -498,7 +526,7 @@ qx.Class.define("qx.Promise", {
     all: function(iterable) {
       return this.__callStaticMethod('all', arguments);
     },
-    
+
     /**
      * Returns a promise that resolves or rejects as soon as one of the promises in the iterable resolves 
      * or rejects, with the value or reason from that promise.
@@ -509,14 +537,14 @@ qx.Class.define("qx.Promise", {
       return this.__callStaticMethod('race', arguments);
     },
 
-    
-    
+
+
     /* *********************************************************************************
      * 
      * Extension API methods
      * 
      */
-    
+
     /**
      * Like Promise.some, with 1 as count. However, if the promise fulfills, the fulfillment value is not an 
      * array of 1 but the value directly.
@@ -527,7 +555,7 @@ qx.Class.define("qx.Promise", {
     any: function(iterable) {
       return this.__callStaticMethod('any', arguments);
     },
-    
+
     /**
      * Given an Iterable (arrays are Iterable), or a promise of an Iterable, which produces promises (or a mix 
      * of promises and values), iterate over all the values in the Iterable into an array and return a promise 
@@ -541,7 +569,7 @@ qx.Class.define("qx.Promise", {
     some: function(iterable, count) {
       return this.__callStaticMethod('some', arguments);
     },
-    
+
     /**
      * Iterate over an array, or a promise of an array, which contains promises (or a mix of promises and values) 
      * with the given <code>iterator</code> function with the signature <code>(value, index, length)</code> where 
@@ -559,7 +587,7 @@ qx.Class.define("qx.Promise", {
     forEach: function(iterable, iterator) {
       return this.__callStaticMethod('each', arguments);
     },
-    
+
     /**
      * Given an Iterable(arrays are Iterable), or a promise of an Iterable, which produces promises (or a mix of 
      * promises and values), iterate over all the values in the Iterable into an array and filter the array to 
@@ -587,7 +615,7 @@ qx.Class.define("qx.Promise", {
     filter: function(iterable, iterator, options) {
       return this.__callStaticMethod('filter', arguments);
     },
-    
+
     /**
      * Given an <code>Iterable</code> (arrays are <code>Iterable</code>), or a promise of an 
      * <code>Iterable</code>, which produces promises (or a mix of promises and values), iterate over 
@@ -632,7 +660,7 @@ qx.Class.define("qx.Promise", {
     map: function(iterable, iterator, options) {
       return this.__callStaticMethod('map', arguments);
     },
-    
+
     /**
      * Given an <code>Iterable</code>(arrays are <code>Iterable</code>), or a promise of an 
      * <code>Iterable</code>, which produces promises (or a mix of promises and values), iterate over 
@@ -671,7 +699,7 @@ qx.Class.define("qx.Promise", {
     mapSeries: function(iterable, iterator) {
       return this.__callStaticMethod('mapSeries', arguments);
     },
-    
+
     /**
      * Given an <code>Iterable</code> (arrays are <code>Iterable</code>), or a promise of an 
      * <code>Iterable</code>, which produces promises (or a mix of promises and values), iterate 
@@ -724,7 +752,7 @@ qx.Class.define("qx.Promise", {
         return qx.Promise.__wrap(wrappedCb.apply(this, arguments));
       };
     },
-    
+
     /**
      * Like .all but for object properties or Maps* entries instead of iterated values. Returns a promise that 
      * is fulfilled when all the properties of the object or the Map's' values** are fulfilled. The promise's 
@@ -742,15 +770,15 @@ qx.Class.define("qx.Promise", {
     props: function(input) {
       return this.__callStaticMethod('props', arguments);
     },
-    
-    
-    
+
+
+
     /* *********************************************************************************
      * 
      * Internal API methods
      * 
      */
-    
+
     /**
      * Called when the Bluebird Promise class is loaded
      * @param Promise {Class} the Promise class
@@ -766,7 +794,7 @@ qx.Class.define("qx.Promise", {
 
     /** Whether one-time initialisaton has happened */
     __initialized: false,
-    
+
     /**
      * One-time initializer
      */
@@ -780,7 +808,7 @@ qx.Class.define("qx.Promise", {
         qx.log.Logger.error(this, "Promises are installed and initialised but disabled from properties because qx.promise==false; this may cause unexpected behaviour");
       }
     },
-    
+
     /**
      * Handles unhandled errors and passes them through to Qooxdoo's global error handler
      * @param e {NativeEvent}
@@ -798,7 +826,7 @@ qx.Class.define("qx.Promise", {
       qx.log.Logger.error(this, "Unhandled promise rejection: " + (reason ? reason.stack : "(not from exception)"));
       qx.event.GlobalError.handleError(reason);
     },
-    
+
     /**
      * Wraps values, converting Promise into qx.Promise
      * @param value {Object}
@@ -814,7 +842,7 @@ qx.Class.define("qx.Promise", {
       }
       return value;
     },
-    
+
     /**
      * Binds all functions in the array to the context at the end of the array;
      * the last value must be a qx.core.Object to distinguish itself from configuration
@@ -827,7 +855,7 @@ qx.Class.define("qx.Promise", {
     __bindArgs: function(args, minArgs) {
       args = qx.lang.Array.fromArguments(args);
       if (minArgs === undefined) {
-      	minArgs = 1;
+        minArgs = 1;
       }
       if (args.length > minArgs) {
         var context = args[args.length - 1];
@@ -842,7 +870,7 @@ qx.Class.define("qx.Promise", {
       }
       return args;
     },
-    
+
     /**
      * Helper method used to call a Bluebird Promise method
      * @param methodName {String} method name to call
@@ -854,28 +882,28 @@ qx.Class.define("qx.Promise", {
       args = qx.Promise.__bindArgs(args, minArgs);
       return this.__wrap(qx.Promise.Bluebird[methodName].apply(qx.Promise.Bluebird, this.__mapArgs(args)));
     },
-    
+
     /**
      * Maps all arguments ready for passing to a Bluebird function; qx.data.Array are
      * translated to native arrays and qx.Promise to Promise.  This is not recursive.
      */
     __mapArgs: function(args) {
-    	var dest = [];
-    	args.forEach(function(arg) {
-    		if (arg instanceof qx.data.Array) {
-    			dest.push(arg.toArray());
-    			
-    		} else if (arg instanceof qx.Promise) {
+      var dest = [];
+      args.forEach(function(arg) {
+        if (arg instanceof qx.data.Array) {
+          dest.push(arg.toArray());
+
+        } else if (arg instanceof qx.Promise) {
           dest.push(arg.toPromise());
-          
+
         } else {
-        	dest.push(arg);
+          dest.push(arg);
         }
-    	});
-    	return dest;
+      });
+      return dest;
     }    
   },
-  
+
   defer: function(statics, members) {
     statics.Promise = statics.Native = window.Promise;
     var debug = qx.core.Environment.get("qx.debug");
@@ -925,5630 +953,5630 @@ qx.Class.define("qx.Promise", {
  * @ignore(setImmediate) 
  */
 (function() {
-/* @preserve
- * The MIT License (MIT)
- * 
- * Copyright (c) 2013-2015 Petka Antonov
- * 
- * Permission is hereby granted, free of charge, to any person obtaining a copy
- * of this software and associated documentation files (the "Software"), to deal
- * in the Software without restriction, including without limitation the rights
- * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
- * copies of the Software, and to permit persons to whom the Software is
- * furnished to do so, subject to the following conditions:
- * 
- * The above copyright notice and this permission notice shall be included in
- * all copies or substantial portions of the Software.
- * 
- * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
- * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
- * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.  IN NO EVENT SHALL THE
- * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
- * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
- * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
- * THE SOFTWARE.
- * 
- */
-/**
- * bluebird build version 3.4.5
- * Features enabled: core, race, call_get, generators, map, nodeify, promisify, props, reduce, settle, some, using, timers, filter, any, each
-*/
-!function(e){
-  qx.Promise.__attachBluebird(e());
-}
-(function(){
-  var define,module,exports;
-  return (function e(t,n,r){
-    function s(o,u){
-      if(!n[o]){
-        if(!t[o]){
-          var a=typeof _dereq_=="function"&&_dereq_;
-          if(!u&&a)
-            return a(o,!0);
-          if(i)
-            return i(o,!0);
-          var f=new Error("Cannot find module '"+o+"'");
-          throw f.code="MODULE_NOT_FOUND",f
-        }
-        var l=n[o]={exports:{}};
-        t[o][0].call(l.exports, function(e){
+  /* @preserve
+   * The MIT License (MIT)
+   * 
+   * Copyright (c) 2013-2015 Petka Antonov
+   * 
+   * Permission is hereby granted, free of charge, to any person obtaining a copy
+   * of this software and associated documentation files (the "Software"), to deal
+   * in the Software without restriction, including without limitation the rights
+   * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+   * copies of the Software, and to permit persons to whom the Software is
+   * furnished to do so, subject to the following conditions:
+   * 
+   * The above copyright notice and this permission notice shall be included in
+   * all copies or substantial portions of the Software.
+   * 
+   * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+   * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+   * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.  IN NO EVENT SHALL THE
+   * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+   * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+   * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+   * THE SOFTWARE.
+   * 
+   */
+  /**
+   * bluebird build version 3.4.5
+   * Features enabled: core, race, call_get, generators, map, nodeify, promisify, props, reduce, settle, some, using, timers, filter, any, each
+   */
+  !function(e){
+    qx.Promise.__attachBluebird(e());
+  }
+  (function(){
+    var define,module,exports;
+    return (function e(t,n,r){
+      function s(o,u){
+        if(!n[o]){
+          if(!t[o]){
+            var a=typeof _dereq_=="function"&&_dereq_;
+            if(!u&&a)
+              return a(o,!0);
+            if(i)
+              return i(o,!0);
+            var f=new Error("Cannot find module '"+o+"'");
+            throw f.code="MODULE_NOT_FOUND",f
+          }
+          var l=n[o]={exports:{}};
+          t[o][0].call(l.exports, function(e){
             var n=t[o][1][e];
             return s(n?n:e)
           },l,l.exports,e,t,n,r)
+        }
+        return n[o].exports
       }
-      return n[o].exports
-    }
-    var i=typeof _dereq_=="function"&&_dereq_;
-    for(var o=0;o<r.length;o++)
-      s(r[o]);
-    return s
-  })({
-    1:[
-      function(_dereq_,module,exports){
-    "use strict";
-module.exports = function(Promise) {
-var SomePromiseArray = Promise._SomePromiseArray;
-function any(promises) {
-    var ret = new SomePromiseArray(promises);
-    var promise = ret.promise();
-    ret.setHowMany(1);
-    ret.setUnwrap();
-    ret.init();
-    return promise;
-}
+      var i=typeof _dereq_=="function"&&_dereq_;
+      for(var o=0;o<r.length;o++)
+        s(r[o]);
+      return s
+    })({
+      1:[
+        function(_dereq_,module,exports){
+          "use strict";
+          module.exports = function(Promise) {
+            var SomePromiseArray = Promise._SomePromiseArray;
+            function any(promises) {
+              var ret = new SomePromiseArray(promises);
+              var promise = ret.promise();
+              ret.setHowMany(1);
+              ret.setUnwrap();
+              ret.init();
+              return promise;
+            }
 
-Promise.any = function (promises) {
-    return any(promises);
-};
+            Promise.any = function (promises) {
+              return any(promises);
+            };
 
-Promise.prototype.any = function () {
-    return any(this);
-};
+            Promise.prototype.any = function () {
+              return any(this);
+            };
 
-};
+          };
 
-},{}],2:[function(_dereq_,module,exports){
-"use strict";
-var firstLineError;
-try {throw new Error(); } catch (e) {firstLineError = e;}
-var schedule = _dereq_("./schedule");
-var Queue = _dereq_("./queue");
-var util = _dereq_("./util");
+        },{}],2:[function(_dereq_,module,exports){
+          "use strict";
+          var firstLineError;
+          try {throw new Error(); } catch (e) {firstLineError = e;}
+          var schedule = _dereq_("./schedule");
+          var Queue = _dereq_("./queue");
+          var util = _dereq_("./util");
 
-function Async() {
-    this._customScheduler = false;
-    this._isTickUsed = false;
-    this._lateQueue = new Queue(16);
-    this._normalQueue = new Queue(16);
-    this._haveDrainedQueues = false;
-    this._trampolineEnabled = true;
-    var self = this;
-    this.drainQueues = function () {
-        self._drainQueues();
-    };
-    this._schedule = schedule;
-}
+          function Async() {
+            this._customScheduler = false;
+            this._isTickUsed = false;
+            this._lateQueue = new Queue(16);
+            this._normalQueue = new Queue(16);
+            this._haveDrainedQueues = false;
+            this._trampolineEnabled = true;
+            var self = this;
+            this.drainQueues = function () {
+              self._drainQueues();
+            };
+            this._schedule = schedule;
+          }
 
-Async.prototype.setScheduler = function(fn) {
-    var prev = this._schedule;
-    this._schedule = fn;
-    this._customScheduler = true;
-    return prev;
-};
+          Async.prototype.setScheduler = function(fn) {
+            var prev = this._schedule;
+            this._schedule = fn;
+            this._customScheduler = true;
+            return prev;
+          };
 
-Async.prototype.hasCustomScheduler = function() {
-    return this._customScheduler;
-};
+          Async.prototype.hasCustomScheduler = function() {
+            return this._customScheduler;
+          };
 
-Async.prototype.enableTrampoline = function() {
-    this._trampolineEnabled = true;
-};
+          Async.prototype.enableTrampoline = function() {
+            this._trampolineEnabled = true;
+          };
 
-Async.prototype.disableTrampolineIfNecessary = function() {
-    if (util.hasDevTools) {
-        this._trampolineEnabled = false;
-    }
-};
+          Async.prototype.disableTrampolineIfNecessary = function() {
+            if (util.hasDevTools) {
+              this._trampolineEnabled = false;
+            }
+          };
 
-Async.prototype.haveItemsQueued = function () {
-    return this._isTickUsed || this._haveDrainedQueues;
-};
+          Async.prototype.haveItemsQueued = function () {
+            return this._isTickUsed || this._haveDrainedQueues;
+          };
 
 
-Async.prototype.fatalError = function(e, isNode) {
-    if (isNode) {
-        process.stderr.write("Fatal " + (e instanceof Error ? e.stack : e) +
-            "\n");
-        process.exit(2);
-    } else {
-        this.throwLater(e);
-    }
-};
+          Async.prototype.fatalError = function(e, isNode) {
+            if (isNode) {
+              process.stderr.write("Fatal " + (e instanceof Error ? e.stack : e) +
+              "\n");
+              process.exit(2);
+            } else {
+              this.throwLater(e);
+            }
+          };
 
-Async.prototype.throwLater = function(fn, arg) {
-    if (arguments.length === 1) {
-        arg = fn;
-        fn = function () { throw arg; };
-    }
-    if (typeof setTimeout !== "undefined") {
-        setTimeout(function() {
-            fn(arg);
-        }, 0);
-    } else try {
-        this._schedule(function() {
-            fn(arg);
-        });
-    } catch (e) {
-        throw new Error("No async scheduler available\u000a\u000a    See http://goo.gl/MqrFmX\u000a");
-    }
-};
+          Async.prototype.throwLater = function(fn, arg) {
+            if (arguments.length === 1) {
+              arg = fn;
+              fn = function () { throw arg; };
+            }
+            if (typeof setTimeout !== "undefined") {
+              setTimeout(function() {
+                fn(arg);
+              }, 0);
+            } else try {
+              this._schedule(function() {
+                fn(arg);
+              });
+            } catch (e) {
+              throw new Error("No async scheduler available\u000a\u000a    See http://goo.gl/MqrFmX\u000a");
+            }
+          };
 
-function AsyncInvokeLater(fn, receiver, arg) {
-    this._lateQueue.push(fn, receiver, arg);
-    this._queueTick();
-}
+          function AsyncInvokeLater(fn, receiver, arg) {
+            this._lateQueue.push(fn, receiver, arg);
+            this._queueTick();
+          }
 
-function AsyncInvoke(fn, receiver, arg) {
-    this._normalQueue.push(fn, receiver, arg);
-    this._queueTick();
-}
+          function AsyncInvoke(fn, receiver, arg) {
+            this._normalQueue.push(fn, receiver, arg);
+            this._queueTick();
+          }
 
-function AsyncSettlePromises(promise) {
-    this._normalQueue._pushOne(promise);
-    this._queueTick();
-}
+          function AsyncSettlePromises(promise) {
+            this._normalQueue._pushOne(promise);
+            this._queueTick();
+          }
 
-if (!util.hasDevTools) {
-    Async.prototype.invokeLater = AsyncInvokeLater;
-    Async.prototype.invoke = AsyncInvoke;
-    Async.prototype.settlePromises = AsyncSettlePromises;
-} else {
-    Async.prototype.invokeLater = function (fn, receiver, arg) {
-        if (this._trampolineEnabled) {
-            AsyncInvokeLater.call(this, fn, receiver, arg);
-        } else {
-            this._schedule(function() {
-                setTimeout(function() {
+          if (!util.hasDevTools) {
+            Async.prototype.invokeLater = AsyncInvokeLater;
+            Async.prototype.invoke = AsyncInvoke;
+            Async.prototype.settlePromises = AsyncSettlePromises;
+          } else {
+            Async.prototype.invokeLater = function (fn, receiver, arg) {
+              if (this._trampolineEnabled) {
+                AsyncInvokeLater.call(this, fn, receiver, arg);
+              } else {
+                this._schedule(function() {
+                  setTimeout(function() {
                     fn.call(receiver, arg);
-                }, 100);
-            });
-        }
-    };
+                  }, 100);
+                });
+              }
+            };
 
-    Async.prototype.invoke = function (fn, receiver, arg) {
-        if (this._trampolineEnabled) {
-            AsyncInvoke.call(this, fn, receiver, arg);
-        } else {
-            this._schedule(function() {
-                fn.call(receiver, arg);
-            });
-        }
-    };
+            Async.prototype.invoke = function (fn, receiver, arg) {
+              if (this._trampolineEnabled) {
+                AsyncInvoke.call(this, fn, receiver, arg);
+              } else {
+                this._schedule(function() {
+                  fn.call(receiver, arg);
+                });
+              }
+            };
 
-    Async.prototype.settlePromises = function(promise) {
-        if (this._trampolineEnabled) {
-            AsyncSettlePromises.call(this, promise);
-        } else {
-            this._schedule(function() {
-                promise._settlePromises();
-            });
-        }
-    };
-}
+            Async.prototype.settlePromises = function(promise) {
+              if (this._trampolineEnabled) {
+                AsyncSettlePromises.call(this, promise);
+              } else {
+                this._schedule(function() {
+                  promise._settlePromises();
+                });
+              }
+            };
+          }
 
-Async.prototype.invokeFirst = function (fn, receiver, arg) {
-    this._normalQueue.unshift(fn, receiver, arg);
-    this._queueTick();
-};
+          Async.prototype.invokeFirst = function (fn, receiver, arg) {
+            this._normalQueue.unshift(fn, receiver, arg);
+            this._queueTick();
+          };
 
-Async.prototype._drainQueue = function(queue) {
-    while (queue.length() > 0) {
-        var fn = queue.shift();
-        if (typeof fn !== "function") {
-            fn._settlePromises();
-            continue;
-        }
-        var receiver = queue.shift();
-        var arg = queue.shift();
-        fn.call(receiver, arg);
-    }
-};
+          Async.prototype._drainQueue = function(queue) {
+            while (queue.length() > 0) {
+              var fn = queue.shift();
+              if (typeof fn !== "function") {
+                fn._settlePromises();
+                continue;
+              }
+              var receiver = queue.shift();
+              var arg = queue.shift();
+              fn.call(receiver, arg);
+            }
+          };
 
-Async.prototype._drainQueues = function () {
-    this._drainQueue(this._normalQueue);
-    this._reset();
-    this._haveDrainedQueues = true;
-    this._drainQueue(this._lateQueue);
-};
+          Async.prototype._drainQueues = function () {
+            this._drainQueue(this._normalQueue);
+            this._reset();
+            this._haveDrainedQueues = true;
+            this._drainQueue(this._lateQueue);
+          };
 
-Async.prototype._queueTick = function () {
-    if (!this._isTickUsed) {
-        this._isTickUsed = true;
-        this._schedule(this.drainQueues);
-    }
-};
+          Async.prototype._queueTick = function () {
+            if (!this._isTickUsed) {
+              this._isTickUsed = true;
+              this._schedule(this.drainQueues);
+            }
+          };
 
-Async.prototype._reset = function () {
-    this._isTickUsed = false;
-};
+          Async.prototype._reset = function () {
+            this._isTickUsed = false;
+          };
 
-module.exports = Async;
-module.exports.firstLineError = firstLineError;
+          module.exports = Async;
+          module.exports.firstLineError = firstLineError;
 
-},{"./queue":26,"./schedule":29,"./util":36}],3:[function(_dereq_,module,exports){
-"use strict";
-module.exports = function(Promise, INTERNAL, tryConvertToPromise, debug) {
-var calledBind = false;
-var rejectThis = function(_, e) {
-    this._reject(e);
-};
+        },{"./queue":26,"./schedule":29,"./util":36}],3:[function(_dereq_,module,exports){
+          "use strict";
+          module.exports = function(Promise, INTERNAL, tryConvertToPromise, debug) {
+            var calledBind = false;
+            var rejectThis = function(_, e) {
+              this._reject(e);
+            };
 
-var targetRejected = function(e, context) {
-    context.promiseRejectionQueued = true;
-    context.bindingPromise._then(rejectThis, rejectThis, null, this, e);
-};
+            var targetRejected = function(e, context) {
+              context.promiseRejectionQueued = true;
+              context.bindingPromise._then(rejectThis, rejectThis, null, this, e);
+            };
 
-var bindingResolved = function(thisArg, context) {
-    if (((this._bitField & 50397184) === 0)) {
-        this._resolveCallback(context.target);
-    }
-};
+            var bindingResolved = function(thisArg, context) {
+              if (((this._bitField & 50397184) === 0)) {
+                this._resolveCallback(context.target);
+              }
+            };
 
-var bindingRejected = function(e, context) {
-    if (!context.promiseRejectionQueued) this._reject(e);
-};
+            var bindingRejected = function(e, context) {
+              if (!context.promiseRejectionQueued) this._reject(e);
+            };
 
-Promise.prototype.bind = function (thisArg) {
-    if (!calledBind) {
-        calledBind = true;
-        Promise.prototype._propagateFrom = debug.propagateFromFunction();
-        Promise.prototype._boundValue = debug.boundValueFunction();
-    }
-    var maybePromise = tryConvertToPromise(thisArg);
-    var ret = new Promise(INTERNAL);
-    ret._propagateFrom(this, 1);
-    var target = this._target();
-    ret._setBoundTo(maybePromise);
-    if (maybePromise instanceof Promise) {
-        var context = {
-            promiseRejectionQueued: false,
-            promise: ret,
-            target: target,
-            bindingPromise: maybePromise
-        };
-        target._then(INTERNAL, targetRejected, undefined, ret, context);
-        maybePromise._then(
-            bindingResolved, bindingRejected, undefined, ret, context);
-        ret._setOnCancel(maybePromise);
-    } else {
-        ret._resolveCallback(target);
-    }
-    return ret;
-};
+            Promise.prototype.bind = function (thisArg) {
+              if (!calledBind) {
+                calledBind = true;
+                Promise.prototype._propagateFrom = debug.propagateFromFunction();
+                Promise.prototype._boundValue = debug.boundValueFunction();
+              }
+              var maybePromise = tryConvertToPromise(thisArg);
+              var ret = new Promise(INTERNAL);
+              ret._propagateFrom(this, 1);
+              var target = this._target();
+              ret._setBoundTo(maybePromise);
+              if (maybePromise instanceof Promise) {
+                var context = {
+                    promiseRejectionQueued: false,
+                    promise: ret,
+                    target: target,
+                    bindingPromise: maybePromise
+                };
+                target._then(INTERNAL, targetRejected, undefined, ret, context);
+                maybePromise._then(
+                    bindingResolved, bindingRejected, undefined, ret, context);
+                ret._setOnCancel(maybePromise);
+              } else {
+                ret._resolveCallback(target);
+              }
+              return ret;
+            };
 
-Promise.prototype._setBoundTo = function (obj) {
-    if (obj !== undefined) {
-        this._bitField = this._bitField | 2097152;
-        this._boundTo = obj;
-    } else {
-        this._bitField = this._bitField & (~2097152);
-    }
-};
+            Promise.prototype._setBoundTo = function (obj) {
+              if (obj !== undefined) {
+                this._bitField = this._bitField | 2097152;
+                this._boundTo = obj;
+              } else {
+                this._bitField = this._bitField & (~2097152);
+              }
+            };
 
-Promise.prototype._isBound = function () {
-    return (this._bitField & 2097152) === 2097152;
-};
+            Promise.prototype._isBound = function () {
+              return (this._bitField & 2097152) === 2097152;
+            };
 
-Promise.bind = function (thisArg, value) {
-    return Promise.resolve(value).bind(thisArg);
-};
-};
+            Promise.bind = function (thisArg, value) {
+              return Promise.resolve(value).bind(thisArg);
+            };
+          };
 
-},{}],4:[function(_dereq_,module,exports){
-"use strict";
-var old;
-if (typeof Promise !== "undefined") old = Promise;
-function noConflict() {
-    try { if (Promise === bluebird) Promise = old; }
-    catch (e) {}
-    return bluebird;
-}
-var bluebird = _dereq_("./promise")();
-bluebird.noConflict = noConflict;
-module.exports = bluebird;
+        },{}],4:[function(_dereq_,module,exports){
+          "use strict";
+          var old;
+          if (typeof Promise !== "undefined") old = Promise;
+          function noConflict() {
+            try { if (Promise === bluebird) Promise = old; }
+            catch (e) {}
+            return bluebird;
+          }
+          var bluebird = _dereq_("./promise")();
+          bluebird.noConflict = noConflict;
+          module.exports = bluebird;
 
-},{"./promise":22}],5:[function(_dereq_,module,exports){
-"use strict";
-var cr = Object.create;
-if (cr) {
-    var callerCache = cr(null);
-    var getterCache = cr(null);
-    callerCache[" size"] = getterCache[" size"] = 0;
-}
+        },{"./promise":22}],5:[function(_dereq_,module,exports){
+          "use strict";
+          var cr = Object.create;
+          if (cr) {
+            var callerCache = cr(null);
+            var getterCache = cr(null);
+            callerCache[" size"] = getterCache[" size"] = 0;
+          }
 
-module.exports = function(Promise) {
-var util = _dereq_("./util");
-var canEvaluate = util.canEvaluate;
-var isIdentifier = util.isIdentifier;
+          module.exports = function(Promise) {
+            var util = _dereq_("./util");
+            var canEvaluate = util.canEvaluate;
+            var isIdentifier = util.isIdentifier;
 
-var getMethodCaller;
-var getGetter;
-if (!true) {
-var makeMethodCaller = function (methodName) {
-    return new Function("ensureMethod", "                                    \n\
-        return function(obj) {                                               \n\
-            'use strict'                                                     \n\
-            var len = this.length;                                           \n\
-            ensureMethod(obj, 'methodName');                                 \n\
-            switch(len) {                                                    \n\
-                case 1: return obj.methodName(this[0]);                      \n\
-                case 2: return obj.methodName(this[0], this[1]);             \n\
-                case 3: return obj.methodName(this[0], this[1], this[2]);    \n\
-                case 0: return obj.methodName();                             \n\
-                default:                                                     \n\
+            var getMethodCaller;
+            var getGetter;
+            if (!true) {
+              var makeMethodCaller = function (methodName) {
+                return new Function("ensureMethod", "                                    \n\
+                    return function(obj) {                                               \n\
+                    'use strict'                                                     \n\
+                    var len = this.length;                                           \n\
+                    ensureMethod(obj, 'methodName');                                 \n\
+                    switch(len) {                                                    \n\
+                    case 1: return obj.methodName(this[0]);                      \n\
+                    case 2: return obj.methodName(this[0], this[1]);             \n\
+                    case 3: return obj.methodName(this[0], this[1], this[2]);    \n\
+                    case 0: return obj.methodName();                             \n\
+                    default:                                                     \n\
                     return obj.methodName.apply(obj, this);                  \n\
-            }                                                                \n\
-        };                                                                   \n\
-        ".replace(/methodName/g, methodName))(ensureMethod);
-};
+                    }                                                                \n\
+                    };                                                                   \n\
+                    ".replace(/methodName/g, methodName))(ensureMethod);
+              };
 
-var makeGetter = function (propertyName) {
-    return new Function("obj", "                                             \n\
-        'use strict';                                                        \n\
-        return obj.propertyName;                                             \n\
-        ".replace("propertyName", propertyName));
-};
+              var makeGetter = function (propertyName) {
+                return new Function("obj", "                                             \n\
+                    'use strict';                                                        \n\
+                    return obj.propertyName;                                             \n\
+                    ".replace("propertyName", propertyName));
+              };
 
-var getCompiled = function(name, compiler, cache) {
-    var ret = cache[name];
-    if (typeof ret !== "function") {
-        if (!isIdentifier(name)) {
-            return null;
-        }
-        ret = compiler(name);
-        cache[name] = ret;
-        cache[" size"]++;
-        if (cache[" size"] > 512) {
-            var keys = Object.keys(cache);
-            for (var i = 0; i < 256; ++i) delete cache[keys[i]];
-            cache[" size"] = keys.length - 256;
-        }
-    }
-    return ret;
-};
-
-getMethodCaller = function(name) {
-    return getCompiled(name, makeMethodCaller, callerCache);
-};
-
-getGetter = function(name) {
-    return getCompiled(name, makeGetter, getterCache);
-};
-}
-
-function ensureMethod(obj, methodName) {
-    var fn;
-    if (obj != null) fn = obj[methodName];
-    if (typeof fn !== "function") {
-        var message = "Object " + util.classString(obj) + " has no method '" +
-            util.toString(methodName) + "'";
-        throw new Promise.TypeError(message);
-    }
-    return fn;
-}
-
-function caller(obj) {
-    var methodName = this.pop();
-    var fn = ensureMethod(obj, methodName);
-    return fn.apply(obj, this);
-}
-Promise.prototype.call = function (methodName) {
-    var args = [].slice.call(arguments, 1);;
-    if (!true) {
-        if (canEvaluate) {
-            var maybeCaller = getMethodCaller(methodName);
-            if (maybeCaller !== null) {
-                return this._then(
-                    maybeCaller, undefined, undefined, args, undefined);
-            }
-        }
-    }
-    args.push(methodName);
-    return this._then(caller, undefined, undefined, args, undefined);
-};
-
-function namedGetter(obj) {
-    return obj[this];
-}
-function indexedGetter(obj) {
-    var index = +this;
-    if (index < 0) index = Math.max(0, index + obj.length);
-    return obj[index];
-}
-Promise.prototype.get = function (propertyName) {
-    var isIndex = (typeof propertyName === "number");
-    var getter;
-    if (!isIndex) {
-        if (canEvaluate) {
-            var maybeGetter = getGetter(propertyName);
-            getter = maybeGetter !== null ? maybeGetter : namedGetter;
-        } else {
-            getter = namedGetter;
-        }
-    } else {
-        getter = indexedGetter;
-    }
-    return this._then(getter, undefined, undefined, propertyName, undefined);
-};
-};
-
-},{"./util":36}],6:[function(_dereq_,module,exports){
-"use strict";
-module.exports = function(Promise, PromiseArray, apiRejection, debug) {
-var util = _dereq_("./util");
-var tryCatch = util.tryCatch;
-var errorObj = util.errorObj;
-var async = Promise._async;
-
-Promise.prototype["break"] = Promise.prototype.cancel = function() {
-    if (!debug.cancellation()) return this._warn("cancellation is disabled");
-
-    var promise = this;
-    var child = promise;
-    while (promise._isCancellable()) {
-        if (!promise._cancelBy(child)) {
-            if (child._isFollowing()) {
-                child._followee().cancel();
-            } else {
-                child._cancelBranched();
-            }
-            break;
-        }
-
-        var parent = promise._cancellationParent;
-        if (parent == null || !parent._isCancellable()) {
-            if (promise._isFollowing()) {
-                promise._followee().cancel();
-            } else {
-                promise._cancelBranched();
-            }
-            break;
-        } else {
-            if (promise._isFollowing()) promise._followee().cancel();
-            promise._setWillBeCancelled();
-            child = promise;
-            promise = parent;
-        }
-    }
-};
-
-Promise.prototype._branchHasCancelled = function() {
-    this._branchesRemainingToCancel--;
-};
-
-Promise.prototype._enoughBranchesHaveCancelled = function() {
-    return this._branchesRemainingToCancel === undefined ||
-           this._branchesRemainingToCancel <= 0;
-};
-
-Promise.prototype._cancelBy = function(canceller) {
-    if (canceller === this) {
-        this._branchesRemainingToCancel = 0;
-        this._invokeOnCancel();
-        return true;
-    } else {
-        this._branchHasCancelled();
-        if (this._enoughBranchesHaveCancelled()) {
-            this._invokeOnCancel();
-            return true;
-        }
-    }
-    return false;
-};
-
-Promise.prototype._cancelBranched = function() {
-    if (this._enoughBranchesHaveCancelled()) {
-        this._cancel();
-    }
-};
-
-Promise.prototype._cancel = function() {
-    if (!this._isCancellable()) return;
-    this._setCancelled();
-    async.invoke(this._cancelPromises, this, undefined);
-};
-
-Promise.prototype._cancelPromises = function() {
-    if (this._length() > 0) this._settlePromises();
-};
-
-Promise.prototype._unsetOnCancel = function() {
-    this._onCancelField = undefined;
-};
-
-Promise.prototype._isCancellable = function() {
-    return this.isPending() && !this._isCancelled();
-};
-
-Promise.prototype.isCancellable = function() {
-    return this.isPending() && !this.isCancelled();
-};
-
-Promise.prototype._doInvokeOnCancel = function(onCancelCallback, internalOnly) {
-    if (util.isArray(onCancelCallback)) {
-        for (var i = 0; i < onCancelCallback.length; ++i) {
-            this._doInvokeOnCancel(onCancelCallback[i], internalOnly);
-        }
-    } else if (onCancelCallback !== undefined) {
-        if (typeof onCancelCallback === "function") {
-            if (!internalOnly) {
-                var e = tryCatch(onCancelCallback).call(this._boundValue());
-                if (e === errorObj) {
-                    this._attachExtraTrace(e.e);
-                    async.throwLater(e.e);
+              var getCompiled = function(name, compiler, cache) {
+                var ret = cache[name];
+                if (typeof ret !== "function") {
+                  if (!isIdentifier(name)) {
+                    return null;
+                  }
+                  ret = compiler(name);
+                  cache[name] = ret;
+                  cache[" size"]++;
+                  if (cache[" size"] > 512) {
+                    var keys = Object.keys(cache);
+                    for (var i = 0; i < 256; ++i) delete cache[keys[i]];
+                    cache[" size"] = keys.length - 256;
+                  }
                 }
+                return ret;
+              };
+
+              getMethodCaller = function(name) {
+                return getCompiled(name, makeMethodCaller, callerCache);
+              };
+
+              getGetter = function(name) {
+                return getCompiled(name, makeGetter, getterCache);
+              };
             }
-        } else {
-            onCancelCallback._resultCancelled(this);
-        }
-    }
-};
 
-Promise.prototype._invokeOnCancel = function() {
-    var onCancelCallback = this._onCancel();
-    this._unsetOnCancel();
-    async.invoke(this._doInvokeOnCancel, this, onCancelCallback);
-};
+            function ensureMethod(obj, methodName) {
+              var fn;
+              if (obj != null) fn = obj[methodName];
+              if (typeof fn !== "function") {
+                var message = "Object " + util.classString(obj) + " has no method '" +
+                util.toString(methodName) + "'";
+                throw new Promise.TypeError(message);
+              }
+              return fn;
+            }
 
-Promise.prototype._invokeInternalOnCancel = function() {
-    if (this._isCancellable()) {
-        this._doInvokeOnCancel(this._onCancel(), true);
-        this._unsetOnCancel();
-    }
-};
-
-Promise.prototype._resultCancelled = function() {
-    this.cancel();
-};
-
-};
-
-},{"./util":36}],7:[function(_dereq_,module,exports){
-"use strict";
-module.exports = function(NEXT_FILTER) {
-var util = _dereq_("./util");
-var getKeys = _dereq_("./es5").keys;
-var tryCatch = util.tryCatch;
-var errorObj = util.errorObj;
-
-function catchFilter(instances, cb, promise) {
-    return function(e) {
-        var boundTo = promise._boundValue();
-        predicateLoop: for (var i = 0; i < instances.length; ++i) {
-            var item = instances[i];
-
-            if (item === Error ||
-                (item != null && item.prototype instanceof Error)) {
-                if (e instanceof item) {
-                    return tryCatch(cb).call(boundTo, e);
+            function caller(obj) {
+              var methodName = this.pop();
+              var fn = ensureMethod(obj, methodName);
+              return fn.apply(obj, this);
+            }
+            Promise.prototype.call = function (methodName) {
+              var args = [].slice.call(arguments, 1);;
+              if (!true) {
+                if (canEvaluate) {
+                  var maybeCaller = getMethodCaller(methodName);
+                  if (maybeCaller !== null) {
+                    return this._then(
+                        maybeCaller, undefined, undefined, args, undefined);
+                  }
                 }
-            } else if (typeof item === "function") {
-                var matchesPredicate = tryCatch(item).call(boundTo, e);
-                if (matchesPredicate === errorObj) {
-                    return matchesPredicate;
-                } else if (matchesPredicate) {
-                    return tryCatch(cb).call(boundTo, e);
+              }
+              args.push(methodName);
+              return this._then(caller, undefined, undefined, args, undefined);
+            };
+
+            function namedGetter(obj) {
+              return obj[this];
+            }
+            function indexedGetter(obj) {
+              var index = +this;
+              if (index < 0) index = Math.max(0, index + obj.length);
+              return obj[index];
+            }
+            Promise.prototype.get = function (propertyName) {
+              var isIndex = (typeof propertyName === "number");
+              var getter;
+              if (!isIndex) {
+                if (canEvaluate) {
+                  var maybeGetter = getGetter(propertyName);
+                  getter = maybeGetter !== null ? maybeGetter : namedGetter;
+                } else {
+                  getter = namedGetter;
                 }
-            } else if (util.isObject(e)) {
-                var keys = getKeys(item);
-                for (var j = 0; j < keys.length; ++j) {
-                    var key = keys[j];
-                    if (item[key] != e[key]) {
+              } else {
+                getter = indexedGetter;
+              }
+              return this._then(getter, undefined, undefined, propertyName, undefined);
+            };
+          };
+
+        },{"./util":36}],6:[function(_dereq_,module,exports){
+          "use strict";
+          module.exports = function(Promise, PromiseArray, apiRejection, debug) {
+            var util = _dereq_("./util");
+            var tryCatch = util.tryCatch;
+            var errorObj = util.errorObj;
+            var async = Promise._async;
+
+            Promise.prototype["break"] = Promise.prototype.cancel = function() {
+              if (!debug.cancellation()) return this._warn("cancellation is disabled");
+
+              var promise = this;
+              var child = promise;
+              while (promise._isCancellable()) {
+                if (!promise._cancelBy(child)) {
+                  if (child._isFollowing()) {
+                    child._followee().cancel();
+                  } else {
+                    child._cancelBranched();
+                  }
+                  break;
+                }
+
+                var parent = promise._cancellationParent;
+                if (parent == null || !parent._isCancellable()) {
+                  if (promise._isFollowing()) {
+                    promise._followee().cancel();
+                  } else {
+                    promise._cancelBranched();
+                  }
+                  break;
+                } else {
+                  if (promise._isFollowing()) promise._followee().cancel();
+                  promise._setWillBeCancelled();
+                  child = promise;
+                  promise = parent;
+                }
+              }
+            };
+
+            Promise.prototype._branchHasCancelled = function() {
+              this._branchesRemainingToCancel--;
+            };
+
+            Promise.prototype._enoughBranchesHaveCancelled = function() {
+              return this._branchesRemainingToCancel === undefined ||
+              this._branchesRemainingToCancel <= 0;
+            };
+
+            Promise.prototype._cancelBy = function(canceller) {
+              if (canceller === this) {
+                this._branchesRemainingToCancel = 0;
+                this._invokeOnCancel();
+                return true;
+              } else {
+                this._branchHasCancelled();
+                if (this._enoughBranchesHaveCancelled()) {
+                  this._invokeOnCancel();
+                  return true;
+                }
+              }
+              return false;
+            };
+
+            Promise.prototype._cancelBranched = function() {
+              if (this._enoughBranchesHaveCancelled()) {
+                this._cancel();
+              }
+            };
+
+            Promise.prototype._cancel = function() {
+              if (!this._isCancellable()) return;
+              this._setCancelled();
+              async.invoke(this._cancelPromises, this, undefined);
+            };
+
+            Promise.prototype._cancelPromises = function() {
+              if (this._length() > 0) this._settlePromises();
+            };
+
+            Promise.prototype._unsetOnCancel = function() {
+              this._onCancelField = undefined;
+            };
+
+            Promise.prototype._isCancellable = function() {
+              return this.isPending() && !this._isCancelled();
+            };
+
+            Promise.prototype.isCancellable = function() {
+              return this.isPending() && !this.isCancelled();
+            };
+
+            Promise.prototype._doInvokeOnCancel = function(onCancelCallback, internalOnly) {
+              if (util.isArray(onCancelCallback)) {
+                for (var i = 0; i < onCancelCallback.length; ++i) {
+                  this._doInvokeOnCancel(onCancelCallback[i], internalOnly);
+                }
+              } else if (onCancelCallback !== undefined) {
+                if (typeof onCancelCallback === "function") {
+                  if (!internalOnly) {
+                    var e = tryCatch(onCancelCallback).call(this._boundValue());
+                    if (e === errorObj) {
+                      this._attachExtraTrace(e.e);
+                      async.throwLater(e.e);
+                    }
+                  }
+                } else {
+                  onCancelCallback._resultCancelled(this);
+                }
+              }
+            };
+
+            Promise.prototype._invokeOnCancel = function() {
+              var onCancelCallback = this._onCancel();
+              this._unsetOnCancel();
+              async.invoke(this._doInvokeOnCancel, this, onCancelCallback);
+            };
+
+            Promise.prototype._invokeInternalOnCancel = function() {
+              if (this._isCancellable()) {
+                this._doInvokeOnCancel(this._onCancel(), true);
+                this._unsetOnCancel();
+              }
+            };
+
+            Promise.prototype._resultCancelled = function() {
+              this.cancel();
+            };
+
+          };
+
+        },{"./util":36}],7:[function(_dereq_,module,exports){
+          "use strict";
+          module.exports = function(NEXT_FILTER) {
+            var util = _dereq_("./util");
+            var getKeys = _dereq_("./es5").keys;
+            var tryCatch = util.tryCatch;
+            var errorObj = util.errorObj;
+
+            function catchFilter(instances, cb, promise) {
+              return function(e) {
+                var boundTo = promise._boundValue();
+                predicateLoop: for (var i = 0; i < instances.length; ++i) {
+                  var item = instances[i];
+
+                  if (item === Error ||
+                      (item != null && item.prototype instanceof Error)) {
+                    if (e instanceof item) {
+                      return tryCatch(cb).call(boundTo, e);
+                    }
+                  } else if (typeof item === "function") {
+                    var matchesPredicate = tryCatch(item).call(boundTo, e);
+                    if (matchesPredicate === errorObj) {
+                      return matchesPredicate;
+                    } else if (matchesPredicate) {
+                      return tryCatch(cb).call(boundTo, e);
+                    }
+                  } else if (util.isObject(e)) {
+                    var keys = getKeys(item);
+                    for (var j = 0; j < keys.length; ++j) {
+                      var key = keys[j];
+                      if (item[key] != e[key]) {
                         continue predicateLoop;
+                      }
                     }
+                    return tryCatch(cb).call(boundTo, e);
+                  }
                 }
-                return tryCatch(cb).call(boundTo, e);
+                return NEXT_FILTER;
+              };
             }
-        }
-        return NEXT_FILTER;
-    };
-}
 
-return catchFilter;
-};
+            return catchFilter;
+          };
 
-},{"./es5":13,"./util":36}],8:[function(_dereq_,module,exports){
-"use strict";
-module.exports = function(Promise) {
-var longStackTraces = false;
-var contextStack = [];
+        },{"./es5":13,"./util":36}],8:[function(_dereq_,module,exports){
+          "use strict";
+          module.exports = function(Promise) {
+            var longStackTraces = false;
+            var contextStack = [];
 
-Promise.prototype._promiseCreated = function() {};
-Promise.prototype._pushContext = function() {};
-Promise.prototype._popContext = function() {return null;};
-Promise._peekContext = Promise.prototype._peekContext = function() {};
+            Promise.prototype._promiseCreated = function() {};
+            Promise.prototype._pushContext = function() {};
+            Promise.prototype._popContext = function() {return null;};
+            Promise._peekContext = Promise.prototype._peekContext = function() {};
 
-function Context() {
-    this._trace = new Context.CapturedTrace(peekContext());
-}
-Context.prototype._pushContext = function () {
-    if (this._trace !== undefined) {
-        this._trace._promiseCreated = null;
-        contextStack.push(this._trace);
-    }
-};
+            function Context() {
+              this._trace = new Context.CapturedTrace(peekContext());
+            }
+            Context.prototype._pushContext = function () {
+              if (this._trace !== undefined) {
+                this._trace._promiseCreated = null;
+                contextStack.push(this._trace);
+              }
+            };
 
-Context.prototype._popContext = function () {
-    if (this._trace !== undefined) {
-        var trace = contextStack.pop();
-        var ret = trace._promiseCreated;
-        trace._promiseCreated = null;
-        return ret;
-    }
-    return null;
-};
+            Context.prototype._popContext = function () {
+              if (this._trace !== undefined) {
+                var trace = contextStack.pop();
+                var ret = trace._promiseCreated;
+                trace._promiseCreated = null;
+                return ret;
+              }
+              return null;
+            };
 
-function createContext() {
-    if (longStackTraces) return new Context();
-}
+            function createContext() {
+              if (longStackTraces) return new Context();
+            }
 
-function peekContext() {
-    var lastIndex = contextStack.length - 1;
-    if (lastIndex >= 0) {
-        return contextStack[lastIndex];
-    }
-    return undefined;
-}
-Context.CapturedTrace = null;
-Context.create = createContext;
-Context.deactivateLongStackTraces = function() {};
-Context.activateLongStackTraces = function() {
-    var Promise_pushContext = Promise.prototype._pushContext;
-    var Promise_popContext = Promise.prototype._popContext;
-    var Promise_PeekContext = Promise._peekContext;
-    var Promise_peekContext = Promise.prototype._peekContext;
-    var Promise_promiseCreated = Promise.prototype._promiseCreated;
-    Context.deactivateLongStackTraces = function() {
-        Promise.prototype._pushContext = Promise_pushContext;
-        Promise.prototype._popContext = Promise_popContext;
-        Promise._peekContext = Promise_PeekContext;
-        Promise.prototype._peekContext = Promise_peekContext;
-        Promise.prototype._promiseCreated = Promise_promiseCreated;
-        longStackTraces = false;
-    };
-    longStackTraces = true;
-    Promise.prototype._pushContext = Context.prototype._pushContext;
-    Promise.prototype._popContext = Context.prototype._popContext;
-    Promise._peekContext = Promise.prototype._peekContext = peekContext;
-    Promise.prototype._promiseCreated = function() {
-        var ctx = this._peekContext();
-        if (ctx && ctx._promiseCreated == null) ctx._promiseCreated = this;
-    };
-};
-return Context;
-};
+            function peekContext() {
+              var lastIndex = contextStack.length - 1;
+              if (lastIndex >= 0) {
+                return contextStack[lastIndex];
+              }
+              return undefined;
+            }
+            Context.CapturedTrace = null;
+            Context.create = createContext;
+            Context.deactivateLongStackTraces = function() {};
+            Context.activateLongStackTraces = function() {
+              var Promise_pushContext = Promise.prototype._pushContext;
+              var Promise_popContext = Promise.prototype._popContext;
+              var Promise_PeekContext = Promise._peekContext;
+              var Promise_peekContext = Promise.prototype._peekContext;
+              var Promise_promiseCreated = Promise.prototype._promiseCreated;
+              Context.deactivateLongStackTraces = function() {
+                Promise.prototype._pushContext = Promise_pushContext;
+                Promise.prototype._popContext = Promise_popContext;
+                Promise._peekContext = Promise_PeekContext;
+                Promise.prototype._peekContext = Promise_peekContext;
+                Promise.prototype._promiseCreated = Promise_promiseCreated;
+                longStackTraces = false;
+              };
+              longStackTraces = true;
+              Promise.prototype._pushContext = Context.prototype._pushContext;
+              Promise.prototype._popContext = Context.prototype._popContext;
+              Promise._peekContext = Promise.prototype._peekContext = peekContext;
+              Promise.prototype._promiseCreated = function() {
+                var ctx = this._peekContext();
+                if (ctx && ctx._promiseCreated == null) ctx._promiseCreated = this;
+              };
+            };
+            return Context;
+          };
 
-},{}],9:[function(_dereq_,module,exports){
-"use strict";
-module.exports = function(Promise, Context) {
-var getDomain = Promise._getDomain;
-var async = Promise._async;
-var Warning = _dereq_("./errors").Warning;
-var util = _dereq_("./util");
-var canAttachTrace = util.canAttachTrace;
-var unhandledRejectionHandled;
-var possiblyUnhandledRejection;
-var bluebirdFramePattern =
-    /[\\\/]bluebird[\\\/]js[\\\/](release|debug|instrumented)/;
-var nodeFramePattern = /\((?:timers\.js):\d+:\d+\)/;
-var parseLinePattern = /[\/<\(](.+?):(\d+):(\d+)\)?\s*$/;
-var stackFramePattern = null;
-var formatStack = null;
-var indentStackFrames = false;
-var printWarning;
-var debugging = !!(util.env("BLUEBIRD_DEBUG") != 0 &&
-                        (true ||
-                         util.env("BLUEBIRD_DEBUG") ||
-                         util.env("NODE_ENV") === "development"));
+        },{}],9:[function(_dereq_,module,exports){
+          "use strict";
+          module.exports = function(Promise, Context) {
+            var getDomain = Promise._getDomain;
+            var async = Promise._async;
+            var Warning = _dereq_("./errors").Warning;
+            var util = _dereq_("./util");
+            var canAttachTrace = util.canAttachTrace;
+            var unhandledRejectionHandled;
+            var possiblyUnhandledRejection;
+            var bluebirdFramePattern =
+              /[\\\/]bluebird[\\\/]js[\\\/](release|debug|instrumented)/;
+            var nodeFramePattern = /\((?:timers\.js):\d+:\d+\)/;
+            var parseLinePattern = /[\/<\(](.+?):(\d+):(\d+)\)?\s*$/;
+            var stackFramePattern = null;
+            var formatStack = null;
+            var indentStackFrames = false;
+            var printWarning;
+            var debugging = !!(util.env("BLUEBIRD_DEBUG") != 0 &&
+                (true ||
+                    util.env("BLUEBIRD_DEBUG") ||
+                    util.env("NODE_ENV") === "development"));
 
-var warnings = !!(util.env("BLUEBIRD_WARNINGS") != 0 &&
-    (debugging || util.env("BLUEBIRD_WARNINGS")));
+            var warnings = !!(util.env("BLUEBIRD_WARNINGS") != 0 &&
+                (debugging || util.env("BLUEBIRD_WARNINGS")));
 
-var longStackTraces = !!(util.env("BLUEBIRD_LONG_STACK_TRACES") != 0 &&
-    (debugging || util.env("BLUEBIRD_LONG_STACK_TRACES")));
+            var longStackTraces = !!(util.env("BLUEBIRD_LONG_STACK_TRACES") != 0 &&
+                (debugging || util.env("BLUEBIRD_LONG_STACK_TRACES")));
 
-var wForgottenReturn = util.env("BLUEBIRD_W_FORGOTTEN_RETURN") != 0 &&
-    (warnings || !!util.env("BLUEBIRD_W_FORGOTTEN_RETURN"));
+            var wForgottenReturn = util.env("BLUEBIRD_W_FORGOTTEN_RETURN") != 0 &&
+            (warnings || !!util.env("BLUEBIRD_W_FORGOTTEN_RETURN"));
 
-Promise.prototype.suppressUnhandledRejections = function() {
-    var target = this._target();
-    target._bitField = ((target._bitField & (~1048576)) |
-                      524288);
-};
+            Promise.prototype.suppressUnhandledRejections = function() {
+              var target = this._target();
+              target._bitField = ((target._bitField & (~1048576)) |
+                  524288);
+            };
 
-Promise.prototype._ensurePossibleRejectionHandled = function () {
-    if ((this._bitField & 524288) !== 0) return;
-    this._setRejectionIsUnhandled();
-    async.invokeLater(this._notifyUnhandledRejection, this, undefined);
-};
+            Promise.prototype._ensurePossibleRejectionHandled = function () {
+              if ((this._bitField & 524288) !== 0) return;
+              this._setRejectionIsUnhandled();
+              async.invokeLater(this._notifyUnhandledRejection, this, undefined);
+            };
 
-Promise.prototype._notifyUnhandledRejectionIsHandled = function () {
-    fireRejectionEvent("rejectionHandled",
-                                  unhandledRejectionHandled, undefined, this);
-};
+            Promise.prototype._notifyUnhandledRejectionIsHandled = function () {
+              fireRejectionEvent("rejectionHandled",
+                  unhandledRejectionHandled, undefined, this);
+            };
 
-Promise.prototype._setReturnedNonUndefined = function() {
-    this._bitField = this._bitField | 268435456;
-};
+            Promise.prototype._setReturnedNonUndefined = function() {
+              this._bitField = this._bitField | 268435456;
+            };
 
-Promise.prototype._returnedNonUndefined = function() {
-    return (this._bitField & 268435456) !== 0;
-};
+            Promise.prototype._returnedNonUndefined = function() {
+              return (this._bitField & 268435456) !== 0;
+            };
 
-Promise.prototype._notifyUnhandledRejection = function () {
-    if (this._isRejectionUnhandled()) {
-        var reason = this._settledValue();
-        this._setUnhandledRejectionIsNotified();
-        fireRejectionEvent("unhandledRejection",
-                                      possiblyUnhandledRejection, reason, this);
-    }
-};
+            Promise.prototype._notifyUnhandledRejection = function () {
+              if (this._isRejectionUnhandled()) {
+                var reason = this._settledValue();
+                this._setUnhandledRejectionIsNotified();
+                fireRejectionEvent("unhandledRejection",
+                    possiblyUnhandledRejection, reason, this);
+              }
+            };
 
-Promise.prototype._setUnhandledRejectionIsNotified = function () {
-    this._bitField = this._bitField | 262144;
-};
+            Promise.prototype._setUnhandledRejectionIsNotified = function () {
+              this._bitField = this._bitField | 262144;
+            };
 
-Promise.prototype._unsetUnhandledRejectionIsNotified = function () {
-    this._bitField = this._bitField & (~262144);
-};
+            Promise.prototype._unsetUnhandledRejectionIsNotified = function () {
+              this._bitField = this._bitField & (~262144);
+            };
 
-Promise.prototype._isUnhandledRejectionNotified = function () {
-    return (this._bitField & 262144) > 0;
-};
+            Promise.prototype._isUnhandledRejectionNotified = function () {
+              return (this._bitField & 262144) > 0;
+            };
 
-Promise.prototype._setRejectionIsUnhandled = function () {
-    this._bitField = this._bitField | 1048576;
-};
+            Promise.prototype._setRejectionIsUnhandled = function () {
+              this._bitField = this._bitField | 1048576;
+            };
 
-Promise.prototype._unsetRejectionIsUnhandled = function () {
-    this._bitField = this._bitField & (~1048576);
-    if (this._isUnhandledRejectionNotified()) {
-        this._unsetUnhandledRejectionIsNotified();
-        this._notifyUnhandledRejectionIsHandled();
-    }
-};
+            Promise.prototype._unsetRejectionIsUnhandled = function () {
+              this._bitField = this._bitField & (~1048576);
+              if (this._isUnhandledRejectionNotified()) {
+                this._unsetUnhandledRejectionIsNotified();
+                this._notifyUnhandledRejectionIsHandled();
+              }
+            };
 
-Promise.prototype._isRejectionUnhandled = function () {
-    return (this._bitField & 1048576) > 0;
-};
+            Promise.prototype._isRejectionUnhandled = function () {
+              return (this._bitField & 1048576) > 0;
+            };
 
-Promise.prototype._warn = function(message, shouldUseOwnTrace, promise) {
-    return warn(message, shouldUseOwnTrace, promise || this);
-};
+            Promise.prototype._warn = function(message, shouldUseOwnTrace, promise) {
+              return warn(message, shouldUseOwnTrace, promise || this);
+            };
 
-Promise.onPossiblyUnhandledRejection = function (fn) {
-    var domain = getDomain();
-    possiblyUnhandledRejection =
-        typeof fn === "function" ? (domain === null ?
-                                            fn : util.domainBind(domain, fn))
-                                 : undefined;
-};
+            Promise.onPossiblyUnhandledRejection = function (fn) {
+              var domain = getDomain();
+              possiblyUnhandledRejection =
+                typeof fn === "function" ? (domain === null ?
+                    fn : util.domainBind(domain, fn))
+                    : undefined;
+            };
 
-Promise.onUnhandledRejectionHandled = function (fn) {
-    var domain = getDomain();
-    unhandledRejectionHandled =
-        typeof fn === "function" ? (domain === null ?
-                                            fn : util.domainBind(domain, fn))
-                                 : undefined;
-};
+            Promise.onUnhandledRejectionHandled = function (fn) {
+              var domain = getDomain();
+              unhandledRejectionHandled =
+                typeof fn === "function" ? (domain === null ?
+                    fn : util.domainBind(domain, fn))
+                    : undefined;
+            };
 
-var disableLongStackTraces = function() {};
-Promise.longStackTraces = function () {
-    if (async.haveItemsQueued() && !config.longStackTraces) {
-        throw new Error("cannot enable long stack traces after promises have been created\u000a\u000a    See http://goo.gl/MqrFmX\u000a");
-    }
-    if (!config.longStackTraces && longStackTracesIsSupported()) {
-        var Promise_captureStackTrace = Promise.prototype._captureStackTrace;
-        var Promise_attachExtraTrace = Promise.prototype._attachExtraTrace;
-        config.longStackTraces = true;
-        disableLongStackTraces = function() {
-            if (async.haveItemsQueued() && !config.longStackTraces) {
+            var disableLongStackTraces = function() {};
+            Promise.longStackTraces = function () {
+              if (async.haveItemsQueued() && !config.longStackTraces) {
                 throw new Error("cannot enable long stack traces after promises have been created\u000a\u000a    See http://goo.gl/MqrFmX\u000a");
-            }
-            Promise.prototype._captureStackTrace = Promise_captureStackTrace;
-            Promise.prototype._attachExtraTrace = Promise_attachExtraTrace;
-            Context.deactivateLongStackTraces();
-            async.enableTrampoline();
-            config.longStackTraces = false;
-        };
-        Promise.prototype._captureStackTrace = longStackTracesCaptureStackTrace;
-        Promise.prototype._attachExtraTrace = longStackTracesAttachExtraTrace;
-        Context.activateLongStackTraces();
-        async.disableTrampolineIfNecessary();
-    }
-};
-
-Promise.hasLongStackTraces = function () {
-    return config.longStackTraces && longStackTracesIsSupported();
-};
-
-var fireDomEvent = (function() {
-    try {
-        if (typeof CustomEvent === "function") {
-            var event = new CustomEvent("CustomEvent");
-            util.global.dispatchEvent(event);
-            return function(name, event) {
-                var domEvent = new CustomEvent(name.toLowerCase(), {
-                    detail: event,
-                    cancelable: true
-                });
-                return !util.global.dispatchEvent(domEvent);
+              }
+              if (!config.longStackTraces && longStackTracesIsSupported()) {
+                var Promise_captureStackTrace = Promise.prototype._captureStackTrace;
+                var Promise_attachExtraTrace = Promise.prototype._attachExtraTrace;
+                config.longStackTraces = true;
+                disableLongStackTraces = function() {
+                  if (async.haveItemsQueued() && !config.longStackTraces) {
+                    throw new Error("cannot enable long stack traces after promises have been created\u000a\u000a    See http://goo.gl/MqrFmX\u000a");
+                  }
+                  Promise.prototype._captureStackTrace = Promise_captureStackTrace;
+                  Promise.prototype._attachExtraTrace = Promise_attachExtraTrace;
+                  Context.deactivateLongStackTraces();
+                  async.enableTrampoline();
+                  config.longStackTraces = false;
+                };
+                Promise.prototype._captureStackTrace = longStackTracesCaptureStackTrace;
+                Promise.prototype._attachExtraTrace = longStackTracesAttachExtraTrace;
+                Context.activateLongStackTraces();
+                async.disableTrampolineIfNecessary();
+              }
             };
-        } else if (typeof Event === "function") {
-            var event = new Event("CustomEvent");
-            util.global.dispatchEvent(event);
-            return function(name, event) {
-                var domEvent = new Event(name.toLowerCase(), {
-                    cancelable: true
-                });
-                domEvent.detail = event;
-                return !util.global.dispatchEvent(domEvent);
+
+            Promise.hasLongStackTraces = function () {
+              return config.longStackTraces && longStackTracesIsSupported();
             };
-        } else {
-            var event = document.createEvent("CustomEvent");
-            event.initCustomEvent("testingtheevent", false, true, {});
-            util.global.dispatchEvent(event);
-            return function(name, event) {
-                var domEvent = document.createEvent("CustomEvent");
-                domEvent.initCustomEvent(name.toLowerCase(), false, true,
-                    event);
-                return !util.global.dispatchEvent(domEvent);
-            };
-        }
-    } catch (e) {}
-    return function() {
-        return false;
-    };
-})();
 
-var fireGlobalEvent = (function() {
-    if (util.isNode) {
-        return function() {
-            return process.emit.apply(process, arguments);
-        };
-    } else {
-        if (!util.global) {
-            return function() {
-                return false;
-            };
-        }
-        return function(name) {
-            var methodName = "on" + name.toLowerCase();
-            var method = util.global[methodName];
-            if (!method) return false;
-            method.apply(util.global, [].slice.call(arguments, 1));
-            return true;
-        };
-    }
-})();
-
-function generatePromiseLifecycleEventObject(name, promise) {
-    return {promise: promise};
-}
-
-var eventToObjectGenerator = {
-    promiseCreated: generatePromiseLifecycleEventObject,
-    promiseFulfilled: generatePromiseLifecycleEventObject,
-    promiseRejected: generatePromiseLifecycleEventObject,
-    promiseResolved: generatePromiseLifecycleEventObject,
-    promiseCancelled: generatePromiseLifecycleEventObject,
-    promiseChained: function(name, promise, child) {
-        return {promise: promise, child: child};
-    },
-    warning: function(name, warning) {
-        return {warning: warning};
-    },
-    unhandledRejection: function (name, reason, promise) {
-        return {reason: reason, promise: promise};
-    },
-    rejectionHandled: generatePromiseLifecycleEventObject
-};
-
-var activeFireEvent = function (name) {
-    var globalEventFired = false;
-    try {
-        globalEventFired = fireGlobalEvent.apply(null, arguments);
-    } catch (e) {
-        async.throwLater(e);
-        globalEventFired = true;
-    }
-
-    var domEventFired = false;
-    try {
-        domEventFired = fireDomEvent(name,
-                    eventToObjectGenerator[name].apply(null, arguments));
-    } catch (e) {
-        async.throwLater(e);
-        domEventFired = true;
-    }
-
-    return domEventFired || globalEventFired;
-};
-
-Promise.config = function(opts) {
-    opts = Object(opts);
-    if ("longStackTraces" in opts) {
-        if (opts.longStackTraces) {
-            Promise.longStackTraces();
-        } else if (!opts.longStackTraces && Promise.hasLongStackTraces()) {
-            disableLongStackTraces();
-        }
-    }
-    if ("warnings" in opts) {
-        var warningsOption = opts.warnings;
-        config.warnings = !!warningsOption;
-        wForgottenReturn = config.warnings;
-
-        if (util.isObject(warningsOption)) {
-            if ("wForgottenReturn" in warningsOption) {
-                wForgottenReturn = !!warningsOption.wForgottenReturn;
-            }
-        }
-    }
-    if ("cancellation" in opts && opts.cancellation && !config.cancellation) {
-        if (async.haveItemsQueued()) {
-            throw new Error(
-                "cannot enable cancellation after promises are in use");
-        }
-        Promise.prototype._clearCancellationData =
-            cancellationClearCancellationData;
-        Promise.prototype._propagateFrom = cancellationPropagateFrom;
-        Promise.prototype._onCancel = cancellationOnCancel;
-        Promise.prototype._setOnCancel = cancellationSetOnCancel;
-        Promise.prototype._attachCancellationCallback =
-            cancellationAttachCancellationCallback;
-        Promise.prototype._execute = cancellationExecute;
-        propagateFromFunction = cancellationPropagateFrom;
-        config.cancellation = true;
-    }
-    if ("monitoring" in opts) {
-        if (opts.monitoring && !config.monitoring) {
-            config.monitoring = true;
-            Promise.prototype._fireEvent = activeFireEvent;
-        } else if (!opts.monitoring && config.monitoring) {
-            config.monitoring = false;
-            Promise.prototype._fireEvent = defaultFireEvent;
-        }
-    }
-};
-
-function defaultFireEvent() { return false; }
-
-Promise.prototype._fireEvent = defaultFireEvent;
-Promise.prototype._execute = function(executor, resolve, reject) {
-    try {
-        executor(resolve, reject);
-    } catch (e) {
-        return e;
-    }
-};
-Promise.prototype._onCancel = function () {};
-Promise.prototype._setOnCancel = function (handler) { ; };
-Promise.prototype._attachCancellationCallback = function(onCancel) {
-    ;
-};
-Promise.prototype._captureStackTrace = function () {};
-Promise.prototype._attachExtraTrace = function () {};
-Promise.prototype._clearCancellationData = function() {};
-Promise.prototype._propagateFrom = function (parent, flags) {
-    ;
-    ;
-};
-
-function cancellationExecute(executor, resolve, reject) {
-    var promise = this;
-    try {
-        executor(resolve, reject, function(onCancel) {
-            if (typeof onCancel !== "function") {
-                throw new TypeError("onCancel must be a function, got: " +
-                                    util.toString(onCancel));
-            }
-            promise._attachCancellationCallback(onCancel);
-        });
-    } catch (e) {
-        return e;
-    }
-}
-
-function cancellationAttachCancellationCallback(onCancel) {
-    if (!this._isCancellable()) return this;
-
-    var previousOnCancel = this._onCancel();
-    if (previousOnCancel !== undefined) {
-        if (util.isArray(previousOnCancel)) {
-            previousOnCancel.push(onCancel);
-        } else {
-            this._setOnCancel([previousOnCancel, onCancel]);
-        }
-    } else {
-        this._setOnCancel(onCancel);
-    }
-}
-
-function cancellationOnCancel() {
-    return this._onCancelField;
-}
-
-function cancellationSetOnCancel(onCancel) {
-    this._onCancelField = onCancel;
-}
-
-function cancellationClearCancellationData() {
-    this._cancellationParent = undefined;
-    this._onCancelField = undefined;
-}
-
-function cancellationPropagateFrom(parent, flags) {
-    if ((flags & 1) !== 0) {
-        this._cancellationParent = parent;
-        var branchesRemainingToCancel = parent._branchesRemainingToCancel;
-        if (branchesRemainingToCancel === undefined) {
-            branchesRemainingToCancel = 0;
-        }
-        parent._branchesRemainingToCancel = branchesRemainingToCancel + 1;
-    }
-    if ((flags & 2) !== 0 && parent._isBound()) {
-        this._setBoundTo(parent._boundTo);
-    }
-}
-
-function bindingPropagateFrom(parent, flags) {
-    if ((flags & 2) !== 0 && parent._isBound()) {
-        this._setBoundTo(parent._boundTo);
-    }
-}
-var propagateFromFunction = bindingPropagateFrom;
-
-function boundValueFunction() {
-    var ret = this._boundTo;
-    if (ret !== undefined) {
-        if (ret instanceof Promise) {
-            if (ret.isFulfilled()) {
-                return ret.value();
-            } else {
-                return undefined;
-            }
-        }
-    }
-    return ret;
-}
-
-function longStackTracesCaptureStackTrace() {
-    this._trace = new CapturedTrace(this._peekContext());
-}
-
-function longStackTracesAttachExtraTrace(error, ignoreSelf) {
-    if (canAttachTrace(error)) {
-        var trace = this._trace;
-        if (trace !== undefined) {
-            if (ignoreSelf) trace = trace._parent;
-        }
-        if (trace !== undefined) {
-            trace.attachExtraTrace(error);
-        } else if (!error.__stackCleaned__) {
-            var parsed = parseStackAndMessage(error);
-            util.notEnumerableProp(error, "stack",
-                parsed.message + "\n" + parsed.stack.join("\n"));
-            util.notEnumerableProp(error, "__stackCleaned__", true);
-        }
-    }
-}
-
-function checkForgottenReturns(returnValue, promiseCreated, name, promise,
-                               parent) {
-    if (returnValue === undefined && promiseCreated !== null &&
-        wForgottenReturn) {
-        if (parent !== undefined && parent._returnedNonUndefined()) return;
-        if ((promise._bitField & 65535) === 0) return;
-
-        if (name) name = name + " ";
-        var handlerLine = "";
-        var creatorLine = "";
-        if (promiseCreated._trace) {
-            var traceLines = promiseCreated._trace.stack.split("\n");
-            var stack = cleanStack(traceLines);
-            for (var i = stack.length - 1; i >= 0; --i) {
-                var line = stack[i];
-                if (!nodeFramePattern.test(line)) {
-                    var lineMatches = line.match(parseLinePattern);
-                    if (lineMatches) {
-                        handlerLine  = "at " + lineMatches[1] +
-                            ":" + lineMatches[2] + ":" + lineMatches[3] + " ";
-                    }
-                    break;
+            var fireDomEvent = (function() {
+              try {
+                if (typeof CustomEvent === "function") {
+                  var event = new CustomEvent("CustomEvent");
+                  util.global.dispatchEvent(event);
+                  return function(name, event) {
+                    var domEvent = new CustomEvent(name.toLowerCase(), {
+                      detail: event,
+                      cancelable: true
+                    });
+                    return !util.global.dispatchEvent(domEvent);
+                  };
+                } else if (typeof Event === "function") {
+                  var event = new Event("CustomEvent");
+                  util.global.dispatchEvent(event);
+                  return function(name, event) {
+                    var domEvent = new Event(name.toLowerCase(), {
+                      cancelable: true
+                    });
+                    domEvent.detail = event;
+                    return !util.global.dispatchEvent(domEvent);
+                  };
+                } else {
+                  var event = document.createEvent("CustomEvent");
+                  event.initCustomEvent("testingtheevent", false, true, {});
+                  util.global.dispatchEvent(event);
+                  return function(name, event) {
+                    var domEvent = document.createEvent("CustomEvent");
+                    domEvent.initCustomEvent(name.toLowerCase(), false, true,
+                        event);
+                    return !util.global.dispatchEvent(domEvent);
+                  };
                 }
+              } catch (e) {}
+              return function() {
+                return false;
+              };
+            })();
+
+            var fireGlobalEvent = (function() {
+              if (util.isNode) {
+                return function() {
+                  return process.emit.apply(process, arguments);
+                };
+              } else {
+                if (!util.global) {
+                  return function() {
+                    return false;
+                  };
+                }
+                return function(name) {
+                  var methodName = "on" + name.toLowerCase();
+                  var method = util.global[methodName];
+                  if (!method) return false;
+                  method.apply(util.global, [].slice.call(arguments, 1));
+                  return true;
+                };
+              }
+            })();
+
+            function generatePromiseLifecycleEventObject(name, promise) {
+              return {promise: promise};
             }
 
-            if (stack.length > 0) {
-                var firstUserLine = stack[0];
-                for (var i = 0; i < traceLines.length; ++i) {
+            var eventToObjectGenerator = {
+                promiseCreated: generatePromiseLifecycleEventObject,
+                promiseFulfilled: generatePromiseLifecycleEventObject,
+                promiseRejected: generatePromiseLifecycleEventObject,
+                promiseResolved: generatePromiseLifecycleEventObject,
+                promiseCancelled: generatePromiseLifecycleEventObject,
+                promiseChained: function(name, promise, child) {
+                  return {promise: promise, child: child};
+                },
+                warning: function(name, warning) {
+                  return {warning: warning};
+                },
+                unhandledRejection: function (name, reason, promise) {
+                  return {reason: reason, promise: promise};
+                },
+                rejectionHandled: generatePromiseLifecycleEventObject
+            };
 
-                    if (traceLines[i] === firstUserLine) {
+            var activeFireEvent = function (name) {
+              var globalEventFired = false;
+              try {
+                globalEventFired = fireGlobalEvent.apply(null, arguments);
+              } catch (e) {
+                async.throwLater(e);
+                globalEventFired = true;
+              }
+
+              var domEventFired = false;
+              try {
+                domEventFired = fireDomEvent(name,
+                    eventToObjectGenerator[name].apply(null, arguments));
+              } catch (e) {
+                async.throwLater(e);
+                domEventFired = true;
+              }
+
+              return domEventFired || globalEventFired;
+            };
+
+            Promise.config = function(opts) {
+              opts = Object(opts);
+              if ("longStackTraces" in opts) {
+                if (opts.longStackTraces) {
+                  Promise.longStackTraces();
+                } else if (!opts.longStackTraces && Promise.hasLongStackTraces()) {
+                  disableLongStackTraces();
+                }
+              }
+              if ("warnings" in opts) {
+                var warningsOption = opts.warnings;
+                config.warnings = !!warningsOption;
+                wForgottenReturn = config.warnings;
+
+                if (util.isObject(warningsOption)) {
+                  if ("wForgottenReturn" in warningsOption) {
+                    wForgottenReturn = !!warningsOption.wForgottenReturn;
+                  }
+                }
+              }
+              if ("cancellation" in opts && opts.cancellation && !config.cancellation) {
+                if (async.haveItemsQueued()) {
+                  throw new Error(
+                  "cannot enable cancellation after promises are in use");
+                }
+                Promise.prototype._clearCancellationData =
+                  cancellationClearCancellationData;
+                Promise.prototype._propagateFrom = cancellationPropagateFrom;
+                Promise.prototype._onCancel = cancellationOnCancel;
+                Promise.prototype._setOnCancel = cancellationSetOnCancel;
+                Promise.prototype._attachCancellationCallback =
+                  cancellationAttachCancellationCallback;
+                Promise.prototype._execute = cancellationExecute;
+                propagateFromFunction = cancellationPropagateFrom;
+                config.cancellation = true;
+              }
+              if ("monitoring" in opts) {
+                if (opts.monitoring && !config.monitoring) {
+                  config.monitoring = true;
+                  Promise.prototype._fireEvent = activeFireEvent;
+                } else if (!opts.monitoring && config.monitoring) {
+                  config.monitoring = false;
+                  Promise.prototype._fireEvent = defaultFireEvent;
+                }
+              }
+            };
+
+            function defaultFireEvent() { return false; }
+
+            Promise.prototype._fireEvent = defaultFireEvent;
+            Promise.prototype._execute = function(executor, resolve, reject) {
+              try {
+                executor(resolve, reject);
+              } catch (e) {
+                return e;
+              }
+            };
+            Promise.prototype._onCancel = function () {};
+            Promise.prototype._setOnCancel = function (handler) { ; };
+            Promise.prototype._attachCancellationCallback = function(onCancel) {
+              ;
+            };
+            Promise.prototype._captureStackTrace = function () {};
+            Promise.prototype._attachExtraTrace = function () {};
+            Promise.prototype._clearCancellationData = function() {};
+            Promise.prototype._propagateFrom = function (parent, flags) {
+              ;
+              ;
+            };
+
+            function cancellationExecute(executor, resolve, reject) {
+              var promise = this;
+              try {
+                executor(resolve, reject, function(onCancel) {
+                  if (typeof onCancel !== "function") {
+                    throw new TypeError("onCancel must be a function, got: " +
+                        util.toString(onCancel));
+                  }
+                  promise._attachCancellationCallback(onCancel);
+                });
+              } catch (e) {
+                return e;
+              }
+            }
+
+            function cancellationAttachCancellationCallback(onCancel) {
+              if (!this._isCancellable()) return this;
+
+              var previousOnCancel = this._onCancel();
+              if (previousOnCancel !== undefined) {
+                if (util.isArray(previousOnCancel)) {
+                  previousOnCancel.push(onCancel);
+                } else {
+                  this._setOnCancel([previousOnCancel, onCancel]);
+                }
+              } else {
+                this._setOnCancel(onCancel);
+              }
+            }
+
+            function cancellationOnCancel() {
+              return this._onCancelField;
+            }
+
+            function cancellationSetOnCancel(onCancel) {
+              this._onCancelField = onCancel;
+            }
+
+            function cancellationClearCancellationData() {
+              this._cancellationParent = undefined;
+              this._onCancelField = undefined;
+            }
+
+            function cancellationPropagateFrom(parent, flags) {
+              if ((flags & 1) !== 0) {
+                this._cancellationParent = parent;
+                var branchesRemainingToCancel = parent._branchesRemainingToCancel;
+                if (branchesRemainingToCancel === undefined) {
+                  branchesRemainingToCancel = 0;
+                }
+                parent._branchesRemainingToCancel = branchesRemainingToCancel + 1;
+              }
+              if ((flags & 2) !== 0 && parent._isBound()) {
+                this._setBoundTo(parent._boundTo);
+              }
+            }
+
+            function bindingPropagateFrom(parent, flags) {
+              if ((flags & 2) !== 0 && parent._isBound()) {
+                this._setBoundTo(parent._boundTo);
+              }
+            }
+            var propagateFromFunction = bindingPropagateFrom;
+
+            function boundValueFunction() {
+              var ret = this._boundTo;
+              if (ret !== undefined) {
+                if (ret instanceof Promise) {
+                  if (ret.isFulfilled()) {
+                    return ret.value();
+                  } else {
+                    return undefined;
+                  }
+                }
+              }
+              return ret;
+            }
+
+            function longStackTracesCaptureStackTrace() {
+              this._trace = new CapturedTrace(this._peekContext());
+            }
+
+            function longStackTracesAttachExtraTrace(error, ignoreSelf) {
+              if (canAttachTrace(error)) {
+                var trace = this._trace;
+                if (trace !== undefined) {
+                  if (ignoreSelf) trace = trace._parent;
+                }
+                if (trace !== undefined) {
+                  trace.attachExtraTrace(error);
+                } else if (!error.__stackCleaned__) {
+                  var parsed = parseStackAndMessage(error);
+                  util.notEnumerableProp(error, "stack",
+                      parsed.message + "\n" + parsed.stack.join("\n"));
+                  util.notEnumerableProp(error, "__stackCleaned__", true);
+                }
+              }
+            }
+
+            function checkForgottenReturns(returnValue, promiseCreated, name, promise,
+                parent) {
+              if (returnValue === undefined && promiseCreated !== null &&
+                  wForgottenReturn) {
+                if (parent !== undefined && parent._returnedNonUndefined()) return;
+                if ((promise._bitField & 65535) === 0) return;
+
+                if (name) name = name + " ";
+                var handlerLine = "";
+                var creatorLine = "";
+                if (promiseCreated._trace) {
+                  var traceLines = promiseCreated._trace.stack.split("\n");
+                  var stack = cleanStack(traceLines);
+                  for (var i = stack.length - 1; i >= 0; --i) {
+                    var line = stack[i];
+                    if (!nodeFramePattern.test(line)) {
+                      var lineMatches = line.match(parseLinePattern);
+                      if (lineMatches) {
+                        handlerLine  = "at " + lineMatches[1] +
+                        ":" + lineMatches[2] + ":" + lineMatches[3] + " ";
+                      }
+                      break;
+                    }
+                  }
+
+                  if (stack.length > 0) {
+                    var firstUserLine = stack[0];
+                    for (var i = 0; i < traceLines.length; ++i) {
+
+                      if (traceLines[i] === firstUserLine) {
                         if (i > 0) {
-                            creatorLine = "\n" + traceLines[i - 1];
+                          creatorLine = "\n" + traceLines[i - 1];
                         }
                         break;
+                      }
                     }
+
+                  }
+                }
+                var msg = "a promise was created in a " + name +
+                "handler " + handlerLine + "but was not returned from it, " +
+                "see http://goo.gl/rRqMUw" +
+                creatorLine;
+                promise._warn(msg, true, promiseCreated);
+              }
+            }
+
+            function deprecated(name, replacement) {
+              var message = name +
+              " is deprecated and will be removed in a future version.";
+              if (replacement) message += " Use " + replacement + " instead.";
+              return warn(message);
+            }
+
+            function warn(message, shouldUseOwnTrace, promise) {
+              if (!config.warnings) return;
+              var warning = new Warning(message);
+              var ctx;
+              if (shouldUseOwnTrace) {
+                promise._attachExtraTrace(warning);
+              } else if (config.longStackTraces && (ctx = Promise._peekContext())) {
+                ctx.attachExtraTrace(warning);
+              } else {
+                var parsed = parseStackAndMessage(warning);
+                warning.stack = parsed.message + "\n" + parsed.stack.join("\n");
+              }
+
+              if (!activeFireEvent("warning", warning)) {
+                formatAndLogError(warning, "", true);
+              }
+            }
+
+            function reconstructStack(message, stacks) {
+              for (var i = 0; i < stacks.length - 1; ++i) {
+                stacks[i].push("From previous event:");
+                stacks[i] = stacks[i].join("\n");
+              }
+              if (i < stacks.length) {
+                stacks[i] = stacks[i].join("\n");
+              }
+              return message + "\n" + stacks.join("\n");
+            }
+
+            function removeDuplicateOrEmptyJumps(stacks) {
+              for (var i = 0; i < stacks.length; ++i) {
+                if (stacks[i].length === 0 ||
+                    ((i + 1 < stacks.length) && stacks[i][0] === stacks[i+1][0])) {
+                  stacks.splice(i, 1);
+                  i--;
+                }
+              }
+            }
+
+            function removeCommonRoots(stacks) {
+              var current = stacks[0];
+              for (var i = 1; i < stacks.length; ++i) {
+                var prev = stacks[i];
+                var currentLastIndex = current.length - 1;
+                var currentLastLine = current[currentLastIndex];
+                var commonRootMeetPoint = -1;
+
+                for (var j = prev.length - 1; j >= 0; --j) {
+                  if (prev[j] === currentLastLine) {
+                    commonRootMeetPoint = j;
+                    break;
+                  }
                 }
 
+                for (var j = commonRootMeetPoint; j >= 0; --j) {
+                  var line = prev[j];
+                  if (current[currentLastIndex] === line) {
+                    current.pop();
+                    currentLastIndex--;
+                  } else {
+                    break;
+                  }
+                }
+                current = prev;
+              }
             }
-        }
-        var msg = "a promise was created in a " + name +
-            "handler " + handlerLine + "but was not returned from it, " +
-            "see http://goo.gl/rRqMUw" +
-            creatorLine;
-        promise._warn(msg, true, promiseCreated);
-    }
-}
 
-function deprecated(name, replacement) {
-    var message = name +
-        " is deprecated and will be removed in a future version.";
-    if (replacement) message += " Use " + replacement + " instead.";
-    return warn(message);
-}
-
-function warn(message, shouldUseOwnTrace, promise) {
-    if (!config.warnings) return;
-    var warning = new Warning(message);
-    var ctx;
-    if (shouldUseOwnTrace) {
-        promise._attachExtraTrace(warning);
-    } else if (config.longStackTraces && (ctx = Promise._peekContext())) {
-        ctx.attachExtraTrace(warning);
-    } else {
-        var parsed = parseStackAndMessage(warning);
-        warning.stack = parsed.message + "\n" + parsed.stack.join("\n");
-    }
-
-    if (!activeFireEvent("warning", warning)) {
-        formatAndLogError(warning, "", true);
-    }
-}
-
-function reconstructStack(message, stacks) {
-    for (var i = 0; i < stacks.length - 1; ++i) {
-        stacks[i].push("From previous event:");
-        stacks[i] = stacks[i].join("\n");
-    }
-    if (i < stacks.length) {
-        stacks[i] = stacks[i].join("\n");
-    }
-    return message + "\n" + stacks.join("\n");
-}
-
-function removeDuplicateOrEmptyJumps(stacks) {
-    for (var i = 0; i < stacks.length; ++i) {
-        if (stacks[i].length === 0 ||
-            ((i + 1 < stacks.length) && stacks[i][0] === stacks[i+1][0])) {
-            stacks.splice(i, 1);
-            i--;
-        }
-    }
-}
-
-function removeCommonRoots(stacks) {
-    var current = stacks[0];
-    for (var i = 1; i < stacks.length; ++i) {
-        var prev = stacks[i];
-        var currentLastIndex = current.length - 1;
-        var currentLastLine = current[currentLastIndex];
-        var commonRootMeetPoint = -1;
-
-        for (var j = prev.length - 1; j >= 0; --j) {
-            if (prev[j] === currentLastLine) {
-                commonRootMeetPoint = j;
-                break;
+            function cleanStack(stack) {
+              var ret = [];
+              for (var i = 0; i < stack.length; ++i) {
+                var line = stack[i];
+                var isTraceLine = "    (No stack trace)" === line ||
+                stackFramePattern.test(line);
+                var isInternalFrame = isTraceLine && shouldIgnore(line);
+                if (isTraceLine && !isInternalFrame) {
+                  if (indentStackFrames && line.charAt(0) !== " ") {
+                    line = "    " + line;
+                  }
+                  ret.push(line);
+                }
+              }
+              return ret;
             }
-        }
 
-        for (var j = commonRootMeetPoint; j >= 0; --j) {
-            var line = prev[j];
-            if (current[currentLastIndex] === line) {
-                current.pop();
-                currentLastIndex--;
-            } else {
-                break;
+            function stackFramesAsArray(error) {
+              var stack = error.stack.replace(/\s+$/g, "").split("\n");
+              for (var i = 0; i < stack.length; ++i) {
+                var line = stack[i];
+                if ("    (No stack trace)" === line || stackFramePattern.test(line)) {
+                  break;
+                }
+              }
+              if (i > 0) {
+                stack = stack.slice(i);
+              }
+              return stack;
             }
-        }
-        current = prev;
-    }
-}
 
-function cleanStack(stack) {
-    var ret = [];
-    for (var i = 0; i < stack.length; ++i) {
-        var line = stack[i];
-        var isTraceLine = "    (No stack trace)" === line ||
-            stackFramePattern.test(line);
-        var isInternalFrame = isTraceLine && shouldIgnore(line);
-        if (isTraceLine && !isInternalFrame) {
-            if (indentStackFrames && line.charAt(0) !== " ") {
-                line = "    " + line;
+            function parseStackAndMessage(error) {
+              var stack = error.stack;
+              var message = error.toString();
+              stack = typeof stack === "string" && stack.length > 0
+              ? stackFramesAsArray(error) : ["    (No stack trace)"];
+              return {
+                message: message,
+                stack: cleanStack(stack)
+              };
             }
-            ret.push(line);
-        }
-    }
-    return ret;
-}
 
-function stackFramesAsArray(error) {
-    var stack = error.stack.replace(/\s+$/g, "").split("\n");
-    for (var i = 0; i < stack.length; ++i) {
-        var line = stack[i];
-        if ("    (No stack trace)" === line || stackFramePattern.test(line)) {
-            break;
-        }
-    }
-    if (i > 0) {
-        stack = stack.slice(i);
-    }
-    return stack;
-}
-
-function parseStackAndMessage(error) {
-    var stack = error.stack;
-    var message = error.toString();
-    stack = typeof stack === "string" && stack.length > 0
-                ? stackFramesAsArray(error) : ["    (No stack trace)"];
-    return {
-        message: message,
-        stack: cleanStack(stack)
-    };
-}
-
-function formatAndLogError(error, title, isSoft) {
-    if (typeof console !== "undefined") {
-        var message;
-        if (util.isObject(error)) {
-            var stack = error.stack;
-            message = title + formatStack(stack, error);
-        } else {
-            message = title + String(error);
-        }
-        if (typeof printWarning === "function") {
-            printWarning(message, isSoft);
-        } else if (typeof console.log === "function" ||
-            typeof console.log === "object") {
-            console.log(message);
-        }
-    }
-}
-
-function fireRejectionEvent(name, localHandler, reason, promise) {
-    var localEventFired = false;
-    try {
-        if (typeof localHandler === "function") {
-            localEventFired = true;
-            if (name === "rejectionHandled") {
-                localHandler(promise);
-            } else {
-                localHandler(reason, promise);
+            function formatAndLogError(error, title, isSoft) {
+              if (typeof console !== "undefined") {
+                var message;
+                if (util.isObject(error)) {
+                  var stack = error.stack;
+                  message = title + formatStack(stack, error);
+                } else {
+                  message = title + String(error);
+                }
+                if (typeof printWarning === "function") {
+                  printWarning(message, isSoft);
+                } else if (typeof console.log === "function" ||
+                    typeof console.log === "object") {
+                  console.log(message);
+                }
+              }
             }
-        }
-    } catch (e) {
-        async.throwLater(e);
-    }
 
-    if (name === "unhandledRejection") {
-        if (!activeFireEvent(name, reason, promise) && !localEventFired) {
-            formatAndLogError(reason, "Unhandled rejection ");
-        }
-    } else {
-        activeFireEvent(name, promise);
-    }
-}
+            function fireRejectionEvent(name, localHandler, reason, promise) {
+              var localEventFired = false;
+              try {
+                if (typeof localHandler === "function") {
+                  localEventFired = true;
+                  if (name === "rejectionHandled") {
+                    localHandler(promise);
+                  } else {
+                    localHandler(reason, promise);
+                  }
+                }
+              } catch (e) {
+                async.throwLater(e);
+              }
 
-function formatNonError(obj) {
-    var str;
-    if (typeof obj === "function") {
-        str = "[function " +
-            (obj.name || "anonymous") +
-            "]";
-    } else {
-        str = obj && typeof obj.toString === "function"
-            ? obj.toString() : util.toString(obj);
-        var ruselessToString = /\[object [a-zA-Z0-9$_]+\]/;
-        if (ruselessToString.test(str)) {
-            try {
-                var newStr = JSON.stringify(obj);
-                str = newStr;
+              if (name === "unhandledRejection") {
+                if (!activeFireEvent(name, reason, promise) && !localEventFired) {
+                  formatAndLogError(reason, "Unhandled rejection ");
+                }
+              } else {
+                activeFireEvent(name, promise);
+              }
             }
-            catch(e) {
 
+            function formatNonError(obj) {
+              var str;
+              if (typeof obj === "function") {
+                str = "[function " +
+                (obj.name || "anonymous") +
+                "]";
+              } else {
+                str = obj && typeof obj.toString === "function"
+                  ? obj.toString() : util.toString(obj);
+                  var ruselessToString = /\[object [a-zA-Z0-9$_]+\]/;
+                  if (ruselessToString.test(str)) {
+                    try {
+                      var newStr = JSON.stringify(obj);
+                      str = newStr;
+                    }
+                    catch(e) {
+
+                    }
+                  }
+                  if (str.length === 0) {
+                    str = "(empty array)";
+                  }
+              }
+              return ("(<" + snip(str) + ">, no stack trace)");
             }
-        }
-        if (str.length === 0) {
-            str = "(empty array)";
-        }
-    }
-    return ("(<" + snip(str) + ">, no stack trace)");
-}
 
-function snip(str) {
-    var maxChars = 41;
-    if (str.length < maxChars) {
-        return str;
-    }
-    return str.substr(0, maxChars - 3) + "...";
-}
-
-function longStackTracesIsSupported() {
-    return typeof captureStackTrace === "function";
-}
-
-var shouldIgnore = function() { return false; };
-var parseLineInfoRegex = /[\/<\(]([^:\/]+):(\d+):(?:\d+)\)?\s*$/;
-function parseLineInfo(line) {
-    var matches = line.match(parseLineInfoRegex);
-    if (matches) {
-        return {
-            fileName: matches[1],
-            line: parseInt(matches[2], 10)
-        };
-    }
-}
-
-function setBounds(firstLineError, lastLineError) {
-    if (!longStackTracesIsSupported()) return;
-    var firstStackLines = firstLineError.stack.split("\n");
-    var lastStackLines = lastLineError.stack.split("\n");
-    var firstIndex = -1;
-    var lastIndex = -1;
-    var firstFileName;
-    var lastFileName;
-    for (var i = 0; i < firstStackLines.length; ++i) {
-        var result = parseLineInfo(firstStackLines[i]);
-        if (result) {
-            firstFileName = result.fileName;
-            firstIndex = result.line;
-            break;
-        }
-    }
-    for (var i = 0; i < lastStackLines.length; ++i) {
-        var result = parseLineInfo(lastStackLines[i]);
-        if (result) {
-            lastFileName = result.fileName;
-            lastIndex = result.line;
-            break;
-        }
-    }
-    if (firstIndex < 0 || lastIndex < 0 || !firstFileName || !lastFileName ||
-        firstFileName !== lastFileName || firstIndex >= lastIndex) {
-        return;
-    }
-
-    shouldIgnore = function(line) {
-        if (bluebirdFramePattern.test(line)) return true;
-        var info = parseLineInfo(line);
-        if (info) {
-            if (info.fileName === firstFileName &&
-                (firstIndex <= info.line && info.line <= lastIndex)) {
-                return true;
+            function snip(str) {
+              var maxChars = 41;
+              if (str.length < maxChars) {
+                return str;
+              }
+              return str.substr(0, maxChars - 3) + "...";
             }
-        }
-        return false;
-    };
-}
 
-function CapturedTrace(parent) {
-    this._parent = parent;
-    this._promisesCreated = 0;
-    var length = this._length = 1 + (parent === undefined ? 0 : parent._length);
-    captureStackTrace(this, CapturedTrace);
-    if (length > 32) this.uncycle();
-}
-util.inherits(CapturedTrace, Error);
-Context.CapturedTrace = CapturedTrace;
-
-CapturedTrace.prototype.uncycle = function() {
-    var length = this._length;
-    if (length < 2) return;
-    var nodes = [];
-    var stackToIndex = {};
-
-    for (var i = 0, node = this; node !== undefined; ++i) {
-        nodes.push(node);
-        node = node._parent;
-    }
-    length = this._length = i;
-    for (var i = length - 1; i >= 0; --i) {
-        var stack = nodes[i].stack;
-        if (stackToIndex[stack] === undefined) {
-            stackToIndex[stack] = i;
-        }
-    }
-    for (var i = 0; i < length; ++i) {
-        var currentStack = nodes[i].stack;
-        var index = stackToIndex[currentStack];
-        if (index !== undefined && index !== i) {
-            if (index > 0) {
-                nodes[index - 1]._parent = undefined;
-                nodes[index - 1]._length = 1;
+            function longStackTracesIsSupported() {
+              return typeof captureStackTrace === "function";
             }
-            nodes[i]._parent = undefined;
-            nodes[i]._length = 1;
-            var cycleEdgeNode = i > 0 ? nodes[i - 1] : this;
 
-            if (index < length - 1) {
-                cycleEdgeNode._parent = nodes[index + 1];
-                cycleEdgeNode._parent.uncycle();
-                cycleEdgeNode._length =
-                    cycleEdgeNode._parent._length + 1;
-            } else {
-                cycleEdgeNode._parent = undefined;
-                cycleEdgeNode._length = 1;
+            var shouldIgnore = function() { return false; };
+            var parseLineInfoRegex = /[\/<\(]([^:\/]+):(\d+):(?:\d+)\)?\s*$/;
+            function parseLineInfo(line) {
+              var matches = line.match(parseLineInfoRegex);
+              if (matches) {
+                return {
+                  fileName: matches[1],
+                  line: parseInt(matches[2], 10)
+                };
+              }
             }
-            var currentChildLength = cycleEdgeNode._length + 1;
-            for (var j = i - 2; j >= 0; --j) {
-                nodes[j]._length = currentChildLength;
-                currentChildLength++;
+
+            function setBounds(firstLineError, lastLineError) {
+              if (!longStackTracesIsSupported()) return;
+              var firstStackLines = firstLineError.stack.split("\n");
+              var lastStackLines = lastLineError.stack.split("\n");
+              var firstIndex = -1;
+              var lastIndex = -1;
+              var firstFileName;
+              var lastFileName;
+              for (var i = 0; i < firstStackLines.length; ++i) {
+                var result = parseLineInfo(firstStackLines[i]);
+                if (result) {
+                  firstFileName = result.fileName;
+                  firstIndex = result.line;
+                  break;
+                }
+              }
+              for (var i = 0; i < lastStackLines.length; ++i) {
+                var result = parseLineInfo(lastStackLines[i]);
+                if (result) {
+                  lastFileName = result.fileName;
+                  lastIndex = result.line;
+                  break;
+                }
+              }
+              if (firstIndex < 0 || lastIndex < 0 || !firstFileName || !lastFileName ||
+                  firstFileName !== lastFileName || firstIndex >= lastIndex) {
+                return;
+              }
+
+              shouldIgnore = function(line) {
+                if (bluebirdFramePattern.test(line)) return true;
+                var info = parseLineInfo(line);
+                if (info) {
+                  if (info.fileName === firstFileName &&
+                      (firstIndex <= info.line && info.line <= lastIndex)) {
+                    return true;
+                  }
+                }
+                return false;
+              };
             }
-            return;
-        }
-    }
-};
 
-CapturedTrace.prototype.attachExtraTrace = function(error) {
-    if (error.__stackCleaned__) return;
-    this.uncycle();
-    var parsed = parseStackAndMessage(error);
-    var message = parsed.message;
-    var stacks = [parsed.stack];
+            function CapturedTrace(parent) {
+              this._parent = parent;
+              this._promisesCreated = 0;
+              var length = this._length = 1 + (parent === undefined ? 0 : parent._length);
+              captureStackTrace(this, CapturedTrace);
+              if (length > 32) this.uncycle();
+            }
+            util.inherits(CapturedTrace, Error);
+            Context.CapturedTrace = CapturedTrace;
 
-    var trace = this;
-    while (trace !== undefined) {
-        stacks.push(cleanStack(trace.stack.split("\n")));
-        trace = trace._parent;
-    }
-    removeCommonRoots(stacks);
-    removeDuplicateOrEmptyJumps(stacks);
-    util.notEnumerableProp(error, "stack", reconstructStack(message, stacks));
-    util.notEnumerableProp(error, "__stackCleaned__", true);
-};
+            CapturedTrace.prototype.uncycle = function() {
+              var length = this._length;
+              if (length < 2) return;
+              var nodes = [];
+              var stackToIndex = {};
 
-var captureStackTrace = (function stackDetection() {
-    var v8stackFramePattern = /^\s*at\s*/;
-    var v8stackFormatter = function(stack, error) {
-        if (typeof stack === "string") return stack;
+              for (var i = 0, node = this; node !== undefined; ++i) {
+                nodes.push(node);
+                node = node._parent;
+              }
+              length = this._length = i;
+              for (var i = length - 1; i >= 0; --i) {
+                var stack = nodes[i].stack;
+                if (stackToIndex[stack] === undefined) {
+                  stackToIndex[stack] = i;
+                }
+              }
+              for (var i = 0; i < length; ++i) {
+                var currentStack = nodes[i].stack;
+                var index = stackToIndex[currentStack];
+                if (index !== undefined && index !== i) {
+                  if (index > 0) {
+                    nodes[index - 1]._parent = undefined;
+                    nodes[index - 1]._length = 1;
+                  }
+                  nodes[i]._parent = undefined;
+                  nodes[i]._length = 1;
+                  var cycleEdgeNode = i > 0 ? nodes[i - 1] : this;
 
-        if (error.name !== undefined &&
-            error.message !== undefined) {
-            return error.toString();
-        }
-        return formatNonError(error);
-    };
+                  if (index < length - 1) {
+                    cycleEdgeNode._parent = nodes[index + 1];
+                    cycleEdgeNode._parent.uncycle();
+                    cycleEdgeNode._length =
+                      cycleEdgeNode._parent._length + 1;
+                  } else {
+                    cycleEdgeNode._parent = undefined;
+                    cycleEdgeNode._length = 1;
+                  }
+                  var currentChildLength = cycleEdgeNode._length + 1;
+                  for (var j = i - 2; j >= 0; --j) {
+                    nodes[j]._length = currentChildLength;
+                    currentChildLength++;
+                  }
+                  return;
+                }
+              }
+            };
 
-    if (typeof Error.stackTraceLimit === "number" &&
-        typeof Error.captureStackTrace === "function") {
-        Error.stackTraceLimit += 6;
-        stackFramePattern = v8stackFramePattern;
-        formatStack = v8stackFormatter;
-        var captureStackTrace = Error.captureStackTrace;
+            CapturedTrace.prototype.attachExtraTrace = function(error) {
+              if (error.__stackCleaned__) return;
+              this.uncycle();
+              var parsed = parseStackAndMessage(error);
+              var message = parsed.message;
+              var stacks = [parsed.stack];
 
-        shouldIgnore = function(line) {
-            return bluebirdFramePattern.test(line);
-        };
-        return function(receiver, ignoreUntil) {
-            Error.stackTraceLimit += 6;
-            captureStackTrace(receiver, ignoreUntil);
-            Error.stackTraceLimit -= 6;
-        };
-    }
-    var err = new Error();
+              var trace = this;
+              while (trace !== undefined) {
+                stacks.push(cleanStack(trace.stack.split("\n")));
+                trace = trace._parent;
+              }
+              removeCommonRoots(stacks);
+              removeDuplicateOrEmptyJumps(stacks);
+              util.notEnumerableProp(error, "stack", reconstructStack(message, stacks));
+              util.notEnumerableProp(error, "__stackCleaned__", true);
+            };
 
-    if (typeof err.stack === "string" &&
-        err.stack.split("\n")[0].indexOf("stackDetection@") >= 0) {
-        stackFramePattern = /@/;
-        formatStack = v8stackFormatter;
-        indentStackFrames = true;
-        return function captureStackTrace(o) {
-            o.stack = new Error().stack;
-        };
-    }
+            var captureStackTrace = (function stackDetection() {
+              var v8stackFramePattern = /^\s*at\s*/;
+              var v8stackFormatter = function(stack, error) {
+                if (typeof stack === "string") return stack;
 
-    var hasStackAfterThrow;
-    try { throw new Error(); }
-    catch(e) {
-        hasStackAfterThrow = ("stack" in e);
-    }
-    if (!("stack" in err) && hasStackAfterThrow &&
-        typeof Error.stackTraceLimit === "number") {
-        stackFramePattern = v8stackFramePattern;
-        formatStack = v8stackFormatter;
-        return function captureStackTrace(o) {
-            Error.stackTraceLimit += 6;
-            try { throw new Error(); }
-            catch(e) { o.stack = e.stack; }
-            Error.stackTraceLimit -= 6;
-        };
-    }
+                if (error.name !== undefined &&
+                    error.message !== undefined) {
+                  return error.toString();
+                }
+                return formatNonError(error);
+              };
 
-    formatStack = function(stack, error) {
-        if (typeof stack === "string") return stack;
+              if (typeof Error.stackTraceLimit === "number" &&
+                  typeof Error.captureStackTrace === "function") {
+                Error.stackTraceLimit += 6;
+                stackFramePattern = v8stackFramePattern;
+                formatStack = v8stackFormatter;
+                var captureStackTrace = Error.captureStackTrace;
 
-        if ((typeof error === "object" ||
-            typeof error === "function") &&
-            error.name !== undefined &&
-            error.message !== undefined) {
-            return error.toString();
-        }
-        return formatNonError(error);
-    };
+                shouldIgnore = function(line) {
+                  return bluebirdFramePattern.test(line);
+                };
+                return function(receiver, ignoreUntil) {
+                  Error.stackTraceLimit += 6;
+                  captureStackTrace(receiver, ignoreUntil);
+                  Error.stackTraceLimit -= 6;
+                };
+              }
+              var err = new Error();
 
-    return null;
+              if (typeof err.stack === "string" &&
+                  err.stack.split("\n")[0].indexOf("stackDetection@") >= 0) {
+                stackFramePattern = /@/;
+                formatStack = v8stackFormatter;
+                indentStackFrames = true;
+                return function captureStackTrace(o) {
+                  o.stack = new Error().stack;
+                };
+              }
 
-})([]);
+              var hasStackAfterThrow;
+              try { throw new Error(); }
+              catch(e) {
+                hasStackAfterThrow = ("stack" in e);
+              }
+              if (!("stack" in err) && hasStackAfterThrow &&
+                  typeof Error.stackTraceLimit === "number") {
+                stackFramePattern = v8stackFramePattern;
+                formatStack = v8stackFormatter;
+                return function captureStackTrace(o) {
+                  Error.stackTraceLimit += 6;
+                  try { throw new Error(); }
+                  catch(e) { o.stack = e.stack; }
+                  Error.stackTraceLimit -= 6;
+                };
+              }
 
-if (typeof console !== "undefined" && typeof console.warn !== "undefined") {
-    printWarning = function (message) {
-        console.warn(message);
-    };
-    if (util.isNode && process.stderr.isTTY) {
-        printWarning = function(message, isSoft) {
-            var color = isSoft ? "\u001b[33m" : "\u001b[31m";
-            console.warn(color + message + "\u001b[0m\n");
-        };
-    } else if (!util.isNode && typeof (new Error().stack) === "string") {
-        printWarning = function(message, isSoft) {
-            console.warn("%c" + message,
-                        isSoft ? "color: darkorange" : "color: red");
-        };
-    }
-}
+              formatStack = function(stack, error) {
+                if (typeof stack === "string") return stack;
 
-var config = {
-    warnings: warnings,
-    longStackTraces: false,
-    cancellation: false,
-    monitoring: false
-};
+                if ((typeof error === "object" ||
+                    typeof error === "function") &&
+                    error.name !== undefined &&
+                    error.message !== undefined) {
+                  return error.toString();
+                }
+                return formatNonError(error);
+              };
 
-if (longStackTraces) Promise.longStackTraces();
+              return null;
 
-return {
-    longStackTraces: function() {
-        return config.longStackTraces;
-    },
-    warnings: function() {
-        return config.warnings;
-    },
-    cancellation: function() {
-        return config.cancellation;
-    },
-    monitoring: function() {
-        return config.monitoring;
-    },
-    propagateFromFunction: function() {
-        return propagateFromFunction;
-    },
-    boundValueFunction: function() {
-        return boundValueFunction;
-    },
-    checkForgottenReturns: checkForgottenReturns,
-    setBounds: setBounds,
-    warn: warn,
-    deprecated: deprecated,
-    CapturedTrace: CapturedTrace,
-    fireDomEvent: fireDomEvent,
-    fireGlobalEvent: fireGlobalEvent
-};
-};
+            })([]);
 
-},{"./errors":12,"./util":36}],10:[function(_dereq_,module,exports){
-"use strict";
-module.exports = function(Promise) {
-function returner() {
-    return this.value;
-}
-function thrower() {
-    throw this.reason;
-}
+            if (typeof console !== "undefined" && typeof console.warn !== "undefined") {
+              printWarning = function (message) {
+                console.warn(message);
+              };
+              if (util.isNode && process.stderr.isTTY) {
+                printWarning = function(message, isSoft) {
+                  var color = isSoft ? "\u001b[33m" : "\u001b[31m";
+                  console.warn(color + message + "\u001b[0m\n");
+                };
+              } else if (!util.isNode && typeof (new Error().stack) === "string") {
+                printWarning = function(message, isSoft) {
+                  console.warn("%c" + message,
+                      isSoft ? "color: darkorange" : "color: red");
+                };
+              }
+            }
 
-Promise.prototype["return"] =
-Promise.prototype.thenReturn = function (value) {
-    if (value instanceof Promise) value.suppressUnhandledRejections();
-    return this._then(
-        returner, undefined, undefined, {value: value}, undefined);
-};
+            var config = {
+                warnings: warnings,
+                longStackTraces: false,
+                cancellation: false,
+                monitoring: false
+            };
 
-Promise.prototype["throw"] =
-Promise.prototype.thenThrow = function (reason) {
-    return this._then(
-        thrower, undefined, undefined, {reason: reason}, undefined);
-};
+            if (longStackTraces) Promise.longStackTraces();
 
-Promise.prototype.catchThrow = function (reason) {
-    if (arguments.length <= 1) {
-        return this._then(
-            undefined, thrower, undefined, {reason: reason}, undefined);
-    } else {
-        var _reason = arguments[1];
-        var handler = function() {throw _reason;};
-        return this.caught(reason, handler);
-    }
-};
+            return {
+              longStackTraces: function() {
+                return config.longStackTraces;
+              },
+              warnings: function() {
+                return config.warnings;
+              },
+              cancellation: function() {
+                return config.cancellation;
+              },
+              monitoring: function() {
+                return config.monitoring;
+              },
+              propagateFromFunction: function() {
+                return propagateFromFunction;
+              },
+              boundValueFunction: function() {
+                return boundValueFunction;
+              },
+              checkForgottenReturns: checkForgottenReturns,
+              setBounds: setBounds,
+              warn: warn,
+              deprecated: deprecated,
+              CapturedTrace: CapturedTrace,
+              fireDomEvent: fireDomEvent,
+              fireGlobalEvent: fireGlobalEvent
+            };
+          };
 
-Promise.prototype.catchReturn = function (value) {
-    if (arguments.length <= 1) {
-        if (value instanceof Promise) value.suppressUnhandledRejections();
-        return this._then(
-            undefined, returner, undefined, {value: value}, undefined);
-    } else {
-        var _value = arguments[1];
-        if (_value instanceof Promise) _value.suppressUnhandledRejections();
-        var handler = function() {return _value;};
-        return this.caught(value, handler);
-    }
-};
-};
+        },{"./errors":12,"./util":36}],10:[function(_dereq_,module,exports){
+          "use strict";
+          module.exports = function(Promise) {
+            function returner() {
+              return this.value;
+            }
+            function thrower() {
+              throw this.reason;
+            }
 
-},{}],11:[function(_dereq_,module,exports){
-"use strict";
-module.exports = function(Promise, INTERNAL) {
-var PromiseReduce = Promise.reduce;
-var PromiseAll = Promise.all;
+            Promise.prototype["return"] =
+              Promise.prototype.thenReturn = function (value) {
+              if (value instanceof Promise) value.suppressUnhandledRejections();
+              return this._then(
+                  returner, undefined, undefined, {value: value}, undefined);
+            };
 
-function promiseAllThis() {
-    return PromiseAll(this);
-}
+            Promise.prototype["throw"] =
+              Promise.prototype.thenThrow = function (reason) {
+              return this._then(
+                  thrower, undefined, undefined, {reason: reason}, undefined);
+            };
 
-function PromiseMapSeries(promises, fn) {
-    return PromiseReduce(promises, fn, INTERNAL, INTERNAL);
-}
+            Promise.prototype.catchThrow = function (reason) {
+              if (arguments.length <= 1) {
+                return this._then(
+                    undefined, thrower, undefined, {reason: reason}, undefined);
+              } else {
+                var _reason = arguments[1];
+                var handler = function() {throw _reason;};
+                return this.caught(reason, handler);
+              }
+            };
 
-Promise.prototype.each = function (fn) {
-    return PromiseReduce(this, fn, INTERNAL, 0)
+            Promise.prototype.catchReturn = function (value) {
+              if (arguments.length <= 1) {
+                if (value instanceof Promise) value.suppressUnhandledRejections();
+                return this._then(
+                    undefined, returner, undefined, {value: value}, undefined);
+              } else {
+                var _value = arguments[1];
+                if (_value instanceof Promise) _value.suppressUnhandledRejections();
+                var handler = function() {return _value;};
+                return this.caught(value, handler);
+              }
+            };
+          };
+
+        },{}],11:[function(_dereq_,module,exports){
+          "use strict";
+          module.exports = function(Promise, INTERNAL) {
+            var PromiseReduce = Promise.reduce;
+            var PromiseAll = Promise.all;
+
+            function promiseAllThis() {
+              return PromiseAll(this);
+            }
+
+            function PromiseMapSeries(promises, fn) {
+              return PromiseReduce(promises, fn, INTERNAL, INTERNAL);
+            }
+
+            Promise.prototype.each = function (fn) {
+              return PromiseReduce(this, fn, INTERNAL, 0)
               ._then(promiseAllThis, undefined, undefined, this, undefined);
-};
+            };
 
-Promise.prototype.mapSeries = function (fn) {
-    return PromiseReduce(this, fn, INTERNAL, INTERNAL);
-};
+            Promise.prototype.mapSeries = function (fn) {
+              return PromiseReduce(this, fn, INTERNAL, INTERNAL);
+            };
 
-Promise.each = function (promises, fn) {
-    return PromiseReduce(promises, fn, INTERNAL, 0)
+            Promise.each = function (promises, fn) {
+              return PromiseReduce(promises, fn, INTERNAL, 0)
               ._then(promiseAllThis, undefined, undefined, promises, undefined);
-};
+            };
 
-Promise.mapSeries = PromiseMapSeries;
-};
+            Promise.mapSeries = PromiseMapSeries;
+          };
 
 
-},{}],12:[function(_dereq_,module,exports){
-"use strict";
-var es5 = _dereq_("./es5");
-var Objectfreeze = es5.freeze;
-var util = _dereq_("./util");
-var inherits = util.inherits;
-var notEnumerableProp = util.notEnumerableProp;
+        },{}],12:[function(_dereq_,module,exports){
+          "use strict";
+          var es5 = _dereq_("./es5");
+          var Objectfreeze = es5.freeze;
+          var util = _dereq_("./util");
+          var inherits = util.inherits;
+          var notEnumerableProp = util.notEnumerableProp;
 
-function subError(nameProperty, defaultMessage) {
-    function SubError(message) {
-        if (!(this instanceof SubError)) return new SubError(message);
-        notEnumerableProp(this, "message",
-            typeof message === "string" ? message : defaultMessage);
-        notEnumerableProp(this, "name", nameProperty);
-        if (Error.captureStackTrace) {
-            Error.captureStackTrace(this, this.constructor);
-        } else {
-            Error.call(this);
-        }
-    }
-    inherits(SubError, Error);
-    return SubError;
-}
-
-var _TypeError, _RangeError;
-var Warning = subError("Warning", "warning");
-var CancellationError = subError("CancellationError", "cancellation error");
-var TimeoutError = subError("TimeoutError", "timeout error");
-var AggregateError = subError("AggregateError", "aggregate error");
-try {
-    _TypeError = TypeError;
-    _RangeError = RangeError;
-} catch(e) {
-    _TypeError = subError("TypeError", "type error");
-    _RangeError = subError("RangeError", "range error");
-}
-
-var methods = ("join pop push shift unshift slice filter forEach some " +
-    "every map indexOf lastIndexOf reduce reduceRight sort reverse").split(" ");
-
-for (var i = 0; i < methods.length; ++i) {
-    if (typeof Array.prototype[methods[i]] === "function") {
-        AggregateError.prototype[methods[i]] = Array.prototype[methods[i]];
-    }
-}
-
-es5.defineProperty(AggregateError.prototype, "length", {
-    value: 0,
-    configurable: false,
-    writable: true,
-    enumerable: true
-});
-AggregateError.prototype["isOperational"] = true;
-var level = 0;
-AggregateError.prototype.toString = function() {
-    var indent = Array(level * 4 + 1).join(" ");
-    var ret = "\n" + indent + "AggregateError of:" + "\n";
-    level++;
-    indent = Array(level * 4 + 1).join(" ");
-    for (var i = 0; i < this.length; ++i) {
-        var str = this[i] === this ? "[Circular AggregateError]" : this[i] + "";
-        var lines = str.split("\n");
-        for (var j = 0; j < lines.length; ++j) {
-            lines[j] = indent + lines[j];
-        }
-        str = lines.join("\n");
-        ret += str + "\n";
-    }
-    level--;
-    return ret;
-};
-
-function OperationalError(message) {
-    if (!(this instanceof OperationalError))
-        return new OperationalError(message);
-    notEnumerableProp(this, "name", "OperationalError");
-    notEnumerableProp(this, "message", message);
-    this.cause = message;
-    this["isOperational"] = true;
-
-    if (message instanceof Error) {
-        notEnumerableProp(this, "message", message.message);
-        notEnumerableProp(this, "stack", message.stack);
-    } else if (Error.captureStackTrace) {
-        Error.captureStackTrace(this, this.constructor);
-    }
-
-}
-inherits(OperationalError, Error);
-
-var errorTypes = Error["__BluebirdErrorTypes__"];
-if (!errorTypes) {
-    errorTypes = Objectfreeze({
-        CancellationError: CancellationError,
-        TimeoutError: TimeoutError,
-        OperationalError: OperationalError,
-        RejectionError: OperationalError,
-        AggregateError: AggregateError
-    });
-    es5.defineProperty(Error, "__BluebirdErrorTypes__", {
-        value: errorTypes,
-        writable: false,
-        enumerable: false,
-        configurable: false
-    });
-}
-
-module.exports = {
-    Error: Error,
-    TypeError: _TypeError,
-    RangeError: _RangeError,
-    CancellationError: errorTypes.CancellationError,
-    OperationalError: errorTypes.OperationalError,
-    TimeoutError: errorTypes.TimeoutError,
-    AggregateError: errorTypes.AggregateError,
-    Warning: Warning
-};
-
-},{"./es5":13,"./util":36}],13:[function(_dereq_,module,exports){
-var isES5 = (function(){
-    "use strict";
-    return this === undefined;
-})();
-
-if (isES5) {
-    module.exports = {
-        freeze: Object.freeze,
-        defineProperty: Object.defineProperty,
-        getDescriptor: Object.getOwnPropertyDescriptor,
-        keys: Object.keys,
-        names: Object.getOwnPropertyNames,
-        getPrototypeOf: Object.getPrototypeOf,
-        isArray: Array.isArray,
-        isES5: isES5,
-        propertyIsWritable: function(obj, prop) {
-            var descriptor = Object.getOwnPropertyDescriptor(obj, prop);
-            return !!(!descriptor || descriptor.writable || descriptor.set);
-        }
-    };
-} else {
-    var has = {}.hasOwnProperty;
-    var str = {}.toString;
-    var proto = {}.constructor.prototype;
-
-    var ObjectKeys = function (o) {
-        var ret = [];
-        for (var key in o) {
-            if (has.call(o, key)) {
-                ret.push(key);
+          function subError(nameProperty, defaultMessage) {
+            function SubError(message) {
+              if (!(this instanceof SubError)) return new SubError(message);
+              notEnumerableProp(this, "message",
+                  typeof message === "string" ? message : defaultMessage);
+              notEnumerableProp(this, "name", nameProperty);
+              if (Error.captureStackTrace) {
+                Error.captureStackTrace(this, this.constructor);
+              } else {
+                Error.call(this);
+              }
             }
-        }
-        return ret;
-    };
+            inherits(SubError, Error);
+            return SubError;
+          }
 
-    var ObjectGetDescriptor = function(o, key) {
-        return {value: o[key]};
-    };
+          var _TypeError, _RangeError;
+          var Warning = subError("Warning", "warning");
+          var CancellationError = subError("CancellationError", "cancellation error");
+          var TimeoutError = subError("TimeoutError", "timeout error");
+          var AggregateError = subError("AggregateError", "aggregate error");
+          try {
+            _TypeError = TypeError;
+            _RangeError = RangeError;
+          } catch(e) {
+            _TypeError = subError("TypeError", "type error");
+            _RangeError = subError("RangeError", "range error");
+          }
 
-    var ObjectDefineProperty = function (o, key, desc) {
-        o[key] = desc.value;
-        return o;
-    };
+          var methods = ("join pop push shift unshift slice filter forEach some " +
+          "every map indexOf lastIndexOf reduce reduceRight sort reverse").split(" ");
 
-    var ObjectFreeze = function (obj) {
-        return obj;
-    };
+          for (var i = 0; i < methods.length; ++i) {
+            if (typeof Array.prototype[methods[i]] === "function") {
+              AggregateError.prototype[methods[i]] = Array.prototype[methods[i]];
+            }
+          }
 
-    var ObjectGetPrototypeOf = function (obj) {
-        try {
-            return Object(obj).constructor.prototype;
-        }
-        catch (e) {
-            return proto;
-        }
-    };
+          es5.defineProperty(AggregateError.prototype, "length", {
+            value: 0,
+            configurable: false,
+            writable: true,
+            enumerable: true
+          });
+          AggregateError.prototype["isOperational"] = true;
+          var level = 0;
+          AggregateError.prototype.toString = function() {
+            var indent = Array(level * 4 + 1).join(" ");
+            var ret = "\n" + indent + "AggregateError of:" + "\n";
+            level++;
+            indent = Array(level * 4 + 1).join(" ");
+            for (var i = 0; i < this.length; ++i) {
+              var str = this[i] === this ? "[Circular AggregateError]" : this[i] + "";
+              var lines = str.split("\n");
+              for (var j = 0; j < lines.length; ++j) {
+                lines[j] = indent + lines[j];
+              }
+              str = lines.join("\n");
+              ret += str + "\n";
+            }
+            level--;
+            return ret;
+          };
 
-    var ArrayIsArray = function (obj) {
-        try {
-            return str.call(obj) === "[object Array]";
-        }
-        catch(e) {
-            return false;
-        }
-    };
+          function OperationalError(message) {
+            if (!(this instanceof OperationalError))
+              return new OperationalError(message);
+            notEnumerableProp(this, "name", "OperationalError");
+            notEnumerableProp(this, "message", message);
+            this.cause = message;
+            this["isOperational"] = true;
 
-    module.exports = {
-        isArray: ArrayIsArray,
-        keys: ObjectKeys,
-        names: ObjectKeys,
-        defineProperty: ObjectDefineProperty,
-        getDescriptor: ObjectGetDescriptor,
-        freeze: ObjectFreeze,
-        getPrototypeOf: ObjectGetPrototypeOf,
-        isES5: isES5,
-        propertyIsWritable: function() {
-            return true;
-        }
-    };
-}
+            if (message instanceof Error) {
+              notEnumerableProp(this, "message", message.message);
+              notEnumerableProp(this, "stack", message.stack);
+            } else if (Error.captureStackTrace) {
+              Error.captureStackTrace(this, this.constructor);
+            }
 
-},{}],14:[function(_dereq_,module,exports){
-"use strict";
-module.exports = function(Promise, INTERNAL) {
-var PromiseMap = Promise.map;
+          }
+          inherits(OperationalError, Error);
 
-Promise.prototype.filter = function (fn, options) {
-    return PromiseMap(this, fn, options, INTERNAL);
-};
+          var errorTypes = Error["__BluebirdErrorTypes__"];
+          if (!errorTypes) {
+            errorTypes = Objectfreeze({
+              CancellationError: CancellationError,
+              TimeoutError: TimeoutError,
+              OperationalError: OperationalError,
+              RejectionError: OperationalError,
+              AggregateError: AggregateError
+            });
+            es5.defineProperty(Error, "__BluebirdErrorTypes__", {
+              value: errorTypes,
+              writable: false,
+              enumerable: false,
+              configurable: false
+            });
+          }
 
-Promise.filter = function (promises, fn, options) {
-    return PromiseMap(promises, fn, options, INTERNAL);
-};
-};
+          module.exports = {
+              Error: Error,
+              TypeError: _TypeError,
+              RangeError: _RangeError,
+              CancellationError: errorTypes.CancellationError,
+              OperationalError: errorTypes.OperationalError,
+              TimeoutError: errorTypes.TimeoutError,
+              AggregateError: errorTypes.AggregateError,
+              Warning: Warning
+          };
 
-},{}],15:[function(_dereq_,module,exports){
-"use strict";
-module.exports = function(Promise, tryConvertToPromise) {
-var util = _dereq_("./util");
-var CancellationError = Promise.CancellationError;
-var errorObj = util.errorObj;
+        },{"./es5":13,"./util":36}],13:[function(_dereq_,module,exports){
+          var isES5 = (function(){
+            "use strict";
+            return this === undefined;
+          })();
 
-function PassThroughHandlerContext(promise, type, handler) {
-    this.promise = promise;
-    this.type = type;
-    this.handler = handler;
-    this.called = false;
-    this.cancelPromise = null;
-}
+          if (isES5) {
+            module.exports = {
+                freeze: Object.freeze,
+                defineProperty: Object.defineProperty,
+                getDescriptor: Object.getOwnPropertyDescriptor,
+                keys: Object.keys,
+                names: Object.getOwnPropertyNames,
+                getPrototypeOf: Object.getPrototypeOf,
+                isArray: Array.isArray,
+                isES5: isES5,
+                propertyIsWritable: function(obj, prop) {
+                  var descriptor = Object.getOwnPropertyDescriptor(obj, prop);
+                  return !!(!descriptor || descriptor.writable || descriptor.set);
+                }
+            };
+          } else {
+            var has = {}.hasOwnProperty;
+            var str = {}.toString;
+            var proto = {}.constructor.prototype;
 
-PassThroughHandlerContext.prototype.isFinallyHandler = function() {
-    return this.type === 0;
-};
+            var ObjectKeys = function (o) {
+              var ret = [];
+              for (var key in o) {
+                if (has.call(o, key)) {
+                  ret.push(key);
+                }
+              }
+              return ret;
+            };
 
-function FinallyHandlerCancelReaction(finallyHandler) {
-    this.finallyHandler = finallyHandler;
-}
+            var ObjectGetDescriptor = function(o, key) {
+              return {value: o[key]};
+            };
 
-FinallyHandlerCancelReaction.prototype._resultCancelled = function() {
-    checkCancel(this.finallyHandler);
-};
+            var ObjectDefineProperty = function (o, key, desc) {
+              o[key] = desc.value;
+              return o;
+            };
 
-function checkCancel(ctx, reason) {
-    if (ctx.cancelPromise != null) {
-        if (arguments.length > 1) {
-            ctx.cancelPromise._reject(reason);
-        } else {
-            ctx.cancelPromise._cancel();
-        }
-        ctx.cancelPromise = null;
-        return true;
-    }
-    return false;
-}
+            var ObjectFreeze = function (obj) {
+              return obj;
+            };
 
-function succeed() {
-    return finallyHandler.call(this, this.promise._target()._settledValue());
-}
-function fail(reason) {
-    if (checkCancel(this, reason)) return;
-    errorObj.e = reason;
-    return errorObj;
-}
-function finallyHandler(reasonOrValue) {
-    var promise = this.promise;
-    var handler = this.handler;
+            var ObjectGetPrototypeOf = function (obj) {
+              try {
+                return Object(obj).constructor.prototype;
+              }
+              catch (e) {
+                return proto;
+              }
+            };
 
-    if (!this.called) {
-        this.called = true;
-        var ret = this.isFinallyHandler()
-            ? handler.call(promise._boundValue())
-            : handler.call(promise._boundValue(), reasonOrValue);
-        if (ret !== undefined) {
-            promise._setReturnedNonUndefined();
-            var maybePromise = tryConvertToPromise(ret, promise);
-            if (maybePromise instanceof Promise) {
-                if (this.cancelPromise != null) {
-                    if (maybePromise._isCancelled()) {
+            var ArrayIsArray = function (obj) {
+              try {
+                return str.call(obj) === "[object Array]";
+              }
+              catch(e) {
+                return false;
+              }
+            };
+
+            module.exports = {
+                isArray: ArrayIsArray,
+                keys: ObjectKeys,
+                names: ObjectKeys,
+                defineProperty: ObjectDefineProperty,
+                getDescriptor: ObjectGetDescriptor,
+                freeze: ObjectFreeze,
+                getPrototypeOf: ObjectGetPrototypeOf,
+                isES5: isES5,
+                propertyIsWritable: function() {
+                  return true;
+                }
+            };
+          }
+
+        },{}],14:[function(_dereq_,module,exports){
+          "use strict";
+          module.exports = function(Promise, INTERNAL) {
+            var PromiseMap = Promise.map;
+
+            Promise.prototype.filter = function (fn, options) {
+              return PromiseMap(this, fn, options, INTERNAL);
+            };
+
+            Promise.filter = function (promises, fn, options) {
+              return PromiseMap(promises, fn, options, INTERNAL);
+            };
+          };
+
+        },{}],15:[function(_dereq_,module,exports){
+          "use strict";
+          module.exports = function(Promise, tryConvertToPromise) {
+            var util = _dereq_("./util");
+            var CancellationError = Promise.CancellationError;
+            var errorObj = util.errorObj;
+
+            function PassThroughHandlerContext(promise, type, handler) {
+              this.promise = promise;
+              this.type = type;
+              this.handler = handler;
+              this.called = false;
+              this.cancelPromise = null;
+            }
+
+            PassThroughHandlerContext.prototype.isFinallyHandler = function() {
+              return this.type === 0;
+            };
+
+            function FinallyHandlerCancelReaction(finallyHandler) {
+              this.finallyHandler = finallyHandler;
+            }
+
+            FinallyHandlerCancelReaction.prototype._resultCancelled = function() {
+              checkCancel(this.finallyHandler);
+            };
+
+            function checkCancel(ctx, reason) {
+              if (ctx.cancelPromise != null) {
+                if (arguments.length > 1) {
+                  ctx.cancelPromise._reject(reason);
+                } else {
+                  ctx.cancelPromise._cancel();
+                }
+                ctx.cancelPromise = null;
+                return true;
+              }
+              return false;
+            }
+
+            function succeed() {
+              return finallyHandler.call(this, this.promise._target()._settledValue());
+            }
+            function fail(reason) {
+              if (checkCancel(this, reason)) return;
+              errorObj.e = reason;
+              return errorObj;
+            }
+            function finallyHandler(reasonOrValue) {
+              var promise = this.promise;
+              var handler = this.handler;
+
+              if (!this.called) {
+                this.called = true;
+                var ret = this.isFinallyHandler()
+                ? handler.call(promise._boundValue())
+                    : handler.call(promise._boundValue(), reasonOrValue);
+                if (ret !== undefined) {
+                  promise._setReturnedNonUndefined();
+                  var maybePromise = tryConvertToPromise(ret, promise);
+                  if (maybePromise instanceof Promise) {
+                    if (this.cancelPromise != null) {
+                      if (maybePromise._isCancelled()) {
                         var reason =
-                            new CancellationError("late cancellation observer");
+                          new CancellationError("late cancellation observer");
                         promise._attachExtraTrace(reason);
                         errorObj.e = reason;
                         return errorObj;
-                    } else if (maybePromise.isPending()) {
+                      } else if (maybePromise.isPending()) {
                         maybePromise._attachCancellationCallback(
                             new FinallyHandlerCancelReaction(this));
+                      }
                     }
+                    return maybePromise._then(
+                        succeed, fail, undefined, this, undefined);
+                  }
                 }
-                return maybePromise._then(
-                    succeed, fail, undefined, this, undefined);
+              }
+
+              if (promise.isRejected()) {
+                checkCancel(this);
+                errorObj.e = reasonOrValue;
+                return errorObj;
+              } else {
+                checkCancel(this);
+                return reasonOrValue;
+              }
             }
-        }
-    }
 
-    if (promise.isRejected()) {
-        checkCancel(this);
-        errorObj.e = reasonOrValue;
-        return errorObj;
-    } else {
-        checkCancel(this);
-        return reasonOrValue;
-    }
-}
+            Promise.prototype._passThrough = function(handler, type, success, fail) {
+              if (typeof handler !== "function") return this.then();
+              return this._then(success,
+                  fail,
+                  undefined,
+                  new PassThroughHandlerContext(this, type, handler),
+                  undefined);
+            };
 
-Promise.prototype._passThrough = function(handler, type, success, fail) {
-    if (typeof handler !== "function") return this.then();
-    return this._then(success,
-                      fail,
-                      undefined,
-                      new PassThroughHandlerContext(this, type, handler),
-                      undefined);
-};
+            Promise.prototype.lastly =
+              Promise.prototype["finally"] = function (handler) {
+              return this._passThrough(handler,
+                  0,
+                  finallyHandler,
+                  finallyHandler);
+            };
 
-Promise.prototype.lastly =
-Promise.prototype["finally"] = function (handler) {
-    return this._passThrough(handler,
-                             0,
-                             finallyHandler,
-                             finallyHandler);
-};
+            Promise.prototype.tap = function (handler) {
+              return this._passThrough(handler, 1, finallyHandler);
+            };
 
-Promise.prototype.tap = function (handler) {
-    return this._passThrough(handler, 1, finallyHandler);
-};
+            return PassThroughHandlerContext;
+          };
 
-return PassThroughHandlerContext;
-};
+        },{"./util":36}],16:[function(_dereq_,module,exports){
+          "use strict";
+          module.exports = function(Promise,
+              apiRejection,
+              INTERNAL,
+              tryConvertToPromise,
+              Proxyable,
+              debug) {
+            var errors = _dereq_("./errors");
+            var TypeError = errors.TypeError;
+            var util = _dereq_("./util");
+            var errorObj = util.errorObj;
+            var tryCatch = util.tryCatch;
+            var yieldHandlers = [];
 
-},{"./util":36}],16:[function(_dereq_,module,exports){
-"use strict";
-module.exports = function(Promise,
-                          apiRejection,
-                          INTERNAL,
-                          tryConvertToPromise,
-                          Proxyable,
-                          debug) {
-var errors = _dereq_("./errors");
-var TypeError = errors.TypeError;
-var util = _dereq_("./util");
-var errorObj = util.errorObj;
-var tryCatch = util.tryCatch;
-var yieldHandlers = [];
-
-function promiseFromYieldHandler(value, yieldHandlers, traceParent) {
-    for (var i = 0; i < yieldHandlers.length; ++i) {
-        traceParent._pushContext();
-        var result = tryCatch(yieldHandlers[i])(value);
-        traceParent._popContext();
-        if (result === errorObj) {
-            traceParent._pushContext();
-            var ret = Promise.reject(errorObj.e);
-            traceParent._popContext();
-            return ret;
-        }
-        var maybePromise = tryConvertToPromise(result, traceParent);
-        if (maybePromise instanceof Promise) return maybePromise;
-    }
-    return null;
-}
-
-function PromiseSpawn(generatorFunction, receiver, yieldHandler, stack) {
-    if (debug.cancellation()) {
-        var internal = new Promise(INTERNAL);
-        var _finallyPromise = this._finallyPromise = new Promise(INTERNAL);
-        this._promise = internal.lastly(function() {
-            return _finallyPromise;
-        });
-        internal._captureStackTrace();
-        internal._setOnCancel(this);
-    } else {
-        var promise = this._promise = new Promise(INTERNAL);
-        promise._captureStackTrace();
-    }
-    this._stack = stack;
-    this._generatorFunction = generatorFunction;
-    this._receiver = receiver;
-    this._generator = undefined;
-    this._yieldHandlers = typeof yieldHandler === "function"
-        ? [yieldHandler].concat(yieldHandlers)
-        : yieldHandlers;
-    this._yieldedPromise = null;
-    this._cancellationPhase = false;
-}
-util.inherits(PromiseSpawn, Proxyable);
-
-PromiseSpawn.prototype._isResolved = function() {
-    return this._promise === null;
-};
-
-PromiseSpawn.prototype._cleanup = function() {
-    this._promise = this._generator = null;
-    if (debug.cancellation() && this._finallyPromise !== null) {
-        this._finallyPromise._fulfill();
-        this._finallyPromise = null;
-    }
-};
-
-PromiseSpawn.prototype._promiseCancelled = function() {
-    if (this._isResolved()) return;
-    var implementsReturn = typeof this._generator["return"] !== "undefined";
-
-    var result;
-    if (!implementsReturn) {
-        var reason = new Promise.CancellationError(
-            "generator .return() sentinel");
-        Promise.coroutine.returnSentinel = reason;
-        this._promise._attachExtraTrace(reason);
-        this._promise._pushContext();
-        result = tryCatch(this._generator["throw"]).call(this._generator,
-                                                         reason);
-        this._promise._popContext();
-    } else {
-        this._promise._pushContext();
-        result = tryCatch(this._generator["return"]).call(this._generator,
-                                                          undefined);
-        this._promise._popContext();
-    }
-    this._cancellationPhase = true;
-    this._yieldedPromise = null;
-    this._continue(result);
-};
-
-PromiseSpawn.prototype._promiseFulfilled = function(value) {
-    this._yieldedPromise = null;
-    this._promise._pushContext();
-    var result = tryCatch(this._generator.next).call(this._generator, value);
-    this._promise._popContext();
-    this._continue(result);
-};
-
-PromiseSpawn.prototype._promiseRejected = function(reason) {
-    this._yieldedPromise = null;
-    this._promise._attachExtraTrace(reason);
-    this._promise._pushContext();
-    var result = tryCatch(this._generator["throw"])
-        .call(this._generator, reason);
-    this._promise._popContext();
-    this._continue(result);
-};
-
-PromiseSpawn.prototype._resultCancelled = function() {
-    if (this._yieldedPromise instanceof Promise) {
-        var promise = this._yieldedPromise;
-        this._yieldedPromise = null;
-        promise.cancel();
-    }
-};
-
-PromiseSpawn.prototype.promise = function () {
-    return this._promise;
-};
-
-PromiseSpawn.prototype._run = function () {
-    this._generator = this._generatorFunction.call(this._receiver);
-    this._receiver =
-        this._generatorFunction = undefined;
-    this._promiseFulfilled(undefined);
-};
-
-PromiseSpawn.prototype._continue = function (result) {
-    var promise = this._promise;
-    if (result === errorObj) {
-        this._cleanup();
-        if (this._cancellationPhase) {
-            return promise.cancel();
-        } else {
-            return promise._rejectCallback(result.e, false);
-        }
-    }
-
-    var value = result.value;
-    if (result.done === true) {
-        this._cleanup();
-        if (this._cancellationPhase) {
-            return promise.cancel();
-        } else {
-            return promise._resolveCallback(value);
-        }
-    } else {
-        var maybePromise = tryConvertToPromise(value, this._promise);
-        if (!(maybePromise instanceof Promise)) {
-            maybePromise =
-                promiseFromYieldHandler(maybePromise,
-                                        this._yieldHandlers,
-                                        this._promise);
-            if (maybePromise === null) {
-                this._promiseRejected(
-                    new TypeError(
-                        "A value %s was yielded that could not be treated as a promise\u000a\u000a    See http://goo.gl/MqrFmX\u000a\u000a".replace("%s", value) +
-                        "From coroutine:\u000a" +
-                        this._stack.split("\n").slice(1, -7).join("\n")
-                    )
-                );
-                return;
+            function promiseFromYieldHandler(value, yieldHandlers, traceParent) {
+              for (var i = 0; i < yieldHandlers.length; ++i) {
+                traceParent._pushContext();
+                var result = tryCatch(yieldHandlers[i])(value);
+                traceParent._popContext();
+                if (result === errorObj) {
+                  traceParent._pushContext();
+                  var ret = Promise.reject(errorObj.e);
+                  traceParent._popContext();
+                  return ret;
+                }
+                var maybePromise = tryConvertToPromise(result, traceParent);
+                if (maybePromise instanceof Promise) return maybePromise;
+              }
+              return null;
             }
-        }
-        maybePromise = maybePromise._target();
-        var bitField = maybePromise._bitField;
-        ;
-        if (((bitField & 50397184) === 0)) {
-            this._yieldedPromise = maybePromise;
-            maybePromise._proxy(this, null);
-        } else if (((bitField & 33554432) !== 0)) {
-            Promise._async.invoke(
-                this._promiseFulfilled, this, maybePromise._value()
-            );
-        } else if (((bitField & 16777216) !== 0)) {
-            Promise._async.invoke(
-                this._promiseRejected, this, maybePromise._reason()
-            );
-        } else {
-            this._promiseCancelled();
-        }
-    }
-};
 
-Promise.coroutine = function (generatorFunction, options) {
-    if (typeof generatorFunction !== "function") {
-        throw new TypeError("generatorFunction must be a function\u000a\u000a    See http://goo.gl/MqrFmX\u000a");
-    }
-    var yieldHandler = Object(options).yieldHandler;
-    var PromiseSpawn$ = PromiseSpawn;
-    var stack = new Error().stack;
-    return function () {
-        var generator = generatorFunction.apply(this, arguments);
-        var spawn = new PromiseSpawn$(undefined, undefined, yieldHandler,
-                                      stack);
-        var ret = spawn.promise();
-        spawn._generator = generator;
-        spawn._promiseFulfilled(undefined);
-        return ret;
-    };
-};
+            function PromiseSpawn(generatorFunction, receiver, yieldHandler, stack) {
+              if (debug.cancellation()) {
+                var internal = new Promise(INTERNAL);
+                var _finallyPromise = this._finallyPromise = new Promise(INTERNAL);
+                this._promise = internal.lastly(function() {
+                  return _finallyPromise;
+                });
+                internal._captureStackTrace();
+                internal._setOnCancel(this);
+              } else {
+                var promise = this._promise = new Promise(INTERNAL);
+                promise._captureStackTrace();
+              }
+              this._stack = stack;
+              this._generatorFunction = generatorFunction;
+              this._receiver = receiver;
+              this._generator = undefined;
+              this._yieldHandlers = typeof yieldHandler === "function"
+                ? [yieldHandler].concat(yieldHandlers)
+                    : yieldHandlers;
+                this._yieldedPromise = null;
+                this._cancellationPhase = false;
+            }
+            util.inherits(PromiseSpawn, Proxyable);
 
-Promise.coroutine.addYieldHandler = function(fn) {
-    if (typeof fn !== "function") {
-        throw new TypeError("expecting a function but got " + util.classString(fn));
-    }
-    yieldHandlers.push(fn);
-};
+            PromiseSpawn.prototype._isResolved = function() {
+              return this._promise === null;
+            };
 
-Promise.spawn = function (generatorFunction) {
-    debug.deprecated("Promise.spawn()", "Promise.coroutine()");
-    if (typeof generatorFunction !== "function") {
-        return apiRejection("generatorFunction must be a function\u000a\u000a    See http://goo.gl/MqrFmX\u000a");
-    }
-    var spawn = new PromiseSpawn(generatorFunction, this);
-    var ret = spawn.promise();
-    spawn._run(Promise.spawn);
-    return ret;
-};
-};
+            PromiseSpawn.prototype._cleanup = function() {
+              this._promise = this._generator = null;
+              if (debug.cancellation() && this._finallyPromise !== null) {
+                this._finallyPromise._fulfill();
+                this._finallyPromise = null;
+              }
+            };
 
-},{"./errors":12,"./util":36}],17:[function(_dereq_,module,exports){
-"use strict";
-module.exports =
-function(Promise, PromiseArray, tryConvertToPromise, INTERNAL, async,
-         getDomain) {
-var util = _dereq_("./util");
-var canEvaluate = util.canEvaluate;
-var tryCatch = util.tryCatch;
-var errorObj = util.errorObj;
-var reject;
+            PromiseSpawn.prototype._promiseCancelled = function() {
+              if (this._isResolved()) return;
+              var implementsReturn = typeof this._generator["return"] !== "undefined";
 
-if (!true) {
-if (canEvaluate) {
-    var thenCallback = function(i) {
-        return new Function("value", "holder", "                             \n\
-            'use strict';                                                    \n\
-            holder.pIndex = value;                                           \n\
-            holder.checkFulfillment(this);                                   \n\
-            ".replace(/Index/g, i));
-    };
+              var result;
+              if (!implementsReturn) {
+                var reason = new Promise.CancellationError(
+                "generator .return() sentinel");
+                Promise.coroutine.returnSentinel = reason;
+                this._promise._attachExtraTrace(reason);
+                this._promise._pushContext();
+                result = tryCatch(this._generator["throw"]).call(this._generator,
+                    reason);
+                this._promise._popContext();
+              } else {
+                this._promise._pushContext();
+                result = tryCatch(this._generator["return"]).call(this._generator,
+                    undefined);
+                this._promise._popContext();
+              }
+              this._cancellationPhase = true;
+              this._yieldedPromise = null;
+              this._continue(result);
+            };
 
-    var promiseSetter = function(i) {
-        return new Function("promise", "holder", "                           \n\
-            'use strict';                                                    \n\
-            holder.pIndex = promise;                                         \n\
-            ".replace(/Index/g, i));
-    };
+            PromiseSpawn.prototype._promiseFulfilled = function(value) {
+              this._yieldedPromise = null;
+              this._promise._pushContext();
+              var result = tryCatch(this._generator.next).call(this._generator, value);
+              this._promise._popContext();
+              this._continue(result);
+            };
 
-    var generateHolderClass = function(total) {
-        var props = new Array(total);
-        for (var i = 0; i < props.length; ++i) {
-            props[i] = "this.p" + (i+1);
-        }
-        var assignment = props.join(" = ") + " = null;";
-        var cancellationCode= "var promise;\n" + props.map(function(prop) {
-            return "                                                         \n\
-                promise = " + prop + ";                                      \n\
-                if (promise instanceof Promise) {                            \n\
+            PromiseSpawn.prototype._promiseRejected = function(reason) {
+              this._yieldedPromise = null;
+              this._promise._attachExtraTrace(reason);
+              this._promise._pushContext();
+              var result = tryCatch(this._generator["throw"])
+              .call(this._generator, reason);
+              this._promise._popContext();
+              this._continue(result);
+            };
+
+            PromiseSpawn.prototype._resultCancelled = function() {
+              if (this._yieldedPromise instanceof Promise) {
+                var promise = this._yieldedPromise;
+                this._yieldedPromise = null;
+                promise.cancel();
+              }
+            };
+
+            PromiseSpawn.prototype.promise = function () {
+              return this._promise;
+            };
+
+            PromiseSpawn.prototype._run = function () {
+              this._generator = this._generatorFunction.call(this._receiver);
+              this._receiver =
+                this._generatorFunction = undefined;
+              this._promiseFulfilled(undefined);
+            };
+
+            PromiseSpawn.prototype._continue = function (result) {
+              var promise = this._promise;
+              if (result === errorObj) {
+                this._cleanup();
+                if (this._cancellationPhase) {
+                  return promise.cancel();
+                } else {
+                  return promise._rejectCallback(result.e, false);
+                }
+              }
+
+              var value = result.value;
+              if (result.done === true) {
+                this._cleanup();
+                if (this._cancellationPhase) {
+                  return promise.cancel();
+                } else {
+                  return promise._resolveCallback(value);
+                }
+              } else {
+                var maybePromise = tryConvertToPromise(value, this._promise);
+                if (!(maybePromise instanceof Promise)) {
+                  maybePromise =
+                    promiseFromYieldHandler(maybePromise,
+                        this._yieldHandlers,
+                        this._promise);
+                  if (maybePromise === null) {
+                    this._promiseRejected(
+                        new TypeError(
+                            "A value %s was yielded that could not be treated as a promise\u000a\u000a    See http://goo.gl/MqrFmX\u000a\u000a".replace("%s", value) +
+                            "From coroutine:\u000a" +
+                            this._stack.split("\n").slice(1, -7).join("\n")
+                        )
+                    );
+                    return;
+                  }
+                }
+                maybePromise = maybePromise._target();
+                var bitField = maybePromise._bitField;
+                ;
+                if (((bitField & 50397184) === 0)) {
+                  this._yieldedPromise = maybePromise;
+                  maybePromise._proxy(this, null);
+                } else if (((bitField & 33554432) !== 0)) {
+                  Promise._async.invoke(
+                      this._promiseFulfilled, this, maybePromise._value()
+                  );
+                } else if (((bitField & 16777216) !== 0)) {
+                  Promise._async.invoke(
+                      this._promiseRejected, this, maybePromise._reason()
+                  );
+                } else {
+                  this._promiseCancelled();
+                }
+              }
+            };
+
+            Promise.coroutine = function (generatorFunction, options) {
+              if (typeof generatorFunction !== "function") {
+                throw new TypeError("generatorFunction must be a function\u000a\u000a    See http://goo.gl/MqrFmX\u000a");
+              }
+              var yieldHandler = Object(options).yieldHandler;
+              var PromiseSpawn$ = PromiseSpawn;
+              var stack = new Error().stack;
+              return function () {
+                var generator = generatorFunction.apply(this, arguments);
+                var spawn = new PromiseSpawn$(undefined, undefined, yieldHandler,
+                    stack);
+                var ret = spawn.promise();
+                spawn._generator = generator;
+                spawn._promiseFulfilled(undefined);
+                return ret;
+              };
+            };
+
+            Promise.coroutine.addYieldHandler = function(fn) {
+              if (typeof fn !== "function") {
+                throw new TypeError("expecting a function but got " + util.classString(fn));
+              }
+              yieldHandlers.push(fn);
+            };
+
+            Promise.spawn = function (generatorFunction) {
+              debug.deprecated("Promise.spawn()", "Promise.coroutine()");
+              if (typeof generatorFunction !== "function") {
+                return apiRejection("generatorFunction must be a function\u000a\u000a    See http://goo.gl/MqrFmX\u000a");
+              }
+              var spawn = new PromiseSpawn(generatorFunction, this);
+              var ret = spawn.promise();
+              spawn._run(Promise.spawn);
+              return ret;
+            };
+          };
+
+        },{"./errors":12,"./util":36}],17:[function(_dereq_,module,exports){
+          "use strict";
+          module.exports =
+            function(Promise, PromiseArray, tryConvertToPromise, INTERNAL, async,
+                getDomain) {
+            var util = _dereq_("./util");
+            var canEvaluate = util.canEvaluate;
+            var tryCatch = util.tryCatch;
+            var errorObj = util.errorObj;
+            var reject;
+
+            if (!true) {
+              if (canEvaluate) {
+                var thenCallback = function(i) {
+                  return new Function("value", "holder", "                             \n\
+                      'use strict';                                                    \n\
+                      holder.pIndex = value;                                           \n\
+                      holder.checkFulfillment(this);                                   \n\
+                      ".replace(/Index/g, i));
+                };
+
+                var promiseSetter = function(i) {
+                  return new Function("promise", "holder", "                           \n\
+                      'use strict';                                                    \n\
+                      holder.pIndex = promise;                                         \n\
+                      ".replace(/Index/g, i));
+                };
+
+                var generateHolderClass = function(total) {
+                  var props = new Array(total);
+                  for (var i = 0; i < props.length; ++i) {
+                    props[i] = "this.p" + (i+1);
+                  }
+                  var assignment = props.join(" = ") + " = null;";
+                  var cancellationCode= "var promise;\n" + props.map(function(prop) {
+                    return "                                                         \n\
+                    promise = " + prop + ";                                      \n\
+                    if (promise instanceof Promise) {                            \n\
                     promise.cancel();                                        \n\
-                }                                                            \n\
-            ";
-        }).join("\n");
-        var passedArguments = props.join(", ");
-        var name = "Holder$" + total;
+                    }                                                            \n\
+                    ";
+                  }).join("\n");
+                  var passedArguments = props.join(", ");
+                  var name = "Holder$" + total;
 
 
-        var code = "return function(tryCatch, errorObj, Promise, async) {    \n\
-            'use strict';                                                    \n\
-            function [TheName](fn) {                                         \n\
-                [TheProperties]                                              \n\
-                this.fn = fn;                                                \n\
-                this.asyncNeeded = true;                                     \n\
-                this.now = 0;                                                \n\
-            }                                                                \n\
-                                                                             \n\
-            [TheName].prototype._callFunction = function(promise) {          \n\
-                promise._pushContext();                                      \n\
-                var ret = tryCatch(this.fn)([ThePassedArguments]);           \n\
-                promise._popContext();                                       \n\
-                if (ret === errorObj) {                                      \n\
+                  var code = "return function(tryCatch, errorObj, Promise, async) {    \n\
+                    'use strict';                                                    \n\
+                    function [TheName](fn) {                                         \n\
+                    [TheProperties]                                              \n\
+                    this.fn = fn;                                                \n\
+                    this.asyncNeeded = true;                                     \n\
+                    this.now = 0;                                                \n\
+                    }                                                                \n\
+                    \n\
+                    [TheName].prototype._callFunction = function(promise) {          \n\
+                    promise._pushContext();                                      \n\
+                    var ret = tryCatch(this.fn)([ThePassedArguments]);           \n\
+                    promise._popContext();                                       \n\
+                    if (ret === errorObj) {                                      \n\
                     promise._rejectCallback(ret.e, false);                   \n\
-                } else {                                                     \n\
+                    } else {                                                     \n\
                     promise._resolveCallback(ret);                           \n\
-                }                                                            \n\
-            };                                                               \n\
-                                                                             \n\
-            [TheName].prototype.checkFulfillment = function(promise) {       \n\
-                var now = ++this.now;                                        \n\
-                if (now === [TheTotal]) {                                    \n\
+                    }                                                            \n\
+                    };                                                               \n\
+                    \n\
+                    [TheName].prototype.checkFulfillment = function(promise) {       \n\
+                    var now = ++this.now;                                        \n\
+                    if (now === [TheTotal]) {                                    \n\
                     if (this.asyncNeeded) {                                  \n\
-                        async.invoke(this._callFunction, this, promise);     \n\
+                    async.invoke(this._callFunction, this, promise);     \n\
                     } else {                                                 \n\
-                        this._callFunction(promise);                         \n\
+                    this._callFunction(promise);                         \n\
                     }                                                        \n\
-                                                                             \n\
-                }                                                            \n\
-            };                                                               \n\
-                                                                             \n\
-            [TheName].prototype._resultCancelled = function() {              \n\
-                [CancellationCode]                                           \n\
-            };                                                               \n\
-                                                                             \n\
-            return [TheName];                                                \n\
-        }(tryCatch, errorObj, Promise, async);                               \n\
-        ";
+                    \n\
+                    }                                                            \n\
+                    };                                                               \n\
+                    \n\
+                    [TheName].prototype._resultCancelled = function() {              \n\
+                    [CancellationCode]                                           \n\
+                    };                                                               \n\
+                    \n\
+                    return [TheName];                                                \n\
+                    }(tryCatch, errorObj, Promise, async);                               \n\
+                    ";
 
-        code = code.replace(/\[TheName\]/g, name)
-            .replace(/\[TheTotal\]/g, total)
-            .replace(/\[ThePassedArguments\]/g, passedArguments)
-            .replace(/\[TheProperties\]/g, assignment)
-            .replace(/\[CancellationCode\]/g, cancellationCode);
+                  code = code.replace(/\[TheName\]/g, name)
+                  .replace(/\[TheTotal\]/g, total)
+                  .replace(/\[ThePassedArguments\]/g, passedArguments)
+                  .replace(/\[TheProperties\]/g, assignment)
+                  .replace(/\[CancellationCode\]/g, cancellationCode);
 
-        return new Function("tryCatch", "errorObj", "Promise", "async", code)
-                           (tryCatch, errorObj, Promise, async);
-    };
+                  return new Function("tryCatch", "errorObj", "Promise", "async", code)
+                  (tryCatch, errorObj, Promise, async);
+                };
 
-    var holderClasses = [];
-    var thenCallbacks = [];
-    var promiseSetters = [];
+                var holderClasses = [];
+                var thenCallbacks = [];
+                var promiseSetters = [];
 
-    for (var i = 0; i < 8; ++i) {
-        holderClasses.push(generateHolderClass(i + 1));
-        thenCallbacks.push(thenCallback(i + 1));
-        promiseSetters.push(promiseSetter(i + 1));
-    }
+                for (var i = 0; i < 8; ++i) {
+                  holderClasses.push(generateHolderClass(i + 1));
+                  thenCallbacks.push(thenCallback(i + 1));
+                  promiseSetters.push(promiseSetter(i + 1));
+                }
 
-    reject = function (reason) {
-        this._reject(reason);
-    };
-}}
+                reject = function (reason) {
+                  this._reject(reason);
+                };
+              }}
 
-Promise.join = function () {
-    var last = arguments.length - 1;
-    var fn;
-    if (last > 0 && typeof arguments[last] === "function") {
-        fn = arguments[last];
-        if (!true) {
-            if (last <= 8 && canEvaluate) {
-                var ret = new Promise(INTERNAL);
-                ret._captureStackTrace();
-                var HolderClass = holderClasses[last - 1];
-                var holder = new HolderClass(fn);
-                var callbacks = thenCallbacks;
+            Promise.join = function () {
+              var last = arguments.length - 1;
+              var fn;
+              if (last > 0 && typeof arguments[last] === "function") {
+                fn = arguments[last];
+                if (!true) {
+                  if (last <= 8 && canEvaluate) {
+                    var ret = new Promise(INTERNAL);
+                    ret._captureStackTrace();
+                    var HolderClass = holderClasses[last - 1];
+                    var holder = new HolderClass(fn);
+                    var callbacks = thenCallbacks;
 
-                for (var i = 0; i < last; ++i) {
-                    var maybePromise = tryConvertToPromise(arguments[i], ret);
-                    if (maybePromise instanceof Promise) {
+                    for (var i = 0; i < last; ++i) {
+                      var maybePromise = tryConvertToPromise(arguments[i], ret);
+                      if (maybePromise instanceof Promise) {
                         maybePromise = maybePromise._target();
                         var bitField = maybePromise._bitField;
                         ;
                         if (((bitField & 50397184) === 0)) {
-                            maybePromise._then(callbacks[i], reject,
-                                               undefined, ret, holder);
-                            promiseSetters[i](maybePromise, holder);
-                            holder.asyncNeeded = false;
+                          maybePromise._then(callbacks[i], reject,
+                              undefined, ret, holder);
+                          promiseSetters[i](maybePromise, holder);
+                          holder.asyncNeeded = false;
                         } else if (((bitField & 33554432) !== 0)) {
-                            callbacks[i].call(ret,
-                                              maybePromise._value(), holder);
+                          callbacks[i].call(ret,
+                              maybePromise._value(), holder);
                         } else if (((bitField & 16777216) !== 0)) {
-                            ret._reject(maybePromise._reason());
+                          ret._reject(maybePromise._reason());
                         } else {
-                            ret._cancel();
+                          ret._cancel();
                         }
-                    } else {
+                      } else {
                         callbacks[i].call(ret, maybePromise, holder);
+                      }
                     }
-                }
 
-                if (!ret._isFateSealed()) {
-                    if (holder.asyncNeeded) {
+                    if (!ret._isFateSealed()) {
+                      if (holder.asyncNeeded) {
                         var domain = getDomain();
                         if (domain !== null) {
-                            holder.fn = util.domainBind(domain, holder.fn);
+                          holder.fn = util.domainBind(domain, holder.fn);
                         }
+                      }
+                      ret._setAsyncGuaranteed();
+                      ret._setOnCancel(holder);
                     }
-                    ret._setAsyncGuaranteed();
-                    ret._setOnCancel(holder);
+                    return ret;
+                  }
+                }
+              }
+              var args = [].slice.call(arguments);;
+              if (fn) args.pop();
+              var ret = new PromiseArray(args).promise();
+              return fn !== undefined ? ret.spread(fn) : ret;
+            };
+
+          };
+
+        },{"./util":36}],18:[function(_dereq_,module,exports){
+          "use strict";
+          module.exports = function(Promise,
+              PromiseArray,
+              apiRejection,
+              tryConvertToPromise,
+              INTERNAL,
+              debug) {
+            var getDomain = Promise._getDomain;
+            var util = _dereq_("./util");
+            var tryCatch = util.tryCatch;
+            var errorObj = util.errorObj;
+
+            function MappingPromiseArray(promises, fn, limit, _filter) {
+              this.constructor$(promises);
+              this._promise._captureStackTrace();
+              var domain = getDomain();
+              this._callback = domain === null ? fn : util.domainBind(domain, fn);
+              this._preservedValues = _filter === INTERNAL
+              ? new Array(this.length())
+              : null;
+              this._limit = limit;
+              this._inFlight = 0;
+              this._queue = [];
+              this._init$(undefined, -2);
+            }
+            util.inherits(MappingPromiseArray, PromiseArray);
+
+            MappingPromiseArray.prototype._init = function () {};
+
+            MappingPromiseArray.prototype._promiseFulfilled = function (value, index) {
+              var values = this._values;
+              var length = this.length();
+              var preservedValues = this._preservedValues;
+              var limit = this._limit;
+
+              if (index < 0) {
+                index = (index * -1) - 1;
+                values[index] = value;
+                if (limit >= 1) {
+                  this._inFlight--;
+                  this._drainQueue();
+                  if (this._isResolved()) return true;
+                }
+              } else {
+                if (limit >= 1 && this._inFlight >= limit) {
+                  values[index] = value;
+                  this._queue.push(index);
+                  return false;
+                }
+                if (preservedValues !== null) preservedValues[index] = value;
+
+                var promise = this._promise;
+                var callback = this._callback;
+                var receiver = promise._boundValue();
+                promise._pushContext();
+                var ret = tryCatch(callback).call(receiver, value, index, length);
+                var promiseCreated = promise._popContext();
+                debug.checkForgottenReturns(
+                    ret,
+                    promiseCreated,
+                    preservedValues !== null ? "Promise.filter" : "Promise.map",
+                        promise
+                );
+                if (ret === errorObj) {
+                  this._reject(ret.e);
+                  return true;
+                }
+
+                var maybePromise = tryConvertToPromise(ret, this._promise);
+                if (maybePromise instanceof Promise) {
+                  maybePromise = maybePromise._target();
+                  var bitField = maybePromise._bitField;
+                  ;
+                  if (((bitField & 50397184) === 0)) {
+                    if (limit >= 1) this._inFlight++;
+                    values[index] = maybePromise;
+                    maybePromise._proxy(this, (index + 1) * -1);
+                    return false;
+                  } else if (((bitField & 33554432) !== 0)) {
+                    ret = maybePromise._value();
+                  } else if (((bitField & 16777216) !== 0)) {
+                    this._reject(maybePromise._reason());
+                    return true;
+                  } else {
+                    this._cancel();
+                    return true;
+                  }
+                }
+                values[index] = ret;
+              }
+              var totalResolved = ++this._totalResolved;
+              if (totalResolved >= length) {
+                if (preservedValues !== null) {
+                  this._filter(values, preservedValues);
+                } else {
+                  this._resolve(values);
+                }
+                return true;
+              }
+              return false;
+            };
+
+            MappingPromiseArray.prototype._drainQueue = function () {
+              var queue = this._queue;
+              var limit = this._limit;
+              var values = this._values;
+              while (queue.length > 0 && this._inFlight < limit) {
+                if (this._isResolved()) return;
+                var index = queue.pop();
+                this._promiseFulfilled(values[index], index);
+              }
+            };
+
+            MappingPromiseArray.prototype._filter = function (booleans, values) {
+              var len = values.length;
+              var ret = new Array(len);
+              var j = 0;
+              for (var i = 0; i < len; ++i) {
+                if (booleans[i]) ret[j++] = values[i];
+              }
+              ret.length = j;
+              this._resolve(ret);
+            };
+
+            MappingPromiseArray.prototype.preservedValues = function () {
+              return this._preservedValues;
+            };
+
+            function map(promises, fn, options, _filter) {
+              if (typeof fn !== "function") {
+                return apiRejection("expecting a function but got " + util.classString(fn));
+              }
+
+              var limit = 0;
+              if (options !== undefined) {
+                if (typeof options === "object" && options !== null) {
+                  if (typeof options.concurrency !== "number") {
+                    return Promise.reject(
+                        new TypeError("'concurrency' must be a number but it is " +
+                            util.classString(options.concurrency)));
+                  }
+                  limit = options.concurrency;
+                } else {
+                  return Promise.reject(new TypeError(
+                      "options argument must be an object but it is " +
+                      util.classString(options)));
+                }
+              }
+              limit = typeof limit === "number" &&
+              isFinite(limit) && limit >= 1 ? limit : 0;
+              return new MappingPromiseArray(promises, fn, limit, _filter).promise();
+            }
+
+            Promise.prototype.map = function (fn, options) {
+              return map(this, fn, options, null);
+            };
+
+            Promise.map = function (promises, fn, options, _filter) {
+              return map(promises, fn, options, _filter);
+            };
+
+
+          };
+
+        },{"./util":36}],19:[function(_dereq_,module,exports){
+          "use strict";
+          module.exports =
+            function(Promise, INTERNAL, tryConvertToPromise, apiRejection, debug) {
+            var util = _dereq_("./util");
+            var tryCatch = util.tryCatch;
+
+            Promise.method = function (fn) {
+              if (typeof fn !== "function") {
+                throw new Promise.TypeError("expecting a function but got " + util.classString(fn));
+              }
+              return function () {
+                var ret = new Promise(INTERNAL);
+                ret._captureStackTrace();
+                ret._pushContext();
+                var value = tryCatch(fn).apply(this, arguments);
+                var promiseCreated = ret._popContext();
+                debug.checkForgottenReturns(
+                    value, promiseCreated, "Promise.method", ret);
+                ret._resolveFromSyncValue(value);
+                return ret;
+              };
+            };
+
+            Promise.attempt = Promise["try"] = function (fn) {
+              if (typeof fn !== "function") {
+                return apiRejection("expecting a function but got " + util.classString(fn));
+              }
+              var ret = new Promise(INTERNAL);
+              ret._captureStackTrace();
+              ret._pushContext();
+              var value;
+              if (arguments.length > 1) {
+                debug.deprecated("calling Promise.try with more than 1 argument");
+                var arg = arguments[1];
+                var ctx = arguments[2];
+                value = util.isArray(arg) ? tryCatch(fn).apply(ctx, arg)
+                    : tryCatch(fn).call(ctx, arg);
+              } else {
+                value = tryCatch(fn)();
+              }
+              var promiseCreated = ret._popContext();
+              debug.checkForgottenReturns(
+                  value, promiseCreated, "Promise.try", ret);
+              ret._resolveFromSyncValue(value);
+              return ret;
+            };
+
+            Promise.prototype._resolveFromSyncValue = function (value) {
+              if (value === util.errorObj) {
+                this._rejectCallback(value.e, false);
+              } else {
+                this._resolveCallback(value, true);
+              }
+            };
+          };
+
+        },{"./util":36}],20:[function(_dereq_,module,exports){
+          "use strict";
+          var util = _dereq_("./util");
+          var maybeWrapAsError = util.maybeWrapAsError;
+          var errors = _dereq_("./errors");
+          var OperationalError = errors.OperationalError;
+          var es5 = _dereq_("./es5");
+
+          function isUntypedError(obj) {
+            return obj instanceof Error &&
+            es5.getPrototypeOf(obj) === Error.prototype;
+          }
+
+          var rErrorKey = /^(?:name|message|stack|cause)$/;
+          function wrapAsOperationalError(obj) {
+            var ret;
+            if (isUntypedError(obj)) {
+              ret = new OperationalError(obj);
+              ret.name = obj.name;
+              ret.message = obj.message;
+              ret.stack = obj.stack;
+              var keys = es5.keys(obj);
+              for (var i = 0; i < keys.length; ++i) {
+                var key = keys[i];
+                if (!rErrorKey.test(key)) {
+                  ret[key] = obj[key];
+                }
+              }
+              return ret;
+            }
+            util.markAsOriginatingFromRejection(obj);
+            return obj;
+          }
+
+          function nodebackForPromise(promise, multiArgs) {
+            return function(err, value) {
+              if (promise === null) return;
+              if (err) {
+                var wrapped = wrapAsOperationalError(maybeWrapAsError(err));
+                promise._attachExtraTrace(wrapped);
+                promise._reject(wrapped);
+              } else if (!multiArgs) {
+                promise._fulfill(value);
+              } else {
+                var args = [].slice.call(arguments, 1);;
+                promise._fulfill(args);
+              }
+              promise = null;
+            };
+          }
+
+          module.exports = nodebackForPromise;
+
+        },{"./errors":12,"./es5":13,"./util":36}],21:[function(_dereq_,module,exports){
+          "use strict";
+          module.exports = function(Promise) {
+            var util = _dereq_("./util");
+            var async = Promise._async;
+            var tryCatch = util.tryCatch;
+            var errorObj = util.errorObj;
+
+            function spreadAdapter(val, nodeback) {
+              var promise = this;
+              if (!util.isArray(val)) return successAdapter.call(promise, val, nodeback);
+              var ret =
+                tryCatch(nodeback).apply(promise._boundValue(), [null].concat(val));
+              if (ret === errorObj) {
+                async.throwLater(ret.e);
+              }
+            }
+
+            function successAdapter(val, nodeback) {
+              var promise = this;
+              var receiver = promise._boundValue();
+              var ret = val === undefined
+              ? tryCatch(nodeback).call(receiver, null)
+                  : tryCatch(nodeback).call(receiver, null, val);
+              if (ret === errorObj) {
+                async.throwLater(ret.e);
+              }
+            }
+            function errorAdapter(reason, nodeback) {
+              var promise = this;
+              if (!reason) {
+                var newReason = new Error(reason + "");
+                newReason.cause = reason;
+                reason = newReason;
+              }
+              var ret = tryCatch(nodeback).call(promise._boundValue(), reason);
+              if (ret === errorObj) {
+                async.throwLater(ret.e);
+              }
+            }
+
+            Promise.prototype.asCallback = Promise.prototype.nodeify = function (nodeback,
+                options) {
+              if (typeof nodeback == "function") {
+                var adapter = successAdapter;
+                if (options !== undefined && Object(options).spread) {
+                  adapter = spreadAdapter;
+                }
+                this._then(
+                    adapter,
+                    errorAdapter,
+                    undefined,
+                    this,
+                    nodeback
+                );
+              }
+              return this;
+            };
+          };
+
+        },{"./util":36}],22:[function(_dereq_,module,exports){
+          "use strict";
+          module.exports = function() {
+            var makeSelfResolutionError = function () {
+              return new TypeError("circular promise resolution chain\u000a\u000a    See http://goo.gl/MqrFmX\u000a");
+            };
+            var reflectHandler = function() {
+              return new Promise.PromiseInspection(this._target());
+            };
+            var apiRejection = function(msg) {
+              return Promise.reject(new TypeError(msg));
+            };
+            function Proxyable() {}
+            var UNDEFINED_BINDING = {};
+            var util = _dereq_("./util");
+
+            var getDomain;
+            if (util.isNode) {
+              getDomain = function() {
+                var ret = process.domain;
+                if (ret === undefined) ret = null;
+                return ret;
+              };
+            } else {
+              getDomain = function() {
+                return null;
+              };
+            }
+            util.notEnumerableProp(Promise, "_getDomain", getDomain);
+
+            var es5 = _dereq_("./es5");
+            var Async = _dereq_("./async");
+            var async = new Async();
+            es5.defineProperty(Promise, "_async", {value: async});
+            var errors = _dereq_("./errors");
+            var TypeError = Promise.TypeError = errors.TypeError;
+            Promise.RangeError = errors.RangeError;
+            var CancellationError = Promise.CancellationError = errors.CancellationError;
+            Promise.TimeoutError = errors.TimeoutError;
+            Promise.OperationalError = errors.OperationalError;
+            Promise.RejectionError = errors.OperationalError;
+            Promise.AggregateError = errors.AggregateError;
+            var INTERNAL = function(){};
+            var APPLY = {};
+            var NEXT_FILTER = {};
+            var tryConvertToPromise = _dereq_("./thenables")(Promise, INTERNAL);
+            var PromiseArray =
+              _dereq_("./promise_array")(Promise, INTERNAL,
+                  tryConvertToPromise, apiRejection, Proxyable);
+            var Context = _dereq_("./context")(Promise);
+            /*jshint unused:false*/
+            var createContext = Context.create;
+            var debug = _dereq_("./debuggability")(Promise, Context);
+            var CapturedTrace = debug.CapturedTrace;
+            var PassThroughHandlerContext =
+              _dereq_("./finally")(Promise, tryConvertToPromise);
+            var catchFilter = _dereq_("./catch_filter")(NEXT_FILTER);
+            var nodebackForPromise = _dereq_("./nodeback");
+            var errorObj = util.errorObj;
+            var tryCatch = util.tryCatch;
+            function check(self, executor) {
+              if (typeof executor !== "function") {
+                throw new TypeError("expecting a function but got " + util.classString(executor));
+              }
+              if (self.constructor !== Promise) {
+                throw new TypeError("the promise constructor cannot be invoked directly\u000a\u000a    See http://goo.gl/MqrFmX\u000a");
+              }
+            }
+
+            function Promise(executor) {
+              this._bitField = 0;
+              this._fulfillmentHandler0 = undefined;
+              this._rejectionHandler0 = undefined;
+              this._promise0 = undefined;
+              this._receiver0 = undefined;
+              if (executor !== INTERNAL) {
+                check(this, executor);
+                this._resolveFromExecutor(executor);
+              }
+              this._promiseCreated();
+              this._fireEvent("promiseCreated", this);
+            }
+
+            Promise.prototype.toString = function () {
+              return "[object Promise]";
+            };
+
+            Promise.prototype.caught = Promise.prototype["catch"] = function (fn) {
+              var len = arguments.length;
+              if (len > 1) {
+                var catchInstances = new Array(len - 1),
+                j = 0, i;
+                for (i = 0; i < len - 1; ++i) {
+                  var item = arguments[i];
+                  if (util.isObject(item)) {
+                    catchInstances[j++] = item;
+                  } else {
+                    return apiRejection("expecting an object but got " +
+                        "A catch statement predicate " + util.classString(item));
+                  }
+                }
+                catchInstances.length = j;
+                fn = arguments[i];
+                return this.then(undefined, catchFilter(catchInstances, fn, this));
+              }
+              return this.then(undefined, fn);
+            };
+
+            Promise.prototype.reflect = function () {
+              return this._then(reflectHandler,
+                  reflectHandler, undefined, this, undefined);
+            };
+
+            Promise.prototype.then = function (didFulfill, didReject) {
+              if (debug.warnings() && arguments.length > 0 &&
+                  typeof didFulfill !== "function" &&
+                  typeof didReject !== "function") {
+                var msg = ".then() only accepts functions but was passed: " +
+                util.classString(didFulfill);
+                if (arguments.length > 1) {
+                  msg += ", " + util.classString(didReject);
+                }
+                this._warn(msg);
+              }
+              return this._then(didFulfill, didReject, undefined, undefined, undefined);
+            };
+
+            Promise.prototype.done = function (didFulfill, didReject) {
+              var promise =
+                this._then(didFulfill, didReject, undefined, undefined, undefined);
+              promise._setIsFinal();
+            };
+
+            Promise.prototype.spread = function (fn) {
+              if (typeof fn !== "function") {
+                return apiRejection("expecting a function but got " + util.classString(fn));
+              }
+              return this.all()._then(fn, undefined, undefined, APPLY, undefined);
+            };
+
+            Promise.prototype.toJSON = function () {
+              var ret = {
+                  isFulfilled: false,
+                  isRejected: false,
+                  fulfillmentValue: undefined,
+                  rejectionReason: undefined
+              };
+              if (this.isFulfilled()) {
+                ret.fulfillmentValue = this.value();
+                ret.isFulfilled = true;
+              } else if (this.isRejected()) {
+                ret.rejectionReason = this.reason();
+                ret.isRejected = true;
+              }
+              return ret;
+            };
+
+            Promise.prototype.all = function () {
+              if (arguments.length > 0) {
+                this._warn(".all() was passed arguments but it does not take any");
+              }
+              return new PromiseArray(this).promise();
+            };
+
+            Promise.prototype.error = function (fn) {
+              return this.caught(util.originatesFromRejection, fn);
+            };
+
+            Promise.getNewLibraryCopy = module.exports;
+
+            Promise.is = function (val) {
+              return val instanceof Promise;
+            };
+
+            Promise.fromNode = Promise.fromCallback = function(fn) {
+              var ret = new Promise(INTERNAL);
+              ret._captureStackTrace();
+              var multiArgs = arguments.length > 1 ? !!Object(arguments[1]).multiArgs
+                  : false;
+              var result = tryCatch(fn)(nodebackForPromise(ret, multiArgs));
+              if (result === errorObj) {
+                ret._rejectCallback(result.e, true);
+              }
+              if (!ret._isFateSealed()) ret._setAsyncGuaranteed();
+              return ret;
+            };
+
+            Promise.all = function (promises) {
+              return new PromiseArray(promises).promise();
+            };
+
+            Promise.cast = function (obj) {
+              var ret = tryConvertToPromise(obj);
+              if (!(ret instanceof Promise)) {
+                ret = new Promise(INTERNAL);
+                ret._captureStackTrace();
+                ret._setFulfilled();
+                ret._rejectionHandler0 = obj;
+              }
+              return ret;
+            };
+
+            Promise.resolve = Promise.fulfilled = Promise.cast;
+
+            Promise.reject = Promise.rejected = function (reason) {
+              var ret = new Promise(INTERNAL);
+              ret._captureStackTrace();
+              ret._rejectCallback(reason, true);
+              return ret;
+            };
+
+            Promise.setScheduler = function(fn) {
+              if (typeof fn !== "function") {
+                throw new TypeError("expecting a function but got " + util.classString(fn));
+              }
+              return async.setScheduler(fn);
+            };
+
+            Promise.prototype._then = function (
+                didFulfill,
+                didReject,
+                _,    receiver,
+                internalData
+            ) {
+              var haveInternalData = internalData !== undefined;
+              var promise = haveInternalData ? internalData : new Promise(INTERNAL);
+              var target = this._target();
+              var bitField = target._bitField;
+
+              if (!haveInternalData) {
+                promise._propagateFrom(this, 3);
+                promise._captureStackTrace();
+                if (receiver === undefined &&
+                    ((this._bitField & 2097152) !== 0)) {
+                  if (!((bitField & 50397184) === 0)) {
+                    receiver = this._boundValue();
+                  } else {
+                    receiver = target === this ? undefined : this._boundTo;
+                  }
+                }
+                this._fireEvent("promiseChained", this, promise);
+              }
+
+              var domain = getDomain();
+              if (!((bitField & 50397184) === 0)) {
+                var handler, value, settler = target._settlePromiseCtx;
+                if (((bitField & 33554432) !== 0)) {
+                  value = target._rejectionHandler0;
+                  handler = didFulfill;
+                } else if (((bitField & 16777216) !== 0)) {
+                  value = target._fulfillmentHandler0;
+                  handler = didReject;
+                  target._unsetRejectionIsUnhandled();
+                } else {
+                  settler = target._settlePromiseLateCancellationObserver;
+                  value = new CancellationError("late cancellation observer");
+                  target._attachExtraTrace(value);
+                  handler = didReject;
+                }
+
+                async.invoke(settler, target, {
+                  handler: domain === null ? handler
+                      : (typeof handler === "function" &&
+                          util.domainBind(domain, handler)),
+                          promise: promise,
+                          receiver: receiver,
+                          value: value
+                });
+              } else {
+                target._addCallbacks(didFulfill, didReject, promise, receiver, domain);
+              }
+
+              return promise;
+            };
+
+            Promise.prototype._length = function () {
+              return this._bitField & 65535;
+            };
+
+            Promise.prototype._isFateSealed = function () {
+              return (this._bitField & 117506048) !== 0;
+            };
+
+            Promise.prototype._isFollowing = function () {
+              return (this._bitField & 67108864) === 67108864;
+            };
+
+            Promise.prototype._setLength = function (len) {
+              this._bitField = (this._bitField & -65536) |
+              (len & 65535);
+            };
+
+            Promise.prototype._setFulfilled = function () {
+              this._bitField = this._bitField | 33554432;
+              this._fireEvent("promiseFulfilled", this);
+            };
+
+            Promise.prototype._setRejected = function () {
+              this._bitField = this._bitField | 16777216;
+              this._fireEvent("promiseRejected", this);
+            };
+
+            Promise.prototype._setFollowing = function () {
+              this._bitField = this._bitField | 67108864;
+              this._fireEvent("promiseResolved", this);
+            };
+
+            Promise.prototype._setIsFinal = function () {
+              this._bitField = this._bitField | 4194304;
+            };
+
+            Promise.prototype._isFinal = function () {
+              return (this._bitField & 4194304) > 0;
+            };
+
+            Promise.prototype._unsetCancelled = function() {
+              this._bitField = this._bitField & (~65536);
+            };
+
+            Promise.prototype._setCancelled = function() {
+              this._bitField = this._bitField | 65536;
+              this._fireEvent("promiseCancelled", this);
+            };
+
+            Promise.prototype._setWillBeCancelled = function() {
+              this._bitField = this._bitField | 8388608;
+            };
+
+            Promise.prototype._setAsyncGuaranteed = function() {
+              if (async.hasCustomScheduler()) return;
+              this._bitField = this._bitField | 134217728;
+            };
+
+            Promise.prototype._receiverAt = function (index) {
+              var ret = index === 0 ? this._receiver0 : this[
+                index * 4 - 4 + 3];
+              if (ret === UNDEFINED_BINDING) {
+                return undefined;
+              } else if (ret === undefined && this._isBound()) {
+                return this._boundValue();
+              }
+              return ret;
+            };
+
+            Promise.prototype._promiseAt = function (index) {
+              return this[
+                index * 4 - 4 + 2];
+            };
+
+            Promise.prototype._fulfillmentHandlerAt = function (index) {
+              return this[
+                index * 4 - 4 + 0];
+            };
+
+            Promise.prototype._rejectionHandlerAt = function (index) {
+              return this[
+                index * 4 - 4 + 1];
+            };
+
+            Promise.prototype._boundValue = function() {};
+
+            Promise.prototype._migrateCallback0 = function (follower) {
+              var bitField = follower._bitField;
+              var fulfill = follower._fulfillmentHandler0;
+              var reject = follower._rejectionHandler0;
+              var promise = follower._promise0;
+              var receiver = follower._receiverAt(0);
+              if (receiver === undefined) receiver = UNDEFINED_BINDING;
+              this._addCallbacks(fulfill, reject, promise, receiver, null);
+            };
+
+            Promise.prototype._migrateCallbackAt = function (follower, index) {
+              var fulfill = follower._fulfillmentHandlerAt(index);
+              var reject = follower._rejectionHandlerAt(index);
+              var promise = follower._promiseAt(index);
+              var receiver = follower._receiverAt(index);
+              if (receiver === undefined) receiver = UNDEFINED_BINDING;
+              this._addCallbacks(fulfill, reject, promise, receiver, null);
+            };
+
+            Promise.prototype._addCallbacks = function (
+                fulfill,
+                reject,
+                promise,
+                receiver,
+                domain
+            ) {
+              var index = this._length();
+
+              if (index >= 65535 - 4) {
+                index = 0;
+                this._setLength(0);
+              }
+
+              if (index === 0) {
+                this._promise0 = promise;
+                this._receiver0 = receiver;
+                if (typeof fulfill === "function") {
+                  this._fulfillmentHandler0 =
+                    domain === null ? fulfill : util.domainBind(domain, fulfill);
+                }
+                if (typeof reject === "function") {
+                  this._rejectionHandler0 =
+                    domain === null ? reject : util.domainBind(domain, reject);
+                }
+              } else {
+                var base = index * 4 - 4;
+                this[base + 2] = promise;
+                this[base + 3] = receiver;
+                if (typeof fulfill === "function") {
+                  this[base + 0] =
+                    domain === null ? fulfill : util.domainBind(domain, fulfill);
+                }
+                if (typeof reject === "function") {
+                  this[base + 1] =
+                    domain === null ? reject : util.domainBind(domain, reject);
+                }
+              }
+              this._setLength(index + 1);
+              return index;
+            };
+
+            Promise.prototype._proxy = function (proxyable, arg) {
+              this._addCallbacks(undefined, undefined, arg, proxyable, null);
+            };
+
+            Promise.prototype._resolveCallback = function(value, shouldBind) {
+              if (((this._bitField & 117506048) !== 0)) return;
+              if (value === this)
+                return this._rejectCallback(makeSelfResolutionError(), false);
+              var maybePromise = tryConvertToPromise(value, this);
+              if (!(maybePromise instanceof Promise)) return this._fulfill(value);
+
+              if (shouldBind) this._propagateFrom(maybePromise, 2);
+
+              var promise = maybePromise._target();
+
+              if (promise === this) {
+                this._reject(makeSelfResolutionError());
+                return;
+              }
+
+              var bitField = promise._bitField;
+              if (((bitField & 50397184) === 0)) {
+                var len = this._length();
+                if (len > 0) promise._migrateCallback0(this);
+                for (var i = 1; i < len; ++i) {
+                  promise._migrateCallbackAt(this, i);
+                }
+                this._setFollowing();
+                this._setLength(0);
+                this._setFollowee(promise);
+              } else if (((bitField & 33554432) !== 0)) {
+                this._fulfill(promise._value());
+              } else if (((bitField & 16777216) !== 0)) {
+                this._reject(promise._reason());
+              } else {
+                var reason = new CancellationError("late cancellation observer");
+                promise._attachExtraTrace(reason);
+                this._reject(reason);
+              }
+            };
+
+            Promise.prototype._rejectCallback =
+              function(reason, synchronous, ignoreNonErrorWarnings) {
+              var trace = util.ensureErrorObject(reason);
+              var hasStack = trace === reason;
+              if (!hasStack && !ignoreNonErrorWarnings && debug.warnings()) {
+                var message = "a promise was rejected with a non-error: " +
+                util.classString(reason);
+                this._warn(message, true);
+              }
+              this._attachExtraTrace(trace, synchronous ? hasStack : false);
+              this._reject(reason);
+            };
+
+            Promise.prototype._resolveFromExecutor = function (executor) {
+              var promise = this;
+              this._captureStackTrace();
+              this._pushContext();
+              var synchronous = true;
+              var r = this._execute(executor, function(value) {
+                promise._resolveCallback(value);
+              }, function (reason) {
+                promise._rejectCallback(reason, synchronous);
+              });
+              synchronous = false;
+              this._popContext();
+
+              if (r !== undefined) {
+                promise._rejectCallback(r, true);
+              }
+            };
+
+            Promise.prototype._settlePromiseFromHandler = function (
+                handler, receiver, value, promise
+            ) {
+              var bitField = promise._bitField;
+              if (((bitField & 65536) !== 0)) return;
+              promise._pushContext();
+              var x;
+              if (receiver === APPLY) {
+                if (!value || typeof value.length !== "number") {
+                  x = errorObj;
+                  x.e = new TypeError("cannot .spread() a non-array: " +
+                      util.classString(value));
+                } else {
+                  x = tryCatch(handler).apply(this._boundValue(), value);
+                }
+              } else {
+                x = tryCatch(handler).call(receiver, value);
+              }
+              var promiseCreated = promise._popContext();
+              bitField = promise._bitField;
+              if (((bitField & 65536) !== 0)) return;
+
+              if (x === NEXT_FILTER) {
+                promise._reject(value);
+              } else if (x === errorObj) {
+                promise._rejectCallback(x.e, false);
+              } else {
+                debug.checkForgottenReturns(x, promiseCreated, "",  promise, this);
+                promise._resolveCallback(x);
+              }
+            };
+
+            Promise.prototype._target = function() {
+              var ret = this;
+              while (ret._isFollowing()) ret = ret._followee();
+              return ret;
+            };
+
+            Promise.prototype._followee = function() {
+              return this._rejectionHandler0;
+            };
+
+            Promise.prototype._setFollowee = function(promise) {
+              this._rejectionHandler0 = promise;
+            };
+
+            Promise.prototype._settlePromise = function(promise, handler, receiver, value) {
+              var isPromise = promise instanceof Promise;
+              var bitField = this._bitField;
+              var asyncGuaranteed = ((bitField & 134217728) !== 0);
+              if (((bitField & 65536) !== 0)) {
+                if (isPromise) promise._invokeInternalOnCancel();
+
+                if (receiver instanceof PassThroughHandlerContext &&
+                    receiver.isFinallyHandler()) {
+                  receiver.cancelPromise = promise;
+                  if (tryCatch(handler).call(receiver, value) === errorObj) {
+                    promise._reject(errorObj.e);
+                  }
+                } else if (handler === reflectHandler) {
+                  promise._fulfill(reflectHandler.call(receiver));
+                } else if (receiver instanceof Proxyable) {
+                  receiver._promiseCancelled(promise);
+                } else if (isPromise || promise instanceof PromiseArray) {
+                  promise._cancel();
+                } else {
+                  receiver.cancel();
+                }
+              } else if (typeof handler === "function") {
+                if (!isPromise) {
+                  handler.call(receiver, value, promise);
+                } else {
+                  if (asyncGuaranteed) promise._setAsyncGuaranteed();
+                  this._settlePromiseFromHandler(handler, receiver, value, promise);
+                }
+              } else if (receiver instanceof Proxyable) {
+                if (!receiver._isResolved()) {
+                  if (((bitField & 33554432) !== 0)) {
+                    receiver._promiseFulfilled(value, promise);
+                  } else {
+                    receiver._promiseRejected(value, promise);
+                  }
+                }
+              } else if (isPromise) {
+                if (asyncGuaranteed) promise._setAsyncGuaranteed();
+                if (((bitField & 33554432) !== 0)) {
+                  promise._fulfill(value);
+                } else {
+                  promise._reject(value);
+                }
+              }
+            };
+
+            Promise.prototype._settlePromiseLateCancellationObserver = function(ctx) {
+              var handler = ctx.handler;
+              var promise = ctx.promise;
+              var receiver = ctx.receiver;
+              var value = ctx.value;
+              if (typeof handler === "function") {
+                if (!(promise instanceof Promise)) {
+                  handler.call(receiver, value, promise);
+                } else {
+                  this._settlePromiseFromHandler(handler, receiver, value, promise);
+                }
+              } else if (promise instanceof Promise) {
+                promise._reject(value);
+              }
+            };
+
+            Promise.prototype._settlePromiseCtx = function(ctx) {
+              this._settlePromise(ctx.promise, ctx.handler, ctx.receiver, ctx.value);
+            };
+
+            Promise.prototype._settlePromise0 = function(handler, value, bitField) {
+              var promise = this._promise0;
+              var receiver = this._receiverAt(0);
+              this._promise0 = undefined;
+              this._receiver0 = undefined;
+              this._settlePromise(promise, handler, receiver, value);
+            };
+
+            Promise.prototype._clearCallbackDataAtIndex = function(index) {
+              var base = index * 4 - 4;
+              this[base + 2] =
+                this[base + 3] =
+                  this[base + 0] =
+                    this[base + 1] = undefined;
+            };
+
+            Promise.prototype._fulfill = function (value) {
+              var bitField = this._bitField;
+              if (((bitField & 117506048) >>> 16)) return;
+              if (value === this) {
+                var err = makeSelfResolutionError();
+                this._attachExtraTrace(err);
+                return this._reject(err);
+              }
+              this._setFulfilled();
+              this._rejectionHandler0 = value;
+
+              if ((bitField & 65535) > 0) {
+                if (((bitField & 134217728) !== 0)) {
+                  this._settlePromises();
+                } else {
+                  async.settlePromises(this);
+                }
+              }
+            };
+
+            Promise.prototype._reject = function (reason) {
+              var bitField = this._bitField;
+              if (((bitField & 117506048) >>> 16)) return;
+              this._setRejected();
+              this._fulfillmentHandler0 = reason;
+
+              if (this._isFinal()) {
+                return async.fatalError(reason, util.isNode);
+              }
+
+              if ((bitField & 65535) > 0) {
+                async.settlePromises(this);
+              } else {
+                this._ensurePossibleRejectionHandled();
+              }
+            };
+
+            Promise.prototype._fulfillPromises = function (len, value) {
+              for (var i = 1; i < len; i++) {
+                var handler = this._fulfillmentHandlerAt(i);
+                var promise = this._promiseAt(i);
+                var receiver = this._receiverAt(i);
+                this._clearCallbackDataAtIndex(i);
+                this._settlePromise(promise, handler, receiver, value);
+              }
+            };
+
+            Promise.prototype._rejectPromises = function (len, reason) {
+              for (var i = 1; i < len; i++) {
+                var handler = this._rejectionHandlerAt(i);
+                var promise = this._promiseAt(i);
+                var receiver = this._receiverAt(i);
+                this._clearCallbackDataAtIndex(i);
+                this._settlePromise(promise, handler, receiver, reason);
+              }
+            };
+
+            Promise.prototype._settlePromises = function () {
+              var bitField = this._bitField;
+              var len = (bitField & 65535);
+
+              if (len > 0) {
+                if (((bitField & 16842752) !== 0)) {
+                  var reason = this._fulfillmentHandler0;
+                  this._settlePromise0(this._rejectionHandler0, reason, bitField);
+                  this._rejectPromises(len, reason);
+                } else {
+                  var value = this._rejectionHandler0;
+                  this._settlePromise0(this._fulfillmentHandler0, value, bitField);
+                  this._fulfillPromises(len, value);
+                }
+                this._setLength(0);
+              }
+              this._clearCancellationData();
+            };
+
+            Promise.prototype._settledValue = function() {
+              var bitField = this._bitField;
+              if (((bitField & 33554432) !== 0)) {
+                return this._rejectionHandler0;
+              } else if (((bitField & 16777216) !== 0)) {
+                return this._fulfillmentHandler0;
+              }
+            };
+
+            function deferResolve(v) {this.promise._resolveCallback(v);}
+            function deferReject(v) {this.promise._rejectCallback(v, false);}
+
+            Promise.defer = Promise.pending = function() {
+              debug.deprecated("Promise.defer", "new Promise");
+              var promise = new Promise(INTERNAL);
+              return {
+                promise: promise,
+                resolve: deferResolve,
+                reject: deferReject
+              };
+            };
+
+            util.notEnumerableProp(Promise,
+                "_makeSelfResolutionError",
+                makeSelfResolutionError);
+
+            _dereq_("./method")(Promise, INTERNAL, tryConvertToPromise, apiRejection,
+                debug);
+            _dereq_("./bind")(Promise, INTERNAL, tryConvertToPromise, debug);
+            _dereq_("./cancel")(Promise, PromiseArray, apiRejection, debug);
+            _dereq_("./direct_resolve")(Promise);
+            _dereq_("./synchronous_inspection")(Promise);
+            _dereq_("./join")(
+                Promise, PromiseArray, tryConvertToPromise, INTERNAL, async, getDomain);
+            Promise.Promise = Promise;
+            Promise.version = "3.4.5";
+            _dereq_('./map.js')(Promise, PromiseArray, apiRejection, tryConvertToPromise, INTERNAL, debug);
+            _dereq_('./call_get.js')(Promise);
+            _dereq_('./using.js')(Promise, apiRejection, tryConvertToPromise, createContext, INTERNAL, debug);
+            _dereq_('./timers.js')(Promise, INTERNAL, debug);
+            _dereq_('./generators.js')(Promise, apiRejection, INTERNAL, tryConvertToPromise, Proxyable, debug);
+            _dereq_('./nodeify.js')(Promise);
+            _dereq_('./promisify.js')(Promise, INTERNAL);
+            _dereq_('./props.js')(Promise, PromiseArray, tryConvertToPromise, apiRejection);
+            _dereq_('./race.js')(Promise, INTERNAL, tryConvertToPromise, apiRejection);
+            _dereq_('./reduce.js')(Promise, PromiseArray, apiRejection, tryConvertToPromise, INTERNAL, debug);
+            _dereq_('./settle.js')(Promise, PromiseArray, debug);
+            _dereq_('./some.js')(Promise, PromiseArray, apiRejection);
+            _dereq_('./filter.js')(Promise, INTERNAL);
+            _dereq_('./each.js')(Promise, INTERNAL);
+            _dereq_('./any.js')(Promise);
+
+            util.toFastProperties(Promise);                                          
+            util.toFastProperties(Promise.prototype);                                
+            function fillTypes(value) {                                              
+              var p = new Promise(INTERNAL);                                       
+              p._fulfillmentHandler0 = value;                                      
+              p._rejectionHandler0 = value;                                        
+              p._promise0 = value;                                                 
+              p._receiver0 = value;                                                
+            }                                                                        
+            // Complete slack tracking, opt out of field-type tracking and           
+            // stabilize map                                                         
+            fillTypes({a: 1});                                                       
+            fillTypes({b: 2});                                                       
+            fillTypes({c: 3});                                                       
+            fillTypes(1);                                                            
+            fillTypes(function(){});                                                 
+            fillTypes(undefined);                                                    
+            fillTypes(false);                                                        
+            fillTypes(new Promise(INTERNAL));                                        
+            debug.setBounds(Async.firstLineError, util.lastLineError);               
+            return Promise;                                                          
+
+          };
+
+        },{"./any.js":1,"./async":2,"./bind":3,"./call_get.js":5,"./cancel":6,"./catch_filter":7,"./context":8,"./debuggability":9,"./direct_resolve":10,"./each.js":11,"./errors":12,"./es5":13,"./filter.js":14,"./finally":15,"./generators.js":16,"./join":17,"./map.js":18,"./method":19,"./nodeback":20,"./nodeify.js":21,"./promise_array":23,"./promisify.js":24,"./props.js":25,"./race.js":27,"./reduce.js":28,"./settle.js":30,"./some.js":31,"./synchronous_inspection":32,"./thenables":33,"./timers.js":34,"./using.js":35,"./util":36}],23:[function(_dereq_,module,exports){
+          "use strict";
+          module.exports = function(Promise, INTERNAL, tryConvertToPromise,
+              apiRejection, Proxyable) {
+            var util = _dereq_("./util");
+            var isArray = util.isArray;
+
+            function toResolutionValue(val) {
+              switch(val) {
+              case -2: return [];
+              case -3: return {};
+              }
+            }
+
+            function PromiseArray(values) {
+              var promise = this._promise = new Promise(INTERNAL);
+              if (values instanceof Promise) {
+                promise._propagateFrom(values, 3);
+              }
+              promise._setOnCancel(this);
+              this._values = values;
+              this._length = 0;
+              this._totalResolved = 0;
+              this._init(undefined, -2);
+            }
+            util.inherits(PromiseArray, Proxyable);
+
+            PromiseArray.prototype.length = function () {
+              return this._length;
+            };
+
+            PromiseArray.prototype.promise = function () {
+              return this._promise;
+            };
+
+            PromiseArray.prototype._init = function init(_, resolveValueIfEmpty) {
+              var values = tryConvertToPromise(this._values, this._promise);
+              if (values instanceof Promise) {
+                values = values._target();
+                var bitField = values._bitField;
+                ;
+                this._values = values;
+
+                if (((bitField & 50397184) === 0)) {
+                  this._promise._setAsyncGuaranteed();
+                  return values._then(
+                      init,
+                      this._reject,
+                      undefined,
+                      this,
+                      resolveValueIfEmpty
+                  );
+                } else if (((bitField & 33554432) !== 0)) {
+                  values = values._value();
+                } else if (((bitField & 16777216) !== 0)) {
+                  return this._reject(values._reason());
+                } else {
+                  return this._cancel();
+                }
+              }
+              values = util.asArray(values);
+              if (values === null) {
+                var err = apiRejection(
+                    "expecting an array or an iterable object but got " + util.classString(values)).reason();
+                this._promise._rejectCallback(err, false);
+                return;
+              }
+
+              if (values.length === 0) {
+                if (resolveValueIfEmpty === -5) {
+                  this._resolveEmptyArray();
+                }
+                else {
+                  this._resolve(toResolutionValue(resolveValueIfEmpty));
+                }
+                return;
+              }
+              this._iterate(values);
+            };
+
+            PromiseArray.prototype._iterate = function(values) {
+              var len = this.getActualLength(values.length);
+              this._length = len;
+              this._values = this.shouldCopyValues() ? new Array(len) : this._values;
+              var result = this._promise;
+              var isResolved = false;
+              var bitField = null;
+              for (var i = 0; i < len; ++i) {
+                var maybePromise = tryConvertToPromise(values[i], result);
+
+                if (maybePromise instanceof Promise) {
+                  maybePromise = maybePromise._target();
+                  bitField = maybePromise._bitField;
+                } else {
+                  bitField = null;
+                }
+
+                if (isResolved) {
+                  if (bitField !== null) {
+                    maybePromise.suppressUnhandledRejections();
+                  }
+                } else if (bitField !== null) {
+                  if (((bitField & 50397184) === 0)) {
+                    maybePromise._proxy(this, i);
+                    this._values[i] = maybePromise;
+                  } else if (((bitField & 33554432) !== 0)) {
+                    isResolved = this._promiseFulfilled(maybePromise._value(), i);
+                  } else if (((bitField & 16777216) !== 0)) {
+                    isResolved = this._promiseRejected(maybePromise._reason(), i);
+                  } else {
+                    isResolved = this._promiseCancelled(i);
+                  }
+                } else {
+                  isResolved = this._promiseFulfilled(maybePromise, i);
+                }
+              }
+              if (!isResolved) result._setAsyncGuaranteed();
+            };
+
+            PromiseArray.prototype._isResolved = function () {
+              return this._values === null;
+            };
+
+            PromiseArray.prototype._resolve = function (value) {
+              this._values = null;
+              this._promise._fulfill(value);
+            };
+
+            PromiseArray.prototype._cancel = function() {
+              if (this._isResolved() || !this._promise._isCancellable()) return;
+              this._values = null;
+              this._promise._cancel();
+            };
+
+            PromiseArray.prototype._reject = function (reason) {
+              this._values = null;
+              this._promise._rejectCallback(reason, false);
+            };
+
+            PromiseArray.prototype._promiseFulfilled = function (value, index) {
+              this._values[index] = value;
+              var totalResolved = ++this._totalResolved;
+              if (totalResolved >= this._length) {
+                this._resolve(this._values);
+                return true;
+              }
+              return false;
+            };
+
+            PromiseArray.prototype._promiseCancelled = function() {
+              this._cancel();
+              return true;
+            };
+
+            PromiseArray.prototype._promiseRejected = function (reason) {
+              this._totalResolved++;
+              this._reject(reason);
+              return true;
+            };
+
+            PromiseArray.prototype._resultCancelled = function() {
+              if (this._isResolved()) return;
+              var values = this._values;
+              this._cancel();
+              if (values instanceof Promise) {
+                values.cancel();
+              } else {
+                for (var i = 0; i < values.length; ++i) {
+                  if (values[i] instanceof Promise) {
+                    values[i].cancel();
+                  }
+                }
+              }
+            };
+
+            PromiseArray.prototype.shouldCopyValues = function () {
+              return true;
+            };
+
+            PromiseArray.prototype.getActualLength = function (len) {
+              return len;
+            };
+
+            return PromiseArray;
+          };
+
+        },{"./util":36}],24:[function(_dereq_,module,exports){
+          "use strict";
+          module.exports = function(Promise, INTERNAL) {
+            var THIS = {};
+            var util = _dereq_("./util");
+            var nodebackForPromise = _dereq_("./nodeback");
+            var withAppended = util.withAppended;
+            var maybeWrapAsError = util.maybeWrapAsError;
+            var canEvaluate = util.canEvaluate;
+            var TypeError = _dereq_("./errors").TypeError;
+            var defaultSuffix = "Async";
+            var defaultPromisified = {__isPromisified__: true};
+            var noCopyProps = [
+              "arity",    "length",
+              "name",
+              "arguments",
+              "caller",
+              "callee",
+              "prototype",
+              "__isPromisified__"
+              ];
+            var noCopyPropsPattern = new RegExp("^(?:" + noCopyProps.join("|") + ")$");
+
+            var defaultFilter = function(name) {
+              return util.isIdentifier(name) &&
+              name.charAt(0) !== "_" &&
+              name !== "constructor";
+            };
+
+            function propsFilter(key) {
+              return !noCopyPropsPattern.test(key);
+            }
+
+            function isPromisified(fn) {
+              try {
+                return fn.__isPromisified__ === true;
+              }
+              catch (e) {
+                return false;
+              }
+            }
+
+            function hasPromisified(obj, key, suffix) {
+              var val = util.getDataPropertyOrDefault(obj, key + suffix,
+                  defaultPromisified);
+              return val ? isPromisified(val) : false;
+            }
+            function checkValid(ret, suffix, suffixRegexp) {
+              for (var i = 0; i < ret.length; i += 2) {
+                var key = ret[i];
+                if (suffixRegexp.test(key)) {
+                  var keyWithoutAsyncSuffix = key.replace(suffixRegexp, "");
+                  for (var j = 0; j < ret.length; j += 2) {
+                    if (ret[j] === keyWithoutAsyncSuffix) {
+                      throw new TypeError("Cannot promisify an API that has normal methods with '%s'-suffix\u000a\u000a    See http://goo.gl/MqrFmX\u000a"
+                          .replace("%s", suffix));
+                    }
+                  }
+                }
+              }
+            }
+
+            function promisifiableMethods(obj, suffix, suffixRegexp, filter) {
+              var keys = util.inheritedDataKeys(obj);
+              var ret = [];
+              for (var i = 0; i < keys.length; ++i) {
+                var key = keys[i];
+                var value = obj[key];
+                var passesDefaultFilter = filter === defaultFilter
+                ? true : defaultFilter(key, value, obj);
+                if (typeof value === "function" &&
+                    !isPromisified(value) &&
+                    !hasPromisified(obj, key, suffix) &&
+                    filter(key, value, obj, passesDefaultFilter)) {
+                  ret.push(key, value);
+                }
+              }
+              checkValid(ret, suffix, suffixRegexp);
+              return ret;
+            }
+
+            var escapeIdentRegex = function(str) {
+              return str.replace(/([$])/, "\\$");
+            };
+
+            var makeNodePromisifiedEval;
+            if (!true) {
+              var switchCaseArgumentOrder = function(likelyArgumentCount) {
+                var ret = [likelyArgumentCount];
+                var min = Math.max(0, likelyArgumentCount - 1 - 3);
+                for(var i = likelyArgumentCount - 1; i >= min; --i) {
+                  ret.push(i);
+                }
+                for(var i = likelyArgumentCount + 1; i <= 3; ++i) {
+                  ret.push(i);
                 }
                 return ret;
-            }
-        }
-    }
-    var args = [].slice.call(arguments);;
-    if (fn) args.pop();
-    var ret = new PromiseArray(args).promise();
-    return fn !== undefined ? ret.spread(fn) : ret;
-};
-
-};
-
-},{"./util":36}],18:[function(_dereq_,module,exports){
-"use strict";
-module.exports = function(Promise,
-                          PromiseArray,
-                          apiRejection,
-                          tryConvertToPromise,
-                          INTERNAL,
-                          debug) {
-var getDomain = Promise._getDomain;
-var util = _dereq_("./util");
-var tryCatch = util.tryCatch;
-var errorObj = util.errorObj;
-
-function MappingPromiseArray(promises, fn, limit, _filter) {
-    this.constructor$(promises);
-    this._promise._captureStackTrace();
-    var domain = getDomain();
-    this._callback = domain === null ? fn : util.domainBind(domain, fn);
-    this._preservedValues = _filter === INTERNAL
-        ? new Array(this.length())
-        : null;
-    this._limit = limit;
-    this._inFlight = 0;
-    this._queue = [];
-    this._init$(undefined, -2);
-}
-util.inherits(MappingPromiseArray, PromiseArray);
-
-MappingPromiseArray.prototype._init = function () {};
-
-MappingPromiseArray.prototype._promiseFulfilled = function (value, index) {
-    var values = this._values;
-    var length = this.length();
-    var preservedValues = this._preservedValues;
-    var limit = this._limit;
-
-    if (index < 0) {
-        index = (index * -1) - 1;
-        values[index] = value;
-        if (limit >= 1) {
-            this._inFlight--;
-            this._drainQueue();
-            if (this._isResolved()) return true;
-        }
-    } else {
-        if (limit >= 1 && this._inFlight >= limit) {
-            values[index] = value;
-            this._queue.push(index);
-            return false;
-        }
-        if (preservedValues !== null) preservedValues[index] = value;
-
-        var promise = this._promise;
-        var callback = this._callback;
-        var receiver = promise._boundValue();
-        promise._pushContext();
-        var ret = tryCatch(callback).call(receiver, value, index, length);
-        var promiseCreated = promise._popContext();
-        debug.checkForgottenReturns(
-            ret,
-            promiseCreated,
-            preservedValues !== null ? "Promise.filter" : "Promise.map",
-            promise
-        );
-        if (ret === errorObj) {
-            this._reject(ret.e);
-            return true;
-        }
-
-        var maybePromise = tryConvertToPromise(ret, this._promise);
-        if (maybePromise instanceof Promise) {
-            maybePromise = maybePromise._target();
-            var bitField = maybePromise._bitField;
-            ;
-            if (((bitField & 50397184) === 0)) {
-                if (limit >= 1) this._inFlight++;
-                values[index] = maybePromise;
-                maybePromise._proxy(this, (index + 1) * -1);
-                return false;
-            } else if (((bitField & 33554432) !== 0)) {
-                ret = maybePromise._value();
-            } else if (((bitField & 16777216) !== 0)) {
-                this._reject(maybePromise._reason());
-                return true;
-            } else {
-                this._cancel();
-                return true;
-            }
-        }
-        values[index] = ret;
-    }
-    var totalResolved = ++this._totalResolved;
-    if (totalResolved >= length) {
-        if (preservedValues !== null) {
-            this._filter(values, preservedValues);
-        } else {
-            this._resolve(values);
-        }
-        return true;
-    }
-    return false;
-};
-
-MappingPromiseArray.prototype._drainQueue = function () {
-    var queue = this._queue;
-    var limit = this._limit;
-    var values = this._values;
-    while (queue.length > 0 && this._inFlight < limit) {
-        if (this._isResolved()) return;
-        var index = queue.pop();
-        this._promiseFulfilled(values[index], index);
-    }
-};
-
-MappingPromiseArray.prototype._filter = function (booleans, values) {
-    var len = values.length;
-    var ret = new Array(len);
-    var j = 0;
-    for (var i = 0; i < len; ++i) {
-        if (booleans[i]) ret[j++] = values[i];
-    }
-    ret.length = j;
-    this._resolve(ret);
-};
-
-MappingPromiseArray.prototype.preservedValues = function () {
-    return this._preservedValues;
-};
-
-function map(promises, fn, options, _filter) {
-    if (typeof fn !== "function") {
-        return apiRejection("expecting a function but got " + util.classString(fn));
-    }
-
-    var limit = 0;
-    if (options !== undefined) {
-        if (typeof options === "object" && options !== null) {
-            if (typeof options.concurrency !== "number") {
-                return Promise.reject(
-                    new TypeError("'concurrency' must be a number but it is " +
-                                    util.classString(options.concurrency)));
-            }
-            limit = options.concurrency;
-        } else {
-            return Promise.reject(new TypeError(
-                            "options argument must be an object but it is " +
-                             util.classString(options)));
-        }
-    }
-    limit = typeof limit === "number" &&
-        isFinite(limit) && limit >= 1 ? limit : 0;
-    return new MappingPromiseArray(promises, fn, limit, _filter).promise();
-}
-
-Promise.prototype.map = function (fn, options) {
-    return map(this, fn, options, null);
-};
-
-Promise.map = function (promises, fn, options, _filter) {
-    return map(promises, fn, options, _filter);
-};
-
-
-};
-
-},{"./util":36}],19:[function(_dereq_,module,exports){
-"use strict";
-module.exports =
-function(Promise, INTERNAL, tryConvertToPromise, apiRejection, debug) {
-var util = _dereq_("./util");
-var tryCatch = util.tryCatch;
-
-Promise.method = function (fn) {
-    if (typeof fn !== "function") {
-        throw new Promise.TypeError("expecting a function but got " + util.classString(fn));
-    }
-    return function () {
-        var ret = new Promise(INTERNAL);
-        ret._captureStackTrace();
-        ret._pushContext();
-        var value = tryCatch(fn).apply(this, arguments);
-        var promiseCreated = ret._popContext();
-        debug.checkForgottenReturns(
-            value, promiseCreated, "Promise.method", ret);
-        ret._resolveFromSyncValue(value);
-        return ret;
-    };
-};
-
-Promise.attempt = Promise["try"] = function (fn) {
-    if (typeof fn !== "function") {
-        return apiRejection("expecting a function but got " + util.classString(fn));
-    }
-    var ret = new Promise(INTERNAL);
-    ret._captureStackTrace();
-    ret._pushContext();
-    var value;
-    if (arguments.length > 1) {
-        debug.deprecated("calling Promise.try with more than 1 argument");
-        var arg = arguments[1];
-        var ctx = arguments[2];
-        value = util.isArray(arg) ? tryCatch(fn).apply(ctx, arg)
-                                  : tryCatch(fn).call(ctx, arg);
-    } else {
-        value = tryCatch(fn)();
-    }
-    var promiseCreated = ret._popContext();
-    debug.checkForgottenReturns(
-        value, promiseCreated, "Promise.try", ret);
-    ret._resolveFromSyncValue(value);
-    return ret;
-};
-
-Promise.prototype._resolveFromSyncValue = function (value) {
-    if (value === util.errorObj) {
-        this._rejectCallback(value.e, false);
-    } else {
-        this._resolveCallback(value, true);
-    }
-};
-};
-
-},{"./util":36}],20:[function(_dereq_,module,exports){
-"use strict";
-var util = _dereq_("./util");
-var maybeWrapAsError = util.maybeWrapAsError;
-var errors = _dereq_("./errors");
-var OperationalError = errors.OperationalError;
-var es5 = _dereq_("./es5");
-
-function isUntypedError(obj) {
-    return obj instanceof Error &&
-        es5.getPrototypeOf(obj) === Error.prototype;
-}
-
-var rErrorKey = /^(?:name|message|stack|cause)$/;
-function wrapAsOperationalError(obj) {
-    var ret;
-    if (isUntypedError(obj)) {
-        ret = new OperationalError(obj);
-        ret.name = obj.name;
-        ret.message = obj.message;
-        ret.stack = obj.stack;
-        var keys = es5.keys(obj);
-        for (var i = 0; i < keys.length; ++i) {
-            var key = keys[i];
-            if (!rErrorKey.test(key)) {
-                ret[key] = obj[key];
-            }
-        }
-        return ret;
-    }
-    util.markAsOriginatingFromRejection(obj);
-    return obj;
-}
-
-function nodebackForPromise(promise, multiArgs) {
-    return function(err, value) {
-        if (promise === null) return;
-        if (err) {
-            var wrapped = wrapAsOperationalError(maybeWrapAsError(err));
-            promise._attachExtraTrace(wrapped);
-            promise._reject(wrapped);
-        } else if (!multiArgs) {
-            promise._fulfill(value);
-        } else {
-            var args = [].slice.call(arguments, 1);;
-            promise._fulfill(args);
-        }
-        promise = null;
-    };
-}
-
-module.exports = nodebackForPromise;
-
-},{"./errors":12,"./es5":13,"./util":36}],21:[function(_dereq_,module,exports){
-"use strict";
-module.exports = function(Promise) {
-var util = _dereq_("./util");
-var async = Promise._async;
-var tryCatch = util.tryCatch;
-var errorObj = util.errorObj;
-
-function spreadAdapter(val, nodeback) {
-    var promise = this;
-    if (!util.isArray(val)) return successAdapter.call(promise, val, nodeback);
-    var ret =
-        tryCatch(nodeback).apply(promise._boundValue(), [null].concat(val));
-    if (ret === errorObj) {
-        async.throwLater(ret.e);
-    }
-}
-
-function successAdapter(val, nodeback) {
-    var promise = this;
-    var receiver = promise._boundValue();
-    var ret = val === undefined
-        ? tryCatch(nodeback).call(receiver, null)
-        : tryCatch(nodeback).call(receiver, null, val);
-    if (ret === errorObj) {
-        async.throwLater(ret.e);
-    }
-}
-function errorAdapter(reason, nodeback) {
-    var promise = this;
-    if (!reason) {
-        var newReason = new Error(reason + "");
-        newReason.cause = reason;
-        reason = newReason;
-    }
-    var ret = tryCatch(nodeback).call(promise._boundValue(), reason);
-    if (ret === errorObj) {
-        async.throwLater(ret.e);
-    }
-}
-
-Promise.prototype.asCallback = Promise.prototype.nodeify = function (nodeback,
-                                                                     options) {
-    if (typeof nodeback == "function") {
-        var adapter = successAdapter;
-        if (options !== undefined && Object(options).spread) {
-            adapter = spreadAdapter;
-        }
-        this._then(
-            adapter,
-            errorAdapter,
-            undefined,
-            this,
-            nodeback
-        );
-    }
-    return this;
-};
-};
-
-},{"./util":36}],22:[function(_dereq_,module,exports){
-"use strict";
-module.exports = function() {
-var makeSelfResolutionError = function () {
-    return new TypeError("circular promise resolution chain\u000a\u000a    See http://goo.gl/MqrFmX\u000a");
-};
-var reflectHandler = function() {
-    return new Promise.PromiseInspection(this._target());
-};
-var apiRejection = function(msg) {
-    return Promise.reject(new TypeError(msg));
-};
-function Proxyable() {}
-var UNDEFINED_BINDING = {};
-var util = _dereq_("./util");
-
-var getDomain;
-if (util.isNode) {
-    getDomain = function() {
-        var ret = process.domain;
-        if (ret === undefined) ret = null;
-        return ret;
-    };
-} else {
-    getDomain = function() {
-        return null;
-    };
-}
-util.notEnumerableProp(Promise, "_getDomain", getDomain);
-
-var es5 = _dereq_("./es5");
-var Async = _dereq_("./async");
-var async = new Async();
-es5.defineProperty(Promise, "_async", {value: async});
-var errors = _dereq_("./errors");
-var TypeError = Promise.TypeError = errors.TypeError;
-Promise.RangeError = errors.RangeError;
-var CancellationError = Promise.CancellationError = errors.CancellationError;
-Promise.TimeoutError = errors.TimeoutError;
-Promise.OperationalError = errors.OperationalError;
-Promise.RejectionError = errors.OperationalError;
-Promise.AggregateError = errors.AggregateError;
-var INTERNAL = function(){};
-var APPLY = {};
-var NEXT_FILTER = {};
-var tryConvertToPromise = _dereq_("./thenables")(Promise, INTERNAL);
-var PromiseArray =
-    _dereq_("./promise_array")(Promise, INTERNAL,
-                               tryConvertToPromise, apiRejection, Proxyable);
-var Context = _dereq_("./context")(Promise);
- /*jshint unused:false*/
-var createContext = Context.create;
-var debug = _dereq_("./debuggability")(Promise, Context);
-var CapturedTrace = debug.CapturedTrace;
-var PassThroughHandlerContext =
-    _dereq_("./finally")(Promise, tryConvertToPromise);
-var catchFilter = _dereq_("./catch_filter")(NEXT_FILTER);
-var nodebackForPromise = _dereq_("./nodeback");
-var errorObj = util.errorObj;
-var tryCatch = util.tryCatch;
-function check(self, executor) {
-    if (typeof executor !== "function") {
-        throw new TypeError("expecting a function but got " + util.classString(executor));
-    }
-    if (self.constructor !== Promise) {
-        throw new TypeError("the promise constructor cannot be invoked directly\u000a\u000a    See http://goo.gl/MqrFmX\u000a");
-    }
-}
-
-function Promise(executor) {
-    this._bitField = 0;
-    this._fulfillmentHandler0 = undefined;
-    this._rejectionHandler0 = undefined;
-    this._promise0 = undefined;
-    this._receiver0 = undefined;
-    if (executor !== INTERNAL) {
-        check(this, executor);
-        this._resolveFromExecutor(executor);
-    }
-    this._promiseCreated();
-    this._fireEvent("promiseCreated", this);
-}
-
-Promise.prototype.toString = function () {
-    return "[object Promise]";
-};
-
-Promise.prototype.caught = Promise.prototype["catch"] = function (fn) {
-    var len = arguments.length;
-    if (len > 1) {
-        var catchInstances = new Array(len - 1),
-            j = 0, i;
-        for (i = 0; i < len - 1; ++i) {
-            var item = arguments[i];
-            if (util.isObject(item)) {
-                catchInstances[j++] = item;
-            } else {
-                return apiRejection("expecting an object but got " +
-                    "A catch statement predicate " + util.classString(item));
-            }
-        }
-        catchInstances.length = j;
-        fn = arguments[i];
-        return this.then(undefined, catchFilter(catchInstances, fn, this));
-    }
-    return this.then(undefined, fn);
-};
-
-Promise.prototype.reflect = function () {
-    return this._then(reflectHandler,
-        reflectHandler, undefined, this, undefined);
-};
-
-Promise.prototype.then = function (didFulfill, didReject) {
-    if (debug.warnings() && arguments.length > 0 &&
-        typeof didFulfill !== "function" &&
-        typeof didReject !== "function") {
-        var msg = ".then() only accepts functions but was passed: " +
-                util.classString(didFulfill);
-        if (arguments.length > 1) {
-            msg += ", " + util.classString(didReject);
-        }
-        this._warn(msg);
-    }
-    return this._then(didFulfill, didReject, undefined, undefined, undefined);
-};
-
-Promise.prototype.done = function (didFulfill, didReject) {
-    var promise =
-        this._then(didFulfill, didReject, undefined, undefined, undefined);
-    promise._setIsFinal();
-};
-
-Promise.prototype.spread = function (fn) {
-    if (typeof fn !== "function") {
-        return apiRejection("expecting a function but got " + util.classString(fn));
-    }
-    return this.all()._then(fn, undefined, undefined, APPLY, undefined);
-};
-
-Promise.prototype.toJSON = function () {
-    var ret = {
-        isFulfilled: false,
-        isRejected: false,
-        fulfillmentValue: undefined,
-        rejectionReason: undefined
-    };
-    if (this.isFulfilled()) {
-        ret.fulfillmentValue = this.value();
-        ret.isFulfilled = true;
-    } else if (this.isRejected()) {
-        ret.rejectionReason = this.reason();
-        ret.isRejected = true;
-    }
-    return ret;
-};
-
-Promise.prototype.all = function () {
-    if (arguments.length > 0) {
-        this._warn(".all() was passed arguments but it does not take any");
-    }
-    return new PromiseArray(this).promise();
-};
-
-Promise.prototype.error = function (fn) {
-    return this.caught(util.originatesFromRejection, fn);
-};
-
-Promise.getNewLibraryCopy = module.exports;
-
-Promise.is = function (val) {
-    return val instanceof Promise;
-};
-
-Promise.fromNode = Promise.fromCallback = function(fn) {
-    var ret = new Promise(INTERNAL);
-    ret._captureStackTrace();
-    var multiArgs = arguments.length > 1 ? !!Object(arguments[1]).multiArgs
-                                         : false;
-    var result = tryCatch(fn)(nodebackForPromise(ret, multiArgs));
-    if (result === errorObj) {
-        ret._rejectCallback(result.e, true);
-    }
-    if (!ret._isFateSealed()) ret._setAsyncGuaranteed();
-    return ret;
-};
-
-Promise.all = function (promises) {
-    return new PromiseArray(promises).promise();
-};
-
-Promise.cast = function (obj) {
-    var ret = tryConvertToPromise(obj);
-    if (!(ret instanceof Promise)) {
-        ret = new Promise(INTERNAL);
-        ret._captureStackTrace();
-        ret._setFulfilled();
-        ret._rejectionHandler0 = obj;
-    }
-    return ret;
-};
-
-Promise.resolve = Promise.fulfilled = Promise.cast;
-
-Promise.reject = Promise.rejected = function (reason) {
-    var ret = new Promise(INTERNAL);
-    ret._captureStackTrace();
-    ret._rejectCallback(reason, true);
-    return ret;
-};
-
-Promise.setScheduler = function(fn) {
-    if (typeof fn !== "function") {
-        throw new TypeError("expecting a function but got " + util.classString(fn));
-    }
-    return async.setScheduler(fn);
-};
-
-Promise.prototype._then = function (
-    didFulfill,
-    didReject,
-    _,    receiver,
-    internalData
-) {
-    var haveInternalData = internalData !== undefined;
-    var promise = haveInternalData ? internalData : new Promise(INTERNAL);
-    var target = this._target();
-    var bitField = target._bitField;
-
-    if (!haveInternalData) {
-        promise._propagateFrom(this, 3);
-        promise._captureStackTrace();
-        if (receiver === undefined &&
-            ((this._bitField & 2097152) !== 0)) {
-            if (!((bitField & 50397184) === 0)) {
-                receiver = this._boundValue();
-            } else {
-                receiver = target === this ? undefined : this._boundTo;
-            }
-        }
-        this._fireEvent("promiseChained", this, promise);
-    }
-
-    var domain = getDomain();
-    if (!((bitField & 50397184) === 0)) {
-        var handler, value, settler = target._settlePromiseCtx;
-        if (((bitField & 33554432) !== 0)) {
-            value = target._rejectionHandler0;
-            handler = didFulfill;
-        } else if (((bitField & 16777216) !== 0)) {
-            value = target._fulfillmentHandler0;
-            handler = didReject;
-            target._unsetRejectionIsUnhandled();
-        } else {
-            settler = target._settlePromiseLateCancellationObserver;
-            value = new CancellationError("late cancellation observer");
-            target._attachExtraTrace(value);
-            handler = didReject;
-        }
-
-        async.invoke(settler, target, {
-            handler: domain === null ? handler
-                : (typeof handler === "function" &&
-                    util.domainBind(domain, handler)),
-            promise: promise,
-            receiver: receiver,
-            value: value
-        });
-    } else {
-        target._addCallbacks(didFulfill, didReject, promise, receiver, domain);
-    }
-
-    return promise;
-};
-
-Promise.prototype._length = function () {
-    return this._bitField & 65535;
-};
-
-Promise.prototype._isFateSealed = function () {
-    return (this._bitField & 117506048) !== 0;
-};
-
-Promise.prototype._isFollowing = function () {
-    return (this._bitField & 67108864) === 67108864;
-};
-
-Promise.prototype._setLength = function (len) {
-    this._bitField = (this._bitField & -65536) |
-        (len & 65535);
-};
-
-Promise.prototype._setFulfilled = function () {
-    this._bitField = this._bitField | 33554432;
-    this._fireEvent("promiseFulfilled", this);
-};
-
-Promise.prototype._setRejected = function () {
-    this._bitField = this._bitField | 16777216;
-    this._fireEvent("promiseRejected", this);
-};
-
-Promise.prototype._setFollowing = function () {
-    this._bitField = this._bitField | 67108864;
-    this._fireEvent("promiseResolved", this);
-};
-
-Promise.prototype._setIsFinal = function () {
-    this._bitField = this._bitField | 4194304;
-};
-
-Promise.prototype._isFinal = function () {
-    return (this._bitField & 4194304) > 0;
-};
-
-Promise.prototype._unsetCancelled = function() {
-    this._bitField = this._bitField & (~65536);
-};
-
-Promise.prototype._setCancelled = function() {
-    this._bitField = this._bitField | 65536;
-    this._fireEvent("promiseCancelled", this);
-};
-
-Promise.prototype._setWillBeCancelled = function() {
-    this._bitField = this._bitField | 8388608;
-};
-
-Promise.prototype._setAsyncGuaranteed = function() {
-    if (async.hasCustomScheduler()) return;
-    this._bitField = this._bitField | 134217728;
-};
-
-Promise.prototype._receiverAt = function (index) {
-    var ret = index === 0 ? this._receiver0 : this[
-            index * 4 - 4 + 3];
-    if (ret === UNDEFINED_BINDING) {
-        return undefined;
-    } else if (ret === undefined && this._isBound()) {
-        return this._boundValue();
-    }
-    return ret;
-};
-
-Promise.prototype._promiseAt = function (index) {
-    return this[
-            index * 4 - 4 + 2];
-};
-
-Promise.prototype._fulfillmentHandlerAt = function (index) {
-    return this[
-            index * 4 - 4 + 0];
-};
-
-Promise.prototype._rejectionHandlerAt = function (index) {
-    return this[
-            index * 4 - 4 + 1];
-};
-
-Promise.prototype._boundValue = function() {};
-
-Promise.prototype._migrateCallback0 = function (follower) {
-    var bitField = follower._bitField;
-    var fulfill = follower._fulfillmentHandler0;
-    var reject = follower._rejectionHandler0;
-    var promise = follower._promise0;
-    var receiver = follower._receiverAt(0);
-    if (receiver === undefined) receiver = UNDEFINED_BINDING;
-    this._addCallbacks(fulfill, reject, promise, receiver, null);
-};
-
-Promise.prototype._migrateCallbackAt = function (follower, index) {
-    var fulfill = follower._fulfillmentHandlerAt(index);
-    var reject = follower._rejectionHandlerAt(index);
-    var promise = follower._promiseAt(index);
-    var receiver = follower._receiverAt(index);
-    if (receiver === undefined) receiver = UNDEFINED_BINDING;
-    this._addCallbacks(fulfill, reject, promise, receiver, null);
-};
-
-Promise.prototype._addCallbacks = function (
-    fulfill,
-    reject,
-    promise,
-    receiver,
-    domain
-) {
-    var index = this._length();
-
-    if (index >= 65535 - 4) {
-        index = 0;
-        this._setLength(0);
-    }
-
-    if (index === 0) {
-        this._promise0 = promise;
-        this._receiver0 = receiver;
-        if (typeof fulfill === "function") {
-            this._fulfillmentHandler0 =
-                domain === null ? fulfill : util.domainBind(domain, fulfill);
-        }
-        if (typeof reject === "function") {
-            this._rejectionHandler0 =
-                domain === null ? reject : util.domainBind(domain, reject);
-        }
-    } else {
-        var base = index * 4 - 4;
-        this[base + 2] = promise;
-        this[base + 3] = receiver;
-        if (typeof fulfill === "function") {
-            this[base + 0] =
-                domain === null ? fulfill : util.domainBind(domain, fulfill);
-        }
-        if (typeof reject === "function") {
-            this[base + 1] =
-                domain === null ? reject : util.domainBind(domain, reject);
-        }
-    }
-    this._setLength(index + 1);
-    return index;
-};
-
-Promise.prototype._proxy = function (proxyable, arg) {
-    this._addCallbacks(undefined, undefined, arg, proxyable, null);
-};
-
-Promise.prototype._resolveCallback = function(value, shouldBind) {
-    if (((this._bitField & 117506048) !== 0)) return;
-    if (value === this)
-        return this._rejectCallback(makeSelfResolutionError(), false);
-    var maybePromise = tryConvertToPromise(value, this);
-    if (!(maybePromise instanceof Promise)) return this._fulfill(value);
-
-    if (shouldBind) this._propagateFrom(maybePromise, 2);
-
-    var promise = maybePromise._target();
-
-    if (promise === this) {
-        this._reject(makeSelfResolutionError());
-        return;
-    }
-
-    var bitField = promise._bitField;
-    if (((bitField & 50397184) === 0)) {
-        var len = this._length();
-        if (len > 0) promise._migrateCallback0(this);
-        for (var i = 1; i < len; ++i) {
-            promise._migrateCallbackAt(this, i);
-        }
-        this._setFollowing();
-        this._setLength(0);
-        this._setFollowee(promise);
-    } else if (((bitField & 33554432) !== 0)) {
-        this._fulfill(promise._value());
-    } else if (((bitField & 16777216) !== 0)) {
-        this._reject(promise._reason());
-    } else {
-        var reason = new CancellationError("late cancellation observer");
-        promise._attachExtraTrace(reason);
-        this._reject(reason);
-    }
-};
-
-Promise.prototype._rejectCallback =
-function(reason, synchronous, ignoreNonErrorWarnings) {
-    var trace = util.ensureErrorObject(reason);
-    var hasStack = trace === reason;
-    if (!hasStack && !ignoreNonErrorWarnings && debug.warnings()) {
-        var message = "a promise was rejected with a non-error: " +
-            util.classString(reason);
-        this._warn(message, true);
-    }
-    this._attachExtraTrace(trace, synchronous ? hasStack : false);
-    this._reject(reason);
-};
-
-Promise.prototype._resolveFromExecutor = function (executor) {
-    var promise = this;
-    this._captureStackTrace();
-    this._pushContext();
-    var synchronous = true;
-    var r = this._execute(executor, function(value) {
-        promise._resolveCallback(value);
-    }, function (reason) {
-        promise._rejectCallback(reason, synchronous);
-    });
-    synchronous = false;
-    this._popContext();
-
-    if (r !== undefined) {
-        promise._rejectCallback(r, true);
-    }
-};
-
-Promise.prototype._settlePromiseFromHandler = function (
-    handler, receiver, value, promise
-) {
-    var bitField = promise._bitField;
-    if (((bitField & 65536) !== 0)) return;
-    promise._pushContext();
-    var x;
-    if (receiver === APPLY) {
-        if (!value || typeof value.length !== "number") {
-            x = errorObj;
-            x.e = new TypeError("cannot .spread() a non-array: " +
-                                    util.classString(value));
-        } else {
-            x = tryCatch(handler).apply(this._boundValue(), value);
-        }
-    } else {
-        x = tryCatch(handler).call(receiver, value);
-    }
-    var promiseCreated = promise._popContext();
-    bitField = promise._bitField;
-    if (((bitField & 65536) !== 0)) return;
-
-    if (x === NEXT_FILTER) {
-        promise._reject(value);
-    } else if (x === errorObj) {
-        promise._rejectCallback(x.e, false);
-    } else {
-        debug.checkForgottenReturns(x, promiseCreated, "",  promise, this);
-        promise._resolveCallback(x);
-    }
-};
-
-Promise.prototype._target = function() {
-    var ret = this;
-    while (ret._isFollowing()) ret = ret._followee();
-    return ret;
-};
-
-Promise.prototype._followee = function() {
-    return this._rejectionHandler0;
-};
-
-Promise.prototype._setFollowee = function(promise) {
-    this._rejectionHandler0 = promise;
-};
-
-Promise.prototype._settlePromise = function(promise, handler, receiver, value) {
-    var isPromise = promise instanceof Promise;
-    var bitField = this._bitField;
-    var asyncGuaranteed = ((bitField & 134217728) !== 0);
-    if (((bitField & 65536) !== 0)) {
-        if (isPromise) promise._invokeInternalOnCancel();
-
-        if (receiver instanceof PassThroughHandlerContext &&
-            receiver.isFinallyHandler()) {
-            receiver.cancelPromise = promise;
-            if (tryCatch(handler).call(receiver, value) === errorObj) {
-                promise._reject(errorObj.e);
-            }
-        } else if (handler === reflectHandler) {
-            promise._fulfill(reflectHandler.call(receiver));
-        } else if (receiver instanceof Proxyable) {
-            receiver._promiseCancelled(promise);
-        } else if (isPromise || promise instanceof PromiseArray) {
-            promise._cancel();
-        } else {
-            receiver.cancel();
-        }
-    } else if (typeof handler === "function") {
-        if (!isPromise) {
-            handler.call(receiver, value, promise);
-        } else {
-            if (asyncGuaranteed) promise._setAsyncGuaranteed();
-            this._settlePromiseFromHandler(handler, receiver, value, promise);
-        }
-    } else if (receiver instanceof Proxyable) {
-        if (!receiver._isResolved()) {
-            if (((bitField & 33554432) !== 0)) {
-                receiver._promiseFulfilled(value, promise);
-            } else {
-                receiver._promiseRejected(value, promise);
-            }
-        }
-    } else if (isPromise) {
-        if (asyncGuaranteed) promise._setAsyncGuaranteed();
-        if (((bitField & 33554432) !== 0)) {
-            promise._fulfill(value);
-        } else {
-            promise._reject(value);
-        }
-    }
-};
-
-Promise.prototype._settlePromiseLateCancellationObserver = function(ctx) {
-    var handler = ctx.handler;
-    var promise = ctx.promise;
-    var receiver = ctx.receiver;
-    var value = ctx.value;
-    if (typeof handler === "function") {
-        if (!(promise instanceof Promise)) {
-            handler.call(receiver, value, promise);
-        } else {
-            this._settlePromiseFromHandler(handler, receiver, value, promise);
-        }
-    } else if (promise instanceof Promise) {
-        promise._reject(value);
-    }
-};
-
-Promise.prototype._settlePromiseCtx = function(ctx) {
-    this._settlePromise(ctx.promise, ctx.handler, ctx.receiver, ctx.value);
-};
-
-Promise.prototype._settlePromise0 = function(handler, value, bitField) {
-    var promise = this._promise0;
-    var receiver = this._receiverAt(0);
-    this._promise0 = undefined;
-    this._receiver0 = undefined;
-    this._settlePromise(promise, handler, receiver, value);
-};
-
-Promise.prototype._clearCallbackDataAtIndex = function(index) {
-    var base = index * 4 - 4;
-    this[base + 2] =
-    this[base + 3] =
-    this[base + 0] =
-    this[base + 1] = undefined;
-};
-
-Promise.prototype._fulfill = function (value) {
-    var bitField = this._bitField;
-    if (((bitField & 117506048) >>> 16)) return;
-    if (value === this) {
-        var err = makeSelfResolutionError();
-        this._attachExtraTrace(err);
-        return this._reject(err);
-    }
-    this._setFulfilled();
-    this._rejectionHandler0 = value;
-
-    if ((bitField & 65535) > 0) {
-        if (((bitField & 134217728) !== 0)) {
-            this._settlePromises();
-        } else {
-            async.settlePromises(this);
-        }
-    }
-};
-
-Promise.prototype._reject = function (reason) {
-    var bitField = this._bitField;
-    if (((bitField & 117506048) >>> 16)) return;
-    this._setRejected();
-    this._fulfillmentHandler0 = reason;
-
-    if (this._isFinal()) {
-        return async.fatalError(reason, util.isNode);
-    }
-
-    if ((bitField & 65535) > 0) {
-        async.settlePromises(this);
-    } else {
-        this._ensurePossibleRejectionHandled();
-    }
-};
-
-Promise.prototype._fulfillPromises = function (len, value) {
-    for (var i = 1; i < len; i++) {
-        var handler = this._fulfillmentHandlerAt(i);
-        var promise = this._promiseAt(i);
-        var receiver = this._receiverAt(i);
-        this._clearCallbackDataAtIndex(i);
-        this._settlePromise(promise, handler, receiver, value);
-    }
-};
-
-Promise.prototype._rejectPromises = function (len, reason) {
-    for (var i = 1; i < len; i++) {
-        var handler = this._rejectionHandlerAt(i);
-        var promise = this._promiseAt(i);
-        var receiver = this._receiverAt(i);
-        this._clearCallbackDataAtIndex(i);
-        this._settlePromise(promise, handler, receiver, reason);
-    }
-};
-
-Promise.prototype._settlePromises = function () {
-    var bitField = this._bitField;
-    var len = (bitField & 65535);
-
-    if (len > 0) {
-        if (((bitField & 16842752) !== 0)) {
-            var reason = this._fulfillmentHandler0;
-            this._settlePromise0(this._rejectionHandler0, reason, bitField);
-            this._rejectPromises(len, reason);
-        } else {
-            var value = this._rejectionHandler0;
-            this._settlePromise0(this._fulfillmentHandler0, value, bitField);
-            this._fulfillPromises(len, value);
-        }
-        this._setLength(0);
-    }
-    this._clearCancellationData();
-};
-
-Promise.prototype._settledValue = function() {
-    var bitField = this._bitField;
-    if (((bitField & 33554432) !== 0)) {
-        return this._rejectionHandler0;
-    } else if (((bitField & 16777216) !== 0)) {
-        return this._fulfillmentHandler0;
-    }
-};
-
-function deferResolve(v) {this.promise._resolveCallback(v);}
-function deferReject(v) {this.promise._rejectCallback(v, false);}
-
-Promise.defer = Promise.pending = function() {
-    debug.deprecated("Promise.defer", "new Promise");
-    var promise = new Promise(INTERNAL);
-    return {
-        promise: promise,
-        resolve: deferResolve,
-        reject: deferReject
-    };
-};
-
-util.notEnumerableProp(Promise,
-                       "_makeSelfResolutionError",
-                       makeSelfResolutionError);
-
-_dereq_("./method")(Promise, INTERNAL, tryConvertToPromise, apiRejection,
-    debug);
-_dereq_("./bind")(Promise, INTERNAL, tryConvertToPromise, debug);
-_dereq_("./cancel")(Promise, PromiseArray, apiRejection, debug);
-_dereq_("./direct_resolve")(Promise);
-_dereq_("./synchronous_inspection")(Promise);
-_dereq_("./join")(
-    Promise, PromiseArray, tryConvertToPromise, INTERNAL, async, getDomain);
-Promise.Promise = Promise;
-Promise.version = "3.4.5";
-_dereq_('./map.js')(Promise, PromiseArray, apiRejection, tryConvertToPromise, INTERNAL, debug);
-_dereq_('./call_get.js')(Promise);
-_dereq_('./using.js')(Promise, apiRejection, tryConvertToPromise, createContext, INTERNAL, debug);
-_dereq_('./timers.js')(Promise, INTERNAL, debug);
-_dereq_('./generators.js')(Promise, apiRejection, INTERNAL, tryConvertToPromise, Proxyable, debug);
-_dereq_('./nodeify.js')(Promise);
-_dereq_('./promisify.js')(Promise, INTERNAL);
-_dereq_('./props.js')(Promise, PromiseArray, tryConvertToPromise, apiRejection);
-_dereq_('./race.js')(Promise, INTERNAL, tryConvertToPromise, apiRejection);
-_dereq_('./reduce.js')(Promise, PromiseArray, apiRejection, tryConvertToPromise, INTERNAL, debug);
-_dereq_('./settle.js')(Promise, PromiseArray, debug);
-_dereq_('./some.js')(Promise, PromiseArray, apiRejection);
-_dereq_('./filter.js')(Promise, INTERNAL);
-_dereq_('./each.js')(Promise, INTERNAL);
-_dereq_('./any.js')(Promise);
-                                                         
-    util.toFastProperties(Promise);                                          
-    util.toFastProperties(Promise.prototype);                                
-    function fillTypes(value) {                                              
-        var p = new Promise(INTERNAL);                                       
-        p._fulfillmentHandler0 = value;                                      
-        p._rejectionHandler0 = value;                                        
-        p._promise0 = value;                                                 
-        p._receiver0 = value;                                                
-    }                                                                        
-    // Complete slack tracking, opt out of field-type tracking and           
-    // stabilize map                                                         
-    fillTypes({a: 1});                                                       
-    fillTypes({b: 2});                                                       
-    fillTypes({c: 3});                                                       
-    fillTypes(1);                                                            
-    fillTypes(function(){});                                                 
-    fillTypes(undefined);                                                    
-    fillTypes(false);                                                        
-    fillTypes(new Promise(INTERNAL));                                        
-    debug.setBounds(Async.firstLineError, util.lastLineError);               
-    return Promise;                                                          
-
-};
-
-},{"./any.js":1,"./async":2,"./bind":3,"./call_get.js":5,"./cancel":6,"./catch_filter":7,"./context":8,"./debuggability":9,"./direct_resolve":10,"./each.js":11,"./errors":12,"./es5":13,"./filter.js":14,"./finally":15,"./generators.js":16,"./join":17,"./map.js":18,"./method":19,"./nodeback":20,"./nodeify.js":21,"./promise_array":23,"./promisify.js":24,"./props.js":25,"./race.js":27,"./reduce.js":28,"./settle.js":30,"./some.js":31,"./synchronous_inspection":32,"./thenables":33,"./timers.js":34,"./using.js":35,"./util":36}],23:[function(_dereq_,module,exports){
-"use strict";
-module.exports = function(Promise, INTERNAL, tryConvertToPromise,
-    apiRejection, Proxyable) {
-var util = _dereq_("./util");
-var isArray = util.isArray;
-
-function toResolutionValue(val) {
-    switch(val) {
-    case -2: return [];
-    case -3: return {};
-    }
-}
-
-function PromiseArray(values) {
-    var promise = this._promise = new Promise(INTERNAL);
-    if (values instanceof Promise) {
-        promise._propagateFrom(values, 3);
-    }
-    promise._setOnCancel(this);
-    this._values = values;
-    this._length = 0;
-    this._totalResolved = 0;
-    this._init(undefined, -2);
-}
-util.inherits(PromiseArray, Proxyable);
-
-PromiseArray.prototype.length = function () {
-    return this._length;
-};
-
-PromiseArray.prototype.promise = function () {
-    return this._promise;
-};
-
-PromiseArray.prototype._init = function init(_, resolveValueIfEmpty) {
-    var values = tryConvertToPromise(this._values, this._promise);
-    if (values instanceof Promise) {
-        values = values._target();
-        var bitField = values._bitField;
-        ;
-        this._values = values;
-
-        if (((bitField & 50397184) === 0)) {
-            this._promise._setAsyncGuaranteed();
-            return values._then(
-                init,
-                this._reject,
-                undefined,
-                this,
-                resolveValueIfEmpty
-           );
-        } else if (((bitField & 33554432) !== 0)) {
-            values = values._value();
-        } else if (((bitField & 16777216) !== 0)) {
-            return this._reject(values._reason());
-        } else {
-            return this._cancel();
-        }
-    }
-    values = util.asArray(values);
-    if (values === null) {
-        var err = apiRejection(
-            "expecting an array or an iterable object but got " + util.classString(values)).reason();
-        this._promise._rejectCallback(err, false);
-        return;
-    }
-
-    if (values.length === 0) {
-        if (resolveValueIfEmpty === -5) {
-            this._resolveEmptyArray();
-        }
-        else {
-            this._resolve(toResolutionValue(resolveValueIfEmpty));
-        }
-        return;
-    }
-    this._iterate(values);
-};
-
-PromiseArray.prototype._iterate = function(values) {
-    var len = this.getActualLength(values.length);
-    this._length = len;
-    this._values = this.shouldCopyValues() ? new Array(len) : this._values;
-    var result = this._promise;
-    var isResolved = false;
-    var bitField = null;
-    for (var i = 0; i < len; ++i) {
-        var maybePromise = tryConvertToPromise(values[i], result);
-
-        if (maybePromise instanceof Promise) {
-            maybePromise = maybePromise._target();
-            bitField = maybePromise._bitField;
-        } else {
-            bitField = null;
-        }
-
-        if (isResolved) {
-            if (bitField !== null) {
-                maybePromise.suppressUnhandledRejections();
-            }
-        } else if (bitField !== null) {
-            if (((bitField & 50397184) === 0)) {
-                maybePromise._proxy(this, i);
-                this._values[i] = maybePromise;
-            } else if (((bitField & 33554432) !== 0)) {
-                isResolved = this._promiseFulfilled(maybePromise._value(), i);
-            } else if (((bitField & 16777216) !== 0)) {
-                isResolved = this._promiseRejected(maybePromise._reason(), i);
-            } else {
-                isResolved = this._promiseCancelled(i);
-            }
-        } else {
-            isResolved = this._promiseFulfilled(maybePromise, i);
-        }
-    }
-    if (!isResolved) result._setAsyncGuaranteed();
-};
-
-PromiseArray.prototype._isResolved = function () {
-    return this._values === null;
-};
-
-PromiseArray.prototype._resolve = function (value) {
-    this._values = null;
-    this._promise._fulfill(value);
-};
-
-PromiseArray.prototype._cancel = function() {
-    if (this._isResolved() || !this._promise._isCancellable()) return;
-    this._values = null;
-    this._promise._cancel();
-};
-
-PromiseArray.prototype._reject = function (reason) {
-    this._values = null;
-    this._promise._rejectCallback(reason, false);
-};
-
-PromiseArray.prototype._promiseFulfilled = function (value, index) {
-    this._values[index] = value;
-    var totalResolved = ++this._totalResolved;
-    if (totalResolved >= this._length) {
-        this._resolve(this._values);
-        return true;
-    }
-    return false;
-};
-
-PromiseArray.prototype._promiseCancelled = function() {
-    this._cancel();
-    return true;
-};
-
-PromiseArray.prototype._promiseRejected = function (reason) {
-    this._totalResolved++;
-    this._reject(reason);
-    return true;
-};
-
-PromiseArray.prototype._resultCancelled = function() {
-    if (this._isResolved()) return;
-    var values = this._values;
-    this._cancel();
-    if (values instanceof Promise) {
-        values.cancel();
-    } else {
-        for (var i = 0; i < values.length; ++i) {
-            if (values[i] instanceof Promise) {
-                values[i].cancel();
-            }
-        }
-    }
-};
-
-PromiseArray.prototype.shouldCopyValues = function () {
-    return true;
-};
-
-PromiseArray.prototype.getActualLength = function (len) {
-    return len;
-};
-
-return PromiseArray;
-};
-
-},{"./util":36}],24:[function(_dereq_,module,exports){
-"use strict";
-module.exports = function(Promise, INTERNAL) {
-var THIS = {};
-var util = _dereq_("./util");
-var nodebackForPromise = _dereq_("./nodeback");
-var withAppended = util.withAppended;
-var maybeWrapAsError = util.maybeWrapAsError;
-var canEvaluate = util.canEvaluate;
-var TypeError = _dereq_("./errors").TypeError;
-var defaultSuffix = "Async";
-var defaultPromisified = {__isPromisified__: true};
-var noCopyProps = [
-    "arity",    "length",
-    "name",
-    "arguments",
-    "caller",
-    "callee",
-    "prototype",
-    "__isPromisified__"
-];
-var noCopyPropsPattern = new RegExp("^(?:" + noCopyProps.join("|") + ")$");
-
-var defaultFilter = function(name) {
-    return util.isIdentifier(name) &&
-        name.charAt(0) !== "_" &&
-        name !== "constructor";
-};
-
-function propsFilter(key) {
-    return !noCopyPropsPattern.test(key);
-}
-
-function isPromisified(fn) {
-    try {
-        return fn.__isPromisified__ === true;
-    }
-    catch (e) {
-        return false;
-    }
-}
-
-function hasPromisified(obj, key, suffix) {
-    var val = util.getDataPropertyOrDefault(obj, key + suffix,
-                                            defaultPromisified);
-    return val ? isPromisified(val) : false;
-}
-function checkValid(ret, suffix, suffixRegexp) {
-    for (var i = 0; i < ret.length; i += 2) {
-        var key = ret[i];
-        if (suffixRegexp.test(key)) {
-            var keyWithoutAsyncSuffix = key.replace(suffixRegexp, "");
-            for (var j = 0; j < ret.length; j += 2) {
-                if (ret[j] === keyWithoutAsyncSuffix) {
-                    throw new TypeError("Cannot promisify an API that has normal methods with '%s'-suffix\u000a\u000a    See http://goo.gl/MqrFmX\u000a"
-                        .replace("%s", suffix));
+              };
+
+              var argumentSequence = function(argumentCount) {
+                return util.filledRange(argumentCount, "_arg", "");
+              };
+
+              var parameterDeclaration = function(parameterCount) {
+                return util.filledRange(
+                    Math.max(parameterCount, 3), "_arg", "");
+              };
+
+              var parameterCount = function(fn) {
+                if (typeof fn.length === "number") {
+                  return Math.max(Math.min(fn.length, 1023 + 1), 0);
                 }
+                return 0;
+              };
+
+              makeNodePromisifiedEval =
+                function(callback, receiver, originalName, fn, _, multiArgs) {
+                var newParameterCount = Math.max(0, parameterCount(fn) - 1);
+                var argumentOrder = switchCaseArgumentOrder(newParameterCount);
+                var shouldProxyThis = typeof callback === "string" || receiver === THIS;
+
+                function generateCallForArgumentCount(count) {
+                  var args = argumentSequence(count).join(", ");
+                  var comma = count > 0 ? ", " : "";
+                  var ret;
+                  if (shouldProxyThis) {
+                    ret = "ret = callback.call(this, {{args}}, nodeback); break;\n";
+                  } else {
+                    ret = receiver === undefined
+                    ? "ret = callback({{args}}, nodeback); break;\n"
+                        : "ret = callback.call(receiver, {{args}}, nodeback); break;\n";
+                  }
+                  return ret.replace("{{args}}", args).replace(", ", comma);
+                }
+
+                function generateArgumentSwitchCase() {
+                  var ret = "";
+                  for (var i = 0; i < argumentOrder.length; ++i) {
+                    ret += "case " + argumentOrder[i] +":" +
+                    generateCallForArgumentCount(argumentOrder[i]);
+                  }
+
+                  ret += "                                                             \n\
+                    default:                                                             \n\
+                    var args = new Array(len + 1);                                   \n\
+                    var i = 0;                                                       \n\
+                    for (var i = 0; i < len; ++i) {                                  \n\
+                    args[i] = arguments[i];                                       \n\
+                    }                                                                \n\
+                    args[i] = nodeback;                                              \n\
+                    [CodeForCall]                                                    \n\
+                    break;                                                           \n\
+                    ".replace("[CodeForCall]", (shouldProxyThis
+                        ? "ret = callback.apply(this, args);\n"
+                            : "ret = callback.apply(receiver, args);\n"));
+                  return ret;
+                }
+
+                var getFunctionCode = typeof callback === "string"
+                  ? ("this != null ? this['"+callback+"'] : fn")
+                      : "fn";
+                  var body = "'use strict';                                                \n\
+                    var ret = function (Parameters) {                                    \n\
+                    'use strict';                                                    \n\
+                    var len = arguments.length;                                      \n\
+                    var promise = new Promise(INTERNAL);                             \n\
+                    promise._captureStackTrace();                                    \n\
+                    var nodeback = nodebackForPromise(promise, " + multiArgs + ");   \n\
+                    var ret;                                                         \n\
+                    var callback = tryCatch([GetFunctionCode]);                      \n\
+                    switch(len) {                                                    \n\
+                    [CodeForSwitchCase]                                          \n\
+                    }                                                                \n\
+                    if (ret === errorObj) {                                          \n\
+                    promise._rejectCallback(maybeWrapAsError(ret.e), true, true);\n\
+                    }                                                                \n\
+                    if (!promise._isFateSealed()) promise._setAsyncGuaranteed();     \n\
+                    return promise;                                                  \n\
+                    };                                                                   \n\
+                    notEnumerableProp(ret, '__isPromisified__', true);                   \n\
+                    return ret;                                                          \n\
+                    ".replace("[CodeForSwitchCase]", generateArgumentSwitchCase())
+                    .replace("[GetFunctionCode]", getFunctionCode);
+                  body = body.replace("Parameters", parameterDeclaration(newParameterCount));
+                  return new Function("Promise",
+                      "fn",
+                      "receiver",
+                      "withAppended",
+                      "maybeWrapAsError",
+                      "nodebackForPromise",
+                      "tryCatch",
+                      "errorObj",
+                      "notEnumerableProp",
+                      "INTERNAL",
+                      body)(
+                          Promise,
+                          fn,
+                          receiver,
+                          withAppended,
+                          maybeWrapAsError,
+                          nodebackForPromise,
+                          util.tryCatch,
+                          util.errorObj,
+                          util.notEnumerableProp,
+                          INTERNAL);
+              };
             }
-        }
-    }
-}
 
-function promisifiableMethods(obj, suffix, suffixRegexp, filter) {
-    var keys = util.inheritedDataKeys(obj);
-    var ret = [];
-    for (var i = 0; i < keys.length; ++i) {
-        var key = keys[i];
-        var value = obj[key];
-        var passesDefaultFilter = filter === defaultFilter
-            ? true : defaultFilter(key, value, obj);
-        if (typeof value === "function" &&
-            !isPromisified(value) &&
-            !hasPromisified(obj, key, suffix) &&
-            filter(key, value, obj, passesDefaultFilter)) {
-            ret.push(key, value);
-        }
-    }
-    checkValid(ret, suffix, suffixRegexp);
-    return ret;
-}
-
-var escapeIdentRegex = function(str) {
-    return str.replace(/([$])/, "\\$");
-};
-
-var makeNodePromisifiedEval;
-if (!true) {
-var switchCaseArgumentOrder = function(likelyArgumentCount) {
-    var ret = [likelyArgumentCount];
-    var min = Math.max(0, likelyArgumentCount - 1 - 3);
-    for(var i = likelyArgumentCount - 1; i >= min; --i) {
-        ret.push(i);
-    }
-    for(var i = likelyArgumentCount + 1; i <= 3; ++i) {
-        ret.push(i);
-    }
-    return ret;
-};
-
-var argumentSequence = function(argumentCount) {
-    return util.filledRange(argumentCount, "_arg", "");
-};
-
-var parameterDeclaration = function(parameterCount) {
-    return util.filledRange(
-        Math.max(parameterCount, 3), "_arg", "");
-};
-
-var parameterCount = function(fn) {
-    if (typeof fn.length === "number") {
-        return Math.max(Math.min(fn.length, 1023 + 1), 0);
-    }
-    return 0;
-};
-
-makeNodePromisifiedEval =
-function(callback, receiver, originalName, fn, _, multiArgs) {
-    var newParameterCount = Math.max(0, parameterCount(fn) - 1);
-    var argumentOrder = switchCaseArgumentOrder(newParameterCount);
-    var shouldProxyThis = typeof callback === "string" || receiver === THIS;
-
-    function generateCallForArgumentCount(count) {
-        var args = argumentSequence(count).join(", ");
-        var comma = count > 0 ? ", " : "";
-        var ret;
-        if (shouldProxyThis) {
-            ret = "ret = callback.call(this, {{args}}, nodeback); break;\n";
-        } else {
-            ret = receiver === undefined
-                ? "ret = callback({{args}}, nodeback); break;\n"
-                : "ret = callback.call(receiver, {{args}}, nodeback); break;\n";
-        }
-        return ret.replace("{{args}}", args).replace(", ", comma);
-    }
-
-    function generateArgumentSwitchCase() {
-        var ret = "";
-        for (var i = 0; i < argumentOrder.length; ++i) {
-            ret += "case " + argumentOrder[i] +":" +
-                generateCallForArgumentCount(argumentOrder[i]);
-        }
-
-        ret += "                                                             \n\
-        default:                                                             \n\
-            var args = new Array(len + 1);                                   \n\
-            var i = 0;                                                       \n\
-            for (var i = 0; i < len; ++i) {                                  \n\
-               args[i] = arguments[i];                                       \n\
-            }                                                                \n\
-            args[i] = nodeback;                                              \n\
-            [CodeForCall]                                                    \n\
-            break;                                                           \n\
-        ".replace("[CodeForCall]", (shouldProxyThis
-                                ? "ret = callback.apply(this, args);\n"
-                                : "ret = callback.apply(receiver, args);\n"));
-        return ret;
-    }
-
-    var getFunctionCode = typeof callback === "string"
-                                ? ("this != null ? this['"+callback+"'] : fn")
-                                : "fn";
-    var body = "'use strict';                                                \n\
-        var ret = function (Parameters) {                                    \n\
-            'use strict';                                                    \n\
-            var len = arguments.length;                                      \n\
-            var promise = new Promise(INTERNAL);                             \n\
-            promise._captureStackTrace();                                    \n\
-            var nodeback = nodebackForPromise(promise, " + multiArgs + ");   \n\
-            var ret;                                                         \n\
-            var callback = tryCatch([GetFunctionCode]);                      \n\
-            switch(len) {                                                    \n\
-                [CodeForSwitchCase]                                          \n\
-            }                                                                \n\
-            if (ret === errorObj) {                                          \n\
-                promise._rejectCallback(maybeWrapAsError(ret.e), true, true);\n\
-            }                                                                \n\
-            if (!promise._isFateSealed()) promise._setAsyncGuaranteed();     \n\
-            return promise;                                                  \n\
-        };                                                                   \n\
-        notEnumerableProp(ret, '__isPromisified__', true);                   \n\
-        return ret;                                                          \n\
-    ".replace("[CodeForSwitchCase]", generateArgumentSwitchCase())
-        .replace("[GetFunctionCode]", getFunctionCode);
-    body = body.replace("Parameters", parameterDeclaration(newParameterCount));
-    return new Function("Promise",
-                        "fn",
-                        "receiver",
-                        "withAppended",
-                        "maybeWrapAsError",
-                        "nodebackForPromise",
-                        "tryCatch",
-                        "errorObj",
-                        "notEnumerableProp",
-                        "INTERNAL",
-                        body)(
-                    Promise,
-                    fn,
-                    receiver,
-                    withAppended,
-                    maybeWrapAsError,
-                    nodebackForPromise,
-                    util.tryCatch,
-                    util.errorObj,
-                    util.notEnumerableProp,
-                    INTERNAL);
-};
-}
-
-function makeNodePromisifiedClosure(callback, receiver, _, fn, __, multiArgs) {
-    var defaultThis = (function() {return this;})();
-    var method = callback;
-    if (typeof method === "string") {
-        callback = fn;
-    }
-    function promisified() {
-        var _receiver = receiver;
-        if (receiver === THIS) _receiver = this;
-        var promise = new Promise(INTERNAL);
-        promise._captureStackTrace();
-        var cb = typeof method === "string" && this !== defaultThis
-            ? this[method] : callback;
-        var fn = nodebackForPromise(promise, multiArgs);
-        try {
-            cb.apply(_receiver, withAppended(arguments, fn));
-        } catch(e) {
-            promise._rejectCallback(maybeWrapAsError(e), true, true);
-        }
-        if (!promise._isFateSealed()) promise._setAsyncGuaranteed();
-        return promise;
-    }
-    util.notEnumerableProp(promisified, "__isPromisified__", true);
-    return promisified;
-}
-
-var makeNodePromisified = canEvaluate
-    ? makeNodePromisifiedEval
-    : makeNodePromisifiedClosure;
-
-function promisifyAll(obj, suffix, filter, promisifier, multiArgs) {
-    var suffixRegexp = new RegExp(escapeIdentRegex(suffix) + "$");
-    var methods =
-        promisifiableMethods(obj, suffix, suffixRegexp, filter);
-
-    for (var i = 0, len = methods.length; i < len; i+= 2) {
-        var key = methods[i];
-        var fn = methods[i+1];
-        var promisifiedKey = key + suffix;
-        if (promisifier === makeNodePromisified) {
-            obj[promisifiedKey] =
-                makeNodePromisified(key, THIS, key, fn, suffix, multiArgs);
-        } else {
-            var promisified = promisifier(fn, function() {
-                return makeNodePromisified(key, THIS, key,
-                                           fn, suffix, multiArgs);
-            });
-            util.notEnumerableProp(promisified, "__isPromisified__", true);
-            obj[promisifiedKey] = promisified;
-        }
-    }
-    util.toFastProperties(obj);
-    return obj;
-}
-
-function promisify(callback, receiver, multiArgs) {
-    return makeNodePromisified(callback, receiver, undefined,
-                                callback, null, multiArgs);
-}
-
-Promise.promisify = function (fn, options) {
-    if (typeof fn !== "function") {
-        throw new TypeError("expecting a function but got " + util.classString(fn));
-    }
-    if (isPromisified(fn)) {
-        return fn;
-    }
-    options = Object(options);
-    var receiver = options.context === undefined ? THIS : options.context;
-    var multiArgs = !!options.multiArgs;
-    var ret = promisify(fn, receiver, multiArgs);
-    util.copyDescriptors(fn, ret, propsFilter);
-    return ret;
-};
-
-Promise.promisifyAll = function (target, options) {
-    if (typeof target !== "function" && typeof target !== "object") {
-        throw new TypeError("the target of promisifyAll must be an object or a function\u000a\u000a    See http://goo.gl/MqrFmX\u000a");
-    }
-    options = Object(options);
-    var multiArgs = !!options.multiArgs;
-    var suffix = options.suffix;
-    if (typeof suffix !== "string") suffix = defaultSuffix;
-    var filter = options.filter;
-    if (typeof filter !== "function") filter = defaultFilter;
-    var promisifier = options.promisifier;
-    if (typeof promisifier !== "function") promisifier = makeNodePromisified;
-
-    if (!util.isIdentifier(suffix)) {
-        throw new RangeError("suffix must be a valid identifier\u000a\u000a    See http://goo.gl/MqrFmX\u000a");
-    }
-
-    var keys = util.inheritedDataKeys(target);
-    for (var i = 0; i < keys.length; ++i) {
-        var value = target[keys[i]];
-        if (keys[i] !== "constructor" &&
-            util.isClass(value)) {
-            promisifyAll(value.prototype, suffix, filter, promisifier,
-                multiArgs);
-            promisifyAll(value, suffix, filter, promisifier, multiArgs);
-        }
-    }
-
-    return promisifyAll(target, suffix, filter, promisifier, multiArgs);
-};
-};
-
-
-},{"./errors":12,"./nodeback":20,"./util":36}],25:[function(_dereq_,module,exports){
-"use strict";
-module.exports = function(
-    Promise, PromiseArray, tryConvertToPromise, apiRejection) {
-var util = _dereq_("./util");
-var isObject = util.isObject;
-var es5 = _dereq_("./es5");
-var Es6Map;
-if (typeof Map === "function") Es6Map = Map;
-
-var mapToEntries = (function() {
-    var index = 0;
-    var size = 0;
-
-    function extractEntry(value, key) {
-        this[index] = value;
-        this[index + size] = key;
-        index++;
-    }
-
-    return function mapToEntries(map) {
-        size = map.size;
-        index = 0;
-        var ret = new Array(map.size * 2);
-        map.forEach(extractEntry, ret);
-        return ret;
-    };
-})();
-
-var entriesToMap = function(entries) {
-    var ret = new Es6Map();
-    var length = entries.length / 2 | 0;
-    for (var i = 0; i < length; ++i) {
-        var key = entries[length + i];
-        var value = entries[i];
-        ret.set(key, value);
-    }
-    return ret;
-};
-
-function PropertiesPromiseArray(obj) {
-    var isMap = false;
-    var entries;
-    if (Es6Map !== undefined && obj instanceof Es6Map) {
-        entries = mapToEntries(obj);
-        isMap = true;
-    } else {
-        var keys = es5.keys(obj);
-        var len = keys.length;
-        entries = new Array(len * 2);
-        for (var i = 0; i < len; ++i) {
-            var key = keys[i];
-            entries[i] = obj[key];
-            entries[i + len] = key;
-        }
-    }
-    this.constructor$(entries);
-    this._isMap = isMap;
-    this._init$(undefined, -3);
-}
-util.inherits(PropertiesPromiseArray, PromiseArray);
-
-PropertiesPromiseArray.prototype._init = function () {};
-
-PropertiesPromiseArray.prototype._promiseFulfilled = function (value, index) {
-    this._values[index] = value;
-    var totalResolved = ++this._totalResolved;
-    if (totalResolved >= this._length) {
-        var val;
-        if (this._isMap) {
-            val = entriesToMap(this._values);
-        } else {
-            val = {};
-            var keyOffset = this.length();
-            for (var i = 0, len = this.length(); i < len; ++i) {
-                val[this._values[i + keyOffset]] = this._values[i];
+            function makeNodePromisifiedClosure(callback, receiver, _, fn, __, multiArgs) {
+              var defaultThis = (function() {return this;})();
+              var method = callback;
+              if (typeof method === "string") {
+                callback = fn;
+              }
+              function promisified() {
+                var _receiver = receiver;
+                if (receiver === THIS) _receiver = this;
+                var promise = new Promise(INTERNAL);
+                promise._captureStackTrace();
+                var cb = typeof method === "string" && this !== defaultThis
+                ? this[method] : callback;
+                var fn = nodebackForPromise(promise, multiArgs);
+                try {
+                  cb.apply(_receiver, withAppended(arguments, fn));
+                } catch(e) {
+                  promise._rejectCallback(maybeWrapAsError(e), true, true);
+                }
+                if (!promise._isFateSealed()) promise._setAsyncGuaranteed();
+                return promise;
+              }
+              util.notEnumerableProp(promisified, "__isPromisified__", true);
+              return promisified;
             }
-        }
-        this._resolve(val);
-        return true;
-    }
-    return false;
-};
 
-PropertiesPromiseArray.prototype.shouldCopyValues = function () {
-    return false;
-};
+            var makeNodePromisified = canEvaluate
+            ? makeNodePromisifiedEval
+                : makeNodePromisifiedClosure;
 
-PropertiesPromiseArray.prototype.getActualLength = function (len) {
-    return len >> 1;
-};
+            function promisifyAll(obj, suffix, filter, promisifier, multiArgs) {
+              var suffixRegexp = new RegExp(escapeIdentRegex(suffix) + "$");
+              var methods =
+                promisifiableMethods(obj, suffix, suffixRegexp, filter);
 
-function props(promises) {
-    var ret;
-    var castValue = tryConvertToPromise(promises);
+              for (var i = 0, len = methods.length; i < len; i+= 2) {
+                var key = methods[i];
+                var fn = methods[i+1];
+                var promisifiedKey = key + suffix;
+                if (promisifier === makeNodePromisified) {
+                  obj[promisifiedKey] =
+                    makeNodePromisified(key, THIS, key, fn, suffix, multiArgs);
+                } else {
+                  var promisified = promisifier(fn, function() {
+                    return makeNodePromisified(key, THIS, key,
+                        fn, suffix, multiArgs);
+                  });
+                  util.notEnumerableProp(promisified, "__isPromisified__", true);
+                  obj[promisifiedKey] = promisified;
+                }
+              }
+              util.toFastProperties(obj);
+              return obj;
+            }
 
-    if (!isObject(castValue)) {
-        return apiRejection("cannot await properties of a non-object\u000a\u000a    See http://goo.gl/MqrFmX\u000a");
-    } else if (castValue instanceof Promise) {
-        ret = castValue._then(
-            Promise.props, undefined, undefined, undefined, undefined);
-    } else {
-        ret = new PropertiesPromiseArray(castValue).promise();
-    }
+            function promisify(callback, receiver, multiArgs) {
+              return makeNodePromisified(callback, receiver, undefined,
+                  callback, null, multiArgs);
+            }
 
-    if (castValue instanceof Promise) {
-        ret._propagateFrom(castValue, 2);
-    }
-    return ret;
-}
-
-Promise.prototype.props = function () {
-    return props(this);
-};
-
-Promise.props = function (promises) {
-    return props(promises);
-};
-};
-
-},{"./es5":13,"./util":36}],26:[function(_dereq_,module,exports){
-"use strict";
-function arrayMove(src, srcIndex, dst, dstIndex, len) {
-    for (var j = 0; j < len; ++j) {
-        dst[j + dstIndex] = src[j + srcIndex];
-        src[j + srcIndex] = void 0;
-    }
-}
-
-function Queue(capacity) {
-    this._capacity = capacity;
-    this._length = 0;
-    this._front = 0;
-}
-
-Queue.prototype._willBeOverCapacity = function (size) {
-    return this._capacity < size;
-};
-
-Queue.prototype._pushOne = function (arg) {
-    var length = this.length();
-    this._checkCapacity(length + 1);
-    var i = (this._front + length) & (this._capacity - 1);
-    this[i] = arg;
-    this._length = length + 1;
-};
-
-Queue.prototype._unshiftOne = function(value) {
-    var capacity = this._capacity;
-    this._checkCapacity(this.length() + 1);
-    var front = this._front;
-    var i = (((( front - 1 ) &
-                    ( capacity - 1) ) ^ capacity ) - capacity );
-    this[i] = value;
-    this._front = i;
-    this._length = this.length() + 1;
-};
-
-Queue.prototype.unshift = function(fn, receiver, arg) {
-    this._unshiftOne(arg);
-    this._unshiftOne(receiver);
-    this._unshiftOne(fn);
-};
-
-Queue.prototype.push = function (fn, receiver, arg) {
-    var length = this.length() + 3;
-    if (this._willBeOverCapacity(length)) {
-        this._pushOne(fn);
-        this._pushOne(receiver);
-        this._pushOne(arg);
-        return;
-    }
-    var j = this._front + length - 3;
-    this._checkCapacity(length);
-    var wrapMask = this._capacity - 1;
-    this[(j + 0) & wrapMask] = fn;
-    this[(j + 1) & wrapMask] = receiver;
-    this[(j + 2) & wrapMask] = arg;
-    this._length = length;
-};
-
-Queue.prototype.shift = function () {
-    var front = this._front,
-        ret = this[front];
-
-    this[front] = undefined;
-    this._front = (front + 1) & (this._capacity - 1);
-    this._length--;
-    return ret;
-};
-
-Queue.prototype.length = function () {
-    return this._length;
-};
-
-Queue.prototype._checkCapacity = function (size) {
-    if (this._capacity < size) {
-        this._resizeTo(this._capacity << 1);
-    }
-};
-
-Queue.prototype._resizeTo = function (capacity) {
-    var oldCapacity = this._capacity;
-    this._capacity = capacity;
-    var front = this._front;
-    var length = this._length;
-    var moveItemsCount = (front + length) & (oldCapacity - 1);
-    arrayMove(this, 0, this, oldCapacity, moveItemsCount);
-};
-
-module.exports = Queue;
-
-},{}],27:[function(_dereq_,module,exports){
-"use strict";
-module.exports = function(
-    Promise, INTERNAL, tryConvertToPromise, apiRejection) {
-var util = _dereq_("./util");
-
-var raceLater = function (promise) {
-    return promise.then(function(array) {
-        return race(array, promise);
-    });
-};
-
-function race(promises, parent) {
-    var maybePromise = tryConvertToPromise(promises);
-
-    if (maybePromise instanceof Promise) {
-        return raceLater(maybePromise);
-    } else {
-        promises = util.asArray(promises);
-        if (promises === null)
-            return apiRejection("expecting an array or an iterable object but got " + util.classString(promises));
-    }
-
-    var ret = new Promise(INTERNAL);
-    if (parent !== undefined) {
-        ret._propagateFrom(parent, 3);
-    }
-    var fulfill = ret._fulfill;
-    var reject = ret._reject;
-    for (var i = 0, len = promises.length; i < len; ++i) {
-        var val = promises[i];
-
-        if (val === undefined && !(i in promises)) {
-            continue;
-        }
-
-        Promise.cast(val)._then(fulfill, reject, undefined, ret, null);
-    }
-    return ret;
-}
-
-Promise.race = function (promises) {
-    return race(promises, undefined);
-};
-
-Promise.prototype.race = function () {
-    return race(this, undefined);
-};
-
-};
-
-},{"./util":36}],28:[function(_dereq_,module,exports){
-"use strict";
-module.exports = function(Promise,
-                          PromiseArray,
-                          apiRejection,
-                          tryConvertToPromise,
-                          INTERNAL,
-                          debug) {
-var getDomain = Promise._getDomain;
-var util = _dereq_("./util");
-var tryCatch = util.tryCatch;
-
-function ReductionPromiseArray(promises, fn, initialValue, _each) {
-    this.constructor$(promises);
-    var domain = getDomain();
-    this._fn = domain === null ? fn : util.domainBind(domain, fn);
-    if (initialValue !== undefined) {
-        initialValue = Promise.resolve(initialValue);
-        initialValue._attachCancellationCallback(this);
-    }
-    this._initialValue = initialValue;
-    this._currentCancellable = null;
-    if(_each === INTERNAL) {
-        this._eachValues = Array(this._length);
-    } else if (_each === 0) {
-        this._eachValues = null;
-    } else {
-        this._eachValues = undefined;
-    }
-    this._promise._captureStackTrace();
-    this._init$(undefined, -5);
-}
-util.inherits(ReductionPromiseArray, PromiseArray);
-
-ReductionPromiseArray.prototype._gotAccum = function(accum) {
-    if (this._eachValues !== undefined && 
-        this._eachValues !== null && 
-        accum !== INTERNAL) {
-        this._eachValues.push(accum);
-    }
-};
-
-ReductionPromiseArray.prototype._eachComplete = function(value) {
-    if (this._eachValues !== null) {
-        this._eachValues.push(value);
-    }
-    return this._eachValues;
-};
-
-ReductionPromiseArray.prototype._init = function() {};
-
-ReductionPromiseArray.prototype._resolveEmptyArray = function() {
-    this._resolve(this._eachValues !== undefined ? this._eachValues
-                                                 : this._initialValue);
-};
-
-ReductionPromiseArray.prototype.shouldCopyValues = function () {
-    return false;
-};
-
-ReductionPromiseArray.prototype._resolve = function(value) {
-    this._promise._resolveCallback(value);
-    this._values = null;
-};
-
-ReductionPromiseArray.prototype._resultCancelled = function(sender) {
-    if (sender === this._initialValue) return this._cancel();
-    if (this._isResolved()) return;
-    this._resultCancelled$();
-    if (this._currentCancellable instanceof Promise) {
-        this._currentCancellable.cancel();
-    }
-    if (this._initialValue instanceof Promise) {
-        this._initialValue.cancel();
-    }
-};
-
-ReductionPromiseArray.prototype._iterate = function (values) {
-    this._values = values;
-    var value;
-    var i;
-    var length = values.length;
-    if (this._initialValue !== undefined) {
-        value = this._initialValue;
-        i = 0;
-    } else {
-        value = Promise.resolve(values[0]);
-        i = 1;
-    }
-
-    this._currentCancellable = value;
-
-    if (!value.isRejected()) {
-        for (; i < length; ++i) {
-            var ctx = {
-                accum: null,
-                value: values[i],
-                index: i,
-                length: length,
-                array: this
+            Promise.promisify = function (fn, options) {
+              if (typeof fn !== "function") {
+                throw new TypeError("expecting a function but got " + util.classString(fn));
+              }
+              if (isPromisified(fn)) {
+                return fn;
+              }
+              options = Object(options);
+              var receiver = options.context === undefined ? THIS : options.context;
+              var multiArgs = !!options.multiArgs;
+              var ret = promisify(fn, receiver, multiArgs);
+              util.copyDescriptors(fn, ret, propsFilter);
+              return ret;
             };
-            value = value._then(gotAccum, undefined, undefined, ctx, undefined);
-        }
-    }
 
-    if (this._eachValues !== undefined) {
-        value = value
-            ._then(this._eachComplete, undefined, undefined, this, undefined);
-    }
-    value._then(completed, completed, undefined, value, this);
-};
+            Promise.promisifyAll = function (target, options) {
+              if (typeof target !== "function" && typeof target !== "object") {
+                throw new TypeError("the target of promisifyAll must be an object or a function\u000a\u000a    See http://goo.gl/MqrFmX\u000a");
+              }
+              options = Object(options);
+              var multiArgs = !!options.multiArgs;
+              var suffix = options.suffix;
+              if (typeof suffix !== "string") suffix = defaultSuffix;
+              var filter = options.filter;
+              if (typeof filter !== "function") filter = defaultFilter;
+              var promisifier = options.promisifier;
+              if (typeof promisifier !== "function") promisifier = makeNodePromisified;
 
-Promise.prototype.reduce = function (fn, initialValue) {
-    return reduce(this, fn, initialValue, null);
-};
+              if (!util.isIdentifier(suffix)) {
+                throw new RangeError("suffix must be a valid identifier\u000a\u000a    See http://goo.gl/MqrFmX\u000a");
+              }
 
-Promise.reduce = function (promises, fn, initialValue, _each) {
-    return reduce(promises, fn, initialValue, _each);
-};
+              var keys = util.inheritedDataKeys(target);
+              for (var i = 0; i < keys.length; ++i) {
+                var value = target[keys[i]];
+                if (keys[i] !== "constructor" &&
+                    util.isClass(value)) {
+                  promisifyAll(value.prototype, suffix, filter, promisifier,
+                      multiArgs);
+                  promisifyAll(value, suffix, filter, promisifier, multiArgs);
+                }
+              }
 
-function completed(valueOrReason, array) {
-    if (this.isFulfilled()) {
-        array._resolve(valueOrReason);
-    } else {
-        array._reject(valueOrReason);
-    }
-}
+              return promisifyAll(target, suffix, filter, promisifier, multiArgs);
+            };
+          };
 
-function reduce(promises, fn, initialValue, _each) {
-    if (typeof fn !== "function") {
-        return apiRejection("expecting a function but got " + util.classString(fn));
-    }
-    var array = new ReductionPromiseArray(promises, fn, initialValue, _each);
-    return array.promise();
-}
 
-function gotAccum(accum) {
-    this.accum = accum;
-    this.array._gotAccum(accum);
-    var value = tryConvertToPromise(this.value, this.array._promise);
-    if (value instanceof Promise) {
-        this.array._currentCancellable = value;
-        return value._then(gotValue, undefined, undefined, this, undefined);
-    } else {
-        return gotValue.call(this, value);
-    }
-}
+        },{"./errors":12,"./nodeback":20,"./util":36}],25:[function(_dereq_,module,exports){
+          "use strict";
+          module.exports = function(
+              Promise, PromiseArray, tryConvertToPromise, apiRejection) {
+            var util = _dereq_("./util");
+            var isObject = util.isObject;
+            var es5 = _dereq_("./es5");
+            var Es6Map;
+            if (typeof Map === "function") Es6Map = Map;
 
-function gotValue(value) {
-    var array = this.array;
-    var promise = array._promise;
-    var fn = tryCatch(array._fn);
-    promise._pushContext();
-    var ret;
-    if (array._eachValues !== undefined) {
-        ret = fn.call(promise._boundValue(), value, this.index, this.length);
-    } else {
-        ret = fn.call(promise._boundValue(),
-                              this.accum, value, this.index, this.length);
-    }
-    if (ret instanceof Promise) {
-        array._currentCancellable = ret;
-    }
-    var promiseCreated = promise._popContext();
-    debug.checkForgottenReturns(
-        ret,
-        promiseCreated,
-        array._eachValues !== undefined ? "Promise.each" : "Promise.reduce",
-        promise
-    );
-    return ret;
-}
-};
+            var mapToEntries = (function() {
+              var index = 0;
+              var size = 0;
 
-},{"./util":36}],29:[function(_dereq_,module,exports){
-"use strict";
-var util = _dereq_("./util");
-var schedule;
-var noAsyncScheduler = function() {
-    throw new Error("No async scheduler available\u000a\u000a    See http://goo.gl/MqrFmX\u000a");
-};
-var NativePromise = util.getNativePromise();
-if (util.isNode && typeof MutationObserver === "undefined") {
-    var GlobalSetImmediate = global.setImmediate;
-    var ProcessNextTick = process.nextTick;
-    schedule = util.isRecentNode
-                ? function(fn) { GlobalSetImmediate.call(global, fn); }
-                : function(fn) { ProcessNextTick.call(process, fn); };
-} else if (typeof NativePromise === "function" &&
-           typeof NativePromise.resolve === "function") {
-    var nativePromise = NativePromise.resolve();
-    schedule = function(fn) {
-        nativePromise.then(fn);
-    };
-} else if ((typeof MutationObserver !== "undefined") &&
-          !(typeof window !== "undefined" &&
-            window.navigator &&
-            (window.navigator.standalone || window.cordova))) {
-    schedule = (function() {
-        var div = document.createElement("div");
-        var opts = {attributes: true};
-        var toggleScheduled = false;
-        var div2 = document.createElement("div");
-        var o2 = new MutationObserver(function() {
-            div.classList.toggle("foo");
-            toggleScheduled = false;
-        });
-        o2.observe(div2, opts);
+              function extractEntry(value, key) {
+                this[index] = value;
+                this[index + size] = key;
+                index++;
+              }
 
-        var scheduleToggle = function() {
-            if (toggleScheduled) return;
+              return function mapToEntries(map) {
+                size = map.size;
+                index = 0;
+                var ret = new Array(map.size * 2);
+                map.forEach(extractEntry, ret);
+                return ret;
+              };
+            })();
+
+            var entriesToMap = function(entries) {
+              var ret = new Es6Map();
+              var length = entries.length / 2 | 0;
+              for (var i = 0; i < length; ++i) {
+                var key = entries[length + i];
+                var value = entries[i];
+                ret.set(key, value);
+              }
+              return ret;
+            };
+
+            function PropertiesPromiseArray(obj) {
+              var isMap = false;
+              var entries;
+              if (Es6Map !== undefined && obj instanceof Es6Map) {
+                entries = mapToEntries(obj);
+                isMap = true;
+              } else {
+                var keys = es5.keys(obj);
+                var len = keys.length;
+                entries = new Array(len * 2);
+                for (var i = 0; i < len; ++i) {
+                  var key = keys[i];
+                  entries[i] = obj[key];
+                  entries[i + len] = key;
+                }
+              }
+              this.constructor$(entries);
+              this._isMap = isMap;
+              this._init$(undefined, -3);
+            }
+            util.inherits(PropertiesPromiseArray, PromiseArray);
+
+            PropertiesPromiseArray.prototype._init = function () {};
+
+            PropertiesPromiseArray.prototype._promiseFulfilled = function (value, index) {
+              this._values[index] = value;
+              var totalResolved = ++this._totalResolved;
+              if (totalResolved >= this._length) {
+                var val;
+                if (this._isMap) {
+                  val = entriesToMap(this._values);
+                } else {
+                  val = {};
+                  var keyOffset = this.length();
+                  for (var i = 0, len = this.length(); i < len; ++i) {
+                    val[this._values[i + keyOffset]] = this._values[i];
+                  }
+                }
+                this._resolve(val);
+                return true;
+              }
+              return false;
+            };
+
+            PropertiesPromiseArray.prototype.shouldCopyValues = function () {
+              return false;
+            };
+
+            PropertiesPromiseArray.prototype.getActualLength = function (len) {
+              return len >> 1;
+            };
+
+            function props(promises) {
+              var ret;
+              var castValue = tryConvertToPromise(promises);
+
+              if (!isObject(castValue)) {
+                return apiRejection("cannot await properties of a non-object\u000a\u000a    See http://goo.gl/MqrFmX\u000a");
+              } else if (castValue instanceof Promise) {
+                ret = castValue._then(
+                    Promise.props, undefined, undefined, undefined, undefined);
+              } else {
+                ret = new PropertiesPromiseArray(castValue).promise();
+              }
+
+              if (castValue instanceof Promise) {
+                ret._propagateFrom(castValue, 2);
+              }
+              return ret;
+            }
+
+            Promise.prototype.props = function () {
+              return props(this);
+            };
+
+            Promise.props = function (promises) {
+              return props(promises);
+            };
+          };
+
+        },{"./es5":13,"./util":36}],26:[function(_dereq_,module,exports){
+          "use strict";
+          function arrayMove(src, srcIndex, dst, dstIndex, len) {
+            for (var j = 0; j < len; ++j) {
+              dst[j + dstIndex] = src[j + srcIndex];
+              src[j + srcIndex] = void 0;
+            }
+          }
+
+          function Queue(capacity) {
+            this._capacity = capacity;
+            this._length = 0;
+            this._front = 0;
+          }
+
+          Queue.prototype._willBeOverCapacity = function (size) {
+            return this._capacity < size;
+          };
+
+          Queue.prototype._pushOne = function (arg) {
+            var length = this.length();
+            this._checkCapacity(length + 1);
+            var i = (this._front + length) & (this._capacity - 1);
+            this[i] = arg;
+            this._length = length + 1;
+          };
+
+          Queue.prototype._unshiftOne = function(value) {
+            var capacity = this._capacity;
+            this._checkCapacity(this.length() + 1);
+            var front = this._front;
+            var i = (((( front - 1 ) &
+                ( capacity - 1) ) ^ capacity ) - capacity );
+            this[i] = value;
+            this._front = i;
+            this._length = this.length() + 1;
+          };
+
+          Queue.prototype.unshift = function(fn, receiver, arg) {
+            this._unshiftOne(arg);
+            this._unshiftOne(receiver);
+            this._unshiftOne(fn);
+          };
+
+          Queue.prototype.push = function (fn, receiver, arg) {
+            var length = this.length() + 3;
+            if (this._willBeOverCapacity(length)) {
+              this._pushOne(fn);
+              this._pushOne(receiver);
+              this._pushOne(arg);
+              return;
+            }
+            var j = this._front + length - 3;
+            this._checkCapacity(length);
+            var wrapMask = this._capacity - 1;
+            this[(j + 0) & wrapMask] = fn;
+            this[(j + 1) & wrapMask] = receiver;
+            this[(j + 2) & wrapMask] = arg;
+            this._length = length;
+          };
+
+          Queue.prototype.shift = function () {
+            var front = this._front,
+            ret = this[front];
+
+            this[front] = undefined;
+            this._front = (front + 1) & (this._capacity - 1);
+            this._length--;
+            return ret;
+          };
+
+          Queue.prototype.length = function () {
+            return this._length;
+          };
+
+          Queue.prototype._checkCapacity = function (size) {
+            if (this._capacity < size) {
+              this._resizeTo(this._capacity << 1);
+            }
+          };
+
+          Queue.prototype._resizeTo = function (capacity) {
+            var oldCapacity = this._capacity;
+            this._capacity = capacity;
+            var front = this._front;
+            var length = this._length;
+            var moveItemsCount = (front + length) & (oldCapacity - 1);
+            arrayMove(this, 0, this, oldCapacity, moveItemsCount);
+          };
+
+          module.exports = Queue;
+
+        },{}],27:[function(_dereq_,module,exports){
+          "use strict";
+          module.exports = function(
+              Promise, INTERNAL, tryConvertToPromise, apiRejection) {
+            var util = _dereq_("./util");
+
+            var raceLater = function (promise) {
+              return promise.then(function(array) {
+                return race(array, promise);
+              });
+            };
+
+            function race(promises, parent) {
+              var maybePromise = tryConvertToPromise(promises);
+
+              if (maybePromise instanceof Promise) {
+                return raceLater(maybePromise);
+              } else {
+                promises = util.asArray(promises);
+                if (promises === null)
+                  return apiRejection("expecting an array or an iterable object but got " + util.classString(promises));
+              }
+
+              var ret = new Promise(INTERNAL);
+              if (parent !== undefined) {
+                ret._propagateFrom(parent, 3);
+              }
+              var fulfill = ret._fulfill;
+              var reject = ret._reject;
+              for (var i = 0, len = promises.length; i < len; ++i) {
+                var val = promises[i];
+
+                if (val === undefined && !(i in promises)) {
+                  continue;
+                }
+
+                Promise.cast(val)._then(fulfill, reject, undefined, ret, null);
+              }
+              return ret;
+            }
+
+            Promise.race = function (promises) {
+              return race(promises, undefined);
+            };
+
+            Promise.prototype.race = function () {
+              return race(this, undefined);
+            };
+
+          };
+
+        },{"./util":36}],28:[function(_dereq_,module,exports){
+          "use strict";
+          module.exports = function(Promise,
+              PromiseArray,
+              apiRejection,
+              tryConvertToPromise,
+              INTERNAL,
+              debug) {
+            var getDomain = Promise._getDomain;
+            var util = _dereq_("./util");
+            var tryCatch = util.tryCatch;
+
+            function ReductionPromiseArray(promises, fn, initialValue, _each) {
+              this.constructor$(promises);
+              var domain = getDomain();
+              this._fn = domain === null ? fn : util.domainBind(domain, fn);
+              if (initialValue !== undefined) {
+                initialValue = Promise.resolve(initialValue);
+                initialValue._attachCancellationCallback(this);
+              }
+              this._initialValue = initialValue;
+              this._currentCancellable = null;
+              if(_each === INTERNAL) {
+                this._eachValues = Array(this._length);
+              } else if (_each === 0) {
+                this._eachValues = null;
+              } else {
+                this._eachValues = undefined;
+              }
+              this._promise._captureStackTrace();
+              this._init$(undefined, -5);
+            }
+            util.inherits(ReductionPromiseArray, PromiseArray);
+
+            ReductionPromiseArray.prototype._gotAccum = function(accum) {
+              if (this._eachValues !== undefined && 
+                  this._eachValues !== null && 
+                  accum !== INTERNAL) {
+                this._eachValues.push(accum);
+              }
+            };
+
+            ReductionPromiseArray.prototype._eachComplete = function(value) {
+              if (this._eachValues !== null) {
+                this._eachValues.push(value);
+              }
+              return this._eachValues;
+            };
+
+            ReductionPromiseArray.prototype._init = function() {};
+
+            ReductionPromiseArray.prototype._resolveEmptyArray = function() {
+              this._resolve(this._eachValues !== undefined ? this._eachValues
+                  : this._initialValue);
+            };
+
+            ReductionPromiseArray.prototype.shouldCopyValues = function () {
+              return false;
+            };
+
+            ReductionPromiseArray.prototype._resolve = function(value) {
+              this._promise._resolveCallback(value);
+              this._values = null;
+            };
+
+            ReductionPromiseArray.prototype._resultCancelled = function(sender) {
+              if (sender === this._initialValue) return this._cancel();
+              if (this._isResolved()) return;
+              this._resultCancelled$();
+              if (this._currentCancellable instanceof Promise) {
+                this._currentCancellable.cancel();
+              }
+              if (this._initialValue instanceof Promise) {
+                this._initialValue.cancel();
+              }
+            };
+
+            ReductionPromiseArray.prototype._iterate = function (values) {
+              this._values = values;
+              var value;
+              var i;
+              var length = values.length;
+              if (this._initialValue !== undefined) {
+                value = this._initialValue;
+                i = 0;
+              } else {
+                value = Promise.resolve(values[0]);
+                i = 1;
+              }
+
+              this._currentCancellable = value;
+
+              if (!value.isRejected()) {
+                for (; i < length; ++i) {
+                  var ctx = {
+                      accum: null,
+                      value: values[i],
+                      index: i,
+                      length: length,
+                      array: this
+                  };
+                  value = value._then(gotAccum, undefined, undefined, ctx, undefined);
+                }
+              }
+
+              if (this._eachValues !== undefined) {
+                value = value
+                ._then(this._eachComplete, undefined, undefined, this, undefined);
+              }
+              value._then(completed, completed, undefined, value, this);
+            };
+
+            Promise.prototype.reduce = function (fn, initialValue) {
+              return reduce(this, fn, initialValue, null);
+            };
+
+            Promise.reduce = function (promises, fn, initialValue, _each) {
+              return reduce(promises, fn, initialValue, _each);
+            };
+
+            function completed(valueOrReason, array) {
+              if (this.isFulfilled()) {
+                array._resolve(valueOrReason);
+              } else {
+                array._reject(valueOrReason);
+              }
+            }
+
+            function reduce(promises, fn, initialValue, _each) {
+              if (typeof fn !== "function") {
+                return apiRejection("expecting a function but got " + util.classString(fn));
+              }
+              var array = new ReductionPromiseArray(promises, fn, initialValue, _each);
+              return array.promise();
+            }
+
+            function gotAccum(accum) {
+              this.accum = accum;
+              this.array._gotAccum(accum);
+              var value = tryConvertToPromise(this.value, this.array._promise);
+              if (value instanceof Promise) {
+                this.array._currentCancellable = value;
+                return value._then(gotValue, undefined, undefined, this, undefined);
+              } else {
+                return gotValue.call(this, value);
+              }
+            }
+
+            function gotValue(value) {
+              var array = this.array;
+              var promise = array._promise;
+              var fn = tryCatch(array._fn);
+              promise._pushContext();
+              var ret;
+              if (array._eachValues !== undefined) {
+                ret = fn.call(promise._boundValue(), value, this.index, this.length);
+              } else {
+                ret = fn.call(promise._boundValue(),
+                    this.accum, value, this.index, this.length);
+              }
+              if (ret instanceof Promise) {
+                array._currentCancellable = ret;
+              }
+              var promiseCreated = promise._popContext();
+              debug.checkForgottenReturns(
+                  ret,
+                  promiseCreated,
+                  array._eachValues !== undefined ? "Promise.each" : "Promise.reduce",
+                      promise
+              );
+              return ret;
+            }
+          };
+
+        },{"./util":36}],29:[function(_dereq_,module,exports){
+          "use strict";
+          var util = _dereq_("./util");
+          var schedule;
+          var noAsyncScheduler = function() {
+            throw new Error("No async scheduler available\u000a\u000a    See http://goo.gl/MqrFmX\u000a");
+          };
+          var NativePromise = util.getNativePromise();
+          if (util.isNode && typeof MutationObserver === "undefined") {
+            var GlobalSetImmediate = global.setImmediate;
+            var ProcessNextTick = process.nextTick;
+            schedule = util.isRecentNode
+            ? function(fn) { GlobalSetImmediate.call(global, fn); }
+            : function(fn) { ProcessNextTick.call(process, fn); };
+          } else if (typeof NativePromise === "function" &&
+              typeof NativePromise.resolve === "function") {
+            var nativePromise = NativePromise.resolve();
+            schedule = function(fn) {
+              nativePromise.then(fn);
+            };
+          } else if ((typeof MutationObserver !== "undefined") &&
+              !(typeof window !== "undefined" &&
+                  window.navigator &&
+                  (window.navigator.standalone || window.cordova))) {
+            schedule = (function() {
+              var div = document.createElement("div");
+              var opts = {attributes: true};
+              var toggleScheduled = false;
+              var div2 = document.createElement("div");
+              var o2 = new MutationObserver(function() {
+                div.classList.toggle("foo");
+                toggleScheduled = false;
+              });
+              o2.observe(div2, opts);
+
+              var scheduleToggle = function() {
+                if (toggleScheduled) return;
                 toggleScheduled = true;
                 div2.classList.toggle("foo");
+              };
+
+              return function schedule(fn) {
+                var o = new MutationObserver(function() {
+                  o.disconnect();
+                  fn();
+                });
+                o.observe(div, opts);
+                scheduleToggle();
+              };
+            })();
+          } else if (typeof setImmediate !== "undefined") {
+            schedule = function (fn) {
+              setImmediate(fn);
+            };
+          } else if (typeof setTimeout !== "undefined") {
+            schedule = function (fn) {
+              setTimeout(fn, 0);
+            };
+          } else {
+            schedule = noAsyncScheduler;
+          }
+          module.exports = schedule;
+
+        },{"./util":36}],30:[function(_dereq_,module,exports){
+          "use strict";
+          module.exports =
+            function(Promise, PromiseArray, debug) {
+            var PromiseInspection = Promise.PromiseInspection;
+            var util = _dereq_("./util");
+
+            function SettledPromiseArray(values) {
+              this.constructor$(values);
+            }
+            util.inherits(SettledPromiseArray, PromiseArray);
+
+            SettledPromiseArray.prototype._promiseResolved = function (index, inspection) {
+              this._values[index] = inspection;
+              var totalResolved = ++this._totalResolved;
+              if (totalResolved >= this._length) {
+                this._resolve(this._values);
+                return true;
+              }
+              return false;
             };
 
-            return function schedule(fn) {
-            var o = new MutationObserver(function() {
-                o.disconnect();
-                fn();
-            });
-            o.observe(div, opts);
-            scheduleToggle();
-        };
-    })();
-} else if (typeof setImmediate !== "undefined") {
-    schedule = function (fn) {
-        setImmediate(fn);
-    };
-} else if (typeof setTimeout !== "undefined") {
-    schedule = function (fn) {
-        setTimeout(fn, 0);
-    };
-} else {
-    schedule = noAsyncScheduler;
-}
-module.exports = schedule;
+            SettledPromiseArray.prototype._promiseFulfilled = function (value, index) {
+              var ret = new PromiseInspection();
+              ret._bitField = 33554432;
+              ret._settledValueField = value;
+              return this._promiseResolved(index, ret);
+            };
+            SettledPromiseArray.prototype._promiseRejected = function (reason, index) {
+              var ret = new PromiseInspection();
+              ret._bitField = 16777216;
+              ret._settledValueField = reason;
+              return this._promiseResolved(index, ret);
+            };
 
-},{"./util":36}],30:[function(_dereq_,module,exports){
-"use strict";
-module.exports =
-    function(Promise, PromiseArray, debug) {
-var PromiseInspection = Promise.PromiseInspection;
-var util = _dereq_("./util");
+            Promise.settle = function (promises) {
+              debug.deprecated(".settle()", ".reflect()");
+              return new SettledPromiseArray(promises).promise();
+            };
 
-function SettledPromiseArray(values) {
-    this.constructor$(values);
-}
-util.inherits(SettledPromiseArray, PromiseArray);
+            Promise.prototype.settle = function () {
+              return Promise.settle(this);
+            };
+          };
 
-SettledPromiseArray.prototype._promiseResolved = function (index, inspection) {
-    this._values[index] = inspection;
-    var totalResolved = ++this._totalResolved;
-    if (totalResolved >= this._length) {
-        this._resolve(this._values);
-        return true;
-    }
-    return false;
-};
-
-SettledPromiseArray.prototype._promiseFulfilled = function (value, index) {
-    var ret = new PromiseInspection();
-    ret._bitField = 33554432;
-    ret._settledValueField = value;
-    return this._promiseResolved(index, ret);
-};
-SettledPromiseArray.prototype._promiseRejected = function (reason, index) {
-    var ret = new PromiseInspection();
-    ret._bitField = 16777216;
-    ret._settledValueField = reason;
-    return this._promiseResolved(index, ret);
-};
-
-Promise.settle = function (promises) {
-    debug.deprecated(".settle()", ".reflect()");
-    return new SettledPromiseArray(promises).promise();
-};
-
-Promise.prototype.settle = function () {
-    return Promise.settle(this);
-};
-};
-
-},{"./util":36}],31:[function(_dereq_,module,exports){
-"use strict";
-module.exports =
-function(Promise, PromiseArray, apiRejection) {
-var util = _dereq_("./util");
-var RangeError = _dereq_("./errors").RangeError;
-var AggregateError = _dereq_("./errors").AggregateError;
-var isArray = util.isArray;
-var CANCELLATION = {};
+        },{"./util":36}],31:[function(_dereq_,module,exports){
+          "use strict";
+          module.exports =
+            function(Promise, PromiseArray, apiRejection) {
+            var util = _dereq_("./util");
+            var RangeError = _dereq_("./errors").RangeError;
+            var AggregateError = _dereq_("./errors").AggregateError;
+            var isArray = util.isArray;
+            var CANCELLATION = {};
 
 
-function SomePromiseArray(values) {
-    this.constructor$(values);
-    this._howMany = 0;
-    this._unwrap = false;
-    this._initialized = false;
-}
-util.inherits(SomePromiseArray, PromiseArray);
-
-SomePromiseArray.prototype._init = function () {
-    if (!this._initialized) {
-        return;
-    }
-    if (this._howMany === 0) {
-        this._resolve([]);
-        return;
-    }
-    this._init$(undefined, -5);
-    var isArrayResolved = isArray(this._values);
-    if (!this._isResolved() &&
-        isArrayResolved &&
-        this._howMany > this._canPossiblyFulfill()) {
-        this._reject(this._getRangeError(this.length()));
-    }
-};
-
-SomePromiseArray.prototype.init = function () {
-    this._initialized = true;
-    this._init();
-};
-
-SomePromiseArray.prototype.setUnwrap = function () {
-    this._unwrap = true;
-};
-
-SomePromiseArray.prototype.howMany = function () {
-    return this._howMany;
-};
-
-SomePromiseArray.prototype.setHowMany = function (count) {
-    this._howMany = count;
-};
-
-SomePromiseArray.prototype._promiseFulfilled = function (value) {
-    this._addFulfilled(value);
-    if (this._fulfilled() === this.howMany()) {
-        this._values.length = this.howMany();
-        if (this.howMany() === 1 && this._unwrap) {
-            this._resolve(this._values[0]);
-        } else {
-            this._resolve(this._values);
-        }
-        return true;
-    }
-    return false;
-
-};
-SomePromiseArray.prototype._promiseRejected = function (reason) {
-    this._addRejected(reason);
-    return this._checkOutcome();
-};
-
-SomePromiseArray.prototype._promiseCancelled = function () {
-    if (this._values instanceof Promise || this._values == null) {
-        return this._cancel();
-    }
-    this._addRejected(CANCELLATION);
-    return this._checkOutcome();
-};
-
-SomePromiseArray.prototype._checkOutcome = function() {
-    if (this.howMany() > this._canPossiblyFulfill()) {
-        var e = new AggregateError();
-        for (var i = this.length(); i < this._values.length; ++i) {
-            if (this._values[i] !== CANCELLATION) {
-                e.push(this._values[i]);
+            function SomePromiseArray(values) {
+              this.constructor$(values);
+              this._howMany = 0;
+              this._unwrap = false;
+              this._initialized = false;
             }
-        }
-        if (e.length > 0) {
-            this._reject(e);
-        } else {
-            this._cancel();
-        }
-        return true;
-    }
-    return false;
-};
+            util.inherits(SomePromiseArray, PromiseArray);
 
-SomePromiseArray.prototype._fulfilled = function () {
-    return this._totalResolved;
-};
+            SomePromiseArray.prototype._init = function () {
+              if (!this._initialized) {
+                return;
+              }
+              if (this._howMany === 0) {
+                this._resolve([]);
+                return;
+              }
+              this._init$(undefined, -5);
+              var isArrayResolved = isArray(this._values);
+              if (!this._isResolved() &&
+                  isArrayResolved &&
+                  this._howMany > this._canPossiblyFulfill()) {
+                this._reject(this._getRangeError(this.length()));
+              }
+            };
 
-SomePromiseArray.prototype._rejected = function () {
-    return this._values.length - this.length();
-};
+            SomePromiseArray.prototype.init = function () {
+              this._initialized = true;
+              this._init();
+            };
 
-SomePromiseArray.prototype._addRejected = function (reason) {
-    this._values.push(reason);
-};
+            SomePromiseArray.prototype.setUnwrap = function () {
+              this._unwrap = true;
+            };
 
-SomePromiseArray.prototype._addFulfilled = function (value) {
-    this._values[this._totalResolved++] = value;
-};
+            SomePromiseArray.prototype.howMany = function () {
+              return this._howMany;
+            };
 
-SomePromiseArray.prototype._canPossiblyFulfill = function () {
-    return this.length() - this._rejected();
-};
+            SomePromiseArray.prototype.setHowMany = function (count) {
+              this._howMany = count;
+            };
 
-SomePromiseArray.prototype._getRangeError = function (count) {
-    var message = "Input array must contain at least " +
-            this._howMany + " items but contains only " + count + " items";
-    return new RangeError(message);
-};
+            SomePromiseArray.prototype._promiseFulfilled = function (value) {
+              this._addFulfilled(value);
+              if (this._fulfilled() === this.howMany()) {
+                this._values.length = this.howMany();
+                if (this.howMany() === 1 && this._unwrap) {
+                  this._resolve(this._values[0]);
+                } else {
+                  this._resolve(this._values);
+                }
+                return true;
+              }
+              return false;
 
-SomePromiseArray.prototype._resolveEmptyArray = function () {
-    this._reject(this._getRangeError(0));
-};
+            };
+            SomePromiseArray.prototype._promiseRejected = function (reason) {
+              this._addRejected(reason);
+              return this._checkOutcome();
+            };
 
-function some(promises, howMany) {
-    if ((howMany | 0) !== howMany || howMany < 0) {
-        return apiRejection("expecting a positive integer\u000a\u000a    See http://goo.gl/MqrFmX\u000a");
-    }
-    var ret = new SomePromiseArray(promises);
-    var promise = ret.promise();
-    ret.setHowMany(howMany);
-    ret.init();
-    return promise;
-}
+            SomePromiseArray.prototype._promiseCancelled = function () {
+              if (this._values instanceof Promise || this._values == null) {
+                return this._cancel();
+              }
+              this._addRejected(CANCELLATION);
+              return this._checkOutcome();
+            };
 
-Promise.some = function (promises, howMany) {
-    return some(promises, howMany);
-};
+            SomePromiseArray.prototype._checkOutcome = function() {
+              if (this.howMany() > this._canPossiblyFulfill()) {
+                var e = new AggregateError();
+                for (var i = this.length(); i < this._values.length; ++i) {
+                  if (this._values[i] !== CANCELLATION) {
+                    e.push(this._values[i]);
+                  }
+                }
+                if (e.length > 0) {
+                  this._reject(e);
+                } else {
+                  this._cancel();
+                }
+                return true;
+              }
+              return false;
+            };
 
-Promise.prototype.some = function (howMany) {
-    return some(this, howMany);
-};
+            SomePromiseArray.prototype._fulfilled = function () {
+              return this._totalResolved;
+            };
 
-Promise._SomePromiseArray = SomePromiseArray;
-};
+            SomePromiseArray.prototype._rejected = function () {
+              return this._values.length - this.length();
+            };
 
-},{"./errors":12,"./util":36}],32:[function(_dereq_,module,exports){
-"use strict";
-module.exports = function(Promise) {
-function PromiseInspection(promise) {
-    if (promise !== undefined) {
-        promise = promise._target();
-        this._bitField = promise._bitField;
-        this._settledValueField = promise._isFateSealed()
-            ? promise._settledValue() : undefined;
-    }
-    else {
-        this._bitField = 0;
-        this._settledValueField = undefined;
-    }
-}
+            SomePromiseArray.prototype._addRejected = function (reason) {
+              this._values.push(reason);
+            };
 
-PromiseInspection.prototype._settledValue = function() {
-    return this._settledValueField;
-};
+            SomePromiseArray.prototype._addFulfilled = function (value) {
+              this._values[this._totalResolved++] = value;
+            };
 
-var value = PromiseInspection.prototype.value = function () {
-    if (!this.isFulfilled()) {
-        throw new TypeError("cannot get fulfillment value of a non-fulfilled promise\u000a\u000a    See http://goo.gl/MqrFmX\u000a");
-    }
-    return this._settledValue();
-};
+            SomePromiseArray.prototype._canPossiblyFulfill = function () {
+              return this.length() - this._rejected();
+            };
 
-var reason = PromiseInspection.prototype.error =
-PromiseInspection.prototype.reason = function () {
-    if (!this.isRejected()) {
-        throw new TypeError("cannot get rejection reason of a non-rejected promise\u000a\u000a    See http://goo.gl/MqrFmX\u000a");
-    }
-    return this._settledValue();
-};
+            SomePromiseArray.prototype._getRangeError = function (count) {
+              var message = "Input array must contain at least " +
+              this._howMany + " items but contains only " + count + " items";
+              return new RangeError(message);
+            };
 
-var isFulfilled = PromiseInspection.prototype.isFulfilled = function() {
-    return (this._bitField & 33554432) !== 0;
-};
+            SomePromiseArray.prototype._resolveEmptyArray = function () {
+              this._reject(this._getRangeError(0));
+            };
 
-var isRejected = PromiseInspection.prototype.isRejected = function () {
-    return (this._bitField & 16777216) !== 0;
-};
-
-var isPending = PromiseInspection.prototype.isPending = function () {
-    return (this._bitField & 50397184) === 0;
-};
-
-var isResolved = PromiseInspection.prototype.isResolved = function () {
-    return (this._bitField & 50331648) !== 0;
-};
-
-PromiseInspection.prototype.isCancelled = function() {
-    return (this._bitField & 8454144) !== 0;
-};
-
-Promise.prototype.__isCancelled = function() {
-    return (this._bitField & 65536) === 65536;
-};
-
-Promise.prototype._isCancelled = function() {
-    return this._target().__isCancelled();
-};
-
-Promise.prototype.isCancelled = function() {
-    return (this._target()._bitField & 8454144) !== 0;
-};
-
-Promise.prototype.isPending = function() {
-    return isPending.call(this._target());
-};
-
-Promise.prototype.isRejected = function() {
-    return isRejected.call(this._target());
-};
-
-Promise.prototype.isFulfilled = function() {
-    return isFulfilled.call(this._target());
-};
-
-Promise.prototype.isResolved = function() {
-    return isResolved.call(this._target());
-};
-
-Promise.prototype.value = function() {
-    return value.call(this._target());
-};
-
-Promise.prototype.reason = function() {
-    var target = this._target();
-    target._unsetRejectionIsUnhandled();
-    return reason.call(target);
-};
-
-Promise.prototype._value = function() {
-    return this._settledValue();
-};
-
-Promise.prototype._reason = function() {
-    this._unsetRejectionIsUnhandled();
-    return this._settledValue();
-};
-
-Promise.PromiseInspection = PromiseInspection;
-};
-
-},{}],33:[function(_dereq_,module,exports){
-"use strict";
-module.exports = function(Promise, INTERNAL) {
-var util = _dereq_("./util");
-var errorObj = util.errorObj;
-var isObject = util.isObject;
-
-function tryConvertToPromise(obj, context) {
-    if (isObject(obj)) {
-        if (obj instanceof Promise) return obj;
-        var then = getThen(obj);
-        if (then === errorObj) {
-            if (context) context._pushContext();
-            var ret = Promise.reject(then.e);
-            if (context) context._popContext();
-            return ret;
-        } else if (typeof then === "function") {
-            if (isAnyBluebirdPromise(obj)) {
-                var ret = new Promise(INTERNAL);
-                obj._then(
-                    ret._fulfill,
-                    ret._reject,
-                    undefined,
-                    ret,
-                    null
-                );
-                return ret;
+            function some(promises, howMany) {
+              if ((howMany | 0) !== howMany || howMany < 0) {
+                return apiRejection("expecting a positive integer\u000a\u000a    See http://goo.gl/MqrFmX\u000a");
+              }
+              var ret = new SomePromiseArray(promises);
+              var promise = ret.promise();
+              ret.setHowMany(howMany);
+              ret.init();
+              return promise;
             }
-            return doThenable(obj, then, context);
-        }
-    }
-    return obj;
-}
 
-function doGetThen(obj) {
-    return obj.then;
-}
+            Promise.some = function (promises, howMany) {
+              return some(promises, howMany);
+            };
 
-function getThen(obj) {
-    try {
-        return doGetThen(obj);
-    } catch (e) {
-        errorObj.e = e;
-        return errorObj;
-    }
-}
+            Promise.prototype.some = function (howMany) {
+              return some(this, howMany);
+            };
 
-var hasProp = {}.hasOwnProperty;
-function isAnyBluebirdPromise(obj) {
-    try {
-        return hasProp.call(obj, "_promise0");
-    } catch (e) {
-        return false;
-    }
-}
+            Promise._SomePromiseArray = SomePromiseArray;
+          };
 
-function doThenable(x, then, context) {
-    var promise = new Promise(INTERNAL);
-    var ret = promise;
-    if (context) context._pushContext();
-    promise._captureStackTrace();
-    if (context) context._popContext();
-    var synchronous = true;
-    var result = util.tryCatch(then).call(x, resolve, reject);
-    synchronous = false;
+        },{"./errors":12,"./util":36}],32:[function(_dereq_,module,exports){
+          "use strict";
+          module.exports = function(Promise) {
+            function PromiseInspection(promise) {
+              if (promise !== undefined) {
+                promise = promise._target();
+                this._bitField = promise._bitField;
+                this._settledValueField = promise._isFateSealed()
+                ? promise._settledValue() : undefined;
+              }
+              else {
+                this._bitField = 0;
+                this._settledValueField = undefined;
+              }
+            }
 
-    if (promise && result === errorObj) {
-        promise._rejectCallback(result.e, true, true);
-        promise = null;
-    }
+            PromiseInspection.prototype._settledValue = function() {
+              return this._settledValueField;
+            };
 
-    function resolve(value) {
-        if (!promise) return;
-        promise._resolveCallback(value);
-        promise = null;
-    }
+            var value = PromiseInspection.prototype.value = function () {
+              if (!this.isFulfilled()) {
+                throw new TypeError("cannot get fulfillment value of a non-fulfilled promise\u000a\u000a    See http://goo.gl/MqrFmX\u000a");
+              }
+              return this._settledValue();
+            };
 
-    function reject(reason) {
-        if (!promise) return;
-        promise._rejectCallback(reason, synchronous, true);
-        promise = null;
-    }
-    return ret;
-}
+            var reason = PromiseInspection.prototype.error =
+              PromiseInspection.prototype.reason = function () {
+              if (!this.isRejected()) {
+                throw new TypeError("cannot get rejection reason of a non-rejected promise\u000a\u000a    See http://goo.gl/MqrFmX\u000a");
+              }
+              return this._settledValue();
+            };
 
-return tryConvertToPromise;
-};
+            var isFulfilled = PromiseInspection.prototype.isFulfilled = function() {
+              return (this._bitField & 33554432) !== 0;
+            };
 
-},{"./util":36}],34:[function(_dereq_,module,exports){
-"use strict";
-module.exports = function(Promise, INTERNAL, debug) {
-var util = _dereq_("./util");
-var TimeoutError = Promise.TimeoutError;
+            var isRejected = PromiseInspection.prototype.isRejected = function () {
+              return (this._bitField & 16777216) !== 0;
+            };
 
-function HandleWrapper(handle)  {
-    this.handle = handle;
-}
+            var isPending = PromiseInspection.prototype.isPending = function () {
+              return (this._bitField & 50397184) === 0;
+            };
 
-HandleWrapper.prototype._resultCancelled = function() {
-    clearTimeout(this.handle);
-};
+            var isResolved = PromiseInspection.prototype.isResolved = function () {
+              return (this._bitField & 50331648) !== 0;
+            };
 
-var afterValue = function(value) { return delay(+this).thenReturn(value); };
-var delay = Promise.delay = function (ms, value) {
-    var ret;
-    var handle;
-    if (value !== undefined) {
-        ret = Promise.resolve(value)
+            PromiseInspection.prototype.isCancelled = function() {
+              return (this._bitField & 8454144) !== 0;
+            };
+
+            Promise.prototype.__isCancelled = function() {
+              return (this._bitField & 65536) === 65536;
+            };
+
+            Promise.prototype._isCancelled = function() {
+              return this._target().__isCancelled();
+            };
+
+            Promise.prototype.isCancelled = function() {
+              return (this._target()._bitField & 8454144) !== 0;
+            };
+
+            Promise.prototype.isPending = function() {
+              return isPending.call(this._target());
+            };
+
+            Promise.prototype.isRejected = function() {
+              return isRejected.call(this._target());
+            };
+
+            Promise.prototype.isFulfilled = function() {
+              return isFulfilled.call(this._target());
+            };
+
+            Promise.prototype.isResolved = function() {
+              return isResolved.call(this._target());
+            };
+
+            Promise.prototype.value = function() {
+              return value.call(this._target());
+            };
+
+            Promise.prototype.reason = function() {
+              var target = this._target();
+              target._unsetRejectionIsUnhandled();
+              return reason.call(target);
+            };
+
+            Promise.prototype._value = function() {
+              return this._settledValue();
+            };
+
+            Promise.prototype._reason = function() {
+              this._unsetRejectionIsUnhandled();
+              return this._settledValue();
+            };
+
+            Promise.PromiseInspection = PromiseInspection;
+          };
+
+        },{}],33:[function(_dereq_,module,exports){
+          "use strict";
+          module.exports = function(Promise, INTERNAL) {
+            var util = _dereq_("./util");
+            var errorObj = util.errorObj;
+            var isObject = util.isObject;
+
+            function tryConvertToPromise(obj, context) {
+              if (isObject(obj)) {
+                if (obj instanceof Promise) return obj;
+                var then = getThen(obj);
+                if (then === errorObj) {
+                  if (context) context._pushContext();
+                  var ret = Promise.reject(then.e);
+                  if (context) context._popContext();
+                  return ret;
+                } else if (typeof then === "function") {
+                  if (isAnyBluebirdPromise(obj)) {
+                    var ret = new Promise(INTERNAL);
+                    obj._then(
+                        ret._fulfill,
+                        ret._reject,
+                        undefined,
+                        ret,
+                        null
+                    );
+                    return ret;
+                  }
+                  return doThenable(obj, then, context);
+                }
+              }
+              return obj;
+            }
+
+            function doGetThen(obj) {
+              return obj.then;
+            }
+
+            function getThen(obj) {
+              try {
+                return doGetThen(obj);
+              } catch (e) {
+                errorObj.e = e;
+                return errorObj;
+              }
+            }
+
+            var hasProp = {}.hasOwnProperty;
+            function isAnyBluebirdPromise(obj) {
+              try {
+                return hasProp.call(obj, "_promise0");
+              } catch (e) {
+                return false;
+              }
+            }
+
+            function doThenable(x, then, context) {
+              var promise = new Promise(INTERNAL);
+              var ret = promise;
+              if (context) context._pushContext();
+              promise._captureStackTrace();
+              if (context) context._popContext();
+              var synchronous = true;
+              var result = util.tryCatch(then).call(x, resolve, reject);
+              synchronous = false;
+
+              if (promise && result === errorObj) {
+                promise._rejectCallback(result.e, true, true);
+                promise = null;
+              }
+
+              function resolve(value) {
+                if (!promise) return;
+                promise._resolveCallback(value);
+                promise = null;
+              }
+
+              function reject(reason) {
+                if (!promise) return;
+                promise._rejectCallback(reason, synchronous, true);
+                promise = null;
+              }
+              return ret;
+            }
+
+            return tryConvertToPromise;
+          };
+
+        },{"./util":36}],34:[function(_dereq_,module,exports){
+          "use strict";
+          module.exports = function(Promise, INTERNAL, debug) {
+            var util = _dereq_("./util");
+            var TimeoutError = Promise.TimeoutError;
+
+            function HandleWrapper(handle)  {
+              this.handle = handle;
+            }
+
+            HandleWrapper.prototype._resultCancelled = function() {
+              clearTimeout(this.handle);
+            };
+
+            var afterValue = function(value) { return delay(+this).thenReturn(value); };
+            var delay = Promise.delay = function (ms, value) {
+              var ret;
+              var handle;
+              if (value !== undefined) {
+                ret = Promise.resolve(value)
                 ._then(afterValue, null, null, ms, undefined);
-        if (debug.cancellation() && value instanceof Promise) {
-            ret._setOnCancel(value);
-        }
-    } else {
-        ret = new Promise(INTERNAL);
-        handle = setTimeout(function() { ret._fulfill(); }, +ms);
-        if (debug.cancellation()) {
-            ret._setOnCancel(new HandleWrapper(handle));
-        }
-        ret._captureStackTrace();
-    }
-    ret._setAsyncGuaranteed();
-    return ret;
-};
+                if (debug.cancellation() && value instanceof Promise) {
+                  ret._setOnCancel(value);
+                }
+              } else {
+                ret = new Promise(INTERNAL);
+                handle = setTimeout(function() { ret._fulfill(); }, +ms);
+                if (debug.cancellation()) {
+                  ret._setOnCancel(new HandleWrapper(handle));
+                }
+                ret._captureStackTrace();
+              }
+              ret._setAsyncGuaranteed();
+              return ret;
+            };
 
-Promise.prototype.delay = function (ms) {
-    return delay(ms, this);
-};
+            Promise.prototype.delay = function (ms) {
+              return delay(ms, this);
+            };
 
-var afterTimeout = function (promise, message, parent) {
-    var err;
-    if (typeof message !== "string") {
-        if (message instanceof Error) {
-            err = message;
-        } else {
-            err = new TimeoutError("operation timed out");
-        }
-    } else {
-        err = new TimeoutError(message);
-    }
-    util.markAsOriginatingFromRejection(err);
-    promise._attachExtraTrace(err);
-    promise._reject(err);
+            var afterTimeout = function (promise, message, parent) {
+              var err;
+              if (typeof message !== "string") {
+                if (message instanceof Error) {
+                  err = message;
+                } else {
+                  err = new TimeoutError("operation timed out");
+                }
+              } else {
+                err = new TimeoutError(message);
+              }
+              util.markAsOriginatingFromRejection(err);
+              promise._attachExtraTrace(err);
+              promise._reject(err);
 
-    if (parent != null) {
-        parent.cancel();
-    }
-};
+              if (parent != null) {
+                parent.cancel();
+              }
+            };
 
-function successClear(value) {
-    clearTimeout(this.handle);
-    return value;
-}
+            function successClear(value) {
+              clearTimeout(this.handle);
+              return value;
+            }
 
-function failureClear(reason) {
-    clearTimeout(this.handle);
-    throw reason;
-}
+            function failureClear(reason) {
+              clearTimeout(this.handle);
+              throw reason;
+            }
 
-Promise.prototype.timeout = function (ms, message) {
-    ms = +ms;
-    var ret, parent;
+            Promise.prototype.timeout = function (ms, message) {
+              ms = +ms;
+              var ret, parent;
 
-    var handleWrapper = new HandleWrapper(setTimeout(function timeoutTimeout() {
-        if (ret.isPending()) {
-            afterTimeout(ret, message, parent);
-        }
-    }, ms));
+              var handleWrapper = new HandleWrapper(setTimeout(function timeoutTimeout() {
+                if (ret.isPending()) {
+                  afterTimeout(ret, message, parent);
+                }
+              }, ms));
 
-    if (debug.cancellation()) {
-        parent = this.then();
-        ret = parent._then(successClear, failureClear,
-                            undefined, handleWrapper, undefined);
-        ret._setOnCancel(handleWrapper);
-    } else {
-        ret = this._then(successClear, failureClear,
-                            undefined, handleWrapper, undefined);
-    }
+              if (debug.cancellation()) {
+                parent = this.then();
+                ret = parent._then(successClear, failureClear,
+                    undefined, handleWrapper, undefined);
+                ret._setOnCancel(handleWrapper);
+              } else {
+                ret = this._then(successClear, failureClear,
+                    undefined, handleWrapper, undefined);
+              }
 
-    return ret;
-};
+              return ret;
+            };
 
-};
+          };
 
-},{"./util":36}],35:[function(_dereq_,module,exports){
-"use strict";
-module.exports = function (Promise, apiRejection, tryConvertToPromise,
-    createContext, INTERNAL, debug) {
-    var util = _dereq_("./util");
-    var TypeError = _dereq_("./errors").TypeError;
-    var inherits = _dereq_("./util").inherits;
-    var errorObj = util.errorObj;
-    var tryCatch = util.tryCatch;
-    var NULL = {};
+        },{"./util":36}],35:[function(_dereq_,module,exports){
+          "use strict";
+          module.exports = function (Promise, apiRejection, tryConvertToPromise,
+              createContext, INTERNAL, debug) {
+            var util = _dereq_("./util");
+            var TypeError = _dereq_("./errors").TypeError;
+            var inherits = _dereq_("./util").inherits;
+            var errorObj = util.errorObj;
+            var tryCatch = util.tryCatch;
+            var NULL = {};
 
-    function thrower(e) {
-        setTimeout(function(){throw e;}, 0);
-    }
+            function thrower(e) {
+              setTimeout(function(){throw e;}, 0);
+            }
 
-    function castPreservingDisposable(thenable) {
-        var maybePromise = tryConvertToPromise(thenable);
-        if (maybePromise !== thenable &&
-            typeof thenable._isDisposable === "function" &&
-            typeof thenable._getDisposer === "function" &&
-            thenable._isDisposable()) {
-            maybePromise._setDisposable(thenable._getDisposer());
-        }
-        return maybePromise;
-    }
-    function dispose(resources, inspection) {
-        var i = 0;
-        var len = resources.length;
-        var ret = new Promise(INTERNAL);
-        function iterator() {
-            if (i >= len) return ret._fulfill();
-            var maybePromise = castPreservingDisposable(resources[i++]);
-            if (maybePromise instanceof Promise &&
-                maybePromise._isDisposable()) {
-                try {
+            function castPreservingDisposable(thenable) {
+              var maybePromise = tryConvertToPromise(thenable);
+              if (maybePromise !== thenable &&
+                  typeof thenable._isDisposable === "function" &&
+                  typeof thenable._getDisposer === "function" &&
+                  thenable._isDisposable()) {
+                maybePromise._setDisposable(thenable._getDisposer());
+              }
+              return maybePromise;
+            }
+            function dispose(resources, inspection) {
+              var i = 0;
+              var len = resources.length;
+              var ret = new Promise(INTERNAL);
+              function iterator() {
+                if (i >= len) return ret._fulfill();
+                var maybePromise = castPreservingDisposable(resources[i++]);
+                if (maybePromise instanceof Promise &&
+                    maybePromise._isDisposable()) {
+                  try {
                     maybePromise = tryConvertToPromise(
                         maybePromise._getDisposer().tryDispose(inspection),
                         resources.promise);
-                } catch (e) {
+                  } catch (e) {
                     return thrower(e);
-                }
-                if (maybePromise instanceof Promise) {
+                  }
+                  if (maybePromise instanceof Promise) {
                     return maybePromise._then(iterator, thrower,
-                                              null, null, null);
+                        null, null, null);
+                  }
                 }
+                iterator();
+              }
+              iterator();
+              return ret;
             }
-            iterator();
-        }
-        iterator();
-        return ret;
-    }
 
-    function Disposer(data, promise, context) {
-        this._data = data;
-        this._promise = promise;
-        this._context = context;
-    }
-
-    Disposer.prototype.data = function () {
-        return this._data;
-    };
-
-    Disposer.prototype.promise = function () {
-        return this._promise;
-    };
-
-    Disposer.prototype.resource = function () {
-        if (this.promise().isFulfilled()) {
-            return this.promise().value();
-        }
-        return NULL;
-    };
-
-    Disposer.prototype.tryDispose = function(inspection) {
-        var resource = this.resource();
-        var context = this._context;
-        if (context !== undefined) context._pushContext();
-        var ret = resource !== NULL
-            ? this.doDispose(resource, inspection) : null;
-        if (context !== undefined) context._popContext();
-        this._promise._unsetDisposable();
-        this._data = null;
-        return ret;
-    };
-
-    Disposer.isDisposer = function (d) {
-        return (d != null &&
-                typeof d.resource === "function" &&
-                typeof d.tryDispose === "function");
-    };
-
-    function FunctionDisposer(fn, promise, context) {
-        this.constructor$(fn, promise, context);
-    }
-    inherits(FunctionDisposer, Disposer);
-
-    FunctionDisposer.prototype.doDispose = function (resource, inspection) {
-        var fn = this.data();
-        return fn.call(resource, resource, inspection);
-    };
-
-    function maybeUnwrapDisposer(value) {
-        if (Disposer.isDisposer(value)) {
-            this.resources[this.index]._setDisposable(value);
-            return value.promise();
-        }
-        return value;
-    }
-
-    function ResourceList(length) {
-        this.length = length;
-        this.promise = null;
-        this[length-1] = null;
-    }
-
-    ResourceList.prototype._resultCancelled = function() {
-        var len = this.length;
-        for (var i = 0; i < len; ++i) {
-            var item = this[i];
-            if (item instanceof Promise) {
-                item.cancel();
+            function Disposer(data, promise, context) {
+              this._data = data;
+              this._promise = promise;
+              this._context = context;
             }
-        }
-    };
 
-    Promise.using = function () {
-        var len = arguments.length;
-        if (len < 2) return apiRejection(
-                        "you must pass at least 2 arguments to Promise.using");
-        var fn = arguments[len - 1];
-        if (typeof fn !== "function") {
-            return apiRejection("expecting a function but got " + util.classString(fn));
-        }
-        var input;
-        var spreadArgs = true;
-        if (len === 2 && Array.isArray(arguments[0])) {
-            input = arguments[0];
-            len = input.length;
-            spreadArgs = false;
-        } else {
-            input = arguments;
-            len--;
-        }
-        var resources = new ResourceList(len);
-        for (var i = 0; i < len; ++i) {
-            var resource = input[i];
-            if (Disposer.isDisposer(resource)) {
-                var disposer = resource;
-                resource = resource.promise();
-                resource._setDisposable(disposer);
-            } else {
-                var maybePromise = tryConvertToPromise(resource);
-                if (maybePromise instanceof Promise) {
+            Disposer.prototype.data = function () {
+              return this._data;
+            };
+
+            Disposer.prototype.promise = function () {
+              return this._promise;
+            };
+
+            Disposer.prototype.resource = function () {
+              if (this.promise().isFulfilled()) {
+                return this.promise().value();
+              }
+              return NULL;
+            };
+
+            Disposer.prototype.tryDispose = function(inspection) {
+              var resource = this.resource();
+              var context = this._context;
+              if (context !== undefined) context._pushContext();
+              var ret = resource !== NULL
+              ? this.doDispose(resource, inspection) : null;
+              if (context !== undefined) context._popContext();
+              this._promise._unsetDisposable();
+              this._data = null;
+              return ret;
+            };
+
+            Disposer.isDisposer = function (d) {
+              return (d != null &&
+                  typeof d.resource === "function" &&
+                  typeof d.tryDispose === "function");
+            };
+
+            function FunctionDisposer(fn, promise, context) {
+              this.constructor$(fn, promise, context);
+            }
+            inherits(FunctionDisposer, Disposer);
+
+            FunctionDisposer.prototype.doDispose = function (resource, inspection) {
+              var fn = this.data();
+              return fn.call(resource, resource, inspection);
+            };
+
+            function maybeUnwrapDisposer(value) {
+              if (Disposer.isDisposer(value)) {
+                this.resources[this.index]._setDisposable(value);
+                return value.promise();
+              }
+              return value;
+            }
+
+            function ResourceList(length) {
+              this.length = length;
+              this.promise = null;
+              this[length-1] = null;
+            }
+
+            ResourceList.prototype._resultCancelled = function() {
+              var len = this.length;
+              for (var i = 0; i < len; ++i) {
+                var item = this[i];
+                if (item instanceof Promise) {
+                  item.cancel();
+                }
+              }
+            };
+
+            Promise.using = function () {
+              var len = arguments.length;
+              if (len < 2) return apiRejection(
+              "you must pass at least 2 arguments to Promise.using");
+              var fn = arguments[len - 1];
+              if (typeof fn !== "function") {
+                return apiRejection("expecting a function but got " + util.classString(fn));
+              }
+              var input;
+              var spreadArgs = true;
+              if (len === 2 && Array.isArray(arguments[0])) {
+                input = arguments[0];
+                len = input.length;
+                spreadArgs = false;
+              } else {
+                input = arguments;
+                len--;
+              }
+              var resources = new ResourceList(len);
+              for (var i = 0; i < len; ++i) {
+                var resource = input[i];
+                if (Disposer.isDisposer(resource)) {
+                  var disposer = resource;
+                  resource = resource.promise();
+                  resource._setDisposable(disposer);
+                } else {
+                  var maybePromise = tryConvertToPromise(resource);
+                  if (maybePromise instanceof Promise) {
                     resource =
-                        maybePromise._then(maybeUnwrapDisposer, null, null, {
-                            resources: resources,
-                            index: i
-                    }, undefined);
+                      maybePromise._then(maybeUnwrapDisposer, null, null, {
+                        resources: resources,
+                        index: i
+                      }, undefined);
+                  }
                 }
-            }
-            resources[i] = resource;
-        }
+                resources[i] = resource;
+              }
 
-        var reflectedResources = new Array(resources.length);
-        for (var i = 0; i < reflectedResources.length; ++i) {
-            reflectedResources[i] = Promise.resolve(resources[i]).reflect();
-        }
+              var reflectedResources = new Array(resources.length);
+              for (var i = 0; i < reflectedResources.length; ++i) {
+                reflectedResources[i] = Promise.resolve(resources[i]).reflect();
+              }
 
-        var resultPromise = Promise.all(reflectedResources)
-            .then(function(inspections) {
+              var resultPromise = Promise.all(reflectedResources)
+              .then(function(inspections) {
                 for (var i = 0; i < inspections.length; ++i) {
-                    var inspection = inspections[i];
-                    if (inspection.isRejected()) {
-                        errorObj.e = inspection.error();
-                        return errorObj;
-                    } else if (!inspection.isFulfilled()) {
-                        resultPromise.cancel();
-                        return;
-                    }
-                    inspections[i] = inspection.value();
+                  var inspection = inspections[i];
+                  if (inspection.isRejected()) {
+                    errorObj.e = inspection.error();
+                    return errorObj;
+                  } else if (!inspection.isFulfilled()) {
+                    resultPromise.cancel();
+                    return;
+                  }
+                  inspections[i] = inspection.value();
                 }
                 promise._pushContext();
 
                 fn = tryCatch(fn);
                 var ret = spreadArgs
-                    ? fn.apply(undefined, inspections) : fn(inspections);
+                ? fn.apply(undefined, inspections) : fn(inspections);
                 var promiseCreated = promise._popContext();
                 debug.checkForgottenReturns(
                     ret, promiseCreated, "Promise.using", promise);
                 return ret;
-            });
+              });
 
-        var promise = resultPromise.lastly(function() {
-            var inspection = new Promise.PromiseInspection(resultPromise);
-            return dispose(resources, inspection);
-        });
-        resources.promise = promise;
-        promise._setOnCancel(resources);
-        return promise;
-    };
+              var promise = resultPromise.lastly(function() {
+                var inspection = new Promise.PromiseInspection(resultPromise);
+                return dispose(resources, inspection);
+              });
+              resources.promise = promise;
+              promise._setOnCancel(resources);
+              return promise;
+            };
 
-    Promise.prototype._setDisposable = function (disposer) {
-        this._bitField = this._bitField | 131072;
-        this._disposer = disposer;
-    };
+            Promise.prototype._setDisposable = function (disposer) {
+              this._bitField = this._bitField | 131072;
+              this._disposer = disposer;
+            };
 
-    Promise.prototype._isDisposable = function () {
-        return (this._bitField & 131072) > 0;
-    };
+            Promise.prototype._isDisposable = function () {
+              return (this._bitField & 131072) > 0;
+            };
 
-    Promise.prototype._getDisposer = function () {
-        return this._disposer;
-    };
+            Promise.prototype._getDisposer = function () {
+              return this._disposer;
+            };
 
-    Promise.prototype._unsetDisposable = function () {
-        this._bitField = this._bitField & (~131072);
-        this._disposer = undefined;
-    };
+            Promise.prototype._unsetDisposable = function () {
+              this._bitField = this._bitField & (~131072);
+              this._disposer = undefined;
+            };
 
-    Promise.prototype.disposer = function (fn) {
-        if (typeof fn === "function") {
-            return new FunctionDisposer(fn, this, createContext());
-        }
-        throw new TypeError();
-    };
+            Promise.prototype.disposer = function (fn) {
+              if (typeof fn === "function") {
+                return new FunctionDisposer(fn, this, createContext());
+              }
+              throw new TypeError();
+            };
 
-};
+          };
 
-},{"./errors":12,"./util":36}],36:[function(_dereq_,module,exports){
-"use strict";
-var es5 = _dereq_("./es5");
-var canEvaluate = typeof navigator == "undefined";
+        },{"./errors":12,"./util":36}],36:[function(_dereq_,module,exports){
+          "use strict";
+          var es5 = _dereq_("./es5");
+          var canEvaluate = typeof navigator == "undefined";
 
-var errorObj = {e: {}};
-var tryCatchTarget;
-var globalObject = typeof self !== "undefined" ? self :
-    typeof window !== "undefined" ? window :
-    typeof global !== "undefined" ? global :
-    this !== undefined ? this : null;
+          var errorObj = {e: {}};
+          var tryCatchTarget;
+          var globalObject = typeof self !== "undefined" ? self :
+            typeof window !== "undefined" ? window :
+              typeof global !== "undefined" ? global :
+                this !== undefined ? this : null;
 
-function tryCatcher() {
-    try {
-        var target = tryCatchTarget;
-        tryCatchTarget = null;
-        return target.apply(this, arguments);
-    } catch (e) {
-        errorObj.e = e;
-        return errorObj;
-    }
-}
-function tryCatch(fn) {
-    tryCatchTarget = fn;
-    return tryCatcher;
-}
-
-var inherits = function(Child, Parent) {
-    var hasProp = {}.hasOwnProperty;
-
-    function T() {
-        this.constructor = Child;
-        this.constructor$ = Parent;
-        for (var propertyName in Parent.prototype) {
-            if (hasProp.call(Parent.prototype, propertyName) &&
-                propertyName.charAt(propertyName.length-1) !== "$"
-           ) {
-                this[propertyName + "$"] = Parent.prototype[propertyName];
+          function tryCatcher() {
+            try {
+              var target = tryCatchTarget;
+              tryCatchTarget = null;
+              return target.apply(this, arguments);
+            } catch (e) {
+              errorObj.e = e;
+              return errorObj;
             }
-        }
-    }
-    T.prototype = Parent.prototype;
-    Child.prototype = new T();
-    return Child.prototype;
-};
+          }
+          function tryCatch(fn) {
+            tryCatchTarget = fn;
+            return tryCatcher;
+          }
 
+          var inherits = function(Child, Parent) {
+            var hasProp = {}.hasOwnProperty;
 
-function isPrimitive(val) {
-    return val == null || val === true || val === false ||
-        typeof val === "string" || typeof val === "number";
-
-}
-
-function isObject(value) {
-    return typeof value === "function" ||
-           typeof value === "object" && value !== null;
-}
-
-function maybeWrapAsError(maybeError) {
-    if (!isPrimitive(maybeError)) return maybeError;
-
-    return new Error(safeToString(maybeError));
-}
-
-function withAppended(target, appendee) {
-    var len = target.length;
-    var ret = new Array(len + 1);
-    var i;
-    for (i = 0; i < len; ++i) {
-        ret[i] = target[i];
-    }
-    ret[i] = appendee;
-    return ret;
-}
-
-function getDataPropertyOrDefault(obj, key, defaultValue) {
-    if (es5.isES5) {
-        var desc = Object.getOwnPropertyDescriptor(obj, key);
-
-        if (desc != null) {
-            return desc.get == null && desc.set == null
-                    ? desc.value
-                    : defaultValue;
-        }
-    } else {
-        return {}.hasOwnProperty.call(obj, key) ? obj[key] : undefined;
-    }
-}
-
-function notEnumerableProp(obj, name, value) {
-    if (isPrimitive(obj)) return obj;
-    var descriptor = {
-        value: value,
-        configurable: true,
-        enumerable: false,
-        writable: true
-    };
-    es5.defineProperty(obj, name, descriptor);
-    return obj;
-}
-
-function thrower(r) {
-    throw r;
-}
-
-var inheritedDataKeys = (function() {
-    var excludedPrototypes = [
-        Array.prototype,
-        Object.prototype,
-        Function.prototype
-    ];
-
-    var isExcludedProto = function(val) {
-        for (var i = 0; i < excludedPrototypes.length; ++i) {
-            if (excludedPrototypes[i] === val) {
-                return true;
-            }
-        }
-        return false;
-    };
-
-    if (es5.isES5) {
-        var getKeys = Object.getOwnPropertyNames;
-        return function(obj) {
-            var ret = [];
-            var visitedKeys = Object.create(null);
-            while (obj != null && !isExcludedProto(obj)) {
-                var keys;
-                try {
-                    keys = getKeys(obj);
-                } catch (e) {
-                    return ret;
+            function T() {
+              this.constructor = Child;
+              this.constructor$ = Parent;
+              for (var propertyName in Parent.prototype) {
+                if (hasProp.call(Parent.prototype, propertyName) &&
+                    propertyName.charAt(propertyName.length-1) !== "$"
+                ) {
+                  this[propertyName + "$"] = Parent.prototype[propertyName];
                 }
-                for (var i = 0; i < keys.length; ++i) {
+              }
+            }
+            T.prototype = Parent.prototype;
+            Child.prototype = new T();
+            return Child.prototype;
+          };
+
+
+          function isPrimitive(val) {
+            return val == null || val === true || val === false ||
+            typeof val === "string" || typeof val === "number";
+
+          }
+
+          function isObject(value) {
+            return typeof value === "function" ||
+            typeof value === "object" && value !== null;
+          }
+
+          function maybeWrapAsError(maybeError) {
+            if (!isPrimitive(maybeError)) return maybeError;
+
+            return new Error(safeToString(maybeError));
+          }
+
+          function withAppended(target, appendee) {
+            var len = target.length;
+            var ret = new Array(len + 1);
+            var i;
+            for (i = 0; i < len; ++i) {
+              ret[i] = target[i];
+            }
+            ret[i] = appendee;
+            return ret;
+          }
+
+          function getDataPropertyOrDefault(obj, key, defaultValue) {
+            if (es5.isES5) {
+              var desc = Object.getOwnPropertyDescriptor(obj, key);
+
+              if (desc != null) {
+                return desc.get == null && desc.set == null
+                ? desc.value
+                    : defaultValue;
+              }
+            } else {
+              return {}.hasOwnProperty.call(obj, key) ? obj[key] : undefined;
+            }
+          }
+
+          function notEnumerableProp(obj, name, value) {
+            if (isPrimitive(obj)) return obj;
+            var descriptor = {
+                value: value,
+                configurable: true,
+                enumerable: false,
+                writable: true
+            };
+            es5.defineProperty(obj, name, descriptor);
+            return obj;
+          }
+
+          function thrower(r) {
+            throw r;
+          }
+
+          var inheritedDataKeys = (function() {
+            var excludedPrototypes = [
+              Array.prototype,
+              Object.prototype,
+              Function.prototype
+              ];
+
+            var isExcludedProto = function(val) {
+              for (var i = 0; i < excludedPrototypes.length; ++i) {
+                if (excludedPrototypes[i] === val) {
+                  return true;
+                }
+              }
+              return false;
+            };
+
+            if (es5.isES5) {
+              var getKeys = Object.getOwnPropertyNames;
+              return function(obj) {
+                var ret = [];
+                var visitedKeys = Object.create(null);
+                while (obj != null && !isExcludedProto(obj)) {
+                  var keys;
+                  try {
+                    keys = getKeys(obj);
+                  } catch (e) {
+                    return ret;
+                  }
+                  for (var i = 0; i < keys.length; ++i) {
                     var key = keys[i];
                     if (visitedKeys[key]) continue;
                     visitedKeys[key] = true;
                     var desc = Object.getOwnPropertyDescriptor(obj, key);
                     if (desc != null && desc.get == null && desc.set == null) {
-                        ret.push(key);
+                      ret.push(key);
                     }
+                  }
+                  obj = es5.getPrototypeOf(obj);
                 }
-                obj = es5.getPrototypeOf(obj);
-            }
-            return ret;
-        };
-    } else {
-        var hasProp = {}.hasOwnProperty;
-        return function(obj) {
-            if (isExcludedProto(obj)) return [];
-            var ret = [];
+                return ret;
+              };
+            } else {
+              var hasProp = {}.hasOwnProperty;
+              return function(obj) {
+                if (isExcludedProto(obj)) return [];
+                var ret = [];
 
-            /*jshint forin:false */
-            enumeration: for (var key in obj) {
-                if (hasProp.call(obj, key)) {
+                /*jshint forin:false */
+                enumeration: for (var key in obj) {
+                  if (hasProp.call(obj, key)) {
                     ret.push(key);
-                } else {
+                  } else {
                     for (var i = 0; i < excludedPrototypes.length; ++i) {
-                        if (hasProp.call(excludedPrototypes[i], key)) {
-                            continue enumeration;
-                        }
+                      if (hasProp.call(excludedPrototypes[i], key)) {
+                        continue enumeration;
+                      }
                     }
                     ret.push(key);
+                  }
                 }
+                return ret;
+              };
+            }
+
+          })();
+
+          var thisAssignmentPattern = /this\s*\.\s*\S+\s*=/;
+          function isClass(fn) {
+            try {
+              if (typeof fn === "function") {
+                var keys = es5.names(fn.prototype);
+
+                var hasMethods = es5.isES5 && keys.length > 1;
+                var hasMethodsOtherThanConstructor = keys.length > 0 &&
+                !(keys.length === 1 && keys[0] === "constructor");
+                var hasThisAssignmentAndStaticMethods =
+                  thisAssignmentPattern.test(fn + "") && es5.names(fn).length > 0;
+
+                  if (hasMethods || hasMethodsOtherThanConstructor ||
+                      hasThisAssignmentAndStaticMethods) {
+                    return true;
+                  }
+              }
+              return false;
+            } catch (e) {
+              return false;
+            }
+          }
+
+          function toFastProperties(obj) {
+            /*jshint -W027,-W055,-W031*/
+            function FakeConstructor() {}
+            FakeConstructor.prototype = obj;
+            var l = 8;
+            while (l--) new FakeConstructor();
+            return obj;
+            eval(obj);
+          }
+
+          var rident = /^[a-z$_][a-z$_0-9]*$/i;
+          function isIdentifier(str) {
+            return rident.test(str);
+          }
+
+          function filledRange(count, prefix, suffix) {
+            var ret = new Array(count);
+            for(var i = 0; i < count; ++i) {
+              ret[i] = prefix + i + suffix;
             }
             return ret;
-        };
-    }
+          }
 
-})();
-
-var thisAssignmentPattern = /this\s*\.\s*\S+\s*=/;
-function isClass(fn) {
-    try {
-        if (typeof fn === "function") {
-            var keys = es5.names(fn.prototype);
-
-            var hasMethods = es5.isES5 && keys.length > 1;
-            var hasMethodsOtherThanConstructor = keys.length > 0 &&
-                !(keys.length === 1 && keys[0] === "constructor");
-            var hasThisAssignmentAndStaticMethods =
-                thisAssignmentPattern.test(fn + "") && es5.names(fn).length > 0;
-
-            if (hasMethods || hasMethodsOtherThanConstructor ||
-                hasThisAssignmentAndStaticMethods) {
-                return true;
-            }
-        }
-        return false;
-    } catch (e) {
-        return false;
-    }
-}
-
-function toFastProperties(obj) {
-    /*jshint -W027,-W055,-W031*/
-    function FakeConstructor() {}
-    FakeConstructor.prototype = obj;
-    var l = 8;
-    while (l--) new FakeConstructor();
-    return obj;
-    eval(obj);
-}
-
-var rident = /^[a-z$_][a-z$_0-9]*$/i;
-function isIdentifier(str) {
-    return rident.test(str);
-}
-
-function filledRange(count, prefix, suffix) {
-    var ret = new Array(count);
-    for(var i = 0; i < count; ++i) {
-        ret[i] = prefix + i + suffix;
-    }
-    return ret;
-}
-
-function safeToString(obj) {
-    try {
-        return obj + "";
-    } catch (e) {
-        return "[no string representation]";
-    }
-}
-
-function isError(obj) {
-    return obj !== null &&
-           typeof obj === "object" &&
-           typeof obj.message === "string" &&
-           typeof obj.name === "string";
-}
-
-function markAsOriginatingFromRejection(e) {
-    try {
-        notEnumerableProp(e, "isOperational", true);
-    }
-    catch(ignore) {}
-}
-
-function originatesFromRejection(e) {
-    if (e == null) return false;
-    return ((e instanceof Error["__BluebirdErrorTypes__"].OperationalError) ||
-        e["isOperational"] === true);
-}
-
-function canAttachTrace(obj) {
-    return isError(obj) && es5.propertyIsWritable(obj, "stack");
-}
-
-var ensureErrorObject = (function() {
-    if (!("stack" in new Error())) {
-        return function(value) {
-            if (canAttachTrace(value)) return value;
-            try {throw new Error(safeToString(value));}
-            catch(err) {return err;}
-        };
-    } else {
-        return function(value) {
-            if (canAttachTrace(value)) return value;
-            return new Error(safeToString(value));
-        };
-    }
-})();
-
-function classString(obj) {
-    return {}.toString.call(obj);
-}
-
-function copyDescriptors(from, to, filter) {
-    var keys = es5.names(from);
-    for (var i = 0; i < keys.length; ++i) {
-        var key = keys[i];
-        if (filter(key)) {
+          function safeToString(obj) {
             try {
-                es5.defineProperty(to, key, es5.getDescriptor(from, key));
-            } catch (ignore) {}
-        }
-    }
-}
-
-var asArray = function(v) {
-    if (es5.isArray(v)) {
-        return v;
-    }
-    return null;
-};
-
-if (typeof Symbol !== "undefined" && Symbol.iterator) {
-    var ArrayFrom = typeof Array.from === "function" ? function(v) {
-        return Array.from(v);
-    } : function(v) {
-        var ret = [];
-        var it = v[Symbol.iterator]();
-        var itResult;
-        while (!((itResult = it.next()).done)) {
-            ret.push(itResult.value);
-        }
-        return ret;
-    };
-
-    asArray = function(v) {
-        if (es5.isArray(v)) {
-            return v;
-        } else if (v != null && typeof v[Symbol.iterator] === "function") {
-            return ArrayFrom(v);
-        }
-        return null;
-    };
-}
-
-var isNode = typeof process !== "undefined" &&
-        classString(process).toLowerCase() === "[object process]";
-
-function env(key, def) {
-    return isNode ? process.env[key] : def;
-}
-
-function getNativePromise() {
-    if (typeof Promise === "function") {
-        try {
-            var promise = new Promise(function(){});
-            if ({}.toString.call(promise) === "[object Promise]") {
-                return Promise;
+              return obj + "";
+            } catch (e) {
+              return "[no string representation]";
             }
-        } catch (e) {}
-    }
-}
+          }
 
-function domainBind(self, cb) {
-    return self.bind(cb);
-}
+          function isError(obj) {
+            return obj !== null &&
+            typeof obj === "object" &&
+            typeof obj.message === "string" &&
+            typeof obj.name === "string";
+          }
 
-var ret = {
-    isClass: isClass,
-    isIdentifier: isIdentifier,
-    inheritedDataKeys: inheritedDataKeys,
-    getDataPropertyOrDefault: getDataPropertyOrDefault,
-    thrower: thrower,
-    isArray: es5.isArray,
-    asArray: asArray,
-    notEnumerableProp: notEnumerableProp,
-    isPrimitive: isPrimitive,
-    isObject: isObject,
-    isError: isError,
-    canEvaluate: canEvaluate,
-    errorObj: errorObj,
-    tryCatch: tryCatch,
-    inherits: inherits,
-    withAppended: withAppended,
-    maybeWrapAsError: maybeWrapAsError,
-    toFastProperties: toFastProperties,
-    filledRange: filledRange,
-    toString: safeToString,
-    canAttachTrace: canAttachTrace,
-    ensureErrorObject: ensureErrorObject,
-    originatesFromRejection: originatesFromRejection,
-    markAsOriginatingFromRejection: markAsOriginatingFromRejection,
-    classString: classString,
-    copyDescriptors: copyDescriptors,
-    hasDevTools: typeof chrome !== "undefined" && chrome &&
-                 typeof chrome.loadTimes === "function",
-    isNode: isNode,
-    env: env,
-    global: globalObject,
-    getNativePromise: getNativePromise,
-    domainBind: domainBind
-};
-ret.isRecentNode = ret.isNode && (function() {
-    var version = process.versions.node.split(".").map(Number);
-    return (version[0] === 0 && version[1] > 10) || (version[0] > 0);
-})();
+          function markAsOriginatingFromRejection(e) {
+            try {
+              notEnumerableProp(e, "isOperational", true);
+            }
+            catch(ignore) {}
+          }
 
-if (ret.isNode) ret.toFastProperties(process);
+          function originatesFromRejection(e) {
+            if (e == null) return false;
+            return ((e instanceof Error["__BluebirdErrorTypes__"].OperationalError) ||
+                e["isOperational"] === true);
+          }
 
-try {throw new Error(); } catch (e) {ret.lastLineError = e;}
-module.exports = ret;
+          function canAttachTrace(obj) {
+            return isError(obj) && es5.propertyIsWritable(obj, "stack");
+          }
 
-},{"./es5":13}]},{},[4])(4)
-});
+          var ensureErrorObject = (function() {
+            if (!("stack" in new Error())) {
+              return function(value) {
+                if (canAttachTrace(value)) return value;
+                try {throw new Error(safeToString(value));}
+                catch(err) {return err;}
+              };
+            } else {
+              return function(value) {
+                if (canAttachTrace(value)) return value;
+                return new Error(safeToString(value));
+              };
+            }
+          })();
+
+          function classString(obj) {
+            return {}.toString.call(obj);
+          }
+
+          function copyDescriptors(from, to, filter) {
+            var keys = es5.names(from);
+            for (var i = 0; i < keys.length; ++i) {
+              var key = keys[i];
+              if (filter(key)) {
+                try {
+                  es5.defineProperty(to, key, es5.getDescriptor(from, key));
+                } catch (ignore) {}
+              }
+            }
+          }
+
+          var asArray = function(v) {
+            if (es5.isArray(v)) {
+              return v;
+            }
+            return null;
+          };
+
+          if (typeof Symbol !== "undefined" && Symbol.iterator) {
+            var ArrayFrom = typeof Array.from === "function" ? function(v) {
+              return Array.from(v);
+            } : function(v) {
+              var ret = [];
+              var it = v[Symbol.iterator]();
+              var itResult;
+              while (!((itResult = it.next()).done)) {
+                ret.push(itResult.value);
+              }
+              return ret;
+            };
+
+            asArray = function(v) {
+              if (es5.isArray(v)) {
+                return v;
+              } else if (v != null && typeof v[Symbol.iterator] === "function") {
+                return ArrayFrom(v);
+              }
+              return null;
+            };
+          }
+
+          var isNode = typeof process !== "undefined" &&
+          classString(process).toLowerCase() === "[object process]";
+
+          function env(key, def) {
+            return isNode ? process.env[key] : def;
+          }
+
+          function getNativePromise() {
+            if (typeof Promise === "function") {
+              try {
+                var promise = new Promise(function(){});
+                if ({}.toString.call(promise) === "[object Promise]") {
+                  return Promise;
+                }
+              } catch (e) {}
+            }
+          }
+
+          function domainBind(self, cb) {
+            return self.bind(cb);
+          }
+
+          var ret = {
+              isClass: isClass,
+              isIdentifier: isIdentifier,
+              inheritedDataKeys: inheritedDataKeys,
+              getDataPropertyOrDefault: getDataPropertyOrDefault,
+              thrower: thrower,
+              isArray: es5.isArray,
+              asArray: asArray,
+              notEnumerableProp: notEnumerableProp,
+              isPrimitive: isPrimitive,
+              isObject: isObject,
+              isError: isError,
+              canEvaluate: canEvaluate,
+              errorObj: errorObj,
+              tryCatch: tryCatch,
+              inherits: inherits,
+              withAppended: withAppended,
+              maybeWrapAsError: maybeWrapAsError,
+              toFastProperties: toFastProperties,
+              filledRange: filledRange,
+              toString: safeToString,
+              canAttachTrace: canAttachTrace,
+              ensureErrorObject: ensureErrorObject,
+              originatesFromRejection: originatesFromRejection,
+              markAsOriginatingFromRejection: markAsOriginatingFromRejection,
+              classString: classString,
+              copyDescriptors: copyDescriptors,
+              hasDevTools: typeof chrome !== "undefined" && chrome &&
+              typeof chrome.loadTimes === "function",
+              isNode: isNode,
+              env: env,
+              global: globalObject,
+              getNativePromise: getNativePromise,
+              domainBind: domainBind
+          };
+          ret.isRecentNode = ret.isNode && (function() {
+            var version = process.versions.node.split(".").map(Number);
+            return (version[0] === 0 && version[1] > 10) || (version[0] > 0);
+          })();
+
+          if (ret.isNode) ret.toFastProperties(process);
+
+          try {throw new Error(); } catch (e) {ret.lastLineError = e;}
+          module.exports = ret;
+
+        },{"./es5":13}]},{},[4])(4)
+  });
 
 
 })();

--- a/framework/source/class/qx/core/Property.js
+++ b/framework/source/class/qx/core/Property.js
@@ -1854,7 +1854,8 @@ qx.Bootstrap.define("qx.core.Property",
           "}");
       } else {
         code.push(
-          "function fire() {");
+          "function fire() {",
+          "  var tracker={};");
             
         // Fire event
         if (config.event) {
@@ -1862,11 +1863,13 @@ qx.Bootstrap.define("qx.core.Property",
               "var reg=qx.event.Registration;",
               
               "if(reg.hasListener(this, '", config.event, "'))",
-                "reg.fireEvent(this, '", config.event, "', qx.event.type.Data, [computed, old]", ");");
+                "qx.event.Utils.track(tracker, reg.fireEvent(this, '", config.event, "', qx.event.type.Data, [computed, old]", "));");
           if (qx.core.Environment.get("qx.promise")) {
             code.push(
                 "if(reg.hasListener(this, '", config.event, "Async'))",
-                  "reg.fireEventAsync(this, '", config.event, "Async', qx.event.type.Data, [qx.Promise.resolve(computed), old]", ");"
+                  "qx.event.Utils.then(tracker, function() {\n" +
+                  "  return reg.fireEventAsync(this, '", config.event, "Async', qx.event.type.Data, [qx.Promise.resolve(computed), old]", ");\n" +
+                  "});"
                 );
           }
         }
@@ -1882,6 +1885,8 @@ qx.Bootstrap.define("qx.core.Property",
         }
         
         code.push(
+            "if (tracker.promise)\n",
+            "  return tracker.promise.then(function() { return computed; });",
             "return computed;",
           "}");
       }

--- a/framework/source/class/qx/event/IEventDispatcher.js
+++ b/framework/source/class/qx/event/IEventDispatcher.js
@@ -46,6 +46,7 @@ qx.Interface.define("qx.event.IEventDispatcher",
      * @param target {Element|Event} The event dispatch target
      * @param event {qx.event.type.Event} event object to dispatch
      * @param type {String} the event type
+     * @return {qx.Promise?} a promise, if one or more of the event handlers returned a promise
      */
     dispatchEvent : function(target, event, type)
     {

--- a/framework/source/class/qx/event/Utils.js
+++ b/framework/source/class/qx/event/Utils.js
@@ -1,0 +1,328 @@
+/* ************************************************************************
+
+   qooxdoo - the new era of web development
+
+   http://qooxdoo.org
+
+   Copyright:
+     2018 Zenesis Ltd, john.spackman@zenesis.com
+
+   License:
+     MIT: https://opensource.org/licenses/MIT
+     See the LICENSE file in the project's top-level directory for details.
+
+   Authors:
+     * John Spackman (johnspackman)
+
+************************************************************************ */
+
+/**
+ * Utility methods which implement a fast, psuedo-promises mechanism used by event handlers
+ * and dispatchers.
+ * 
+ * Event handlers are allowed to return instances of `qx.Promise`, in which case the event
+ * queue is suspended until the promise is resolved.  The simplest way to handle this would be
+ * to convert the result of every event handler into a `qx.Promise` via `qx.Promise.resolve`,
+ * but given that by far the majority of event handlers do not return promises, this could add
+ * a significant overhead; the static methods in this class allow the event handlers to be
+ * triggered and only when a `qx.Promise` is returned from a handler does the event dispatch
+ * mechanism switch to using promise to suspend the event queue.
+ * 
+ * To use this, the calling code simply creates an empty object (i.e. `var tracker = {};`)
+ * which is then passed to `qx.event.Utils.then`, for example:
+ * 
+ * <code>
+ * var tracker = {};
+ * Utils.then(tracker, function() { ... });
+ * Utils.then(tracker, function() { ... });
+ * Utils.then(tracker, function() { ... });
+ * Utils.catch(tracker, function() { ... });
+ * </code>
+ * 
+ * Following with the morphing nature of this class, the return type will be either the value
+ * returned from the event handlers, or a promise which evaluates to that value.
+ * 
+ * When events are aborted (eg via `event.stopPropagation()`) that causes the promise (if there
+ * is one) to be rejected.
+ * 
+ * Note that this class is not a replacement for promises and has its limitations because it
+ * has been built for the express purposes of the event dispatchers.
+ * 
+ * @internal
+ * @ignore(qx.Promise)
+ */
+qx.Class.define("qx.event.Utils", {
+  extend: qx.core.Object,
+  
+  statics: {
+    ABORT: "[[ qx.event.Utils.ABORT ]]",
+    
+    /**
+     * Evaluates a value, and adds it to the tracker
+     * 
+     * @param tracker {Object} the tracker object
+     * @param fn {Function|Object?} if a function, it's evaluated as a `then`, otherwise 
+     *  it's encapulated in a function for `then`
+     * @return {qx.Promise|Object?}
+     */
+    track: qx.core.Environment.select("qx.promise", {
+      "true": function(tracker, fn) {
+        if (typeof fn !== "function") {
+          fn = (function(value) { return function() { return value; } })(fn);
+        }
+        return this.then(tracker, fn);
+      },
+      "false": function(tracker, fn) {
+        if (typeof fn === "function") {
+          return fn();
+        }
+        return fn;
+      }
+    }),
+    
+    /**
+     * Helper method to store a promise in a tracker
+     * 
+     * @param tracker {Object} the tracker object
+     * @param newPromise {qx.Promise} the new promise
+     * @return {qx.Promise} the new promise
+     */
+    __push: function(tracker, newPromise) {
+      if (qx.core.Environment.get("qx.debug")) {
+        if (tracker.promises === undefined) {
+          tracker.promises = [];
+        }
+        var ex = null;
+        try {
+          throw new Error("");
+        } catch(e) {
+          ex = e;
+        }
+        tracker.promises.push({ promise: newPromise, ex: ex });
+      }
+      tracker.promise = newPromise;
+      return tracker.promise;
+    },
+    
+    /**
+     * Equivalent of `promise.then()`
+     * 
+     * @param tracker {Object} the tracker object
+     * @param fn {Function} the function to call when previous promises are complete
+     * @return {qx.Promise?} the new promise, or the return value from `fn` if no promises are in use
+     */
+    then: qx.core.Environment.select("qx.promise", {
+      "true": function(tracker, fn) {
+        if (tracker.rejected) {
+          return;
+        }
+        if (tracker.promise) {
+          var self = this;
+          this.__push(tracker, tracker.promise.then(function() {
+            if (tracker.rejected) {
+              return null;
+            }
+            var result = fn();
+            if (result === qx.event.Utils.ABORT) {
+              return self.reject(tracker);
+            }
+            return result;
+            })
+          );
+          this.__addCatcher(tracker);
+          return tracker.promise;
+        }
+        var result = fn();
+        if (result instanceof qx.Promise) {
+          return this.__thenPromise(tracker, result);
+        }
+        if (result === qx.event.Utils.ABORT) {
+          return this.reject(tracker);
+        }
+        
+        return result;
+      },
+      
+      "false": function(tracker, fn) {
+        var result = fn();
+        if (result === qx.event.Utils.ABORT) {
+          return this.reject(tracker);
+        }
+        return result;
+      }
+    }),
+    
+    /**
+     * Helper method to append a promise after the current one
+     * 
+     * @param tracker {Object} the tracker object
+     * @param newPromise {qx.Promise} the new promise
+     * @return {qx.Promise} the new promise
+     */
+    __thenPromise: function(tracker, newPromise) {
+      if (tracker.promise) {
+        this.__push(tracker, tracker.promise.then(function() { 
+            return newPromise; 
+          }));
+      } else {
+        this.__push(tracker, newPromise);
+      }
+      this.__addCatcher(tracker);
+      return tracker.promise;
+    },
+    
+    /**
+     * Rejects the tracker, aborting the promise if there is one.  The caller should stop 
+     * immediately because if promises are not in use and exception is not thrown.
+     * 
+     * @param tracker {Object} the tracker object
+     * @return {qx.Promise?} the last promise or the value returned by the catcher
+     */
+    reject: function(tracker) {
+      if (tracker.rejected) {
+        return qx.event.Utils.ABORT;
+      }
+      tracker.rejected = true;
+      
+      if (tracker.promise) {
+        throw new Error("Rejecting Event"); 
+      }
+      var result = this.__catcher(tracker);
+      return result === undefined ? this.ABORT : result;
+    },
+    
+    /**
+     * Helper method that adds a catcher to the tracker
+     * 
+     * @param tracker {Object} the tracker object
+     */
+    __addCatcher: function(tracker) {
+      if (tracker.promise && tracker.catch) {
+        if (!tracker.promise["qx.event.Utils.hasCatcher"]) {
+          this.__push(tracker, tracker.promise.catch(this.__catcher.bind(this, tracker)));
+          tracker.promise["qx.event.Utils.hasCatcher"] = true;
+        }
+      }
+    },
+    
+    /**
+     * This method is added with `.catch` to every promise created; because this is added
+     * all the way up the promise chain to ensure that it catches everything, this method
+     * supresses multiple invocations (i.e. ignores everything except the first)
+     * 
+     * @param tracker {Object} the tracker object
+     */
+    __catcher: function(tracker, err) {
+      var fn = tracker.catch;
+      if (fn) {
+        tracker.catch = null;
+        tracker.rejected = true;
+        return fn(err);
+      }
+      return qx.event.Utils.ABORT;
+    },
+    
+    /**
+     * Equivalent to `.catch()`; note that unlike promises, this method must be called *before*
+     * `.then()` so that it is able to handle rejections when promises are not in use; this is 
+     * because `Promise.catch` only catches rejections from previous promises, but because promises 
+     * are *always* asynchronous the `.catch` goes at the end.  For synchronous, this is nt possible 
+     * so `Utils.catch` must go before `Utils.then` 
+     * 
+     * @param tracker {Object} the tracker object
+     * @param fn {Function} the function to call
+     */
+    "catch": function(tracker, fn) {
+      if (tracker.rejected) {
+        fn();
+        return;
+      }
+      
+      if (tracker.catchers === undefined) {
+        tracker.catchers = [fn];
+      } else {
+        tracker.catchers.push(fn);
+      }
+      
+      if (tracker.catch) {
+        tracker.catch = (function(catch1, catch2) { 
+            return function() { 
+              catch1(); 
+              catch2(); 
+            };
+          })(tracker.catch, fn)
+      } else {
+        tracker.catch = fn;
+      }
+      this.__addCatcher(tracker);
+    },
+
+    /**
+     * Calls a listener, converting propagationStopped into a rejection
+     * 
+     * @param tracker {Object} the tracker object
+     * @param listener {Function} the event handler
+     * @param context {Object?} the `this` for the event handler
+     * @param event {Event} the event being fired
+     * @returns {qx.Promise|?} the result of the handler
+     */
+    callListener: function(tracker, listener, context, event) {
+      if (tracker.rejected) {
+        return qx.event.Utils.ABORT;
+      }
+      var tmp = listener.handler.call(context, event);
+      if (event.getPropagationStopped()) {
+        return qx.event.Utils.ABORT;
+      }
+      return tmp;
+    },
+    
+    /**
+     * Provides a handy way to iterate over an array which at any point could 
+     * become asynchronous
+     * 
+     * @param arr {Array} an array to interate over
+     * @param fn {Function?} the function to call, with parameters (item, index)
+     * @param ignoreAbort {Boolean?} whether to ignore the "ABORT" return value
+     * @return {qx.Promise|Object?}
+     */
+    series: qx.core.Environment.select("qx.promise", {
+      "true": function(arr, fn, ignoreAbort) {
+        var tracker = {};
+        for (var index = 0; index < arr.length; index++) {
+          var result = fn(arr[index], index);
+          if (result instanceof qx.Promise) {
+            for (++index; index < arr.length; index++) {
+              (function(item, index) { 
+                result = result.then(function() {
+                  var tmp = fn(item, index);
+                  if (!ignoreAbort && tmp === qx.event.Utils.ABORT) {
+                    throw new Error("Rejecting in series()");
+                  }
+                  return tmp;
+                });
+              })(arr[index], index);
+            }
+            return result;
+          }
+          
+          if (!ignoreAbort && result === qx.event.Utils.ABORT) {
+            return this.reject(tracker);
+          }
+        }
+        
+        return null;
+      },
+      
+      "false": function(arr, fn, ignoreAbort) {
+        var tracker = {};
+        for (var index = 0; index < arr.length; index++) {
+          var result = fn(arr[index], index);
+          if (!ignoreAbort && result === qx.event.Utils.ABORT) {
+            return this.reject(tracker);
+          }
+        }
+      }
+    })
+  }
+});

--- a/framework/source/class/qx/event/dispatch/AbstractBubbling.js
+++ b/framework/source/class/qx/event/dispatch/AbstractBubbling.js
@@ -95,9 +95,7 @@ qx.Class.define("qx.event.dispatch.AbstractBubbling",
       var parent = target;
       var manager = this._manager;
       var captureListeners, bubbleListeners;
-      var localList;
-      var listener, context;
-      var currentTarget;
+      var context;
 
       // Cache list for AT_TARGET
       var targetList = [];
@@ -148,103 +146,151 @@ qx.Class.define("qx.event.dispatch.AbstractBubbling",
 
         parent = this._getParent(parent);
       }
-
-
-      // capturing phase
-      // loop through the hierarchy in reverted order (from root)
-      event.setEventPhase(qx.event.type.Event.CAPTURING_PHASE);
-      for (var i=captureList.length-1; i>=0; i--)
-      {
-        currentTarget = captureTargets[i];
-        event.setCurrentTarget(currentTarget);
-
-        localList = captureList[i];
-        for (var j=0, jl=localList.length; j<jl; j++)
-        {
-          listener = localList[j];
-          context = listener.context || currentTarget;
-
-          if (qx.core.Environment.get("qx.debug")) {
-            // warn if the context is disposed
-            if (context && context.isDisposed && context.isDisposed()) {
-              this.warn(
-                "The context object '" + context + "' for the event '" +
-                type + "' of '" + currentTarget + "'is already disposed."
-              );
-            }
-          }
-          if (!this._manager.isBlacklisted(listener.unique)) {
-            listener.handler.call(context, event);
-          }
-        }
-
-        if (event.getPropagationStopped()) {
-          return;
+      
+      var self = this;
+      var tracker = {};
+      
+      var __TRACE_LOGGING = false;//(event._type == "pointerup" && event._target.className === "qx-toolbar-button-checked");
+      var __TRACE = function(){};
+      if (__TRACE_LOGGING) {
+        var serial = (this.SERIAL||0)+1;
+        this.SERIAL=serial + 1;
+        __TRACE = function() {
+          var args = [].slice.apply(arguments);
+          args.unshift("serial #" + serial + ": ");
+          console.log.apply(this, args);
         }
       }
+      
+      qx.event.Utils.catch(tracker, function() {
+        // This function must exist to suppress "unhandled rejection" messages from promises
+        __TRACE("Aborted serial=" + serial + ", type=" + event.getType());
+      });
+      
+      // capturing phase
+      qx.event.Utils.then(tracker, function() {
+        // loop through the hierarchy in reverted order (from root)
+        event.setEventPhase(qx.event.type.Event.CAPTURING_PHASE);
+        
+        __TRACE("captureList=" + captureList.length);
+        return qx.event.Utils.series(captureList, function(localList, i) {
+          
+          __TRACE("captureList[" + i + "]: localList.length=" + localList.length);
 
+          var currentTarget = captureTargets[i];
+          event.setCurrentTarget(currentTarget);
+          
+          var result = qx.event.Utils.series(localList, function(listener, listenerIndex) {
+            context = listener.context || currentTarget;
+
+            if (qx.core.Environment.get("qx.debug")) {
+              // warn if the context is disposed
+              if (context && context.isDisposed && context.isDisposed()) {
+                self.warn(
+                  "The context object '" + context + "' for the event '" +
+                  type + "' of '" + currentTarget + "'is already disposed."
+                );
+              }
+            }
+            
+            if (!self._manager.isBlacklisted(listener.unique)) {
+              __TRACE("captureList[" + i + "] => localList[" + listenerIndex + "] callListener");
+              return listener.handler.call(context, event);
+            } else {
+              __TRACE("captureList[" + i + "] => localList[" + listenerIndex + "] is blacklisted");
+            }
+          }, true);
+          if (result === qx.event.Utils.ABORT)
+            return qx.event.Utils.reject(tracker);
+          if (event.getPropagationStopped())
+            return qx.event.Utils.reject(tracker);
+          return result;
+        });
+      });
+      
 
       // at target
-      event.setEventPhase(qx.event.type.Event.AT_TARGET);
-      event.setCurrentTarget(target);
-      for (var i=0, il=targetList.length; i<il; i++)
-      {
-        localList = targetList[i];
-        for (var j=0, jl=localList.length; j<jl; j++)
-        {
-          listener = localList[j];
-          context = listener.context || target;
+      qx.event.Utils.then(tracker, function() {
+        event.setEventPhase(qx.event.type.Event.AT_TARGET);
+        event.setCurrentTarget(target);
+        
+        __TRACE("targetList=" + targetList.length);
+        return qx.event.Utils.series(targetList, function(localList, i) {
+          __TRACE("targetList[" + i + "] localList.length=" + localList.length);
+          
+          var result = qx.event.Utils.series(localList, function(listener, listenerIndex) {
+            __TRACE("targetList[" + i + "] -> localList[" + listenerIndex + "] callListener");
+            context = listener.context || target;
 
-          if (qx.core.Environment.get("qx.debug")) {
-            // warn if the context is disposed
-            if (context && context.isDisposed && context.isDisposed()) {
-              this.warn(
-                "The context object '" + context + "' for the event '" +
-                type + "' of '" + target + "'is already disposed."
-              );
+            if (qx.core.Environment.get("qx.debug")) {
+              // warn if the context is disposed
+              if (context && context.isDisposed && context.isDisposed()) {
+                self.warn(
+                  "The context object '" + context + "' for the event '" +
+                  type + "' of '" + target + "'is already disposed."
+                );
+              }
             }
-          }
 
-          listener.handler.call(context, event);
-        }
+            __TRACE("Calling target serial=" + serial + ", type=" + event.getType());
+            return listener.handler.call(context, event);
+          }, true);
+          if (result === qx.event.Utils.ABORT)
+            return qx.event.Utils.reject(tracker);
+          if (event.getPropagationStopped())
+            return qx.event.Utils.reject(tracker);
+          return result;
+        });
+      });
 
-        if (event.getPropagationStopped()) {
-          return;
-        }
-      }
-
-
+      
       // bubbling phase
       // loop through the hierarchy in normal order (to root)
-      event.setEventPhase(qx.event.type.Event.BUBBLING_PHASE);
-      for (var i=0, il=bubbleList.length; i<il; i++)
-      {
-        currentTarget = bubbleTargets[i];
-        event.setCurrentTarget(currentTarget);
+      qx.event.Utils.then(tracker, function() {
+        event.setEventPhase(qx.event.type.Event.BUBBLING_PHASE);
 
-        localList = bubbleList[i];
-        for (var j=0, jl=localList.length; j<jl; j++)
-        {
-          listener = localList[j];
-          context = listener.context || currentTarget;
+        __TRACE("bubbleList=" + bubbleList.length);
+        return qx.event.Utils.series(bubbleList, function(localList, i) {
+          __TRACE("bubbleList[" + i + "] localList.length=" + localList.length);
+          var currentTarget = bubbleTargets[i];
+          event.setCurrentTarget(currentTarget);
+          
+          var result = qx.event.Utils.series(localList, function(listener, listenerIndex) {
+            __TRACE("bubbleList[" + i + "] -> localList[" + listenerIndex + "] callListener");
+            context = listener.context || currentTarget;
 
-          if (qx.core.Environment.get("qx.debug")) {
-            // warn if the context is disposed
-            if (context && context.isDisposed && context.isDisposed()) {
-              this.warn(
-                "The context object '" + context + "' for the event '" +
-                type + "' of '" + currentTarget + "'is already disposed."
-              );
+            if (qx.core.Environment.get("qx.debug")) {
+              // warn if the context is disposed
+              if (context && context.isDisposed && context.isDisposed()) {
+                self.warn(
+                  "The context object '" + context + "' for the event '" +
+                  type + "' of '" + currentTarget + "'is already disposed."
+                );
+              }
             }
-          }
 
-          listener.handler.call(context, event);
-        }
-
-        if (event.getPropagationStopped()) {
-          return;
+            return listener.handler.call(context, event);
+          }, true);
+          
+          if (result === qx.event.Utils.ABORT)
+            return qx.event.Utils.reject(tracker);
+          if (event.getPropagationStopped())
+            return qx.event.Utils.reject(tracker);
+          return result;
+        });
+      });
+      
+      if (__TRACE_LOGGING) {
+        if (tracker.promise) {
+          __TRACE("events promised");
+          qx.event.Utils.then(tracker, function() {
+            __TRACE("events promised done");
+          });
+        } else {
+          __TRACE("events done");
         }
       }
+      return tracker.promise;
     }
   }
 });

--- a/framework/source/class/qx/event/dispatch/MouseCapture.js
+++ b/framework/source/class/qx/event/dispatch/MouseCapture.js
@@ -102,7 +102,7 @@ qx.Class.define("qx.event.dispatch.MouseCapture",
         target = this.__captureElement;
       }
 
-      this.base(arguments, target, event, type);
+      return this.base(arguments, target, event, type);
     },
 
 

--- a/framework/source/class/qx/event/handler/DragDrop.js
+++ b/framework/source/class/qx/event/handler/DragDrop.js
@@ -229,9 +229,13 @@ qx.Class.define("qx.event.handler.DragDrop",
      * Returns the data of the given type during the <code>drop</code> event
      * on the drop target. This method fires a <code>droprequest</code> at
      * the drag target which should be answered by calls to {@link #addData}.
+     * 
+     * Note that this is a synchronous method and if any of the drag and drop 
+     * events handlers are implemented using Promises, this may fail; @see
+     * `getDataAsync`.
      *
      * @param type {String} Any supported type
-     * @return {var} The result data
+     * @return {var} The result data in a promise
      */
     getData : function(type)
     {
@@ -246,7 +250,7 @@ qx.Class.define("qx.event.handler.DragDrop",
       if (!this.__cache[type])
       {
         this.__currentType = type;
-        this.__fireEvent("droprequest", this.__dragTarget, this.__dropTarget, false);
+        this.__fireEvent("droprequest", this.__dragTarget, this.__dropTarget, false, false);
       }
 
       if (!this.__cache[type]) {
@@ -254,6 +258,44 @@ qx.Class.define("qx.event.handler.DragDrop",
       }
 
       return this.__cache[type] || null;
+    },
+
+
+    /**
+     * Returns the data of the given type during the <code>drop</code> event
+     * on the drop target. This method fires a <code>droprequest</code> at
+     * the drag target which should be answered by calls to {@link #addData}.
+     *
+     * @param type {String} Any supported type
+     * @return {qx.Promise} The result data in a promise
+     */
+    getDataAsync : function(type)
+    {
+      if (!this.__validDrop || !this.__dropTarget) {
+        throw new Error("This method must not be used outside the drop event listener!");
+      }
+
+      if (!this.__types[type]) {
+        throw new Error("Unsupported data type: " + type + "!");
+      }
+
+      var promise = qx.Promise.resolve();
+      var self = this;
+      if (!this.__cache[type])
+      {
+        this.__currentType = type;
+        promise = promise.then(function() {
+          return self.__fireEvent("droprequest", self.__dragTarget, self.__dropTarget, false);
+        });
+      }
+
+      return promise.then(function() {
+        if (!this.__cache[type]) {
+          throw new Error("Please use a droprequest listener to the drag source to fill the manager with data!");
+        }
+
+        return this.__cache[type] || null;
+      });
     },
 
 
@@ -266,6 +308,20 @@ qx.Class.define("qx.event.handler.DragDrop",
     getCurrentAction : function() {
       this.__detectAction();
       return this.__currentAction;
+    },
+
+
+    /**
+     * Returns the currently selected action (by user keyboard modifiers)
+     *
+     * @return {qx.Promise|String} One of <code>move</code>, <code>copy</code> or
+     *    <code>alias</code>
+     */
+    getCurrentActionAsync : function() {
+      var self = this;
+      return this.__detectAction().then(function() {
+        return self.__currentAction;
+      });
     },
 
 
@@ -332,11 +388,13 @@ qx.Class.define("qx.event.handler.DragDrop",
      * Detects the current action and stores it under the private
      * field <code>__currentAction</code>. Also fires the event
      * <code>dragchange</code> on every modification.
+     * 
+     * @return {qx.Promise}
      */
     __detectAction : function()
     {
       if (this.__dragTarget == null) {
-        return;
+        return qx.Promise.reject();
       }
 
       var actions = this.__actions;
@@ -364,22 +422,34 @@ qx.Class.define("qx.event.handler.DragDrop",
         }
       }
 
+      var promise = qx.Promise.resolve();
+      var self = this;
       var old = this.__currentAction;
       if (current != old) {
-
         if (this.__dropTarget) {
           this.__currentAction = current;
-          this.__validAction = this.__fireEvent("dragchange", this.__dropTarget, this.__dragTarget, true);
-          if (!this.__validAction) {
-            current = null;
+          promise = promise.then(function() {
+            return self.__fireEvent("dragchange", self.__dropTarget, self.__dragTarget, true)
+              .then(function() {
+                self.__validAction = true;
+              })
+              .catch(function() {
+                self.__validAction = false;
+                current = null;
+              });
+          });
+        }
+        
+        promise = promise.then(function() {
+          if (current != old) {
+            self.__currentAction = current;
+            return self.__fireEvent("dragchange", self.__dragTarget, self.__dropTarget, false);
           }
-        }
+        });
 
-        if (current != old) {
-          this.__currentAction = current;
-          this.__fireEvent("dragchange", this.__dragTarget, this.__dropTarget, false);
-        }
       }
+      
+      return promise;
     },
 
 
@@ -393,10 +463,10 @@ qx.Class.define("qx.event.handler.DragDrop",
      *    depending on the drag event
      * @param cancelable {Boolean} Whether the event is cancelable
      * @param original {qx.event.type.Pointer} Original pointer event
-     * @return {Boolean} <code>true</code> if the event's default behavior was
-     * not prevented
+     * @return {qx.Promise} resolved, or rejected if the event's default behavior was 
+     *    prevented.  NOTE: Always returns a promise
      */
-    __fireEvent : function(type, target, relatedTarget, cancelable, original)
+    __fireEvent : function(type, target, relatedTarget, cancelable, original, async)
     {
       var Registration = qx.event.Registration;
       var dragEvent = Registration.createEvent(type, qx.event.type.Drag, [ cancelable, original ]);
@@ -405,7 +475,22 @@ qx.Class.define("qx.event.handler.DragDrop",
         dragEvent.setRelatedTarget(relatedTarget);
       }
 
-      return Registration.dispatchEvent(target, dragEvent);
+      var result = Registration.dispatchEvent(target, dragEvent);
+      if (async === undefined || async) {
+        return qx.Promise.resolve(result)
+          .then(function() {
+            if (dragEvent.getDefaultPrevented()) {
+              return qx.Promise.reject();
+            }
+          });
+      } else {
+        if (qx.core.Environment.get("qx.debug")) {
+          if (result instanceof qx.Promise) {
+            this.error("DragDrop event \"" + type + "\" returned a promise but a synchronous event was required, drag and drop may not work as expected (consider using getDataAsync)");
+          }
+        }
+        return result;
+      }
     },
 
 
@@ -457,9 +542,13 @@ qx.Class.define("qx.event.handler.DragDrop",
 
     /**
      * Cleans up a drag&drop session when <code>dragstart</code> was fired before.
+     * 
+     * @return {qx.Promise?} promise, if one was created by event handlers
      */
     clearSession : function()
     {
+      //this.debug("clearSession");
+      
       // Deregister from root events
       this.__manager.removeListener(this.__root, "pointermove", this._onPointermove, this);
       this.__manager.removeListener(this.__root, "pointerup", this._onPointerup, this, true);
@@ -469,24 +558,31 @@ qx.Class.define("qx.event.handler.DragDrop",
       this.__manager.removeListener(this.__root, "keypress", this._onKeyPress, this, true);
       this.__manager.removeListener(this.__root, "roll", this._onRoll, this, true);
 
+      var tracker = {};
+      var self = this;
+      
       // Fire dragend event
       if (this.__dragTarget) {
-        this.__fireEvent("dragend", this.__dragTarget, this.__dropTarget, false);
+        qx.event.Utils.then(tracker, function() {
+          return self.__fireEvent("dragend", self.__dragTarget, self.__dropTarget, false);
+        });
       }
 
-      // Cleanup
-      this.__validDrop = false;
-      this.__dropTarget = null;
-      if (this.__dragTargetWidget) {
-        this.__dragTargetWidget.removeState("drag");
-        this.__dragTargetWidget = null;
-      }
-
-      // Clear init
-      this.__dragTarget = null;
-      this.__sessionActive = false;
-      this.__startConfig = null;
-      this.__rebuildStructures();
+      return qx.event.Utils.then(tracker, function() {
+        // Cleanup
+        self.__validDrop = false;
+        self.__dropTarget = null;
+        if (self.__dragTargetWidget) {
+          self.__dragTargetWidget.removeState("drag");
+          self.__dragTargetWidget = null;
+        }
+  
+        // Clear init
+        self.__dragTarget = null;
+        self.__sessionActive = false;
+        self.__startConfig = null;
+        self.__rebuildStructures();
+      });
     },
 
 
@@ -510,7 +606,7 @@ qx.Class.define("qx.event.handler.DragDrop",
       }
       // prevent scrolling
       this.__manager.addListener(this.__root, "roll", this._onRoll, this, true);
-      this._start(e);
+      return this._start(e);
     },
 
 
@@ -547,16 +643,19 @@ qx.Class.define("qx.event.handler.DragDrop",
         }
 
         // fire cancelable dragstart
-        if (!this.__fireEvent("dragstart", this.__dragTarget, this.__dropTarget, true, e)) {
-          return false;
-        }
-
-        this.__manager.addListener(this.__root, "keydown", this._onKeyDown, this, true);
-        this.__manager.addListener(this.__root, "keyup", this._onKeyUp, this, true);
-        this.__manager.addListener(this.__root, "keypress", this._onKeyPress, this, true);
-        this.__sessionActive = true;
-
-        return true;
+        var self = this;
+        return this.__fireEvent("dragstart", this.__dragTarget, this.__dropTarget, true, e)
+          .then(function () {
+            //self.debug("dragstart ok, setting __sessionActive=true")
+            self.__manager.addListener(self.__root, "keydown", self._onKeyDown, self, true);
+            self.__manager.addListener(self.__root, "keyup", self._onKeyUp, self, true);
+            self.__manager.addListener(self.__root, "keypress", self._onKeyPress, self, true);
+            self.__sessionActive = true;
+          })
+          .catch(function() {
+            //self.debug("dragstart FAILED, setting __sessionActive=false");
+            self.__sessionActive = false;
+          });
       }
     },
 
@@ -590,80 +689,103 @@ qx.Class.define("qx.event.handler.DragDrop",
       if (!e.isPrimary()) {
         return;
       }
+      
+      //this.debug("_onPointermove: start");
+      
+      var self = this;
+      var promise = qx.Promise.resolve();
 
       // start the drag session for mouse
-      if (!this.__sessionActive && e.getPointerType() == "mouse") {
-        var delta = this._getDelta(e);
+      if (!self.__sessionActive && e.getPointerType() == "mouse") {
+        var delta = self._getDelta(e);
         // if the mouse moved a bit in any direction
         var distance = qx.event.handler.DragDrop.MIN_DRAG_DISTANCE;
         if (delta && (Math.abs(delta.x) > distance || Math.abs(delta.y) > distance)) {
-          if (!this._start(e)) {
-            this.clearSession();
+          //self.debug("_onPointermove: outside min drag distance");
+          promise = promise.then(function() {
+            return self._start(e);
+          });
+        }
+      }
+      
+      return promise
+        .then(function() {
+          // check if the session has been activated
+          if (!self.__sessionActive) {
+            //self.debug("not active");
             return;
           }
-        }
-      }
+  
+          //self.debug("active, firing drag");
+          return self.__fireEvent("drag", self.__dragTarget, self.__dropTarget, true, e)
+            .then(function() {
+              //self.debug("drag");
+              // find current hovered droppable
+              var el = e.getTarget();
+              if (self.__startConfig.target === el) {
+                // on touch devices the native events return wrong elements as target (its always the element where the dragging started)
+                el = e.getNativeEvent().view.document.elementFromPoint(e.getDocumentLeft(), e.getDocumentTop());
+              }
+              var cursor = self.getCursor();
+              if (!cursor) {
+                cursor = qx.ui.core.DragDropCursor.getInstance();
+              }
+              var cursorEl = cursor.getContentElement().getDomElement();
+              if (cursorEl && (el === cursorEl || cursorEl.contains(el))) {
+                var display = qx.bom.element.Style.get(cursorEl, "display");
+                // get the cursor out of the way
+                qx.bom.element.Style.set(cursorEl, "display", "none");
+                el = e.getNativeEvent().view.document.elementFromPoint(e.getDocumentLeft(), e.getDocumentTop());
+                qx.bom.element.Style.set(cursorEl, "display", display);
+              }
+  
+              if (el !== cursorEl) {
+                var droppable = self.__findDroppable(el);
+  
+                // new drop target detected
+                if (droppable && droppable != self.__dropTarget) {
+                  // fire dragleave for previous drop target
+                  if (self.__dropTarget) {
+                    return self.__fireEvent("dragleave", self.__dropTarget, self.__dragTarget, false, e);
+                  }
+  
+                  self.__validDrop = true; // initial value should be true
+                  self.__dropTarget = droppable;
+  
+                  return self.__fireEvent("dragover", droppable, self.__dragTarget, true, e)
+                    .then(function() {
+                      self.__validDrop = true;
+                    })
+                    .catch(function() {
+                      self.__validDrop = false;
+                    });
+                }
+  
+                // only previous drop target
+                else if (!droppable && self.__dropTarget) {
+                  return self.__fireEvent("dragleave", self.__dropTarget, self.__dragTarget, false, e)
+                    .then(function() {
+                      self.__dropTarget = null;
+                      self.__validDrop = false;
+        
+                      return self.__detectAction();
+                    });
+                }
+              }
+            })
+            .then(function() {
+              // Reevaluate current action
+              var keys = self.__keys;
+              keys.Control = e.isCtrlPressed();
+              keys.Shift = e.isShiftPressed();
+              keys.Alt = e.isAltPressed();
+              return self.__detectAction();
+            })
+            .catch(function() { 
+              return self.clearSession(); 
+            });
+        });
 
-      // check if the session has been activated
-      if (!this.__sessionActive) {
-        return;
-      }
-
-      if (!this.__fireEvent("drag", this.__dragTarget, this.__dropTarget, true, e)) {
-        this.clearSession();
-      }
-
-      // find current hovered droppable
-      var el = e.getTarget();
-      if (this.__startConfig.target === el) {
-        // on touch devices the native events return wrong elements as target (its always the element where the dragging started)
-        el = e.getNativeEvent().view.document.elementFromPoint(e.getDocumentLeft(), e.getDocumentTop());
-      }
-      var cursor = this.getCursor();
-      if (!cursor) {
-        cursor = qx.ui.core.DragDropCursor.getInstance();
-      }
-      var cursorEl = cursor.getContentElement().getDomElement();
-      if (cursorEl && (el === cursorEl || cursorEl.contains(el))) {
-        var display = qx.bom.element.Style.get(cursorEl, "display");
-        // get the cursor out of the way
-        qx.bom.element.Style.set(cursorEl, "display", "none");
-        el = e.getNativeEvent().view.document.elementFromPoint(e.getDocumentLeft(), e.getDocumentTop());
-        qx.bom.element.Style.set(cursorEl, "display", display);
-      }
-
-      if (el !== cursorEl) {
-        var droppable = this.__findDroppable(el);
-
-        // new drop target detected
-        if (droppable && droppable != this.__dropTarget) {
-          // fire dragleave for previous drop target
-          if (this.__dropTarget) {
-            this.__fireEvent("dragleave", this.__dropTarget, this.__dragTarget, false, e);
-          }
-
-          this.__validDrop = true; // initial value should be true
-          this.__dropTarget = droppable;
-
-          this.__validDrop = this.__fireEvent("dragover", droppable, this.__dragTarget, true, e);
-        }
-
-        // only previous drop target
-        else if (!droppable && this.__dropTarget) {
-          this.__fireEvent("dragleave", this.__dropTarget, this.__dragTarget, false, e);
-          this.__dropTarget = null;
-          this.__validDrop = false;
-
-          qx.event.Timer.once(this.__detectAction, this, 0);
-        }
-      }
-
-      // Reevaluate current action
-      var keys = this.__keys;
-      keys.Control = e.isCtrlPressed();
-      keys.Shift = e.isShiftPressed();
-      keys.Alt = e.isAltPressed();
-      this.__detectAction();
     },
 
 
@@ -699,19 +821,26 @@ qx.Class.define("qx.event.handler.DragDrop",
       if (!e.isPrimary()) {
         return;
       }
+      
+      var promise = qx.Promise.resolve();
+      var self = this;
 
       // Fire drop event in success case
       if (this.__validDrop && this.__validAction) {
-        this.__fireEvent("drop", this.__dropTarget, this.__dragTarget, false, e);
+        promise = promise.then(function() {
+          return self.__fireEvent("drop", self.__dropTarget, self.__dragTarget, false, e);
+        });
       }
 
-      // Stop event
-      if (e.getTarget() == this.__dragTarget) {
-        e.stopPropagation();
-      }
+      return promise.then(function() {
+        // Stop event
+        if (e.getTarget() == self.__dragTarget) {
+          e.stopPropagation();
+        }
 
-      // Clean up
-      this.clearSession();
+        // Clean up
+        return self.clearSession();
+      });
     },
 
 
@@ -730,7 +859,7 @@ qx.Class.define("qx.event.handler.DragDrop",
      * @param e {qx.event.type.Event} Event object
      */
     _onWindowBlur : function(e) {
-      this.clearSession();
+      return this.clearSession();
     },
 
 
@@ -749,7 +878,7 @@ qx.Class.define("qx.event.handler.DragDrop",
           if (!this.__keys[iden])
           {
             this.__keys[iden] = true;
-            this.__detectAction();
+            return this.__detectAction();
           }
       }
     },
@@ -770,7 +899,7 @@ qx.Class.define("qx.event.handler.DragDrop",
           if (this.__keys[iden])
           {
             this.__keys[iden] = false;
-            this.__detectAction();
+            return this.__detectAction();
           }
       }
     },
@@ -786,7 +915,7 @@ qx.Class.define("qx.event.handler.DragDrop",
       switch(iden)
       {
         case "Escape":
-          this.clearSession();
+          return this.clearSession();
       }
     }
   },

--- a/framework/source/class/qx/event/handler/Focus.js
+++ b/framework/source/class/qx/event/handler/Focus.js
@@ -334,13 +334,14 @@ qx.Class.define("qx.event.handler.Focus",
      * @param related {Element} DOM element which is the related target
      * @param type {String} Name of the event to fire
      * @param bubbles {Boolean} Whether the event should bubble
+     * @return {qx.Promise?} a promise, if one or more of the event handlers returned a promise
      */
     __fireEvent : function(target, related, type, bubbles)
     {
       var Registration = qx.event.Registration;
 
       var evt = Registration.createEvent(type, qx.event.type.Focus, [target, related, bubbles]);
-      Registration.dispatchEvent(target, evt);
+      return Registration.dispatchEvent(target, evt);
     },
 
     /*

--- a/framework/source/class/qx/event/handler/GestureCore.js
+++ b/framework/source/class/qx/event/handler/GestureCore.js
@@ -612,6 +612,7 @@ qx.Bootstrap.define("qx.event.handler.GestureCore", {
      * @param domEvent {Event} DOM event
      * @param type {String} type of the event
      * @param target {Element ? null} event target
+     * @return {qx.Promise?} a promise, if one or more of the event handlers returned a promise
      */
     _fireEvent : function(domEvent, type, target) {
       // The target may have been removed, e.g. menu hide on tap
@@ -629,7 +630,7 @@ qx.Bootstrap.define("qx.event.handler.GestureCore", {
           pointerType: domEvent.pointerType,
           momentum : domEvent.momentum
         });
-        target.dispatchEvent(evt);
+        return target.dispatchEvent(evt);
       } else if (this.__emitter) {
         evt = new qx.event.type.dom.Custom(type, domEvent, {
           target : this.__defaultTarget,

--- a/framework/source/class/qx/event/handler/Keyboard.js
+++ b/framework/source/class/qx/event/handler/Keyboard.js
@@ -160,23 +160,31 @@ qx.Class.define("qx.event.handler.Keyboard",
      *
      * @param domEvent {Event} DOM event
      * @param charCode {Integer} character code
+     * @return {qx.Promise?} a promise if the event handlers created one
      */
     _fireInputEvent : function(domEvent, charCode)
     {
       var target = this.__getEventTarget();
+      var tracker = {};
+      var self = this;
 
       // Only fire when target is defined and visible
       if (target && target.offsetWidth != 0)
       {
         var event = qx.event.Registration.createEvent("keyinput", qx.event.type.KeyInput, [domEvent, target, charCode]);
-        this.__manager.dispatchEvent(target, event);
+        qx.event.Utils.then(tracker, function() { self.__manager.dispatchEvent(target, event); });
       }
 
       // Fire user action event
       // Needs to check if still alive first
       if (this.__window) {
-        qx.event.Registration.fireEvent(this.__window, "useraction", qx.event.type.Data, ["keyinput"]);
+        var self = this;
+        qx.event.Utils.then(tracker, function() {
+          return qx.event.Registration.fireEvent(self.__window, "useraction", qx.event.type.Data, ["keyinput"]);
+        });
       }
+      
+      return tracker.promise;
     },
 
 
@@ -186,15 +194,20 @@ qx.Class.define("qx.event.handler.Keyboard",
      * @param domEvent {Event} DOM event
      * @param type {String} type og the event
      * @param keyIdentifier {String} key identifier
+     * @return {qx.Promise?} a promise, if any of the event handlers returned a promise
      */
     _fireSequenceEvent : function(domEvent, type, keyIdentifier)
     {
       var target = this.__getEventTarget();
       var keyCode = domEvent.keyCode;
+      var tracker = {};
+      var self = this;
 
       // Fire key event
       var event = qx.event.Registration.createEvent(type, qx.event.type.KeySequence, [domEvent, target, keyIdentifier]);
-      this.__manager.dispatchEvent(target, event);
+      qx.event.Utils.then(tracker, function() {
+        return self.__manager.dispatchEvent(target, event);
+      });
 
       // IE and Safari suppress a "keypress" event if the "keydown" event's
       // default action was prevented. In this case we emulate the "keypress"
@@ -208,7 +221,9 @@ qx.Class.define("qx.event.handler.Keyboard",
 
           // some key press events are already emulated. Ignore these events.
           if (!qx.event.util.Keyboard.isNonPrintableKeyCode(keyCode) && !this._emulateKeyPress[keyCode]) {
-            this._fireSequenceEvent(domEvent, "keypress", keyIdentifier);
+            qx.event.Utils.then(tracker, function() {
+              return self._fireSequenceEvent(domEvent, "keypress", keyIdentifier);
+            });
           }
         }
       }
@@ -216,8 +231,12 @@ qx.Class.define("qx.event.handler.Keyboard",
       // Fire user action event
       // Needs to check if still alive first
       if (this.__window) {
-        qx.event.Registration.fireEvent(this.__window, "useraction", qx.event.type.Data, [type]);
+        qx.event.Utils.then(tracker, function() {
+          return qx.event.Registration.fireEvent(self.__window, "useraction", qx.event.type.Data, [type]);
+        });
       }
+      
+      return tracker.promise;
     },
 
 
@@ -318,10 +337,14 @@ qx.Class.define("qx.event.handler.Keyboard",
         var keyCode = domEvent.keyCode;
         var charCode = 0;
         var type = domEvent.type;
+        var tracker = {};
+        var self = this;
 
         // Ignore the down in such sequences dp dp dp
         if (!(this.__lastUpDownType[keyCode] == "keydown" && type == "keydown")) {
-          this._idealKeyHandler(keyCode, charCode, type, domEvent);
+          qx.event.Utils.then(tracker, function() {
+            return self._idealKeyHandler(keyCode, charCode, type, domEvent);
+          });
         }
 
         // On non print-able character be sure to add a keypress event
@@ -329,12 +352,16 @@ qx.Class.define("qx.event.handler.Keyboard",
         {
           // non-printable, backspace or tab
           if (qx.event.util.Keyboard.isNonPrintableKeyCode(keyCode) || this._emulateKeyPress[keyCode]) {
-            this._idealKeyHandler(keyCode, charCode, "keypress", domEvent);
+            qx.event.Utils.then(tracker, function() {
+              return self._idealKeyHandler(keyCode, charCode, "keypress", domEvent);
+            });
           }
         }
 
         // Store last type
         this.__lastUpDownType[keyCode] = type;
+        
+        return tracker.promise;
       },
 
       "gecko" : function(domEvent)
@@ -343,6 +370,9 @@ qx.Class.define("qx.event.handler.Keyboard",
         var keyCode = domEvent.keyCode;
         var type = domEvent.type;
         var kbUtil = qx.event.util.Keyboard;
+        
+        var tracker = {};
+        var self = this;
 
         // FF repeats under windows keydown events like IE
         if (qx.core.Environment.get("os.name") == "win")
@@ -350,7 +380,9 @@ qx.Class.define("qx.event.handler.Keyboard",
           var keyIdentifier = keyCode ? kbUtil.keyCodeToIdentifier(keyCode) : kbUtil.charCodeToIdentifier(charCode);
 
           if (!(this.__lastUpDownType[keyIdentifier] == "keydown" && type == "keydown")) {
-            this._idealKeyHandler(keyCode, charCode, type, domEvent);
+            qx.event.Utils.then(tracker, function() {
+              return self._idealKeyHandler(keyCode, charCode, type, domEvent);
+            });
           }
 
           // Store last type
@@ -360,10 +392,13 @@ qx.Class.define("qx.event.handler.Keyboard",
         // all other OSes
         else
         {
-          this._idealKeyHandler(keyCode, charCode, type, domEvent);
+          qx.event.Utils.then(tracker, function() {
+            return self._idealKeyHandler(keyCode, charCode, type, domEvent);
+          });
         }
 
         this.__firefoxInputFix(domEvent.target, type, keyCode);
+        return tracker.promise;
       },
 
       "webkit" : function(domEvent)
@@ -373,26 +408,33 @@ qx.Class.define("qx.event.handler.Keyboard",
         var type = domEvent.type;
 
         keyCode = domEvent.keyCode;
+        
+        var tracker = {};
+        var self = this;
 
-        this._idealKeyHandler(keyCode, charCode, type, domEvent);
+        qx.event.Utils.track(tracker, this._idealKeyHandler(keyCode, charCode, type, domEvent));
 
         // On non print-able character be sure to add a keypress event
         if (type == "keydown")
         {
           // non-printable, backspace or tab
           if (qx.event.util.Keyboard.isNonPrintableKeyCode(keyCode) || this._emulateKeyPress[keyCode]) {
-            this._idealKeyHandler(keyCode, charCode, "keypress", domEvent);
+            qx.event.Utils.then(tracker, function() {
+              return self._idealKeyHandler(keyCode, charCode, "keypress", domEvent);
+            });
           }
         }
 
         // Store last type
         this.__lastUpDownType[keyCode] = type;
+        
+        return tracker.promise;
       },
 
       "opera" : function(domEvent)
       {
         this.__lastKeyCode = domEvent.keyCode;
-        this._idealKeyHandler(domEvent.keyCode, 0, domEvent.type, domEvent);
+        return this._idealKeyHandler(domEvent.keyCode, 0, domEvent.type, domEvent);
       }
     })),
 
@@ -459,9 +501,9 @@ qx.Class.define("qx.event.handler.Keyboard",
         domEvent = window.event || domEvent;
 
         if (this._charCode2KeyCode[domEvent.keyCode]) {
-          this._idealKeyHandler(this._charCode2KeyCode[domEvent.keyCode], 0, domEvent.type, domEvent);
+          return this._idealKeyHandler(this._charCode2KeyCode[domEvent.keyCode], 0, domEvent.type, domEvent);
         } else {
-          this._idealKeyHandler(0, domEvent.keyCode, domEvent.type, domEvent);
+          return this._idealKeyHandler(0, domEvent.keyCode, domEvent.type, domEvent);
         }
       },
 
@@ -470,15 +512,15 @@ qx.Class.define("qx.event.handler.Keyboard",
         var charCode = domEvent.charCode;
         var type = domEvent.type;
 
-        this._idealKeyHandler(domEvent.keyCode, charCode, type, domEvent);
+        return this._idealKeyHandler(domEvent.keyCode, charCode, type, domEvent);
       },
 
       "webkit" : function(domEvent)
       {
         if (this._charCode2KeyCode[domEvent.keyCode]) {
-          this._idealKeyHandler(this._charCode2KeyCode[domEvent.keyCode], 0, domEvent.type, domEvent);
+          return this._idealKeyHandler(this._charCode2KeyCode[domEvent.keyCode], 0, domEvent.type, domEvent);
         } else {
-          this._idealKeyHandler(0, domEvent.keyCode, domEvent.type, domEvent);
+          return this._idealKeyHandler(0, domEvent.keyCode, domEvent.type, domEvent);
         }
       },
 
@@ -494,14 +536,14 @@ qx.Class.define("qx.event.handler.Keyboard",
         // See http://bugzilla.qooxdoo.org/show_bug.cgi?id=603
         if(keyCode != this.__lastKeyCode)
         {
-          this._idealKeyHandler(0, this.__lastKeyCode, type, domEvent);
+          return this._idealKeyHandler(0, this.__lastKeyCode, type, domEvent);
         }
         else
         {
           if (qx.event.util.Keyboard.keyCodeToIdentifierMap[domEvent.keyCode]) {
-            this._idealKeyHandler(domEvent.keyCode, 0, domEvent.type, domEvent);
+            return this._idealKeyHandler(domEvent.keyCode, 0, domEvent.type, domEvent);
           } else {
-            this._idealKeyHandler(0, domEvent.keyCode, domEvent.type, domEvent);
+            return this._idealKeyHandler(0, domEvent.keyCode, domEvent.type, domEvent);
           }
         }
 
@@ -526,6 +568,7 @@ qx.Class.define("qx.event.handler.Keyboard",
      * @param charCode {String} character code
      * @param eventType {String} type of the event (keydown, keypress, keyup)
      * @param domEvent {Element} DomEvent
+     * @return {qx.Promise?} a promise, if an event handler created one
      */
     _idealKeyHandler : function(keyCode, charCode, eventType, domEvent)
     {
@@ -536,7 +579,7 @@ qx.Class.define("qx.event.handler.Keyboard",
       {
         keyIdentifier = qx.event.util.Keyboard.keyCodeToIdentifier(keyCode);
 
-        this._fireSequenceEvent(domEvent, eventType, keyIdentifier);
+        return this._fireSequenceEvent(domEvent, eventType, keyIdentifier);
       }
 
       // Use: charCode
@@ -544,8 +587,12 @@ qx.Class.define("qx.event.handler.Keyboard",
       {
         keyIdentifier = qx.event.util.Keyboard.charCodeToIdentifier(charCode);
 
-        this._fireSequenceEvent(domEvent, "keypress", keyIdentifier);
-        this._fireInputEvent(domEvent, charCode);
+        var tracker = {};
+        var self = this;
+        qx.event.Utils.track(tracker, this._fireSequenceEvent(domEvent, "keypress", keyIdentifier));
+        return qx.event.Utils.then(tracker, function() {
+          return self._fireInputEvent(domEvent, charCode);
+        });
       }
     },
 

--- a/framework/source/class/qx/event/handler/Pointer.js
+++ b/framework/source/class/qx/event/handler/Pointer.js
@@ -138,27 +138,35 @@ qx.Class.define("qx.event.handler.Pointer",
           // Nothing - cannot change properties in strict mode
         }
 
-        qx.event.Registration.fireEvent(
-          target,
-          type,
-          qx.event.type.Pointer,
-          [domEvent, target, null, true, true]
-        );
+        var tracker = {};
+        var self = this;
+        qx.event.Utils.track(tracker, function() {
+          return qx.event.Registration.fireEvent(
+              target,
+              type,
+              qx.event.type.Pointer,
+              [domEvent, target, null, true, true]
+            );
+        });
 
-        if ((domEvent.getPointerType() !== "mouse" ||
-             domEvent.button <= qx.event.handler.PointerCore.LEFT_BUTTON) &&
-          (type == "pointerdown" || type == "pointerup" || type == "pointermove" || type == "pointercancel"))
-        {
-          qx.event.Registration.fireEvent(
-            this.__root,
-            qx.event.handler.PointerCore.POINTER_TO_GESTURE_MAPPING[type],
-            qx.event.type.Pointer,
-            [domEvent, target, null, false, false]
-          );
-        }
-
-        // Fire user action event
-        qx.event.Registration.fireEvent(this.__window, "useraction", qx.event.type.Data, [type]);
+        qx.event.Utils.then(tracker, function() {
+          if ((domEvent.getPointerType() !== "mouse" ||
+              domEvent.button <= qx.event.handler.PointerCore.LEFT_BUTTON) &&
+              (type == "pointerdown" || type == "pointerup" || type == "pointermove" || type == "pointercancel"))
+          {
+             return qx.event.Registration.fireEvent(
+               self.__root,
+               qx.event.handler.PointerCore.POINTER_TO_GESTURE_MAPPING[type],
+               qx.event.type.Pointer,
+               [domEvent, target, null, false, false]
+             );
+           }
+        });
+        qx.event.Utils.then(tracker, function() {
+          // Fire user action event
+          return qx.event.Registration.fireEvent(self.__window, "useraction", qx.event.type.Data, [type]);
+        });
+        return tracker.promise;
       }
     },
 
@@ -169,7 +177,7 @@ qx.Class.define("qx.event.handler.Pointer",
       }
 
       var type = qx.event.handler.PointerCore.MSPOINTER_TO_POINTER_MAPPING[domEvent.type] || domEvent.type;
-      this._fireEvent(domEvent, type, qx.bom.Event.getTarget(domEvent));
+      return this._fireEvent(domEvent, type, qx.bom.Event.getTarget(domEvent));
     },
 
 

--- a/framework/source/class/qx/event/handler/PointerCore.js
+++ b/framework/source/class/qx/event/handler/PointerCore.js
@@ -420,6 +420,7 @@ qx.Bootstrap.define("qx.event.handler.PointerCore", {
      * @param domEvent {Event} DOM event
      * @param type {String ? null} type of the event
      * @param target {Element ? null} event target
+     * @return {qx.Promise?} a promise, if one was returned by event handlers
      */
     _fireEvent : function(domEvent, type, target)
     {
@@ -443,12 +444,18 @@ qx.Bootstrap.define("qx.event.handler.PointerCore", {
       }
 
       if (qx.core.Environment.get("event.dispatchevent")) {
+        var tracker = {};
         if (!this.__nativePointerEvents) {
-          target.dispatchEvent(domEvent);
+          qx.event.Utils.then(tracker, function() {
+            return target.dispatchEvent(domEvent);
+          });
         }
         if (gestureEvent) {
-          target.dispatchEvent(gestureEvent);
+          qx.event.Utils.then(tracker, function() {
+            return target.dispatchEvent(gestureEvent);
+          });
         }
+        return tracker.promise;
       } else {
         // ensure compatibility with native events for IE8
         try {

--- a/framework/source/class/qx/event/type/Drag.js
+++ b/framework/source/class/qx/event/type/Drag.js
@@ -207,12 +207,27 @@ qx.Class.define("qx.event.type.Drag",
 
     /**
      * Returns the data of the given type. Used in the <code>drop</code> listener.
+     * 
+     * Note that this is a synchronous method and if any of the drag and drop 
+     * events handlers are implemented using Promises, this may fail; @see
+     * `getDataAsync`.
      *
      * @param type {String} Any of the supported types.
      * @return {var} The data for the given type
      */
     getData : function(type) {
       return this.getManager().getData(type);
+    },
+
+
+    /**
+     * Returns the data of the given type. Used in the <code>drop</code> listener.
+     * 
+     * @param type {String} Any of the supported types.
+     * @return {qx.Promise|var} The data for the given type
+     */
+    getDataAsync : function(type) {
+      return this.getManager().getDataAsync(type);
     },
 
 
@@ -242,6 +257,23 @@ qx.Class.define("qx.event.type.Drag",
         return null;
       }
       return this.getManager().getCurrentAction();
+    },
+
+    /**
+     * Returns the currently selected action. Depends on the
+     * supported actions of the source target and the modification
+     * keys pressed by the user.
+     *
+     * Used in the <code>droprequest</code> listener.
+     *
+     * @return {qx.Promise|String} The action. May be one of <code>move</code>,
+     *    <code>copy</code> or <code>alias</code>.
+     */
+    getCurrentActionAsync : function() {
+      if (this.getDefaultPrevented()) {
+        return null;
+      }
+      return this.getManager().getCurrentActionAsync();
     },
 
     /**

--- a/framework/source/class/qx/test/event/Utils.js
+++ b/framework/source/class/qx/test/event/Utils.js
@@ -1,0 +1,425 @@
+/* ************************************************************************
+
+   qooxdoo - the new era of web development
+
+   http://qooxdoo.org
+
+   Copyright:
+     2018 Zenesis Ltd, john.spackman@zenesis.com
+
+   License:
+     MIT: https://opensource.org/licenses/MIT
+     See the LICENSE file in the project's top-level directory for details.
+
+   Authors:
+     * John Spackman (johnspackman)
+
+ ************************************************************************ */
+
+qx.Class.define("qx.test.event.Utils", {
+  extend: qx.dev.unit.TestCase,
+
+  members: {
+    testNoPromises: function() {
+      var Utils = qx.event.Utils;
+      var tracker = {};
+      var str = "";
+      var self = this;
+      var finished = false;
+      Utils.catch(tracker, function() { self.assertTrue(false); })
+      Utils.then(tracker, function() { str += "A"; });
+      Utils.then(tracker, function() { str += "B"; });
+      Utils.then(tracker, function() { str += "C"; });
+      Utils.then(tracker, function() {
+        self.assertEquals("ABC", str);
+        finished = true;
+      });
+      this.assertTrue(finished);
+    },
+    
+    testSomeDelayedPromises: function() {
+      var Utils = qx.event.Utils;
+      var tracker = {};
+      var str = "";
+      var self = this;
+      Utils.then(tracker, function() { str += "A"; });
+      Utils.then(tracker, function() { 
+        return new qx.Promise(function(resolve) {
+          setTimeout(function() {
+            str += "B";
+            resolve();
+          }, 200);
+        })
+      });
+      Utils.then(tracker, function() { str += "C"; });
+      Utils.then(tracker, function() {
+          self.assertEquals("ABC", str);
+          self.resume();
+        });
+      self.wait();
+    },
+    
+    testSomeInstantPromises: function() {
+      var Utils = qx.event.Utils;
+      var tracker = {};
+      var str = "";
+      var self = this;
+      Utils.then(tracker, function() { str += "A"; });
+      Utils.then(tracker, function() { 
+        str += "B";
+        return qx.Promise.resolve();
+      });
+      Utils.then(tracker, function() { str += "C"; });
+      Utils.then(tracker, function() {
+          self.assertEquals("ABC", str);
+          self.resume();
+        });
+      self.wait();
+    },
+    
+    testSomeInstantPromises2: function() {
+      var Utils = qx.event.Utils;
+      var tracker = {};
+      var str = "";
+      var self = this;
+      Utils.then(tracker, function() { str += "A"; });
+      Utils.then(tracker, function() { 
+        str += "B";
+        return qx.Promise.resolve();
+      });
+      Utils.then(tracker, function() { 
+        return new qx.Promise(function(resolve) {
+          setTimeout(function() {
+            str += "C"; 
+            resolve();
+          }, 200);
+        })
+      });
+      Utils.then(tracker, function() {
+          self.assertEquals("ABC", str);
+          self.resume();
+        });
+      self.wait();
+    },
+    
+    testSomeAbort: function() {
+      var Utils = qx.event.Utils;
+      var tracker = {};
+      var str = "";
+      var self = this;
+      var finished = false;
+      Utils.then(tracker, function() { str += "A"; });
+      Utils.then(tracker, function() { 
+        return Utils.ABORT;
+      });
+      Utils.then(tracker, function() { str += "C"; });
+      Utils.then(tracker, function() {
+          self.assertTrue(false);
+        });
+      Utils.catch(tracker, function() {
+        self.assertEquals("A", str);
+        finished = true;
+      });
+      this.assertTrue(finished);
+    },
+    
+    testSomeReject: function() {
+      var Utils = qx.event.Utils;
+      var tracker = {};
+      var str = "";
+      var self = this;
+      Utils.then(tracker, function() { str += "A"; });
+      Utils.then(tracker, function() { 
+        return new qx.Promise(function(resolve, reject) {
+          setTimeout(function() {
+            reject();
+          }, 200);
+        })
+      });
+      Utils.then(tracker, function() { str += "C"; });
+      Utils.then(tracker, function() {
+          self.assertTrue(false);
+        });
+      Utils.catch(tracker, function() {
+        self.assertEquals("A", str);
+        self.resume();
+      });
+      self.wait();
+    },
+    
+    testResolveAndReject: function() {
+      var Utils = qx.event.Utils;
+      var tracker = {};
+      var str = "";
+      var self = this;
+      Utils.then(tracker, function() { str += "A"; });
+      Utils.then(tracker, function() { 
+        return new qx.Promise(function(resolve) {
+          setTimeout(function() {
+            str += "B";
+            resolve();
+          }, 200);
+        });
+      });
+      Utils.then(tracker, function() { 
+        return new qx.Promise(function(resolve, reject) {
+          setTimeout(function() {
+            reject();
+          }, 200);
+        });
+      });
+      Utils.then(tracker, function() {
+        self.assertTrue(false);
+        });
+      Utils.catch(tracker, function() {
+        self.assertEquals("AB", str);
+        self.resume();
+      });
+      self.wait();
+    },
+    
+    testSeries1: function() {
+      var Utils = qx.event.Utils;
+      var tracker = {};
+      var str = "";
+      var self = this;
+      Utils.catch(tracker, function() { self.assertTrue(false); })
+      Utils.then(tracker, function() {
+        return Utils.series(["A", "B", "C", "D"], function(value) {
+          if (value === "C") {
+            return new qx.Promise(function(resolve, reject) {
+              setTimeout(function() {
+                str += value;
+                resolve();
+              }, 200);
+            });
+          } else {
+            str += value;
+            return null;
+          }
+        });
+      });
+      Utils.then(tracker, function() {
+        self.assertEquals("ABCD", str);
+        self.resume();
+        return null;
+      });
+      self.wait();
+    },
+    
+    testSeriesAbort: function() {
+      var Utils = qx.event.Utils;
+      var tracker = {};
+      var str = "";
+      var self = this;
+      Utils.catch(tracker, function() { 
+        self.assertEquals("AB", str);
+        self.resume();
+      });
+      Utils.then(tracker, function() {
+        return Utils.series(["A", "B", "C", "D"], function(value) {
+          if (value === "B") {
+            return new qx.Promise(function(resolve, reject) {
+              setTimeout(function() {
+                str += value;
+                resolve();
+              }, 200);
+            });
+          } else if (value === "C") {
+            return Utils.ABORT;
+          } else {
+            str += value;
+            return null;
+          }
+        });
+      });
+      Utils.then(tracker, function() {
+        self.assertTrue(false); 
+      });
+      self.wait();
+    },
+
+    /**
+     * @ignore(Promise)
+     */
+    testNativePromiseReturns: function() {
+      var self = this;
+      var p = new Promise(function(resolve) { setTimeout(resolve, 100); });
+      p = p.then(function() {
+        var p2 = new Promise(function(resolve) { setTimeout(resolve, 100); });
+        return p2.then(function() { return true; });
+      });
+      p = p.then(function() { self.resume(); });
+      this.wait();
+    },
+    
+    testPromiseReturns: function() {
+      var self = this;
+      var p = new qx.Promise(function(resolve) { 
+          setTimeout(function() {
+            console.log("testPromiseReturns:: resolving p");
+            resolve();
+          }, 100); 
+        });
+      p = p.then(function() {
+        var p2 = new qx.Promise(function(resolve) { 
+            setTimeout(function() {
+              console.log("testPromiseReturns:: resolving p2");
+              resolve();
+            }, 100);
+          });
+        return p2.then(function() { 
+          console.log("testPromiseReturns:: resolving post p2"); 
+        });
+      });
+      p = p.then(function() {
+        console.log("testPromiseReturns:: outer then, resuming test");
+        self.resume();
+      });
+      this.wait();
+    },
+    
+    testSeriesReject: function() {
+      var Utils = qx.event.Utils;
+      var tracker = {};
+      var str = "";
+      var self = this;
+      Utils.catch(tracker, function() { 
+        self.assertEquals("AB", str);
+        self.resume();
+      });
+      Utils.then(tracker, function() {
+        return Utils.series(["A", "B", "C", "D"], function(value) {
+          if (value === "C") {
+            return new qx.Promise(function(resolve, reject) {
+              setTimeout(function() {
+                reject();
+              }, 200);
+            });
+          } else {
+            str += value;
+            return null;
+          }
+        });
+      });
+      Utils.then(tracker, function() {
+        self.assertTrue(false); 
+      });
+      self.wait();
+    },
+    
+    testSeriesRejectNested: function() {
+      var Utils = qx.event.Utils;
+      var tracker = {};
+      var str = "";
+      var self = this;
+      Utils.catch(tracker, function() { 
+        self.assertEquals("ABC1", str);
+        self.resume();
+      });
+      Utils.then(tracker, function() {
+        return Utils.series(["A", "B", "C", "D"], function(letter) {
+          if (letter === "C") {
+            str += letter;
+            return Utils.series([1, 2, 3, 4], function(number) {
+              if (number == 2) {
+                return new qx.Promise(function(resolve, reject) {
+                  setTimeout(function() {
+                    reject();
+                  }, 200);
+                });
+              } else {
+                str += number;
+              }
+              return null;
+            });
+          } else {
+            str += letter;
+            return null;
+          }
+        });
+      });
+      Utils.then(tracker, function() {
+        self.assertTrue(false); 
+      });
+      self.wait();
+    },
+    
+    testSeriesNested: function() {
+      var Utils = qx.event.Utils;
+      var tracker = {};
+      var str = "";
+      var self = this;
+      Utils.catch(tracker, function() { 
+        self.assertTrue(false); 
+      });
+      Utils.then(tracker, function() {
+        return Utils.series(["A", "B", "C", "D"], function(letter) {
+          if (letter === "C") {
+            str += letter;
+            return Utils.series([1, 2, 3, 4], function(number) {
+              if (number == 2) {
+                return new qx.Promise(function(resolve, reject) {
+                  setTimeout(function() {
+                    str += number;
+                    resolve();
+                  }, 200);
+                });
+              } else {
+                str += number;
+              }
+              return null;
+            });
+          } else {
+            str += letter;
+            return null;
+          }
+        });
+      });
+      Utils.then(tracker, function() {
+        self.assertEquals("ABC1234D", str);
+        self.resume();
+      });
+      self.wait();
+    },
+    
+    testTrack: function() {
+      var Utils = qx.event.Utils;
+      var str = "";
+      var self = this;
+      var finished = true;
+      
+      function outer() {
+        var tracker = {};
+
+        Utils.track(tracker, inner);
+        Utils.then(tracker, function() {
+          self.assertEquals("ABC", str);
+          finished = true;
+        });
+        self.assertTrue(finished);
+      }
+      
+      function add(ch, delay) {
+        return function() {
+          return new qx.Promise(function(resolve) {
+            setTimeout(function() { 
+                str += ch;
+                resolve();
+              }, 300);
+          });
+        };
+      }
+      
+      function inner() {
+        var tracker = {};
+        Utils.then(tracker, add("A", 300));
+        Utils.then(tracker, add("B", 200));
+        Utils.then(tracker, add("C", 100));
+        return tracker.promise;
+      }
+
+      outer();
+    }
+  }
+});

--- a/framework/source/class/qx/ui/core/EventHandler.js
+++ b/framework/source/class/qx/ui/core/EventHandler.js
@@ -309,23 +309,28 @@ qx.Class.define("qx.ui.core.EventHandler",
       }
 
       // Dispatch it on all listeners
-      for (var i=0, l=listeners.length; i<l; i++)
-      {
-        var context = listeners[i].context || currentWidget;
-        listeners[i].handler.call(context, widgetEvent);
-      }
+      var tracker = {};
+      qx.event.Utils.then(tracker, function() {
+        return qx.event.Utils.series(listeners, function(listener) {
+          var context = listener.context || currentWidget;
+          return listener.handler.call(context, widgetEvent);
+        });
+      });
 
       // Synchronize propagation stopped/prevent default property
-      if (widgetEvent.getPropagationStopped()) {
-        domEvent.stopPropagation();
-      }
+      qx.event.Utils.then(tracker, function() {
+        if (widgetEvent.getPropagationStopped()) {
+          domEvent.stopPropagation();
+        }
 
-      if (widgetEvent.getDefaultPrevented()) {
-        domEvent.preventDefault();
-      }
+        if (widgetEvent.getDefaultPrevented()) {
+          domEvent.preventDefault();
+        }
+      });
 
-      // Release the event instance to the event pool
-      qx.event.Pool.getInstance().poolObject(widgetEvent);
+      return qx.event.Utils.then(tracker, function() {
+        qx.event.Pool.getInstance().poolObject(widgetEvent);
+      });
     },
 
 


### PR DESCRIPTION
Promise support in Events

While events can appear at first glance to be asynchronous, they form part of an API which is (currently) inherently synchronous; EG when multiple handlers are attached to a widget, they are required to complete fully and synchronously before moving on to the next.

Since implementing promises, properties have been extended to support promises as the return value from apply methods, enabling the apply to delay triggering events until some asynchronous work (EG server round trip) has completed - this PR completes the implementation of promises by allowing event handlers to do the same.

With this PR, the event processing model is unchanged except that any event handler may optionally return a promise, which will effectively suspend the event dispatch process until that promise is resolved.  The suspension will affect situations where there are multiple handlers of the same type on a widget, as well as the when there are a sequence of events triggered by another event (EG a single mouse can trigger multiple pointer and gesture events).

Promises are only used if the event handler chooses to create a promise, meaning that the overhead of adding promises is avoided in the general case.

The most obvious use case for this is handling user interactions which require server round trips - for example, a File Explorer user interface could need to check with the server during drag and drop operations, but drag and drop requires a series of related events (`dragstart` -> `dragover` -> `droprequest` -> `drop`) and without promises it is impossible to do any form of asynchronous work during that sequence.

Backwards compatibility is only an issue in code which is calling several `fireEvent` methods in sequence, and those methods are expected to complete synchronously, and an event handler is added which returns a promise.  From the point of view of existing applications, this will not cause an issue unless the coder adds code to return a Promise from an event handler, in which case he/she will be aware of the implications.  The framework itself does not need to return promises so will not introduce any issues (any instances where the framework issues events in sequence would need to be updated however, and should already be part of this PR).
