### PR TITLE
Fix non working non strict mode compatibility fix in qx.ui.table.model.Simple

### DIFF
--- a/framework/source/class/qx/ui/table/model/Simple.js
+++ b/framework/source/class/qx/ui/table/model/Simple.js
@@ -404,9 +404,8 @@ qx.Class.define("qx.ui.table.model.Simple",
                * See discussion in 
                * https://github.com/qooxdoo/qooxdoo/pull/9499#pullrequestreview-99655182
                */ 
-              if(arguments.callee !== undefined) {
-                compare.columnIndex = arguments.callee.columnIndex;
-              }              
+              compare.columnIndex = columnIndex;
+
               return compare(row2, row1, columnIndex);
             }
           };


### PR DESCRIPTION
We don't need to take columnIndex from arguments.callee, as we get it anyway from wrapper around the sort function created in method sortByColumn, as the third parameter! It is enough for backwards compatibility to make arguments.callee.columnIndex available in the user supplied sort function.