### PR TITLE
Merge property groups for appearance and decoration entries

### DIFF
--- a/framework/source/class/qx/core/Property.js
+++ b/framework/source/class/qx/core/Property.js
@@ -327,6 +327,14 @@ qx.Bootstrap.define("qx.core.Property",
     },
 
 
+    /**
+     * Property groups configuration
+     *
+     * @internal
+     */
+    $$groups : {},
+
+
     /** Contains names of inheritable properties, filled by {@link qx.Class.define} */
     $$inheritable : {},
 
@@ -537,6 +545,10 @@ qx.Bootstrap.define("qx.core.Property",
         this.$$method.resetThemed[name] = "resetThemed" + upname;
         members[this.$$method.resetThemed[name]] = new Function(unstyler.join(""));
       }
+
+      // Store groups configuration to extend group properties
+      // then we need to merge them with their group members from another source
+      this.$$groups[name] = qx.lang.Object.clone(config, true);
     },
 
 

--- a/framework/source/class/qx/core/Property.js
+++ b/framework/source/class/qx/core/Property.js
@@ -1912,6 +1912,58 @@ qx.Bootstrap.define("qx.core.Property",
       code.push(
         "return fire.call(this);"
       );
+    },
+
+
+    /**
+     * Merge the group property with existing properties
+     *
+     * @param result {Object} map containing initial and merged properties with their values
+     * @param propName {String} name of the merged property
+     * @param propStyle {var} style value of the property
+     * @param forceCopy {Boolean} always copy propStyle (even propName exists)
+     */
+    __mergeGroupProperty : function(result, groupName, groupStyle, forceCopy)
+    {
+      var handledGroupStyle = qx.lang.Object.clone(groupStyle, true);
+      var groupConfig = this.$$groups[groupName];
+      var group = groupConfig.group;
+      // we need to get a four element list
+      if (handledGroupStyle !== undefined) {
+        handledGroupStyle = qx.lang.Array.fromShortHand(qx.lang.Type.isArray(handledGroupStyle) ? handledGroupStyle : [handledGroupStyle]);
+      } else {
+        handledGroupStyle = [];
+        for (var i = 0; i < group.length; i++) {
+          handledGroupStyle[i] = undefined;
+        }
+      }
+      // expand the group property (recursively) and merge it with result
+      for (var i = 0; i < group.length; i++) {
+        if (this.$$groups[group[i]]) {
+          this.__mergeGroupProperty(result, group[i], handledGroupStyle[i], forceCopy);
+        } else if (forceCopy || !result[group[i]]) {
+          result[group[i]] = qx.lang.Object.clone(handledGroupStyle[i], true);
+        }
+      }
+    },
+
+
+    /**
+     * Merge the single or the group property with existing properties
+     *
+     * @param result {Object} map containing initial and merged properties with their values
+     * @param propName {String} name of the merged property
+     * @param propStyle {var} style value of the property
+     * @param forceCopy {Boolean} always copy propStyle (even propName exists)
+     * @param forceSingle {Boolean} merge the property as a single property (not expand)
+     */
+    mergeProperty : function(result, propName, propStyle, forceCopy, forceSingle)
+    {
+      if (this.$$groups[propName] && !forceSingle) {
+        this.__mergeGroupProperty(result, propName, propStyle, forceCopy);
+      } else {
+        result[propName] = qx.lang.Object.clone(propStyle, true);
+      }
     }
   }
 });

