### PR TITLE
[Fixed] {qx.ui.core.MPlacement#getLayoutLocation} fails with windows

### DIFF
--- a/framework/source/class/qx/ui/core/MPlacement.js
+++ b/framework/source/class/qx/ui/core/MPlacement.js
@@ -262,7 +262,7 @@ qx.Mixin.define("qx.ui.core.MPlacement",
       }
 
       // Add the rendered location of the root widget
-      if (widget.isRootWidget())
+      if (widget && widget.isRootWidget())
       {
         var rootCoords = widget.getContentLocation();
         if (rootCoords)


### PR DESCRIPTION
Popped-up in my console. Ought to be a quick fix.