### PR TITLE
Fixed setValue of VirtualSelectBox not resetting selected item

### DIFF
--- a/framework/source/class/qx/ui/form/VirtualSelectBox.js
+++ b/framework/source/class/qx/ui/form/VirtualSelectBox.js
@@ -121,7 +121,7 @@ qx.Class.define("qx.ui.form.VirtualSelectBox",
      */
     setValue : function(selected) {
       if (null === selected) {
-        this.resetSelection();
+        this.getSelection().removeAll();
         return null;
       }
 
@@ -140,7 +140,7 @@ qx.Class.define("qx.ui.form.VirtualSelectBox",
 
 
     resetValue : function() {
-      this.getSelection().removeAll();
+      this.setValue(null);
     },
 
 


### PR DESCRIPTION
**Problem**
When you call setValue(null) on the VirtualSelectBox, it does not reset its selection (and thus not resets value) when using the initial initSelection array.

The form resetter calls setValue(null) on the field (if the initial value is null).

**Reproduction**
1. Make a VirtualSelectBox with items set on its model
2. Select a random item
3. Call setValue(null) on the selectbox
4. The selection is still on the same item

**Solution**
Let the setValue(null) act as resetter of the field, to be consistent with the other form fields.