### PR TITLE
Remove global invalid tooltip on manager disposal

### DIFF
--- a/framework/source/class/qx/ui/form/validation/Manager.js
+++ b/framework/source/class/qx/ui/form/validation/Manager.js
@@ -675,6 +675,7 @@ qx.Class.define("qx.ui.form.validation.Manager",
   */
   destruct : function()
   {
+    this._showToolTip(true);
     this.__formItems = null;
   }
 });


### PR DESCRIPTION
If a form is currently invalid and the validation manager gets disposed, it can happen that the tooltip is still visible - even if the form and the widget which receives the invalid message are already disposed.

Calling `_showTooltip(true)` (strange naming due to inverse logic, though) does everything we need to close the tooltip on disposal.

Being strict, I'd expect a tooltip for a widget to be removed when the widget itself disappears/gets disposed. But as this is a global one which is shared, not attached to any widget and positioned by the validation manager, I guess it's ok to close remaining tooltips where they originate.