### PR TITLE
Remove background image style when switching to icon font

### DIFF
--- a/framework/source/class/qx/ui/basic/Image.js
+++ b/framework/source/class/qx/ui/basic/Image.js
@@ -644,6 +644,11 @@ qx.Class.define("qx.ui.basic.Image",
             }
           }
 
+          // Don't transfer background image when switching from image to icon font
+          if (this.__getMode() === "font") {
+            delete styles.backgroundImage;
+          }
+
           // Copy dimension and location of the current content element
           var bounds = this.getBounds();
           if (bounds != null)


### PR DESCRIPTION
Create a font icon and then change its source to a regular image path:

```javascript
var img = new qx.ui.basic.Image("@FontAwesome/user");
img.setSource("path/to/icon.jpg");
```
if you then switch back to an icon font:

```javascript
img.setSource("@FontAwesome/user");
```

it will show the icon, but also the image.

@peuter and me figured out that the stylesheets will be transferred when the object changes its content element, including `background-image`.