### PR TITLE
Add promisify; remove `this` from static methods

### DIFF
--- a/framework/source/class/qx/Promise.js
+++ b/framework/source/class/qx/Promise.js
@@ -772,6 +772,24 @@ qx.Class.define("qx.Promise", {
     },
 
 
+    /**
+     * Returns a new function that wraps a function that is in node.js
+     * style. The resulting function returns a promise instead of taking a
+     * callback function as an argument. The promise is resoloved or rejected
+     * by the action of the callback function. The provided function must
+     * accept a callback as its last argument, and that callback function must
+     * expect its first argument to be an error if non-null. If the first
+     * argument is null, the second argument (optional) will be the success
+     * value.
+     * 
+     * @param f {Function} The node.js-style function to be promisified
+     * @return {qx.Promise}
+     */
+    promisify : function(f) {
+      return this.__callStaticMethod('promisify', arguments);
+    },
+    
+    
 
     /* *********************************************************************************
      * 

--- a/framework/source/class/qx/Promise.js
+++ b/framework/source/class/qx/Promise.js
@@ -775,7 +775,7 @@ qx.Class.define("qx.Promise", {
     /**
      * Returns a new function that wraps a function that is in node.js
      * style. The resulting function returns a promise instead of taking a
-     * callback function as an argument. The promise is resoloved or rejected
+     * callback function as an argument. The promise is resolved or rejected
      * by the action of the callback function. The provided function must
      * accept a callback as its last argument, and that callback function must
      * expect its first argument to be an error if non-null. If the first

--- a/framework/source/class/qx/Promise.js
+++ b/framework/source/class/qx/Promise.js
@@ -488,7 +488,7 @@ qx.Class.define("qx.Promise", {
       if (value instanceof qx.Promise) {
         promise = value;
       } else {
-        promise = this.__wrap(qx.Promise.Bluebird.resolve(value));
+        promise = qx.Promise.__wrap(qx.Promise.Bluebird.resolve(value));
       }
       if (context !== undefined) {
         promise = promise.bind(context);
@@ -498,7 +498,7 @@ qx.Class.define("qx.Promise", {
 
     /**
      * Returns a Promise object that is rejected with the given reason.
-     * @param reason {Object} Reason why this Promise rejected.
+     * @param reason {Object?} Reason why this Promise rejected. A warning is generated if not instanceof Error. If undefined, a default Error is used.
      * @param context {Object?} optional context for callbacks to be bound to
      * @return {qx.Promise}
      */
@@ -508,9 +508,9 @@ qx.Class.define("qx.Promise", {
         args.shift();
         args.unshift(qx.Promise.__DEFAULT_ERROR);
       } else if (!(reason instanceof Error)) {
-        this.error("Rejecting a promise with a non-Error value");
+        qx.log.Logger.warn("Rejecting a promise with a non-Error value");
       }
-      var promise = this.__callStaticMethod('reject', args, 0);
+      var promise = qx.Promise.__callStaticMethod('reject', args, 0);
       if (context !== undefined) {
         promise = promise.bind(context);
       }
@@ -524,7 +524,7 @@ qx.Class.define("qx.Promise", {
      * @return {qx.Promise}
      */
     all: function(iterable) {
-      return this.__callStaticMethod('all', arguments);
+      return qx.Promise.__callStaticMethod('all', arguments);
     },
 
     /**
@@ -534,7 +534,7 @@ qx.Class.define("qx.Promise", {
      * @return {qx.Promise}
      */
     race: function(iterable) {
-      return this.__callStaticMethod('race', arguments);
+      return qx.Promise.__callStaticMethod('race', arguments);
     },
 
 
@@ -553,7 +553,7 @@ qx.Class.define("qx.Promise", {
      * @return {qx.Promise}
      */
     any: function(iterable) {
-      return this.__callStaticMethod('any', arguments);
+      return qx.Promise.__callStaticMethod('any', arguments);
     },
 
     /**
@@ -567,7 +567,7 @@ qx.Class.define("qx.Promise", {
      * @return {qx.Promise}
      */
     some: function(iterable, count) {
-      return this.__callStaticMethod('some', arguments);
+      return qx.Promise.__callStaticMethod('some', arguments);
     },
 
     /**
@@ -585,7 +585,7 @@ qx.Class.define("qx.Promise", {
      * @return {qx.Promise}
      */
     forEach: function(iterable, iterator) {
-      return this.__callStaticMethod('each', arguments);
+      return qx.Promise.__callStaticMethod('each', arguments);
     },
 
     /**
@@ -613,7 +613,7 @@ qx.Class.define("qx.Promise", {
      * @return {qx.Promise}
      */
     filter: function(iterable, iterator, options) {
-      return this.__callStaticMethod('filter', arguments);
+      return qx.Promise.__callStaticMethod('filter', arguments);
     },
 
     /**
@@ -658,7 +658,7 @@ qx.Class.define("qx.Promise", {
      * @return {qx.Promise}
      */
     map: function(iterable, iterator, options) {
-      return this.__callStaticMethod('map', arguments);
+      return qx.Promise.__callStaticMethod('map', arguments);
     },
 
     /**
@@ -697,7 +697,7 @@ qx.Class.define("qx.Promise", {
      * @return {qx.Promise}
      */
     mapSeries: function(iterable, iterator) {
-      return this.__callStaticMethod('mapSeries', arguments);
+      return qx.Promise.__callStaticMethod('mapSeries', arguments);
     },
 
     /**
@@ -737,7 +737,7 @@ qx.Class.define("qx.Promise", {
      * @return {qx.Promise}
      */
     reduce: function(iterable, reducer, initialValue) {
-      return this.__callStaticMethod('reduce', arguments);
+      return qx.Promise.__callStaticMethod('reduce', arguments);
     },
 
     /**
@@ -768,7 +768,7 @@ qx.Class.define("qx.Promise", {
      * @return {qx.Promise}
      */
     props: function(input) {
-      return this.__callStaticMethod('props', arguments);
+      return qx.Promise.__callStaticMethod('props', arguments);
     },
 
 
@@ -786,7 +786,7 @@ qx.Class.define("qx.Promise", {
      * @return {qx.Promise}
      */
     promisify : function(f) {
-      return this.__callStaticMethod('promisify', arguments);
+      return qx.Promise.__callStaticMethod('promisify', arguments);
     },
     
     
@@ -802,7 +802,7 @@ qx.Class.define("qx.Promise", {
      * @param Promise {Class} the Promise class
      */
     __attachBluebird: function(Promise) {
-      this.Bluebird = Promise;
+      qx.Promise.Bluebird = Promise;
       Promise.config({
         warnings: qx.core.Environment.get("qx.promise.warnings"),
         longStackTraces: qx.core.Environment.get("qx.promise.longStackTraces"),
@@ -817,11 +817,11 @@ qx.Class.define("qx.Promise", {
      * One-time initializer
      */
     __initialize: function() {
-      if (this.__initialized) {
+      if (qx.Promise.__initialized) {
         return;
       }
-      this.__initialized = true;
-      qx.bom.Event.addNativeListener(window, "unhandledrejection", this.__onUnhandledRejection.bind(this));
+      qx.Promise.__initialized = true;
+      qx.bom.Event.addNativeListener(window, "unhandledrejection", qx.Promise.__onUnhandledRejection.bind(this));
       if (!qx.core.Environment.get("qx.promise")) {
         qx.log.Logger.error(this, "Promises are installed and initialised but disabled from properties because qx.promise==false; this may cause unexpected behaviour");
       }
@@ -898,7 +898,7 @@ qx.Class.define("qx.Promise", {
      */
     __callStaticMethod: function(methodName, args, minArgs) {
       args = qx.Promise.__bindArgs(args, minArgs);
-      return this.__wrap(qx.Promise.Bluebird[methodName].apply(qx.Promise.Bluebird, this.__mapArgs(args)));
+      return qx.Promise.__wrap(qx.Promise.Bluebird[methodName].apply(qx.Promise.Bluebird, qx.Promise.__mapArgs(args)));
     },
 
     /**


### PR DESCRIPTION
- Add new static method qx.Promise.promisify
- Remove the use of `this` from all static methods in qx.Promise. The problem with `this` when used in static methods is that if the developer using a method does something like, 
```
var all = qx.Promise.all
all(xxx);
```
then `this` will have the wrong value, and the code will bork.