### PR TITLE
oo loader template could fail to initialize userAgent

### DIFF
--- a/tool/data/generator/oo.loader.tmpl.js
+++ b/tool/data/generator/oo.loader.tmpl.js
@@ -7,7 +7,7 @@ if (!window.navigator.userAgent) {
   window.navigator.userAgent = "Mozilla/5.0 (Macintosh; U; Intel Mac OS X 10_6_4; de-de) AppleWebKit/533.17.8 (KHTML, like Gecko) Version/5.0.1 Safari/533.17.8";
 }
 if (!window.navigator.product) window.navigator.product = "";
-if (!window.navigator.cpuClass) window.navigator.ecpuClass = "";
+if (!window.navigator.cpuClass) window.navigator.cpuClass = "";
 
 if (!window.qx) window.qx = {};
 

--- a/tool/data/generator/oo.loader.tmpl.js
+++ b/tool/data/generator/oo.loader.tmpl.js
@@ -2,11 +2,12 @@
 
 if (!this.window) window = this;
 
-if (!window.navigator) window.navigator = {
-  userAgent: "Mozilla/5.0 (Macintosh; U; Intel Mac OS X 10_6_4; de-de) AppleWebKit/533.17.8 (KHTML, like Gecko) Version/5.0.1 Safari/533.17.8", 
-  product: "", 
-  cpuClass: ""
-}; 
+if (!window.navigator) window.navigator = {};
+if (!window.navigator.userAgent) {
+  window.navigator.userAgent = "Mozilla/5.0 (Macintosh; U; Intel Mac OS X 10_6_4; de-de) AppleWebKit/533.17.8 (KHTML, like Gecko) Version/5.0.1 Safari/533.17.8";
+}
+if (!window.navigator.product) window.navigator.product = "";
+if (!window.navigator.cpuClass) window.navigator.ecpuClass = "";
 
 if (!window.qx) window.qx = {};
 


### PR DESCRIPTION
In the React Native environment, window.navigator is defined, but
window.navigator.userAgent is not. This patch ensures that userAgent gets
set even if window.navigator was previously set. For consistency, it also
sets window.navigator.product and window.navigator.cpuClass if either is
unset, regardless of whether only those individual members were unset or if
window.navigator was originally unset.