### PR TITLE
fix blob requests

### DIFF
--- a/framework/source/class/qx/io/request/Xhr.js
+++ b/framework/source/class/qx/io/request/Xhr.js
@@ -300,7 +300,7 @@ qx.Class.define("qx.io.request.Xhr",
      * @return {String|Object} The parsed response of the request.
      */
     _getParsedResponse: function() {
-      var response = this._transport.responseText,
+      var response = this._transport.responseType === 'blob' ? this._transport.response : this._transport.responseText,
           contentType = this.getResponseContentType() || "",
           parsedResponse = "";
 


### PR DESCRIPTION
Handling ob blob requests does not work in qooxdoo, because the response can be found in transports response property, responseText is empty in these cases.

Blobs can be requested by manually setting the transports responseType:

```javascript
var req = new qx.io.request.Xhr(image);
req.getTransport().responseType = 'blob';
```