### PR TITLE
fire events if the filteredChange differs from the old value

### DIFF
--- a/framework/source/class/qx/ui/form/AbstractField.js
+++ b/framework/source/class/qx/ui/form/AbstractField.js
@@ -570,7 +570,7 @@ qx.Class.define("qx.ui.form.AbstractField",
         var filteredValue = this._validateInput(value);
         if (filteredValue != value)
         {
-          fireEvents = false;
+          fireEvents = this.__oldInputValue !== filteredValue;
           value = filteredValue;
           this.getContentElement().setValue(value);
         }


### PR DESCRIPTION
This PR fixes the problem when you paste a string into an TextField with a filter, which contains filtered characters. In these cases the events where not fired at all. That's fine if you change the input value by typing something into it, because only the last character might be filtered and in that case the input value does not change at all. But if you paste a string into the field, the filtered value might differ from the old value. This PR adds a test for that.