### PR TITLE
remove stored function during dispose

### DIFF
--- a/framework/source/class/qx/event/Timer.js
+++ b/framework/source/class/qx/event/Timer.js
@@ -121,6 +121,7 @@ qx.Class.define("qx.event.Timer",
       {
         timer.stop();
         func.call(obj, e);
+        delete timer.__onceFunc;
         timer.dispose();
 
         obj = null;


### PR DESCRIPTION
Ensure timer gets disposed cleanly. A prior bug fix had stored a function with the timer object, that should be cleaned up during dispose.