### PR TITLE
Fix drag drop regression

### DIFF
--- a/framework/source/class/qx/event/Manager.js
+++ b/framework/source/class/qx/event/Manager.js
@@ -402,6 +402,11 @@ qx.Class.define("qx.event.Manager",
           this.__registerAtHandler(target, item.type, item.capture);
         }
 
+        if (item.self === window) {
+          console.warn("Listener callback is window");
+          debugger;
+        }
+        
         // Append listener to list
         entryList.push(
         {
@@ -447,6 +452,11 @@ qx.Class.define("qx.event.Manager",
         if (capture !== undefined) {
           qx.core.Assert.assertBoolean(capture, "Invalid capture flag.");
         }
+      }
+      
+      if (self === window) {
+        console.warn("Listener callback is window");
+        debugger;
       }
 
       var targetKey = target.$$hash || qx.core.ObjectRegistry.toHashCode(target);

--- a/framework/source/class/qx/event/Manager.js
+++ b/framework/source/class/qx/event/Manager.js
@@ -402,11 +402,6 @@ qx.Class.define("qx.event.Manager",
           this.__registerAtHandler(target, item.type, item.capture);
         }
 
-        if (item.self === window) {
-          console.warn("Listener callback is window");
-          debugger;
-        }
-        
         // Append listener to list
         entryList.push(
         {
@@ -454,11 +449,6 @@ qx.Class.define("qx.event.Manager",
         }
       }
       
-      if (self === window) {
-        console.warn("Listener callback is window");
-        debugger;
-      }
-
       var targetKey = target.$$hash || qx.core.ObjectRegistry.toHashCode(target);
       var targetMap = this.__listeners[targetKey];
 

--- a/framework/source/class/qx/event/handler/DragDrop.js
+++ b/framework/source/class/qx/event/handler/DragDrop.js
@@ -318,9 +318,10 @@ qx.Class.define("qx.event.handler.DragDrop",
      */
     getCurrentActionAsync : function() {
       var self = this;
-      return this.__detectAction().then(function() {
-        return self.__currentAction;
-      });
+      return qx.Promise.resolve(self.__detectAction())
+        .then(function() {
+          return self.__currentAction;
+        });
     },
 
 


### PR DESCRIPTION
This fixes a regression caused by the recent addition of Promises to event handlers (in this case, returning a promise is optional and a part of the drag and drop event handler incorrectly assumed that a promise would be returned)