### PR TITLE
Exclude metacolumn scrollbar

### DIFF
--- a/framework/source/class/qx/ui/table/Table.js
+++ b/framework/source/class/qx/ui/table/Table.js
@@ -589,6 +589,19 @@ qx.Class.define("qx.ui.table.Table",
 
 
     /**
+     * By default, all Scrollers' (meta-columns') horizontal scrollbars are
+     * shown if any one is required. Allow not showing any that are not
+     * required.
+     */
+    excludeScrollerScrollbarsIfNotNeeded :
+    {
+      check : "Boolean",
+      init : false,
+      nullable : false
+    },
+
+
+    /**
      * A function to instantiate a new column menu button.
      */
     newColumnMenu :
@@ -2030,27 +2043,45 @@ qx.Class.define("qx.ui.table.Table",
       // Check which scroll bars are needed
       var horNeeded = false;
       var verNeeded = false;
+      var excludeScrollerScrollbarsIfNotNeeded;
 
-      for (var i=0; i<scrollerArr.length; i++)
+      
+      // Determine whether we need to render horizontal scrollbars for meta
+      // columns that don't themselves actually require it
+      excludeScrollerScrollbarsIfNotNeeded =
+        this.getExcludeScrollerScrollbarsIfNotNeeded();
+
+      if (! excludeScrollerScrollbarsIfNotNeeded)
       {
-        var isLast = (i == (scrollerArr.length - 1));
+        for (var i=0; i<scrollerArr.length; i++)
+        {
+          var isLast = (i == (scrollerArr.length - 1));
 
-        // Only show the last vertical scrollbar
-        var bars = scrollerArr[i].getNeededScrollBars(horNeeded, !isLast);
+          // Only show the last vertical scrollbar
+          var bars = scrollerArr[i].getNeededScrollBars(horNeeded, !isLast);
 
-        if (bars & horBar) {
-          horNeeded = true;
-        }
+          if (bars & horBar) {
+            horNeeded = true;
+          }
 
-        if (isLast && (bars & verBar)) {
-          verNeeded = true;
+          if (isLast && (bars & verBar)) {
+            verNeeded = true;
+          }
         }
       }
 
       // Set the needed scrollbars
       for (var i=0; i<scrollerArr.length; i++)
       {
-        var isLast = (i == (scrollerArr.length - 1));
+        isLast = (i == (scrollerArr.length - 1));
+
+        // If we don't want to include scrollbars for meta columns that don't
+        // require it, find out whether this meta column requires it.
+        if (excludeScrollerScrollbarsIfNotNeeded)
+        {
+          horNeeded =
+            scrollerArr[i].getNeededScrollBars(false, !isLast) & horBar;
+        }
 
         // Only show the last vertical scrollbar
         scrollerArr[i].setHorizontalScrollBarVisible(horNeeded);
@@ -2059,6 +2090,8 @@ qx.Class.define("qx.ui.table.Table",
         if (isLast)
         {
           // ... then get the current (old) use of vertical scroll bar
+          verNeeded =
+            scrollerArr[i].getNeededScrollBars(false, false) & verBar;
           if (this.__hadVerticalScrollBar == null) {
             this.__hadVerticalScrollBar = scrollerArr[i].getVerticalScrollBarVisible();
             this.__timer = qx.event.Timer.once(function()

--- a/framework/source/class/qx/ui/table/Table.js
+++ b/framework/source/class/qx/ui/table/Table.js
@@ -2080,7 +2080,7 @@ qx.Class.define("qx.ui.table.Table",
         if (excludeScrollerScrollbarsIfNotNeeded)
         {
           horNeeded =
-            scrollerArr[i].getNeededScrollBars(false, !isLast) & horBar;
+            !! (scrollerArr[i].getNeededScrollBars(false, !isLast) & horBar);
 
           // Show the horizontal scrollbar if needed. Specify null to indicate
           // that the scrollbar should be hidden rather than excluded.
@@ -2097,7 +2097,7 @@ qx.Class.define("qx.ui.table.Table",
         {
           // ... then get the current (old) use of vertical scroll bar
           verNeeded =
-            scrollerArr[i].getNeededScrollBars(false, false) & verBar;
+            !! (scrollerArr[i].getNeededScrollBars(false, false) & verBar);
           if (this.__hadVerticalScrollBar == null) {
             this.__hadVerticalScrollBar = scrollerArr[i].getVerticalScrollBarVisible();
             this.__timer = qx.event.Timer.once(function()

--- a/framework/source/class/qx/ui/table/Table.js
+++ b/framework/source/class/qx/ui/table/Table.js
@@ -2081,10 +2081,16 @@ qx.Class.define("qx.ui.table.Table",
         {
           horNeeded =
             scrollerArr[i].getNeededScrollBars(false, !isLast) & horBar;
-        }
 
-        // Only show the last vertical scrollbar
-        scrollerArr[i].setHorizontalScrollBarVisible(horNeeded);
+          // Show the horizontal scrollbar if needed. Specify null to indicate
+          // that the scrollbar should be hidden rather than excluded.
+          scrollerArr[i].setHorizontalScrollBarVisible(horNeeded || null);
+        }
+        else
+        {
+          // Show the horizontal scrollbar if needed.
+          scrollerArr[i].setHorizontalScrollBarVisible(horNeeded);
+        }
 
         // If this is the last meta-column...
         if (isLast)

--- a/framework/source/class/qx/ui/table/pane/Scroller.js
+++ b/framework/source/class/qx/ui/table/pane/Scroller.js
@@ -499,13 +499,13 @@ qx.Class.define("qx.ui.table.pane.Scroller",
 
     // property modifier
     _applyHorizontalScrollBarVisible : function(value, old) {
-      if (typeof value == "boolean")
-      {
-        this.__horScrollBar.setVisibility(value ? "visible" : "excluded");
-      }
-      else                      // it's null
+      if (value === null)
       {
         this.__horScrollBar.setVisibility("hidden");
+      }
+      else
+      {
+        this.__horScrollBar.setVisibility(value ? "visible" : "excluded");
       }
     },
 

--- a/framework/source/class/qx/ui/table/pane/Scroller.js
+++ b/framework/source/class/qx/ui/table/pane/Scroller.js
@@ -214,13 +214,18 @@ qx.Class.define("qx.ui.table.pane.Scroller",
   properties :
   {
 
-    /** Whether to show the horizontal scroll bar */
+    /**
+     * Whether to show the horizontal scroll bar. This is a tri-state
+     * value. `true` means show the scroll bar; `false` means exclude it; null
+     * means hide it so it retains its space but doesn't show a scroll bar.
+     */
     horizontalScrollBarVisible :
     {
       check : "Boolean",
       init : false,
       apply : "_applyHorizontalScrollBarVisible",
-      event : "changeHorizontalScrollBarVisible"
+      event : "changeHorizontalScrollBarVisible",
+      nullable : true
     },
 
     /** Whether to show the vertical scroll bar */
@@ -494,7 +499,14 @@ qx.Class.define("qx.ui.table.pane.Scroller",
 
     // property modifier
     _applyHorizontalScrollBarVisible : function(value, old) {
-      this.__horScrollBar.setVisibility(value ? "visible" : "excluded");
+      if (typeof value == "boolean")
+      {
+        this.__horScrollBar.setVisibility(value ? "visible" : "excluded");
+      }
+      else                      // it's null
+      {
+        this.__horScrollBar.setVisibility("hidden");
+      }
     },
 
 


### PR DESCRIPTION
By default, all Scrollers' (meta-columns') horizontal scrollbars are shown if any one is required. Allow not showing any that are not required. The new property `excludeScrollerScrollbarsIfNotNeeded` is added to `qx.ui.table.Table`, and the property `horizontalScrollBarVisible` of qx.ui.table.pane.Scroller` is now tri-state, where the new third (null) state hides rather than excludes the scrollbar.

This is backward-compatible, in that the default is still to show all horizontal scrollbars if any one is required.

