### PR TITLE
Re-add missing package.json

### DIFF
--- a/application/demobrowser/package.json
+++ b/application/demobrowser/package.json
@@ -1,0 +1,22 @@
+{
+  "name": "demobrowser",
+  "version": "6.0.0-alpha",
+  "private": true,
+  "description": "Contains small samples and tests for most widgets and GUI features",
+  "main": "Gruntfile.js",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/qooxdoo/qooxdoo"
+  },
+  "author": "The qooxdoo project",
+  "license": "MIT",
+  "homepage": "https://github.com/qooxdoo/qooxdoo",
+  "dependencies": {
+    "async": "^0.7.0",
+    "walker": "^1.0.6",
+    "shelljs": "^0.3.0",
+    "graceful-fs": "^2.0.3",
+    "optimist": "^0.6.1",
+    "mkdirp": "^0.5.0"
+  }
+}

--- a/application/demobrowser/package.json
+++ b/application/demobrowser/package.json
@@ -3,7 +3,6 @@
   "version": "6.0.0-alpha",
   "private": true,
   "description": "Contains small samples and tests for most widgets and GUI features",
-  "main": "Gruntfile.js",
   "repository": {
     "type": "git",
     "url": "https://github.com/qooxdoo/qooxdoo"


### PR DESCRIPTION
Add a grunt-stripped version of the package.json back to the repo. It's needed to build the demo files.