### PR TITLE
change hard coded icon theme Tango to ${qx.icontheme}

### DIFF
--- a/framework/config.json
+++ b/framework/config.json
@@ -43,8 +43,6 @@
     "validate-manifest",
     "watch-scss"
   ],
-
-
   "let" :
   {
     "APPLICATION"  : "qx",
@@ -134,7 +132,6 @@
       },
 
       "compile" : { "type" : "build" },
-
       "copy-resources" :
       {
         "target" : "build"
@@ -211,6 +208,10 @@
         "LOCALES" : ["de", "de_DE", "en", "en_GB", "en_US"],
         "TEST_EXCLUDE" : "${TEST_PERFORMANCE_INCLUDE}",
         "TEST_INCLUDE" : "qx.*"
+      },
+      "asset-let" :
+      {
+        "qx.icontheme" : ["Tango"]
       }
     },
 
@@ -324,8 +325,12 @@
       "config-warnings" :
       {
         "environment" : [ "non-literal-keys" ]
+      },
+      "asset-let" :
+      {
+        "qx.icontheme" : ["Tango"]
       }
-    },
+   },
 
     "api-verify" :
     {

--- a/framework/source/class/qx/test/bom/Attribute.js
+++ b/framework/source/class/qx/test/bom/Attribute.js
@@ -20,7 +20,7 @@
 ************************************************************************ */
 /**
  *
- * @asset(qx/icon/Tango/48/places/folder.png)
+ * @asset(qx/icon/${qx.icontheme}/48/places/folder.png)
  */
 
 qx.Class.define("qx.test.bom.Attribute",

--- a/framework/source/class/qx/test/mobile/basic/Atom.js
+++ b/framework/source/class/qx/test/mobile/basic/Atom.js
@@ -20,8 +20,8 @@
 ************************************************************************ */
 /**
  *
- * @asset(qx/icon/Tango/48/places/user-home.png)
- * @asset(qx/icon/Tango/32/places/folder-open.png)
+ * @asset(qx/icon/${qx.icontheme}/48/places/user-home.png)
+ * @asset(qx/icon/${qx.icontheme}/32/places/folder-open.png)
  */
 
 qx.Class.define("qx.test.mobile.basic.Atom",

--- a/framework/source/class/qx/test/mobile/basic/Image.js
+++ b/framework/source/class/qx/test/mobile/basic/Image.js
@@ -17,7 +17,7 @@
 ************************************************************************ */
 
 /**
- * @asset(qx/icon/Tango/48/places/folder.png)
+ * @asset(qx/icon/${qx.icontheme}/48/places/folder.png)
  */
 
 qx.Class.define("qx.test.mobile.basic.Image",

--- a/framework/source/class/qx/test/mobile/list/List.js
+++ b/framework/source/class/qx/test/mobile/list/List.js
@@ -19,7 +19,7 @@
 ************************************************************************ */
 /**
  *
- * @asset(qx/icon/Tango/48/places/folder.png)
+ * @asset(qx/icon/${qx.icontheme}/48/places/folder.png)
  */
 
 qx.Class.define("qx.test.mobile.list.List",

--- a/framework/source/class/qx/test/ui/basic/Image.js
+++ b/framework/source/class/qx/test/ui/basic/Image.js
@@ -18,8 +18,8 @@
 
 /**
  * @asset(qx/test/webfonts/fontawesome-webfont.*)
- * @asset(qx/icon/Tango/48/places/folder.png)
- * @asset(qx/icon/Tango/32/places/folder.png)
+ * @asset(qx/icon/${qx.icontheme}/48/places/folder.png)
+ * @asset(qx/icon/${qx.icontheme}/32/places/folder.png)
  * @asset(qx/static/blank.gif)
  * @asset(qx/static/drawer.png)
  * @asset(qx/static/drawer@2x.png)

--- a/framework/source/class/qx/test/ui/list/List.js
+++ b/framework/source/class/qx/test/ui/list/List.js
@@ -17,7 +17,7 @@
 ************************************************************************ */
 
 /**
- * @asset(qx/icon/Tango/16/places/folder.png)
+ * @asset(qx/icon/${qx.icontheme}/16/places/folder.png)
  */
 
 qx.Class.define("qx.test.ui.list.List",

--- a/framework/source/class/qx/test/ui/virtual/cell/WidgetCell.js
+++ b/framework/source/class/qx/test/ui/virtual/cell/WidgetCell.js
@@ -22,7 +22,7 @@
 ************************************************************************ */
 /**
  *
- * @asset(qx/icon/Tango/22/emotes/face-angel.png)
+ * @asset(qx/icon/${qx.icontheme}/22/emotes/face-angel.png)
  */
 
 qx.Class.define("qx.test.ui.virtual.cell.WidgetCell",

--- a/framework/source/class/qx/theme/indigo/Appearance.js
+++ b/framework/source/class/qx/theme/indigo/Appearance.js
@@ -24,14 +24,14 @@
 /**
  * The simple qooxdoo appearance theme.
  *
- * @asset(qx/icon/Tango/16/apps/office-calendar.png)
- * @asset(qx/icon/Tango/16/places/folder-open.png)
- * @asset(qx/icon/Tango/16/places/folder.png)
- * @asset(qx/icon/Tango/16/mimetypes/text-plain.png)
- * @asset(qx/icon/Tango/16/actions/view-refresh.png)
- * @asset(qx/icon/Tango/16/actions/window-close.png)
- * @asset(qx/icon/Tango/16/actions/dialog-cancel.png)
- * @asset(qx/icon/Tango/16/actions/dialog-ok.png)
+ * @asset(qx/icon/${qx.icontheme}/16/apps/office-calendar.png)
+ * @asset(qx/icon/${qx.icontheme}/16/places/folder-open.png)
+ * @asset(qx/icon/${qx.icontheme}/16/places/folder.png)
+ * @asset(qx/icon/${qx.icontheme}/16/mimetypes/text-plain.png)
+ * @asset(qx/icon/${qx.icontheme}/16/actions/view-refresh.png)
+ * @asset(qx/icon/${qx.icontheme}/16/actions/window-close.png)
+ * @asset(qx/icon/${qx.icontheme}/16/actions/dialog-cancel.png)
+ * @asset(qx/icon/${qx.icontheme}/16/actions/dialog-ok.png)
  */
 qx.Theme.define("qx.theme.indigo.Appearance",
 {

--- a/framework/source/class/qx/theme/modern/Appearance.js
+++ b/framework/source/class/qx/theme/modern/Appearance.js
@@ -29,26 +29,26 @@
 /**
  * The modern appearance theme.
  *
- * @asset(qx/icon/Tango/16/places/folder-open.png)
- * @asset(qx/icon/Tango/16/places/folder.png)
- * @asset(qx/icon/Tango/16/mimetypes/office-document.png)
+ * @asset(qx/icon/${qx.icontheme}/16/places/folder-open.png)
+ * @asset(qx/icon/${qx.icontheme}/16/places/folder.png)
+ * @asset(qx/icon/${qx.icontheme}/16/mimetypes/office-document.png)
 
- * @asset(qx/icon/Tango/16/actions/window-close.png)
+ * @asset(qx/icon/${qx.icontheme}/16/actions/window-close.png)
 
- * @asset(qx/icon/Tango/22/places/folder-open.png)
- * @asset(qx/icon/Tango/22/places/folder.png)
- * @asset(qx/icon/Tango/22/mimetypes/office-document.png)
+ * @asset(qx/icon/${qx.icontheme}/22/places/folder-open.png)
+ * @asset(qx/icon/${qx.icontheme}/22/places/folder.png)
+ * @asset(qx/icon/${qx.icontheme}/22/mimetypes/office-document.png)
 
- * @asset(qx/icon/Tango/32/places/folder-open.png)
- * @asset(qx/icon/Tango/32/places/folder.png)
- * @asset(qx/icon/Tango/32/mimetypes/office-document.png)
+ * @asset(qx/icon/${qx.icontheme}/32/places/folder-open.png)
+ * @asset(qx/icon/${qx.icontheme}/32/places/folder.png)
+ * @asset(qx/icon/${qx.icontheme}/32/mimetypes/office-document.png)
 
- * @asset(qx/icon/Tango/16/apps/office-calendar.png)
- * @asset(qx/icon/Tango/16/apps/utilities-color-chooser.png)
- * @asset(qx/icon/Tango/16/actions/view-refresh.png)
+ * @asset(qx/icon/${qx.icontheme}/16/apps/office-calendar.png)
+ * @asset(qx/icon/${qx.icontheme}/16/apps/utilities-color-chooser.png)
+ * @asset(qx/icon/${qx.icontheme}/16/actions/view-refresh.png)
 
- * @asset(qx/icon/Tango/16/actions/dialog-cancel.png)
- * @asset(qx/icon/Tango/16/actions/dialog-ok.png)
+ * @asset(qx/icon/${qx.icontheme}/16/actions/dialog-cancel.png)
+ * @asset(qx/icon/${qx.icontheme}/16/actions/dialog-ok.png)
 
  * @asset(qx/decoration/Modern/cursors/*)
  *

--- a/framework/source/class/qx/theme/simple/Appearance.js
+++ b/framework/source/class/qx/theme/simple/Appearance.js
@@ -24,14 +24,14 @@
 /**
  * The simple qooxdoo appearance theme.
  *
- * @asset(qx/icon/Tango/16/apps/office-calendar.png)
- * @asset(qx/icon/Tango/16/places/folder-open.png)
- * @asset(qx/icon/Tango/16/places/folder.png)
- * @asset(qx/icon/Tango/16/mimetypes/text-plain.png)
- * @asset(qx/icon/Tango/16/actions/view-refresh.png)
- * @asset(qx/icon/Tango/16/actions/window-close.png)
- * @asset(qx/icon/Tango/16/actions/dialog-cancel.png)
- * @asset(qx/icon/Tango/16/actions/dialog-ok.png)
+ * @asset(qx/icon/${qx.icontheme}/16/apps/office-calendar.png)
+ * @asset(qx/icon/${qx.icontheme}/16/places/folder-open.png)
+ * @asset(qx/icon/${qx.icontheme}/16/places/folder.png)
+ * @asset(qx/icon/${qx.icontheme}/16/mimetypes/text-plain.png)
+ * @asset(qx/icon/${qx.icontheme}/16/actions/view-refresh.png)
+ * @asset(qx/icon/${qx.icontheme}/16/actions/window-close.png)
+ * @asset(qx/icon/${qx.icontheme}/16/actions/dialog-cancel.png)
+ * @asset(qx/icon/${qx.icontheme}/16/actions/dialog-ok.png)
  */
 qx.Theme.define("qx.theme.simple.Appearance",
 {


### PR DESCRIPTION
this is the first step for #9485.
My applications compile without warnings.
The documented warnings in https://github.com/qooxdoo/qooxdoo-compiler/issues/131 are from Building the apiviewer.
IMHO they could be ignored.

With this it's the first time you have an consitent icontheme if you prefer Oxygen