### PR TITLE
Remove use of arguments.callee in deprecation warning

### DIFF
--- a/framework/source/class/qx/ui/table/Table.js
+++ b/framework/source/class/qx/ui/table/Table.js
@@ -1378,8 +1378,8 @@ qx.Class.define("qx.ui.table.Table",
      */
     _onKeyPress : function(evt)
     {
- -     qx.log.Logger.deprecatedMethodWarning(arguments.callee,"The method '_onKeyPress()' is deprecated. Please use '_onKeyDown()' instead.");
- -     qx.log.Logger.deprecateMethodOverriding(this, qx.ui.table.Table, "_onKeyPress", "The method '_onKeyPress()' is deprecated. Please use '_onKeyDown()' instead.");
+       qx.log.Logger.deprecatedMethodWarning(qx.ui.table.Table._onKeyPress, "The method '_onKeyPress()' is deprecated. Please use '_onKeyDown()' instead.");
+       qx.log.Logger.deprecateMethodOverriding(this, qx.ui.table.Table, "_onKeyPress", "The method '_onKeyPress()' is deprecated. Please use '_onKeyDown()' instead.");
        this._onKeyDown(evt);
     },
     /**


### PR DESCRIPTION
This is only a deprecation warning containing arguments.callee for a more accurate indication where the error occurs. Removed in favor of ES5 in strict mode and ES6.

Originally part of #9497 by @johnspackman which was closed.