### PR TITLE
Theme prep function

### DIFF
--- a/framework/source/class/qx/Theme.js
+++ b/framework/source/class/qx/Theme.js
@@ -58,7 +58,7 @@ qx.Bootstrap.define("qx.Theme",
      *   widgets : {},
      *   appearances : {},
      *   meta : {},
-     *   boot : {function(){}}
+     *   boot : function(){}
      * });
      * </pre>
      *

--- a/framework/source/class/qx/Theme.js
+++ b/framework/source/class/qx/Theme.js
@@ -57,7 +57,8 @@ qx.Bootstrap.define("qx.Theme",
      *   fonts : {},
      *   widgets : {},
      *   appearances : {},
-     *   meta : {}
+     *   meta : {},
+     *   boot : {}
      * });
      * </pre>
      *
@@ -116,6 +117,11 @@ qx.Bootstrap.define("qx.Theme",
 
       for (var i=0, a=config.patch, l=a.length; i<l; i++) {
         this.patch(theme, a[i]);
+      }
+      
+      // Run boot code
+      if (config.boot) {
+      	config.boot();
       }
     },
 
@@ -321,7 +327,8 @@ qx.Bootstrap.define("qx.Theme",
         "appearances" : "object", // Map
         "meta"        : "object", // Map
         "include"     : "object", // Array
-        "patch"       : "object"  // Array
+        "patch"       : "object", // Array
+        "boot"		  : "function" // Function
       },
 
       "default" : null

--- a/framework/source/class/qx/Theme.js
+++ b/framework/source/class/qx/Theme.js
@@ -58,7 +58,7 @@ qx.Bootstrap.define("qx.Theme",
      *   widgets : {},
      *   appearances : {},
      *   meta : {},
-     *   boot : {}
+     *   boot : {function(){}}
      * });
      * </pre>
      *
@@ -328,7 +328,7 @@ qx.Bootstrap.define("qx.Theme",
         "meta"        : "object", // Map
         "include"     : "object", // Array
         "patch"       : "object", // Array
-        "boot"		  : "function" // Function
+        "boot"        : "function" // Function
       },
 
       "default" : null


### PR DESCRIPTION
Needed a way to include code into framework classes (i.e. Image, Atom, etc.) in order to support advanced themeing and icon features such as before and after pseudo modifications, and utilizing qx.ui.basic.Image as a means of using embedded SVG for graphics and icons. This gives theme developers the ability to mixin code into framework classes without requiring end users doing it in their application code   