### PR TITLE
add getter/setter for the srcObject prorperty of a HTMLMediaElement

### DIFF
--- a/framework/source/class/qx/bom/media/Abstract.js
+++ b/framework/source/class/qx/bom/media/Abstract.js
@@ -285,6 +285,28 @@ qx.Class.define("qx.bom.media.Abstract",
 
 
     /**
+     * Sets the source object of the media file.
+     *
+     * @param sourceObject {MediaStream} the source media stream.
+     */
+    setSourceObject: function (sourceObject)
+    {
+      this._media.srcObject = sourceObject;
+    },
+
+    
+    /**
+     * Gets the source object of the media file.
+     *
+     * @return {MediaStream|null} the source stream object to the media file, if it exists.
+     */
+    getSourceObject: function ()
+    {
+      return this._media.srcObject;
+    },
+
+
+    /**
      * Checks if the media element shows its controls.
      *
      * @return {Boolean}


### PR DESCRIPTION
Background:

Using media streams in HTMLMediaElements by creating a URL with `URL.createObjectURL(stream)` applying that to HTMLMediaElements `src` attribute is deprecated (since 2013?).

`URL.createObjectURL(stream)` has been removed from the current Firefox and will be removed in Chrome 71. (https://developer.mozilla.org/en-US/docs/Web/API/HTMLMediaElement/srcObject#Usage_notes)

With current browsers you apply the stream to the `srcObject`property directly. This PR adds the possibility to do that.