### PR TITLE
make iconfonts work with latest qxcompiler in --target=build mode

### DIFF
--- a/framework/source/class/qx/ui/basic/Image.js
+++ b/framework/source/class/qx/ui/basic/Image.js
@@ -396,24 +396,21 @@ qx.Class.define("qx.ui.basic.Image",
       var tagName;
       var clazz = qx.html.Image;
 
-      if (mode == "font")
-      {
+      switch (mode) {
+        case "font":
         clazz = qx.html.Label;
         scale = true;
         tagName = "div";
-      }
-      else if (mode == "alphaScaled")
-      {
+          break;
+        case "alphaScaled":
         scale = true;
         tagName = "div";
-      }
-      else if (mode == "nonScaled")
-      {
+          break;
+        case "nonScaled":
         scale = false;
         tagName = "div";
-      }
-      else
-      {
+          break;
+        default:
         scale = true;
         tagName = "img";
       }

--- a/framework/source/class/qx/ui/basic/Image.js
+++ b/framework/source/class/qx/ui/basic/Image.js
@@ -398,21 +398,22 @@ qx.Class.define("qx.ui.basic.Image",
 
       switch (mode) {
         case "font":
-        clazz = qx.html.Label;
-        scale = true;
-        tagName = "div";
+          clazz = qx.html.Label;
+          scale = true;
+          tagName = "div";
           break;
         case "alphaScaled":
-        scale = true;
-        tagName = "div";
+          scale = true;
+          tagName = "div";
           break;
         case "nonScaled":
-        scale = false;
-        tagName = "div";
+          scale = false;
+          tagName = "div";
           break;
         default:
-        scale = true;
-        tagName = "img";
+          scale = true;
+          tagName = "img";
+          break;
       }
 
       var element = new (clazz)(tagName);


### PR DESCRIPTION
It seems that something in the qxcompiler dependencies (babel?) has changed so that the large
`if else` structure in `Image.js` gets damaged in the compilation output when running in build mode. Switching to a `switch case` structure I was able to make icon fonts work again. 

As the code is much nicer like this anyway, I am submitting a patch. But as the `if else` structures do show up elsewhere in the code, further investigation into why this breaks would certainly be warranted. https://github.com/qooxdoo/qooxdoo-compiler/issues/207