### PR TITLE
use other separator than " for classname because it breaks the generated

### DIFF
--- a/framework/source/class/qx/data/marshal/IMarshalerDelegate.js
+++ b/framework/source/class/qx/data/marshal/IMarshalerDelegate.js
@@ -140,6 +140,18 @@ qx.Interface.define("qx.data.marshal.IMarshalerDelegate",
      * @return {Class|null} Returns the class which should be used as array class.
      *   If <code>null</code> will be returned, {@link qx.data.Array} will be used as array class.
      */
-    getArrayClass : function(parentProperty, depth) {}
+    getArrayClass : function(parentProperty, depth) {},
+
+    /**
+     * Converts a given object into a hash which will be used to identify the
+     * classes under the namespace <code>qx.data.model</code>.
+     *
+     * @param data {Object} The JavaScript object from which the hash is
+     *   required.
+     * @param includeBubbleEvents {Boolean?false} Whether the model should
+     *   support the bubbling of change events or not.
+     * @return {String} The hash representation of the given JavaScript object.
+     */
+    getJsonHash : function(data, includeBubbleEvents) {}
   }
 });

--- a/framework/source/class/qx/data/marshal/Json.js
+++ b/framework/source/class/qx/data/marshal/Json.js
@@ -62,6 +62,21 @@ qx.Class.define("qx.data.marshal.Json",
       this.$$instance.toClass(data, includeBubbleEvents);
       // return the model
       return this.$$instance.toModel(data);
+    },
+    
+    /**
+     * Legacy json hash method used as default in Qooxdoo < v6.0.
+     * You can go back to the old behaviour like this:
+     * 
+     * <code>
+     *  var marshaller = new qx.data.marshal.Json({
+     *   getJsonHash: qx.data.marshal.Json.legacyJsonHash
+     *  });
+     * </code>
+     */
+    legacyJsonHash: function (data, includeBubbleEvents) {
+      return Object.keys(data).sort().join('"')
+        + (includeBubbleEvents===true ? "♥" : "");
     }
   },
 

--- a/framework/source/class/qx/data/marshal/Json.js
+++ b/framework/source/class/qx/data/marshal/Json.js
@@ -83,6 +83,9 @@ qx.Class.define("qx.data.marshal.Json",
      */
     __jsonToHash : function (data, includeBubbleEvents)
     {
+      if (this.__delegate && this.__delegate.getJsonHash) {
+        return this.__delegate.getJsonHash(data, includeBubbleEvents);
+      }
       return Object.keys(data).sort().join('|')
            + (includeBubbleEvents===true ? "♥" : "");
     },

--- a/framework/source/class/qx/data/marshal/Json.js
+++ b/framework/source/class/qx/data/marshal/Json.js
@@ -83,7 +83,7 @@ qx.Class.define("qx.data.marshal.Json",
      */
     __jsonToHash : function (data, includeBubbleEvents)
     {
-      return Object.keys(data).sort().join('"')
+      return Object.keys(data).sort().join('|')
            + (includeBubbleEvents===true ? "♥" : "");
     },
 

--- a/framework/source/class/qx/test/data/marshal/Json.js
+++ b/framework/source/class/qx/test/data/marshal/Json.js
@@ -92,9 +92,9 @@ qx.Class.define("qx.test.data.marshal.Json",
       this.__marshaler.toClass(this.__data);
 
       // check if the class is defined
-      this.assertTrue(qx.Class.isDefined('qx.data.model.b"n"s'), "Class not created.");
+      this.assertTrue(qx.Class.isDefined('qx.data.model.b|n|s'), "Class not created.");
 
-      var clazz = qx.Class.getByName('qx.data.model.b"n"s');
+      var clazz = qx.Class.getByName('qx.data.model.b|n|s');
       // check for the properties
       var i = 0;
       for (var name in clazz.$$properties) {
@@ -651,7 +651,7 @@ qx.Class.define("qx.test.data.marshal.Json",
       this.assertException(
         function () { marshaler.toModel(data, true); },
         Error,
-        "Class 'qx.data.model.bar\"foo' found, but it does not support changeBubble event."
+        "Class 'qx.data.model.bar|foo' found, but it does not support changeBubble event."
       );
 
       //
@@ -672,7 +672,7 @@ qx.Class.define("qx.test.data.marshal.Json",
       this.assertException(
         function () { marshaler.toModel(data2, true); },
         Error,
-        "Class 'qx.data.model.bar2\"foo2' found, but it does not support changeBubble event."
+        "Class 'qx.data.model.bar2|foo2' found, but it does not support changeBubble event."
       );
     },
 
@@ -704,7 +704,7 @@ qx.Class.define("qx.test.data.marshal.Json",
       var model = this.__marshaler.toModel(this.__data);
 
       // check for the right class hash
-      this.assertEquals('b"n"s', propertiesSaved);
+      this.assertEquals('b|n|s', propertiesSaved);
 
       // set working values
       model.setS("123456789");
@@ -720,6 +720,24 @@ qx.Class.define("qx.test.data.marshal.Json",
       }, qx.core.ValidationError);
 
       model.dispose();
+    },
+
+    testCustomValidator : function()
+    {
+      var delegate = {
+      getJsonHash: function (data, includeBubbleEvents) {
+        return Object.keys(data).sort().map(function (name) { return qx.lang.String.firstUp(name); }).join('') +
+          (includeBubbleEvents === true ? '#' : '');
+      }};
+
+      this.__marshaler.dispose();
+      this.__marshaler = new qx.data.marshal.Json(delegate);
+      this.__marshaler.toClass({
+        custom: 1,
+        props: true
+      });
+
+      this.assertTrue(qx.Class.isDefined('qx.data.model.CustomProps'), "Class not created.");
     },
 
 
@@ -796,7 +814,7 @@ qx.Class.define("qx.test.data.marshal.Json",
 
       var self = this;
       var delegate = {getModelClass : function(properties) {
-        self.assertEquals('b"n"s', properties);
+        self.assertEquals('b|n|s', properties);
         return qx.test.model.C;
       }};
 
@@ -858,7 +876,7 @@ qx.Class.define("qx.test.data.marshal.Json",
 
       var self = this;
       var delegate = {getModelClass : function(properties) {
-        self.assertEquals('b"n"s', properties);
+        self.assertEquals('b|n|s', properties);
         return qx.test.model.C;
       }};
 

--- a/framework/source/class/qx/test/data/store/Json.js
+++ b/framework/source/class/qx/test/data/store/Json.js
@@ -264,7 +264,7 @@ qx.Class.define("qx.test.data.store.Json",
 
       var delegate = {
         getModelClass : function(properties) {
-          if (properties == 'a"b' || properties == 'a"b♥') {
+          if (properties == 'a|b' || properties == 'a|b♥') {
             return qx.Class.getByName("qx.test.AB");
           }
           return null;


### PR DESCRIPTION
code of properties added by mixins.

The Json marshaller uses `"` as separator for the property names in the classname, which generated classes with names like `qx.data.model.other"test`. If you include a Mixin with a property that uses checks. the code uses the classname for error messages, e.g. `var msg = "Invalid incoming value for property 'modified' of class 'qx.data.model.other"test'"` and this is no valid code.

See http://tinyurl.com/y8g8sq2j for a complete example.

This PR suggests `|`as separator, but any other would be fine too, if there are arguments against this one or for another one.