### PR TITLE
Fixed basic column model disposing cell editor factory when it shouldn't in setter

### DIFF
--- a/framework/source/class/qx/ui/table/columnmodel/Basic.js
+++ b/framework/source/class/qx/ui/table/columnmodel/Basic.js
@@ -396,6 +396,9 @@ qx.Class.define("qx.ui.table.columnmodel.Basic",
       }
 
       var oldFactory = this.__columnDataArr[col].editorFactory;
+      if (oldFactory === factory) {
+        return;
+      }
       if (oldFactory !== this.__editorFactory) {
         oldFactory.dispose();
       }


### PR DESCRIPTION
When setCellEditorFactory was called when the factory of the column was already set to a non-default factory, and when then that same factory was set on the column model again, the factory would be disposed.

This fix makes this setter more in-line with regular setters (in that the state doesn't change when setting the same value) and it fixes the dispose problem described above.