### PR TITLE
Fixed table removeSelectionInterval not correcting selection when removing rows

### DIFF
--- a/framework/source/class/qx/test/ui/table/selection/Model.js
+++ b/framework/source/class/qx/test/ui/table/selection/Model.js
@@ -1,0 +1,111 @@
+/* ************************************************************************
+
+   qooxdoo - the new era of web development
+
+   http://qooxdoo.org
+
+   Copyright:
+     2004-2018 1&1 Internet AG, Germany, http://www.1und1.de
+
+   License:
+     MIT: https://opensource.org/licenses/MIT
+     See the LICENSE file in the project's top-level directory for details.
+
+   Authors:
+     * Milan Damen (milandamen)
+
+************************************************************************ */
+qx.Class.define("qx.test.ui.table.selection.Model",
+{
+  extend : qx.test.ui.LayoutTestCase,
+
+  members :
+  {
+    testRemoveSelectionInterval : function () {
+      var selectionModel = new qx.ui.table.selection.Model();
+      selectionModel.setSelectionMode(4); // MULTIPLE_INTERVAL_SELECTION
+
+      selectionModel.removeSelectionInterval(0, 0);
+      this.assertIdentical(0, selectionModel._getSelectedRangeArr().length);
+      selectionModel.removeSelectionInterval(0, 0, true);
+      this.assertIdentical(0, selectionModel._getSelectedRangeArr().length);
+
+      selectionModel.setSelectionInterval(0, 1);
+      this.assertJsonEquals([{minIndex: 0, maxIndex: 1}], selectionModel._getSelectedRangeArr());
+      selectionModel.removeSelectionInterval(0,1);
+      this.assertIdentical(0, selectionModel._getSelectedRangeArr().length);
+
+      selectionModel.setSelectionInterval(0, 1);
+      selectionModel.removeSelectionInterval(0, 2);
+      this.assertIdentical(0, selectionModel._getSelectedRangeArr().length);
+
+      selectionModel.setSelectionInterval(0, 1);
+      selectionModel.removeSelectionInterval(0, 2, true);
+      this.assertIdentical(0, selectionModel._getSelectedRangeArr().length);
+
+      selectionModel.setSelectionInterval(1, 1);
+      selectionModel.removeSelectionInterval(0, 2);
+      this.assertIdentical(0, selectionModel._getSelectedRangeArr().length);
+
+      selectionModel.setSelectionInterval(1, 1);
+      selectionModel.removeSelectionInterval(0, 2, true);
+      this.assertIdentical(0, selectionModel._getSelectedRangeArr().length);
+
+      selectionModel.setSelectionInterval(0, 1);
+      selectionModel.removeSelectionInterval(0, 0);
+      this.assertJsonEquals([{minIndex: 1, maxIndex: 1}], selectionModel._getSelectedRangeArr());
+
+      selectionModel.setSelectionInterval(0, 1);
+      selectionModel.removeSelectionInterval(0, 0, true);
+      this.assertJsonEquals([{minIndex: 0, maxIndex: 0}], selectionModel._getSelectedRangeArr());
+
+      selectionModel.setSelectionInterval(0, 1);
+      selectionModel.removeSelectionInterval(1, 1);
+      this.assertJsonEquals([{minIndex: 0, maxIndex: 0}], selectionModel._getSelectedRangeArr());
+
+      selectionModel.setSelectionInterval(0, 1);
+      selectionModel.removeSelectionInterval(1, 1, true);
+      this.assertJsonEquals([{minIndex: 0, maxIndex: 0}], selectionModel._getSelectedRangeArr());
+
+      selectionModel.setSelectionInterval(1, 2);
+      selectionModel.removeSelectionInterval(0, 0);
+      this.assertJsonEquals([{minIndex: 1, maxIndex: 2}], selectionModel._getSelectedRangeArr());
+
+      selectionModel.setSelectionInterval(1, 2);
+      selectionModel.removeSelectionInterval(0, 0, true);
+      this.assertJsonEquals([{minIndex: 0, maxIndex: 1}], selectionModel._getSelectedRangeArr());
+
+      selectionModel.setSelectionInterval(0, 1);
+      selectionModel.removeSelectionInterval(2, 2);
+      this.assertJsonEquals([{minIndex: 0, maxIndex: 1}], selectionModel._getSelectedRangeArr());
+
+      selectionModel.setSelectionInterval(0, 1);
+      selectionModel.removeSelectionInterval(2, 2, true);
+      this.assertJsonEquals([{minIndex: 0, maxIndex: 1}], selectionModel._getSelectedRangeArr());
+
+      selectionModel.setSelectionInterval(1, 3);
+      selectionModel.removeSelectionInterval(1, 1);
+      this.assertJsonEquals([{minIndex: 2, maxIndex: 3}], selectionModel._getSelectedRangeArr());
+
+      selectionModel.setSelectionInterval(1, 3);
+      selectionModel.removeSelectionInterval(1, 1, true);
+      this.assertJsonEquals([{minIndex: 1, maxIndex: 2}], selectionModel._getSelectedRangeArr());
+
+      selectionModel.setSelectionInterval(0, 2);
+      selectionModel.removeSelectionInterval(2, 3);
+      this.assertJsonEquals([{minIndex: 0, maxIndex: 1}], selectionModel._getSelectedRangeArr());
+
+      selectionModel.setSelectionInterval(0, 2);
+      selectionModel.removeSelectionInterval(2, 3, true);
+      this.assertJsonEquals([{minIndex: 0, maxIndex: 1}], selectionModel._getSelectedRangeArr());
+
+      selectionModel.setSelectionInterval(0, 5);
+      selectionModel.removeSelectionInterval(2, 3);
+      this.assertJsonEquals([{minIndex: 0, maxIndex: 1}, {minIndex: 4, maxIndex: 5}], selectionModel._getSelectedRangeArr());
+
+      selectionModel.setSelectionInterval(0, 5);
+      selectionModel.removeSelectionInterval(2, 3, true);
+      this.assertJsonEquals([{minIndex: 0, maxIndex: 3}], selectionModel._getSelectedRangeArr());
+    }
+  }
+});

--- a/framework/source/class/qx/ui/table/Table.js
+++ b/framework/source/class/qx/ui/table/Table.js
@@ -1320,7 +1320,7 @@ qx.Class.define("qx.ui.table.Table",
 
       // update selection if rows were removed
       if (removeCount) {
-        this.getSelectionModel().removeSelectionInterval(removeStart, removeStart + removeCount);
+        this.getSelectionModel().removeSelectionInterval(removeStart, removeStart + removeCount - 1, true);
         // remove focus if the focused row has been removed
         if (this.__focusedRow >= removeStart && this.__focusedRow < (removeStart + removeCount)) {
           this.setFocusedCell();


### PR DESCRIPTION
**Problem:**
When removing rows in the table, the selection would not update correctly.

**Reproduction:**
1. Have a table with 3 rows.
2. Select all rows (selection: `{minIndex: 0, maxIndex: 2}`)
3. Remove the first row of the table
4. Get the selected ranges: `table.getSelectionModel().getSelectedRanges()` => `{minIndex: 2, maxIndex: 2}`

Even though there are now only 2 rows instead of 3, the selection still points to the third row.
The selection model has no knowledge of changing rows.

**Solution:**
Make the selection model aware if a selection is removed because of the removal of one or more rows. If this is the case, calculate the selection correctly; moving/cropping selections where needed.