### PR TITLE
Added File to Xhr whitelist because File inherits from Blob

### DIFF
--- a/framework/source/class/qx/bom/request/Xhr.js
+++ b/framework/source/class/qx/bom/request/Xhr.js
@@ -881,7 +881,7 @@ qx.Bootstrap.define("qx.bom.request.Xhr",
       this.__disposed = this.__send = this.__abort = false;
 
       // Initialize data white list
-      this.__dataTypeWhiteList = [ "ArrayBuffer", "Blob", "HTMLDocument", "String", "FormData" ];
+      this.__dataTypeWhiteList = [ "ArrayBuffer", "Blob", "File", "HTMLDocument", "String", "FormData" ];
     },
 
     /**


### PR DESCRIPTION
See https://developer.mozilla.org/en-US/docs/Web/API/File

I've tested this with Chrome 67.0.3396.87 and Firefox 60.0.2.