### PR TITLE
Adds `qx.Promise.allOf`

### DIFF
--- a/framework/source/class/qx/Promise.js
+++ b/framework/source/class/qx/Promise.js
@@ -536,8 +536,10 @@ qx.Class.define("qx.Promise", {
           }
         }
         return qx.Promise.all(arr)
-          .then(arr => {
-            arr.forEach((item, index) => value[names[index]] = item);
+          .then(function(arr) {
+            arr.forEach(function(item, index) { 
+              value[names[index]] = item; 
+            });
             return value;
           });
       }

--- a/framework/source/class/qx/Promise.js
+++ b/framework/source/class/qx/Promise.js
@@ -520,7 +520,7 @@ qx.Class.define("qx.Promise", {
     /**
      * Returns a promise that resolves when all of the promises in the object properties have resolved, 
      * or rejects with the reason of the first passed promise that rejects.  The result of each property
-     * is placed back in the object, replacing the promise. 
+     * is placed back in the object, replacing the promise.  Note that non-promise values are untouched.
      * 
      * @param value {var} An object
      * @return {qx.Promise}
@@ -548,7 +548,9 @@ qx.Class.define("qx.Promise", {
     
     /**
      * Returns a promise that resolves when all of the promises in the iterable argument have resolved, 
-     * or rejects with the reason of the first passed promise that rejects.
+     * or rejects with the reason of the first passed promise that rejects.  Note that non-promise values 
+     * are untouched.
+     * 
      * @param iterable {Iterable} An iterable object, such as an Array
      * @return {qx.Promise}
      */

--- a/framework/source/class/qx/Promise.js
+++ b/framework/source/class/qx/Promise.js
@@ -518,6 +518,33 @@ qx.Class.define("qx.Promise", {
     },
 
     /**
+     * Returns a promise that resolves when all of the promises in the object properties have resolved, 
+     * or rejects with the reason of the first passed promise that rejects.  The result of each property
+     * is placed back in the object, replacing the promise. 
+     * 
+     * @param value {var} An object
+     * @return {qx.Promise}
+     */
+    allOf: function(value) {
+      function action(value) {
+        var arr = [];
+        var names = [];
+        for (var name in value) {
+          if (value.hasOwnProperty(name) && value[name] instanceof qx.Promise) {
+            arr.push(value[name]);
+            names.push(name);
+          }
+        }
+        return qx.Promise.all(arr)
+          .then(arr => {
+            arr.forEach((item, index) => value[names[index]] = item);
+            return value;
+          });
+      }
+      return value instanceof qx.Promise ? value.then(action) : action(value);
+    },
+    
+    /**
      * Returns a promise that resolves when all of the promises in the iterable argument have resolved, 
      * or rejects with the reason of the first passed promise that rejects.
      * @param iterable {Iterable} An iterable object, such as an Array

--- a/framework/source/class/qx/lang/Type.js
+++ b/framework/source/class/qx/lang/Type.js
@@ -64,6 +64,18 @@ qx.Bootstrap.define("qx.lang.Type",
      * @return {Boolean} Whether the value is an object.
      */
      isObject : qx.Bootstrap.isObject,
+     
+     
+     /**
+      * Whether the value is iterable, ie supports the iterable protocol
+      * 
+      * @signature function(value)
+      * @param value {var} Value to check
+      * @return {Boolean} Whether the value is iterable
+      */
+     isIterable : function(value) {
+       return value !== null && (qx.Bootstrap.isArray(value) || Symbol.iterator in Object(value));
+     },
 
 
     /**

--- a/framework/source/class/qx/lang/Type.js
+++ b/framework/source/class/qx/lang/Type.js
@@ -64,18 +64,6 @@ qx.Bootstrap.define("qx.lang.Type",
      * @return {Boolean} Whether the value is an object.
      */
      isObject : qx.Bootstrap.isObject,
-     
-     
-     /**
-      * Whether the value is iterable, ie supports the iterable protocol
-      * 
-      * @signature function(value)
-      * @param value {var} Value to check
-      * @return {Boolean} Whether the value is iterable
-      */
-     isIterable : function(value) {
-       return value !== null && (qx.Bootstrap.isArray(value) || Symbol.iterator in Object(value));
-     },
 
 
     /**

--- a/framework/source/class/qx/test/Promise.js
+++ b/framework/source/class/qx/test/Promise.js
@@ -64,16 +64,22 @@ qx.Class.define("qx.test.Promise", {
      */
     testAllOf: function() {
       var t = this;
+      var dt = new Date();
       var obj = {
           a: new qx.Promise(),
           b: new qx.Promise(),
-          c: new qx.Promise()
+          c: new qx.Promise(),
+          d: "four",
+          e: dt
       }
       qx.Promise.allOf(obj)
-        .then(function() {
+        .then(function(obj2) {
+          t.assertTrue(obj === obj2);
           t.assertEquals("one", obj.a);
           t.assertEquals("two", obj.b);
           t.assertEquals("three", obj.c);
+          t.assertEquals("four", obj.d);
+          t.assertTrue(obj.e === dt);
           t.resume();
         });
       obj.a.then(function() {

--- a/framework/source/class/qx/test/Promise.js
+++ b/framework/source/class/qx/test/Promise.js
@@ -60,6 +60,33 @@ qx.Class.define("qx.test.Promise", {
     },
 
     /**
+     * Tests the qx.Promise.allOf method
+     */
+    testAllOf: function() {
+      var t = this;
+      var obj = {
+          a: new qx.Promise(),
+          b: new qx.Promise(),
+          c: new qx.Promise()
+      }
+      qx.Promise.allOf(obj)
+        .then(function() {
+          t.assertEquals("one", obj.a);
+          t.assertEquals("two", obj.b);
+          t.assertEquals("three", obj.c);
+          t.resume();
+        });
+      obj.a.then(function() {
+        obj.b.resolve("two");
+      });
+      obj.b.then(function() {
+        obj.c.resolve("three");
+      });
+      obj.a.resolve("one");
+      t.wait(1000);
+    },
+
+    /**
      * Tests that setting a property value with a promise will delay setting the
      * value until the promise is resolved.  In this case, the property is *not*
      * marked as async and the setXxx method is used


### PR DESCRIPTION
This PR adds `qx.Promise.allOf`, which is similar to `qx.Promise.all` except that `.allOf` transforms the property values of an object from promises into real values, whereas `.all` transforms the elements of an array (values which are not a promise are transferred unchanged)

This is useful in that it allows changing these kind of constructs:

```
let valueA;
let valueB;
myObj.doA()
  .then(tmp => {
    valueA = tmp;
    return myObj.doB();
  })
  .then(tmp => {
    valueB = tmp;
    return myOtherObj.doC();
  })
  .then(valueC => {
    console.log("a=" + valueA + ", b=" + valueB + ", c=" + valueC);
    /* ... do stuff ... */
  });
```

into this more concise form:

```
qx.Promise.allOf({
  valueA: myObj.doA(),
  valueB: myObj.doB(),
  valueC: myOtherObj.doC()
}).then(obj => {
  console.log("a=" + obj.valueA + ", b=" + obj.valueB + ", c=" + obj.valueC);
  /* ... do stuff ... */
});

``
