### PR TITLE
Fixes #9488: Dispose the previous layout in qx.ui.form.List on orientation change

### DIFF
--- a/framework/source/class/qx/ui/form/List.js
+++ b/framework/source/class/qx/ui/form/List.js
@@ -267,23 +267,27 @@ qx.Class.define("qx.ui.form.List",
     // property apply
     _applyOrientation : function(value, old)
     {
+      var content = this.__content;
+
+      // save old layout for disposal
+      var oldLayout = content.getLayout();
+      
       // Create new layout
       var horizontal = value === "horizontal";
       var layout = horizontal ? new qx.ui.layout.HBox() : new qx.ui.layout.VBox();
 
       // Configure content
-      var content = this.__content;
       content.setLayout(layout);
       content.setAllowGrowX(!horizontal);
       content.setAllowGrowY(horizontal);
 
       // Configure spacing
       this._applySpacing(this.getSpacing());
-    },
-
-    // property apply
-    _applySpacing : function(value, old) {
-      this.__content.getLayout().setSpacing(value);
+      
+      // dispose old layout
+      if(oldLayout) {
+        oldLayout.dispose();
+      }
     },
 
 

--- a/framework/source/class/qx/ui/form/List.js
+++ b/framework/source/class/qx/ui/form/List.js
@@ -290,6 +290,11 @@ qx.Class.define("qx.ui.form.List",
       }
     },
 
+    // property apply
+    _applySpacing : function(value, old) {
+      this.__content.getLayout().setSpacing(value);
+    },
+
 
     /*
     ---------------------------------------------------------------------------


### PR DESCRIPTION
See https://github.com/qooxdoo/qooxdoo/issues/9488