--- a/framework/source/class/qx/theme/manager/Appearance.js
+++ b/framework/source/class/qx/theme/manager/Appearance.js
@@ -286,38 +286,6 @@ qx.Class.define("qx.theme.manager.Appearance",
         // Create new map
         result = {};
 
-        // handler for group properties
-        var groupHandler = function(result, groupName, groupStyle) {
-          // there is a a group property "width" from qx.ui.decoration.Decorator
-          // and a single property "width" from qx.ui.core.LayoutItem
-          // so we can call this function for the single property because there are the same group property
-          if (groupName === "width") {
-            // just copy this like a single property
-            result[groupName] = qx.lang.Object.clone(groupStyle, true);
-            return;
-          }
-          var handledGroupStyle = qx.lang.Object.clone(groupStyle, true);
-          var groupConfig = qx.core.Property.$$groups[groupName];
-          var group = groupConfig.group;
-          // we need to get a four element list
-          if (handledGroupStyle !== undefined) {
-            handledGroupStyle = qx.lang.Array.fromShortHand(qx.lang.Type.isArray(handledGroupStyle) ? handledGroupStyle : [handledGroupStyle]);
-          } else {
-            handledGroupStyle = [];
-            for (var i = 0; i < group.length; i++) {
-              handledGroupStyle[i] = undefined;
-            }
-          }
-          // expand the group property (recursively) and copy it to result
-          for (var i = 0; i < group.length; i++) {
-            if (qx.core.Property.$$groups[group[i]]) {
-              groupHandler(result, group[i], handledGroupStyle[i]);
-            } else {
-              result[group[i]] = qx.lang.Object.clone(handledGroupStyle[i], true);
-            }
-          }
-        };
-
         // Copy base data, but exclude overwritten local and included stuff
         if (entry.base)
         {
@@ -328,11 +296,10 @@ qx.Class.define("qx.theme.manager.Appearance",
             for (var baseIncludeKey in base)
             {
               if (!incl.hasOwnProperty(baseIncludeKey) && !local.hasOwnProperty(baseIncludeKey)) {
-                if (qx.core.Property.$$groups[baseIncludeKey]) {
-                  groupHandler(result, baseIncludeKey, base[baseIncludeKey])
-                } else {
-                  result[baseIncludeKey] = base[baseIncludeKey];
-                }
+                // there is a a group property "width" from qx.ui.decoration.Decorator
+                // and a single property "width" from qx.ui.core.LayoutItem
+                // so we need to call this function with "forceSingle" flag
+                qx.core.Property.mergeProperty(result, baseIncludeKey, base[baseIncludeKey], true, baseIncludeKey === "width");
               }
             }
           }
@@ -341,11 +308,7 @@ qx.Class.define("qx.theme.manager.Appearance",
             for (var baseKey in base)
             {
               if (!local.hasOwnProperty(baseKey)) {
-                if (qx.core.Property.$$groups[baseKey]) {
-                  groupHandler(result, baseKey, base[baseKey])
-                } else {
-                  result[baseKey] = base[baseKey];
-                }
+                qx.core.Property.mergeProperty(result, baseKey, base[baseKey], true, baseKey === "width");
               }
             }
           }
@@ -357,22 +320,14 @@ qx.Class.define("qx.theme.manager.Appearance",
           for (var includeKey in incl)
           {
             if (!local.hasOwnProperty(includeKey)) {
-              if (qx.core.Property.$$groups[includeKey]) {
-                groupHandler(result, includeKey, incl[includeKey])
-              } else {
-                result[includeKey] = incl[includeKey];
-              }
+              qx.core.Property.mergeProperty(result, includeKey, incl[includeKey], true, includeKey === "width");
             }
           }
         }
 
         // Append local data
         for (var localKey in local) {
-          if (qx.core.Property.$$groups[localKey]) {
-            groupHandler(result, localKey, local[localKey])
-          } else {
-            result[localKey] = local[localKey];
-          }
+          qx.core.Property.mergeProperty(result, localKey, local[localKey], true, localKey === "width");
         }
       }
       else

--- a/framework/source/class/qx/theme/manager/Decoration.js
+++ b/framework/source/class/qx/theme/manager/Decoration.js
@@ -225,9 +225,37 @@ qx.Class.define("qx.theme.manager.Decoration",
 
         // styles key
         if (currentEntry.style) {
+          // handler for group properties
+          var groupHandler = function(result, groupName, groupStyle) {
+            var handledGroupStyle = qx.lang.Object.clone(groupStyle, true);
+            var groupConfig = qx.core.Property.$$groups[groupName];
+            var group = groupConfig.group;
+            // we need to get a four element list
+            if (handledGroupStyle !== undefined) {
+              handledGroupStyle = qx.lang.Array.fromShortHand(qx.lang.Type.isArray(handledGroupStyle) ? handledGroupStyle : [handledGroupStyle]);
+            } else {
+              handledGroupStyle = [];
+              for (var i = 0; i < group.length; i++) {
+                handledGroupStyle[i] = undefined;
+              }
+            }
+            // expand the group property (recursively) and merge it with result
+            for (var i = 0; i < group.length; i++) {
+              if (qx.core.Property.$$groups[group[i]]) {
+                groupHandler(result, group[i], handledGroupStyle[i]);
+              } else if (!result[group[i]]) {
+                result[group[i]] = qx.lang.Object.clone(handledGroupStyle[i], true);
+              }
+            }
+          };
+
           for (var key in currentEntry.style) {
             if (entry.style[key] === undefined) {
-              entry.style[key] = qx.lang.Object.clone(currentEntry.style[key], true);
+              if (qx.core.Property.$$groups[key]) {
+                groupHandler(entry.style, key, currentEntry.style[key]);
+              } else {
+                entry.style[key] = qx.lang.Object.clone(currentEntry.style[key], true);
+              }
             }
           }
         }

--- a/framework/source/class/qx/theme/manager/Decoration.js
+++ b/framework/source/class/qx/theme/manager/Decoration.js
@@ -225,37 +225,9 @@ qx.Class.define("qx.theme.manager.Decoration",
 
         // styles key
         if (currentEntry.style) {
-          // handler for group properties
-          var groupHandler = function(result, groupName, groupStyle) {
-            var handledGroupStyle = qx.lang.Object.clone(groupStyle, true);
-            var groupConfig = qx.core.Property.$$groups[groupName];
-            var group = groupConfig.group;
-            // we need to get a four element list
-            if (handledGroupStyle !== undefined) {
-              handledGroupStyle = qx.lang.Array.fromShortHand(qx.lang.Type.isArray(handledGroupStyle) ? handledGroupStyle : [handledGroupStyle]);
-            } else {
-              handledGroupStyle = [];
-              for (var i = 0; i < group.length; i++) {
-                handledGroupStyle[i] = undefined;
-              }
-            }
-            // expand the group property (recursively) and merge it with result
-            for (var i = 0; i < group.length; i++) {
-              if (qx.core.Property.$$groups[group[i]]) {
-                groupHandler(result, group[i], handledGroupStyle[i]);
-              } else if (!result[group[i]]) {
-                result[group[i]] = qx.lang.Object.clone(handledGroupStyle[i], true);
-              }
-            }
-          };
-
           for (var key in currentEntry.style) {
             if (entry.style[key] === undefined) {
-              if (qx.core.Property.$$groups[key]) {
-                groupHandler(entry.style, key, currentEntry.style[key]);
-              } else {
-                entry.style[key] = qx.lang.Object.clone(currentEntry.style[key], true);
-              }
+              qx.core.Property.mergeProperty(entry.style, key, currentEntry.style[key]);
             }
           }
         }


### PR DESCRIPTION
Our team found out property groups for appearance and decoration entries don't merge correctly.

For appearance entries, `styleFrom` method adds local style properties after all others. We can have, for example, 
```
{
padding: [1, 2, 3, 4],
paddingLeft: 5
}
```
as the result of this method. Qooxdoo applies this style properties in order of addition by operator `in` so if `padding: [1, 2, 3, 4]` property was moved from `base` or `include` entry and `paddingLeft: 5` was moved from local style the last one will be applied after the previous one. We think it's incorrectly to rely on it so we offers to expand group properties to merge they correctly. As the result we will have:
```
{
paddingTop: 1,
paddingRight: 2,
paddingBottom: 3,
paddingLeft: 5
}
```
instead of:
```
{
padding: [1, 2, 3, 4],
paddingLeft: 5
}
```

For decoration entries,` resolve` method adds local style properties _before_ all others. Then qooxdoo also applies this style properties in order of addition by operator `in`. So if we have `colorTop: red` property as local style property and `color: green` property as included property we will have
```
{
colorTop: red,
color: green
}
```
as the result and `color: green` property will be applied after `colorTop: red` property. We offers the same solution: group properties expansion. As the result we will have:
```
{
colorTop: red,
colorRight: green,
colorBottom: green,
colorLeft: green
}
```
For this we just store group members.