### PR TITLE
Remove arguments.callee in qx.ui.table.model.Simple and introduce a new third parameter columIndex for sort functions

### DIFF
--- a/application/demobrowser/source/class/demobrowser/demo/table/Table.js
+++ b/application/demobrowser/source/class/demobrowser/demo/table/Table.js
@@ -163,10 +163,10 @@ qx.Class.define("demobrowser.demo.table.Table",
       {
         if (evt.getData())
         {
-          var ascending = function(row1, row2)
+          var ascending = function(row1, row2, columnIndex)
           {
-            var obj1 = row1[arguments.callee.columnIndex];
-            var obj2 = row2[arguments.callee.columnIndex];
+            var obj1 = row1[columnIndex];
+            var obj2 = row2[columnIndex];
             if (obj1 % 2 == 1 && obj2 % 2 == 0)
             {
               return 1;
@@ -178,10 +178,10 @@ qx.Class.define("demobrowser.demo.table.Table",
             return (obj1 > obj2) ? 1 : ((obj1 == obj2) ? 0 : -1);
           };
 
-          var descending = function(row1, row2)
+          var descending = function(row1, row2, columnIndex)
           {
-            var obj1 = row1[arguments.callee.columnIndex];
-            var obj2 = row2[arguments.callee.columnIndex];
+            var obj1 = row1[columnIndex];
+            var obj2 = row2[columnIndex];
             if (obj1 % 2 == 1 && obj2 % 2 == 0)
             {
               return -1;

--- a/application/demobrowser/source/class/demobrowser/demo/table/Table_Context_Menu.js
+++ b/application/demobrowser/source/class/demobrowser/demo/table/Table_Context_Menu.js
@@ -244,10 +244,10 @@ qx.Class.define("demobrowser.demo.table.Table_Context_Menu",
       {
         if (evt.getData())
         {
-          var ascending = function(row1, row2)
+          var ascending = function(row1, row2, columnIndex)
           {
-            var obj1 = row1[arguments.callee.columnIndex];
-            var obj2 = row2[arguments.callee.columnIndex];
+            var obj1 = row1[columnIndex];
+            var obj2 = row2[columnIndex];
             if (obj1 % 2 == 1 && obj2 % 2 == 0)
             {
               return 1;
@@ -259,10 +259,10 @@ qx.Class.define("demobrowser.demo.table.Table_Context_Menu",
             return (obj1 > obj2) ? 1 : ((obj1 == obj2) ? 0 : -1);
           };
 
-          var descending = function(row1, row2)
+          var descending = function(row1, row2, columnIndex)
           {
-            var obj1 = row1[arguments.callee.columnIndex];
-            var obj2 = row2[arguments.callee.columnIndex];
+            var obj1 = row1[columnIndex];
+            var obj2 = row2[columnIndex];
             if (obj1 % 2 == 1 && obj2 % 2 == 0)
             {
               return -1;

--- a/framework/source/class/qx/test/ui/table/model/Simple.js
+++ b/framework/source/class/qx/test/ui/table/model/Simple.js
@@ -125,6 +125,72 @@ qx.Class.define("qx.test.ui.table.model.Simple",
       
       table.destroy();
       model.dispose();
+    },
+    
+    testCustomSortFunctionArgumentsCalleeColumnIndexDeprecated : function()
+    {
+      var stringValues = this.getStringValues();
+      var rowCount = 20;
+      
+      // table
+      var model = new qx.ui.table.model.Simple();
+      model.setColumns([ "ID", "String" ]);
+      model.setData(this.createRandomRows(rowCount));
+
+      // custom individual ascending descending integer sort function for column 0
+      model.setSortMethods(0, {
+        ascending : function(row1, row2) {
+          var columnIndex = arguments.callee.columnIndex;
+          var int1 = row1[columnIndex];
+          var int2 = row2[columnIndex];
+          return (int1 > int2) ? 1 : ((int1 == int2) ? 0 : -1);
+        },
+        descending : function(row2, row1) {
+          var columnIndex = arguments.callee.columnIndex;
+          var int1 = row1[columnIndex];
+          var int2 = row2[columnIndex];
+          return (int1 > int2) ? 1 : ((int1 == int2) ? 0 : -1);
+        } 
+      });
+      
+      // custom single string sort function for column 1
+      model.setSortMethods(1, function(row1, row2) {
+        var columnIndex = arguments.callee.columnIndex;
+        var string1 = row1[columnIndex];
+        var string2 = row2[columnIndex];
+        return string1.localeCompare(string2);
+      });
+      
+      var table = new qx.ui.table.Table(model);
+
+      // test sorting column 1
+      
+      // sort descending
+      model.sortByColumn(1);
+      var data = model.getData();
+      this.assertTrue(data[0][1] == stringValues[stringValues.length-1]);
+      this.assertTrue(data[data.length-1][1] == stringValues[0]);
+
+      // sort ascending
+      model.sortByColumn(1, true);
+      this.assertTrue(data[0][1] == stringValues[0]);
+      this.assertTrue(data[data.length-1][1] == stringValues[stringValues.length-1]);
+
+      
+      // test sorting column 0
+      
+      // sort descending
+      model.sortByColumn(0);
+      this.assertTrue(data[0][0] == rowCount);
+      this.assertTrue(data[data.length-1][0] == 1);
+
+      // sort ascending
+      model.sortByColumn(0, true);
+      this.assertTrue(data[0][0] == 1);
+      this.assertTrue(data[data.length-1][0] == rowCount);
+      
+      table.destroy();
+      model.dispose();
     }
 
   }

--- a/framework/source/class/qx/test/ui/table/model/Simple.js
+++ b/framework/source/class/qx/test/ui/table/model/Simple.js
@@ -48,6 +48,84 @@ qx.Class.define("qx.test.ui.table.model.Simple",
       this.assertEquals("test2", data.col2);
 
       tableModel.dispose();
+    },
+    
+    getStringValues : function() {
+      return ["aaaa", "bbbb", "cccc", "dddd", "eeee", "ffff"];
+    },
+    
+    createRandomRows : function(rowCount)
+    {
+      var rowData = [];
+      var strings = this.getStringValues();
+      for (var row = 0; row < rowCount; row++) {
+        rowData.push([ row+1, strings[row % strings.length] ]);
+      }
+      return rowData;
+    },
+    
+    testCustomSortFunction : function()
+    {
+      var stringValues = this.getStringValues();
+      var rowCount = 20;
+      
+      // table
+      var model = new qx.ui.table.model.Simple();
+      model.setColumns([ "ID", "String" ]);
+      model.setData(this.createRandomRows(rowCount));
+
+      // custom individual ascending descending integer sort function for column 0
+      model.setSortMethods(0, {
+        ascending : function(row1, row2, columnIndex) {
+          var int1 = row1[columnIndex];
+          var int2 = row2[columnIndex];
+          return (int1 > int2) ? 1 : ((int1 == int2) ? 0 : -1);
+        },
+        descending : function(row2, row1, columnIndex) {
+          var int1 = row1[columnIndex];
+          var int2 = row2[columnIndex];
+          return (int1 > int2) ? 1 : ((int1 == int2) ? 0 : -1);
+        } 
+      });
+      
+      // custom single string sort function for column 1
+      model.setSortMethods(1, function(row1, row2, columnIndex) {
+        var string1 = row1[columnIndex];
+        var string2 = row2[columnIndex];
+        return string1.localeCompare(string2);
+      });
+      
+      var table = new qx.ui.table.Table(model);
+
+      // test sorting column 1
+      
+      // sort descending
+      model.sortByColumn(1);
+      var data = model.getData();
+      this.assertTrue(data[0][1] == stringValues[stringValues.length-1]);
+      this.assertTrue(data[data.length-1][1] == stringValues[0]);
+
+      // sort ascending
+      model.sortByColumn(1, true);
+      this.assertTrue(data[0][1] == stringValues[0]);
+      this.assertTrue(data[data.length-1][1] == stringValues[stringValues.length-1]);
+
+      
+      // test sorting column 0
+      
+      // sort descending
+      model.sortByColumn(0);
+      this.assertTrue(data[0][0] == rowCount);
+      this.assertTrue(data[data.length-1][0] == 1);
+
+      // sort ascending
+      model.sortByColumn(0, true);
+      this.assertTrue(data[0][0] == 1);
+      this.assertTrue(data[data.length-1][0] == rowCount);
+      
+      table.destroy();
+      model.dispose();
     }
+
   }
 });

--- a/framework/source/class/qx/ui/table/model/Simple.js
+++ b/framework/source/class/qx/ui/table/model/Simple.js
@@ -360,7 +360,7 @@ qx.Class.define("qx.ui.table.model.Simple",
      *   If provided as a Function, this is the comparator function to sort in
      *   ascending order. It takes three parameters: the two arrays of row data,
      *   row1 and row2, being compared and the column index sorting was requested 
-     *   for. Determining the which column of the row data should be sorted by 
+     *   for. Determining which column of the row data should be sorted by 
      *   accessing arguments.callee.columnIndex is also possible for compatibility 
      *   reasons, but is deprecated and will be removed in future releases.  
      *   The comparator function must return 1, 0 or -1, when the column in row1

--- a/framework/source/class/qx/ui/table/model/Simple.js
+++ b/framework/source/class/qx/ui/table/model/Simple.js
@@ -365,7 +365,8 @@ qx.Class.define("qx.ui.table.model.Simple",
      *   For backwards compatability, user-supplied compare functions may still 
      *   take only two parameters, the two arrays of row data, row1 and row2, 
      *   being compared and obtain the column index as arguments.callee.columnIndex. 
-     *   This is deprecated, however, as arguments.callee is disallowed in ES6.
+     *   This is deprecated, however, as arguments.callee is disallowed in ES5 strict
+     *   mode and ES6.
      *
      *   The comparator function must return 1, 0 or -1, when the column in row1
      *   is greater than, equal to, or less than, respectively, the column in
@@ -395,6 +396,17 @@ qx.Class.define("qx.ui.table.model.Simple",
             ascending  : compare,
             descending : function(row1, row2, columnIndex)
             {
+              /* assure backwards compatibility for sort functions using
+               * arguments.callee.columnIndex and fix a bug where retreiveing
+               * column index via this way did not work for the case where a 
+               * single comparator function was used. 
+               * Note that arguments.callee is not available in ES5 strict mode and ES6. 
+               * See discussion in 
+               * https://github.com/qooxdoo/qooxdoo/pull/9499#pullrequestreview-99655182
+               */ 
+              if(arguments.callee !== undefined) {
+                compare.columnIndex = arguments.callee.columnIndex;
+              }              
               return compare(row2, row1, columnIndex);
             }
           };

--- a/framework/source/class/qx/ui/table/model/Simple.js
+++ b/framework/source/class/qx/ui/table/model/Simple.js
@@ -58,12 +58,13 @@ qx.Class.define("qx.ui.table.model.Simple",
      *
      * @param row1 {var} first row
      * @param row2 {var} second row
+     * @param columnIndex {Integer} the column to be sorted
      * @return {Integer} 1 of row1 is > row2, -1 if row1 is < row2, 0 if row1 == row2
      */
-    _defaultSortComparatorAscending : function(row1, row2)
+    _defaultSortComparatorAscending : function(row1, row2, columnIndex)
     {
-      var obj1 = row1[arguments.callee.columnIndex];
-      var obj2 = row2[arguments.callee.columnIndex];
+      var obj1 = row1[columnIndex];
+      var obj2 = row2[columnIndex];
       if (qx.lang.Type.isNumber(obj1) && qx.lang.Type.isNumber(obj2)) {
         var result = isNaN(obj1) ? isNaN(obj2) ?  0 : 1 : isNaN(obj2) ? -1 : null;
         if (result != null) {
@@ -79,14 +80,15 @@ qx.Class.define("qx.ui.table.model.Simple",
      *
      * @param row1 {var} first row
      * @param row2 {var} second row
+     * @param columnIndex {Integer} the column to be sorted
      * @return {Integer} 1 of row1 is > row2, -1 if row1 is < row2, 0 if row1 == row2
      */
-    _defaultSortComparatorInsensitiveAscending : function(row1, row2)
+    _defaultSortComparatorInsensitiveAscending : function(row1, row2, columnIndex)
     {
-      var obj1 = (row1[arguments.callee.columnIndex].toLowerCase ?
-            row1[arguments.callee.columnIndex].toLowerCase() : row1[arguments.callee.columnIndex]);
-      var obj2 = (row2[arguments.callee.columnIndex].toLowerCase ?
-            row2[arguments.callee.columnIndex].toLowerCase() : row2[arguments.callee.columnIndex]);
+      var obj1 = (row1[columnIndex].toLowerCase ?
+            row1[columnIndex].toLowerCase() : row1[columnIndex]);
+      var obj2 = (row2[columnIndex].toLowerCase ?
+            row2[columnIndex].toLowerCase() : row2[columnIndex]);
 
       if (qx.lang.Type.isNumber(obj1) && qx.lang.Type.isNumber(obj2)) {
         var result = isNaN(obj1) ? isNaN(obj2) ?  0 : 1 : isNaN(obj2) ? -1 : null;
@@ -104,12 +106,13 @@ qx.Class.define("qx.ui.table.model.Simple",
      *
      * @param row1 {var} first row
      * @param row2 {var} second row
+     * @param columnIndex {Integer} the column to be sorted
      * @return {Integer} 1 of row1 is > row2, -1 if row1 is < row2, 0 if row1 == row2
      */
-    _defaultSortComparatorDescending : function(row1, row2)
+    _defaultSortComparatorDescending : function(row1, row2, columnIndex)
     {
-      var obj1 = row1[arguments.callee.columnIndex];
-      var obj2 = row2[arguments.callee.columnIndex];
+      var obj1 = row1[columnIndex];
+      var obj2 = row2[columnIndex];
       if (qx.lang.Type.isNumber(obj1) && qx.lang.Type.isNumber(obj2)) {
         var result = isNaN(obj1) ? isNaN(obj2) ?  0 : 1 : isNaN(obj2) ? -1 : null;
         if (result != null) {
@@ -125,14 +128,15 @@ qx.Class.define("qx.ui.table.model.Simple",
      *
      * @param row1 {var} first row
      * @param row2 {var} second row
+     * @param columnIndex {Integer} the column to be sorted
      * @return {Integer} 1 of row1 is > row2, -1 if row1 is < row2, 0 if row1 == row2
      */
-    _defaultSortComparatorInsensitiveDescending : function(row1, row2)
+    _defaultSortComparatorInsensitiveDescending : function(row1, row2, columnIndex)
     {
-      var obj1 = (row1[arguments.callee.columnIndex].toLowerCase ?
-          row1[arguments.callee.columnIndex].toLowerCase() : row1[arguments.callee.columnIndex]);
-      var obj2 = (row2[arguments.callee.columnIndex].toLowerCase ?
-          row2[arguments.callee.columnIndex].toLowerCase() : row2[arguments.callee.columnIndex]);
+      var obj1 = (row1[columnIndex].toLowerCase ?
+          row1[columnIndex].toLowerCase() : row1[columnIndex]);
+      var obj2 = (row2[columnIndex].toLowerCase ?
+          row2[columnIndex].toLowerCase() : row2[columnIndex]);
       if (qx.lang.Type.isNumber(obj1) && qx.lang.Type.isNumber(obj2)) {
         var result = isNaN(obj1) ? isNaN(obj2) ?  0 : 1 : isNaN(obj2) ? -1 : null;
         if (result != null) {
@@ -326,7 +330,9 @@ qx.Class.define("qx.ui.table.model.Simple",
       }
 
       comparator.columnIndex = columnIndex;
-      this._rowArr.sort(comparator);
+      this._rowArr.sort(function(row1, row2) {
+        return comparator(row1, row2, columnIndex);
+      });
 
       this.__sortColumnIndex = columnIndex;
       this.__sortAscending = ascending;
@@ -352,10 +358,12 @@ qx.Class.define("qx.ui.table.model.Simple",
      *
      * @param compare {Function|Map}
      *   If provided as a Function, this is the comparator function to sort in
-     *   ascending order. It takes two parameters: the two arrays of row data,
-     *   row1 and row2, being compared. It may determine which column of the
-     *   row data to sort on by accessing arguments.callee.columnIndex.  The
-     *   comparator function must return 1, 0 or -1, when the column in row1
+     *   ascending order. It takes three parameters: the two arrays of row data,
+     *   row1 and row2, being compared and the column index sorting was requested 
+     *   for. Determining the which column of the row data should be sorted by 
+     *   accessing arguments.callee.columnIndex is also possible for compatibility 
+     *   reasons, but is deprecated and will be removed in future releases.  
+     *   The comparator function must return 1, 0 or -1, when the column in row1
      *   is greater than, equal to, or less than, respectively, the column in
      *   row2.
      *

--- a/framework/source/class/qx/ui/table/model/Simple.js
+++ b/framework/source/class/qx/ui/table/model/Simple.js
@@ -389,9 +389,9 @@ qx.Class.define("qx.ui.table.model.Simple",
         methods =
           {
             ascending  : compare,
-            descending : function(row1, row2)
+            descending : function(row1, row2, columnIndex)
             {
-              return compare(row2, row1);
+              return compare(row2, row1, columnIndex);
             }
           };
       }

--- a/framework/source/class/qx/ui/table/model/Simple.js
+++ b/framework/source/class/qx/ui/table/model/Simple.js
@@ -360,9 +360,13 @@ qx.Class.define("qx.ui.table.model.Simple",
      *   If provided as a Function, this is the comparator function to sort in
      *   ascending order. It takes three parameters: the two arrays of row data,
      *   row1 and row2, being compared and the column index sorting was requested 
-     *   for. Determining which column of the row data should be sorted by 
-     *   accessing arguments.callee.columnIndex is also possible for compatibility 
-     *   reasons, but is deprecated and will be removed in future releases.  
+     *   for. 
+     *
+     *   For backwards compatability, user-supplied compare functions may still 
+     *   take only two parameters, the two arrays of row data, row1 and row2, 
+     *   being compared and obtain the column index as arguments.callee.columnIndex. 
+     *   This is deprecated, however, as arguments.callee is disallowed in ES6.
+     *
      *   The comparator function must return 1, 0 or -1, when the column in row1
      *   is greater than, equal to, or less than, respectively, the column in
      *   row2.


### PR DESCRIPTION
This is an alternative implementation for @johnspackman s proposal in PR #9497 

It preserves compatibility but adds a new, more clear interface for sort methods.