### PR TITLE
Split the travis testrunner tests into 3 separate stages

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -48,7 +48,7 @@ jobs:
     - stage: Edge-Unit-Tests
       script: ../.travis/test EdgeSL
     - stage: Coverage
-    - script: ../.travis/coverage
+      script: ../.travis/coverage
 
     - stage: Deploy
       script: ../.travis/deploy

--- a/.travis.yml
+++ b/.travis.yml
@@ -28,27 +28,25 @@ install:
 - cd framework
 
 stages:
-  - name: Lint
+  - name: Lint-and-Coverage
   - name: Chrome-Unit-Tests
   - name: Firefox-Unit-Tests
-  - name: Edge-Unit-Tests
-  - name: Coverage
+  - name: Edge-Safari-Unit-Tests
   - name: Deploy
     if: repo = qooxdoo/qooxdoo AND (NOT type IN (pull_request)) AND ( branch = master OR tag =~ ^v[0-9] )
 
 jobs:
   include:
-    - stage: Lint
+    - stage: Lint-and-Coverage
       script: ../.travis/lint
+      script: ../.travis/coverage
 
     - stage: Chrome-Unit-Tests
       script: ../.travis/test ChromeSL,ChromeBetaSL
     - stage: Firefox-Unit-Tests
       script: ../.travis/test FirefoxSL,FirefoxBetaSL
-    - stage: Edge-Unit-Tests
-      script: ../.travis/test EdgeSL
-    - stage: Coverage
-      script: ../.travis/coverage
+    - stage: Edge-Safari-Unit-Tests
+      script: ../.travis/test EdgeSL,SafariSL
 
     - stage: Deploy
       script: ../.travis/deploy

--- a/.travis.yml
+++ b/.travis.yml
@@ -32,6 +32,7 @@ stages:
   - name: Chrome-Unit-Tests
   - name: Firefox-Unit-Tests
   - name: Edge-Unit-Tests
+  - name: Coverage
   - name: Deploy
     if: repo = qooxdoo/qooxdoo AND (NOT type IN (pull_request)) AND ( branch = master OR tag =~ ^v[0-9] )
 
@@ -46,6 +47,7 @@ jobs:
       script: ../.travis/test FirefoxSL,FirefoxBetaSL
     - stage: Edge-Unit-Tests
       script: ../.travis/test EdgeSL
+    - stage: Coverage
     - script: ../.travis/coverage
 
     - stage: Deploy

--- a/.travis.yml
+++ b/.travis.yml
@@ -40,7 +40,9 @@ jobs:
 
     - stage: Unit-Tests
       #script: ../.travis/test ChromeSL,ChromeBetaSL,FirefoxSL,FirefoxBetaSL,SafariSL,EdgeSL,IESL
-      script: ../.travis/test ChromeSL,ChromeBetaSL,FirefoxSL,FirefoxBetaSL,EdgeSL
+      script: ../.travis/test ChromeSL,ChromeBetaSL
+      script: ../.travis/test FirefoxSL,FirefoxBetaSL
+      script: ../.travis/test EdgeSL
     - script: ../.travis/coverage
 
     - stage: Deploy

--- a/.travis.yml
+++ b/.travis.yml
@@ -31,7 +31,7 @@ stages:
   - name: Lint-and-Coverage
   - name: Chrome-Unit-Tests
   - name: Firefox-Unit-Tests
-  - name: Edge-Safari-Unit-Tests
+  - name: Edge-Unit-Tests
   - name: Deploy
     if: repo = qooxdoo/qooxdoo AND (NOT type IN (pull_request)) AND ( branch = master OR tag =~ ^v[0-9] )
 
@@ -45,8 +45,8 @@ jobs:
       script: ../.travis/test ChromeSL,ChromeBetaSL
     - stage: Firefox-Unit-Tests
       script: ../.travis/test FirefoxSL,FirefoxBetaSL
-    - stage: Edge-Safari-Unit-Tests
-      script: ../.travis/test EdgeSL,SafariSL
+    - stage: Edge-Unit-Tests
+      script: ../.travis/test EdgeSL
 
     - stage: Deploy
       script: ../.travis/deploy

--- a/.travis.yml
+++ b/.travis.yml
@@ -29,7 +29,9 @@ install:
 
 stages:
   - name: Lint
-  - name: Unit-Tests
+  - name: Chrome-Unit-Tests
+  - name: Firefox-Unit-Tests
+  - name: Edge-Unit-Tests
   - name: Deploy
     if: repo = qooxdoo/qooxdoo AND (NOT type IN (pull_request)) AND ( branch = master OR tag =~ ^v[0-9] )
 
@@ -38,10 +40,11 @@ jobs:
     - stage: Lint
       script: ../.travis/lint
 
-    - stage: Unit-Tests
-      #script: ../.travis/test ChromeSL,ChromeBetaSL,FirefoxSL,FirefoxBetaSL,SafariSL,EdgeSL,IESL
+    - stage: Chrome-Unit-Tests
       script: ../.travis/test ChromeSL,ChromeBetaSL
+    - stage: Firefox-Unit-Tests
       script: ../.travis/test FirefoxSL,FirefoxBetaSL
+    - stage: Edge-Unit-Tests
       script: ../.travis/test EdgeSL
     - script: ../.travis/coverage
 


### PR DESCRIPTION
Split the tests which were previously run in 1 stage into 3 different stages.

The split is done into

- `Chrome-unit-tests`: ChromeSL,ChromeBetaSL
- `Firefox-unit-tests`: FirefoxSL,FirefoxBetaSL
- `Edge-unit-tests`: EdgeSL

Additionally I've added the lint run and the coverage run into one stage called `Lint-and-coverage`

As a result we now have 4 stages which are run in sequence.

The benefit is that each stage takes from 10 to 15 min run time and with the hope that those stages do not fail as often as the one monolithic ~ 30 min run. And we are able to restart only that stage which fails which means that those 15 min stages rerun but not the whole 30 min monolithic stage.
Additionally the stages are now named by the tested browser platform which allows quicker identification of the failing platform.

The disadvantege is that we may wait ~ 10 min longer for travis to finish, but only for the seldom situation where the tests run completely at the first attempt which happened rarely recent.