### PR TITLE
Appearance property "base" works incorrect, if appearance from parent theme has string value. #9429

### DIFF
--- a/framework/source/class/qx/theme/manager/Appearance.js
+++ b/framework/source/class/qx/theme/manager/Appearance.js
@@ -199,10 +199,7 @@ qx.Class.define("qx.theme.manager.Appearance",
 
       // Resolve ID
       var aliasMap = this.__aliasMap;
-      var resolved = aliasMap[id];
-      if (!resolved) {
-        resolved = aliasMap[id] = this.__resolveId(id, theme, defaultId);
-      }
+      var resolved = aliasMap[id] = this.__resolveId(id, theme, defaultId);
 
       // Query theme for ID
       var entry = theme.appearances[resolved];

--- a/framework/source/class/qx/theme/manager/Appearance.js
+++ b/framework/source/class/qx/theme/manager/Appearance.js
@@ -199,7 +199,13 @@ qx.Class.define("qx.theme.manager.Appearance",
 
       // Resolve ID
       var aliasMap = this.__aliasMap;
-      var resolved = aliasMap[id] = this.__resolveId(id, theme, defaultId);
+      if(!aliasMap[theme.name]) {
+        aliasMap[theme.name] = {};
+      }
+      var resolved = aliasMap[theme.name][id];
+      if (!resolved) {
+        resolved = aliasMap[theme.name][id] = this.__resolveId(id, theme, defaultId);
+      }
 
       // Query theme for ID
       var entry = theme.appearances[resolved];
@@ -251,8 +257,8 @@ qx.Class.define("qx.theme.manager.Appearance",
 
       // Using cache if available
       var cache = this.__styleCache;
-      if (cache[unique] !== undefined) {
-        return cache[unique];
+      if (cache[theme.name] && (cache[theme.name][unique] !== undefined)) {
+        return cache[theme.name][unique];
       }
 
       // Fallback to default (empty) states map
@@ -330,7 +336,10 @@ qx.Class.define("qx.theme.manager.Appearance",
       }
 
       // Cache new entry and return
-      return cache[unique] = result || null;
+      if(!cache[theme.name]) {
+        cache[theme.name] = {};
+      }
+       return cache[theme.name][unique] = result || null;
     }
   }
 });


### PR DESCRIPTION
https://github.com/qooxdoo/qooxdoo/issues/9429

We suggest to store aliases and calculated style caches per theme, so that when styleFrom is called for an appearance, it first picks up an id that this appearance has in a current theme, and therefore styles for it, and then, when base is encountered, it picks up styles from the parent theme, which are assigned through alias in that parent theme.

This way appearance datefield/textfield will pick up both styles defined in current theme, and also styles from parent theme that are specified in combobox/textfield, as it is aliased to that one.