### PR TITLE
Adds support for a special "null" value in `qx.ui.form.SelectBox` and `qx.data.controller.List`

### DIFF
--- a/framework/source/class/qx/data/controller/List.js
+++ b/framework/source/class/qx/data/controller/List.js
@@ -666,6 +666,7 @@ qx.Class.define("qx.data.controller.List",
      * @param index {Number} The index of the ListItem.
      */
     _bindListItem: function(item, index) {
+      // -1 is the special, "null" value item.  Nothing to bind, just fix the display and model
       if (index < 0) {
         item.setLabel(this.getNullValueTitle()||"");
         item.setIcon(this.getNullValueIcon());
@@ -1060,6 +1061,8 @@ qx.Class.define("qx.data.controller.List",
       }
 
       this.__lookupTable = [];
+      
+      // -1 is a special lookup value, to represent the "null" option 
       if (this.isAllowNull())
         this.__lookupTable.push(-1);
       for (var i = 0; i < model.getLength(); i++) {

--- a/framework/source/class/qx/data/controller/List.js
+++ b/framework/source/class/qx/data/controller/List.js
@@ -190,6 +190,42 @@ qx.Class.define("qx.data.controller.List",
       event: "changeDelegate",
       init: null,
       nullable: true
+    },
+    
+    /**
+     * Whether a special "null" value is included in the list
+     */
+    allowNull :
+    {
+      apply: "_applyAllowNull",
+      event: "changeAllowNull",
+      init: false,
+      nullable: false,
+      check: "Boolean"
+    },
+    
+    /**
+     * Title for the special null value entry
+     */
+    nullValueTitle:
+    {
+      apply: "_applyNullValueTitle",
+      event: "changeNullValueTitle",
+      init: null,
+      nullable: true,
+      check: "String"
+    },
+    
+    /**
+     * Icon for the special null value entry
+     */
+    nullValueIcon:
+    {
+      apply: "_applyNullValueIcon",
+      event: "changeNullValueIcon",
+      init: null,
+      nullable: true,
+      check: "String"
     }
   },
 
@@ -295,6 +331,37 @@ qx.Class.define("qx.data.controller.List",
      */
     _applyLabelPath: function(value, old) {
       this.__renewBindings();
+    },
+
+    
+    /**
+     * Apply method for the `allowNull` property 
+     */
+    _applyAllowNull: function(value, oldValue) {
+      this.__refreshModel();
+    },
+    
+    /**
+     * Apply method for the `allowNull` property 
+     */
+    _applyNullValueTitle: function(value, oldValue) {
+      this.__refreshModel();
+    },
+    
+    /**
+     * Apply method for the `allowNull` property 
+     */
+    _applyNullValueIcon: function(value, oldValue) {
+      this.__refreshModel();
+    },
+
+    /**
+     * Refreshes the model, uses when the model and target are not changing but the appearance
+     * and bindings may need to be updated
+     */
+    __refreshModel: function() {
+      if (this.getModel() && this.getTarget())
+        this.update();
     },
 
 
@@ -599,6 +666,12 @@ qx.Class.define("qx.data.controller.List",
      * @param index {Number} The index of the ListItem.
      */
     _bindListItem: function(item, index) {
+      if (index < 0) {
+        item.setLabel(this.getNullValueTitle()||"");
+        item.setIcon(this.getNullValueIcon());
+        item.setModel(null);
+        return;
+      }
       var delegate = this.getDelegate();
       // if a delegate for creating the binding is given, use it
       if (delegate != null && delegate.bindItem != null) {
@@ -759,16 +832,16 @@ qx.Class.define("qx.data.controller.List",
         var id = item.getUserData(this.__boundProperties[i] + "BindingId");
         if (id != null) {
           this.removeBinding(id);
+          item.setUserData(this.__boundProperties[i] + "BindingId", null);
         }
       }
       // go through all reverse bound properties
       for (var i = 0; i < this.__boundPropertiesReverse.length; i++) {
         // get the binding id and remove it, if possible
-        var id = item.getUserData(
-          this.__boundPropertiesReverse[i] + "ReverseBindingId"
-        );
+        var id = item.getUserData(this.__boundPropertiesReverse[i] + "ReverseBindingId");
         if (id != null) {
           item.removeBinding(id);
+          item.getUserData(this.__boundPropertiesReverse[i] + "ReverseBindingId", null);
         }
       };
     },
@@ -987,6 +1060,8 @@ qx.Class.define("qx.data.controller.List",
       }
 
       this.__lookupTable = [];
+      if (this.isAllowNull())
+        this.__lookupTable.push(-1);
       for (var i = 0; i < model.getLength(); i++) {
         if (filter == null || filter(model.getItem(i))) {
           this.__lookupTable.push(i);

--- a/framework/source/class/qx/ui/form/SelectBox.js
+++ b/framework/source/class/qx/ui/form/SelectBox.js
@@ -92,6 +92,12 @@ qx.Class.define("qx.ui.form.SelectBox",
     {
       refine : true,
       init : "selectbox"
+    },
+    
+    rich: {
+      init: false,
+      check: "Boolean",
+      apply: "_applyRich"
     }
   },
 
@@ -114,6 +120,20 @@ qx.Class.define("qx.ui.form.SelectBox",
       WIDGET API
     ---------------------------------------------------------------------------
     */
+
+    _applyRich: function(value, oldValue) {
+      this.getChildControl("atom").setRich(value);
+    },
+    
+    // overridden
+    _defaultFormat: function(item) {
+      if (item) {
+        if (typeof item.isRich == "function" && item.isRich())
+          this.setRich(true);
+        return item.getLabel();
+      }
+      return null;
+    },
 
     // overridden
     _createChildControlImpl : function(id, hash)
@@ -224,7 +244,7 @@ qx.Class.define("qx.ui.form.SelectBox",
       var atom = this.getChildControl("atom");
       var label = listItem ? listItem.getLabel() : "";
       var format = this.getFormat();
-      if (format != null) {
+      if (format != null && listItem) {
         label = format.call(this, listItem);
       }
 

--- a/uitests/selectbox/.gitignore
+++ b/uitests/selectbox/.gitignore
@@ -1,0 +1,13 @@
+# .gitignore template for skeleton-based apps
+/api/
+/build/
+/test/
+/source/script/
+source-output/
+build-output/
+db.json
+resource-db.json
+
+# node-related files
+/node_modules
+npm-debug.log

--- a/uitests/selectbox/Manifest.json
+++ b/uitests/selectbox/Manifest.json
@@ -1,0 +1,34 @@
+{
+  "info" : 
+  {
+    "name" : "selectbox",
+
+    "summary" : "Custom Application",
+    "description" : "This is a skeleton for a custom application with qooxdoo.",
+    
+    "homepage" : "http://some.homepage.url/",
+
+    "license" : "SomeLicense",
+    "authors" : 
+    [
+      {
+        "name" : "First Author (uid)",
+        "email" : "first.author@some.domain"
+      }
+    ],
+
+    "version" : "master",
+    "qooxdoo-versions": ["6.0.0-alpha"]
+  },
+  
+  "provides" : 
+  {
+    "namespace"   : "selectbox",
+    "encoding"    : "utf-8",
+    "class"       : "source/class",
+    "resource"    : "source/resource",
+    "translation" : "source/translation",
+    "type"        : "application"
+  }
+}
+

--- a/uitests/selectbox/compile.json
+++ b/uitests/selectbox/compile.json
@@ -1,0 +1,32 @@
+{
+  "targets": [
+    {
+      "type": "source",
+      "outputPath": "source-output"
+    },
+    {
+      "type": "hybrid",
+      "outputPath": "hybrid-output"
+    },
+    {
+      "type": "build",
+      "outputPath": "build-output",
+      "addCreatedAt": true
+    }
+  ],
+  "defaultTarget": "source",
+  "locales": [ "en" ],
+
+  "applications": [
+    {
+      "class": "selectbox.Application",
+      "theme": "qx.theme.Simple",
+      "name": "selectbox"
+    }
+  ],
+
+  "libraries": [
+    "../../framework",
+    "."
+  ]
+}

--- a/uitests/selectbox/source/class/selectbox/Application.js
+++ b/uitests/selectbox/source/class/selectbox/Application.js
@@ -1,0 +1,92 @@
+/* ************************************************************************
+
+   Copyright:
+
+
+   License:
+
+   Authors:
+
+ ************************************************************************ */
+
+/**
+ * This is the main application class of your custom application "dragndrop"
+ * 
+ * @asset(qx/icon/Tango/16/status/dialog-error.png)
+ */
+qx.Class.define("selectbox.Application", {
+  extend: qx.application.Standalone,
+
+  members: {
+    main: function() {
+      this.base(arguments);
+
+      if (qx.core.Environment.get("qx.debug")) {
+        qx.log.appender.Native;
+        qx.log.appender.Console;
+      }
+
+      var doc = this.getRoot();
+      var root = new qx.ui.container.Composite(new qx.ui.layout.Grid(10, 5));
+      doc.add(root, { left: 10, top: 10, right: 10, bottom: 10 });
+
+      var model = qx.data.marshal.Json.createModel([
+        { name: "alpha" },
+        { name: "bravo" },
+        { name: "charlie" },
+        { name: "delta" }
+      ]);
+      /*
+      var cbo = new qx.ui.form.SelectBox();
+      var ctlr = new qx.data.controller.List(model, cbo, "name");
+      ctlr.getSelection().replace([]);
+      root.add(new qx.ui.basic.Label("Allows null, but user cannot select null :"), { row: 0, column: 0 });
+      root.add(cbo, { row: 0, column: 1 });
+      */
+      
+      function createTest(row, allowNull, userCanSelect, preloadModel) {
+        var cbo = new qx.ui.form.SelectBox();
+        var ctlr = new qx.data.controller.List(preloadModel ? model : null, cbo, "name");
+        if (allowNull && userCanSelect) {
+          ctlr.set({
+            allowNull: true,
+            nullValueTitle: "(No value selected)",
+            nullValueIcon: "qx/icon/Tango/16/status/dialog-error.png"
+          });
+        }
+        if (!preloadModel)
+          ctlr.setModel(model);
+        ctlr.getSelection().replace([]);
+        
+        var str = "Does not allow null";
+        if (allowNull) {
+          str = "Allows null";
+          if (userCanSelect)
+            str += ", user can select null";
+          else
+            str += ", user cannot select null";
+        }
+        if (preloadModel)
+          str += ", preload";
+        root.add(new qx.ui.basic.Label(str + " :"), { row: row, column: 0 });
+        root.add(cbo, { row: row, column: 1 });
+        var txt = new qx.ui.form.TextField().set({ readOnly: true });
+        ctlr.getSelection().addListener("change", () => {
+          var arr = ctlr.getSelection();
+          var item = arr.getLength() ? arr.getItem(0) : null;
+          txt.setValue(item ? item.getName() : "(null)");
+        });
+        root.add(txt, { row: row, column: 2 });
+        var btn = new qx.ui.form.Button("Set to null");
+        btn.addListener("execute", () => ctlr.getSelection().replace([]));
+        root.add(btn, { row: row, column: 3 });
+      }
+      
+      var row = 0;
+      createTest(row++, false, false, true);
+      createTest(row++, true, false, true);
+      createTest(row++, true, true, true);
+      createTest(row++, true, true, false);
+    }
+  }
+});


### PR DESCRIPTION
`qx.ui.form.SelectBox` already supports empty selection, whether or not it is controlled by a `qx.data.controller.List` - however, an empty selection results in the UI displaying the first
 value in the drop down, so the user thinks that something is selected when there is none.  There is no easy way to add a corresponding "null" value when using a controller.

This PR adds properties to `qx.data.controller.List` to allow a special "null" value to be created at the top of the list; it also allows SelectBox to use rich appearance in its list items