### PR TITLE
Add more documentation (and an example) for promisify

### DIFF
--- a/framework/source/class/qx/Promise.js
+++ b/framework/source/class/qx/Promise.js
@@ -781,11 +781,51 @@ qx.Class.define("qx.Promise", {
      * expect its first argument to be an error if non-null. If the first
      * argument is null, the second argument (optional) will be the success
      * value.
-     * 
+     *
+     * Example:
+     *
+     * Assume there is a member method in myApp.Application such as the
+     * following:
+     * <pre><code>
+     *   issueRpc : function(method, params, callback)
+     *   {
+     *     ...
+     *   }
+     * </code></pre>
+     *
+     * where the signature of <code>callback</code> is:
+     * <pre><code>
+     *   function callback(result, e)
+     * </code></pre>
+     *
+     * The <code>issueRpc</code>method could be converted to be called using
+     * promises instead of callbacks, as shown here:
+     * <pre><code>
+     *   let app = qx.core.Init.getApplication();
+     *   let rpc = qx.Promise.promisify(app.issueRpc, { context : app });
+     *   rpc("ping", [ "hello world" ])
+     *     .then(
+     *       (pongValue) =>
+     *         {
+     *           // handle result
+     *         })
+     *     .catch(
+     *       (e) =>
+     *         {
+     *           throw e;
+     *         });
+     * </code></pre>
+     *
      * @param f {Function} The node.js-style function to be promisified
+     *
+     * @param options {Map?}
+     *   The sole user option in this map is <code>context</code>, which may
+     *   be specified to arrange for the provided callback function to be
+     *   called in the specified context.
+     *   
      * @return {qx.Promise}
      */
-    promisify : function(f) {
+    promisify : function(f, options) {
       return qx.Promise.__callStaticMethod('promisify', arguments);
     },
     

--- a/framework/source/class/qx/Promise.js
+++ b/framework/source/class/qx/Promise.js
@@ -806,14 +806,14 @@ qx.Class.define("qx.Promise", {
      *   rpc("ping", [ "hello world" ])
      *     .then(
      *       function(pongValue)
-     *         {
-     *           // handle result
-     *         })
+     *       {
+     *         // handle result
+     *       })
      *     .catch(
      *       function(e)
-     *         {
-     *           throw e;
-     *         });
+     *       {
+     *         throw e;
+     *       });
      * </code></pre>
      *
      * @param f {Function} The node.js-style function to be promisified

--- a/framework/source/class/qx/Promise.js
+++ b/framework/source/class/qx/Promise.js
@@ -801,16 +801,16 @@ qx.Class.define("qx.Promise", {
      * The <code>issueRpc</code>method could be converted to be called using
      * promises instead of callbacks, as shown here:
      * <pre><code>
-     *   let app = qx.core.Init.getApplication();
-     *   let rpc = qx.Promise.promisify(app.issueRpc, { context : app });
+     *   var app = qx.core.Init.getApplication();
+     *   var rpc = qx.Promise.promisify(app.issueRpc, { context : app });
      *   rpc("ping", [ "hello world" ])
      *     .then(
-     *       (pongValue) =>
+     *       function(pongValue)
      *         {
      *           // handle result
      *         })
      *     .catch(
-     *       (e) =>
+     *       function(e)
      *         {
      *           throw e;
      *         });

--- a/framework/source/class/qx/Promise.js
+++ b/framework/source/class/qx/Promise.js
@@ -795,7 +795,7 @@ qx.Class.define("qx.Promise", {
      *
      * where the signature of <code>callback</code> is:
      * <pre><code>
-     *   function callback(result, e)
+     *   function callback(e, result)
      * </code></pre>
      *
      * The <code>issueRpc</code>method could be converted to be called using


### PR DESCRIPTION
@hkollmann requested an example, provided herein. Also, I documented the method of providing a context to the callback function.