### PR TITLE
fix deploy_npm

### DIFF
--- a/.travis/deploy_npm
+++ b/.travis/deploy_npm
@@ -4,36 +4,27 @@ set -o errexit -o nounset
 
 exe() { echo "\$ ${@/eval/}" ; "$@" ; }
 
-if ! [ -z ${TRAVIS_BUILD_DIR+x} ]; then
-    cd $TRAVIS_BUILD_DIR
-fi
-
-if ! [ -z ${TRAVIS_BUILD_DIR+x} ]; then
-    echo "//registry.npmjs.org/:_authToken=${NPM_TOKEN}" > ~/.npmrc
-fi
+cd $TRAVIS_BUILD_DIR
 
 BASE_DIR="$(git rev-parse --show-toplevel)"
 FRAMEWORK_VERSION=$(cat $BASE_DIR/version.txt)
-FRAMEWORK_DATE=$(date +%Y%m%d)
 TAG_VERSION="$FRAMEWORK_VERSION"
-TARGET_DIR="$BASE_DIR/dist"
+REV=$(git rev-parse --short HEAD)
+FRAMEWORK_DATE=$(date +%Y%m%d)
 GENERATE="python $BASE_DIR/tool/bin/generator.py"
-
  
 # Adjust the framework version for non TAG builds
-if [ -z ${TRAVIS_TAG+x}] || ["$TRAVIS_TAG" = "" ]; then
-    TAG_VERSION="$TAG_VERSION-$FRAMEWORK_DATE"
+if [ "$TRAVIS_TAG" = "" ]; then
+    TAG_VERSION="$TAG_VERSION-$FRAMEWORK_DATE-$REV"
 fi
 
 echo "-------------------------------------------------------------------------"
 echo "Framework version: $FRAMEWORK_VERSION"
-echo "Tag version      : $FRAMEWORK_VERSION"
+echo "Revision         : $REV"
+echo "Tag version      : $TAG_VERSION"
+echo "TRAVIS_BUILD_DIR : $TRAVIS_BUILD_DIR"
 echo "Build source     : $BASE_DIR"
-echo "Target           : $TARGET_DIR"
 echo "Generate         : $GENERATE"
-if ! [ -z ${TRAVIS_BUILD_DIR+x} ]; then
-   echo "Travis Build dir : $TRAVIS_BUILD_DIR"
-fi
 echo "-------------------------------------------------------------------------"
 
 cd $BASE_DIR
@@ -42,11 +33,19 @@ if [ "$TAG_VERSION" != "$FRAMEWORK_VERSION" ]; then
     exe tool/admin/bin/bumpqxversion.py $TAG_VERSION
 fi
 
+exe node -v
+exe npm -v
+# for token authentication we need newest npm!
+exe npm i npm@latest -g
+exe npm -v
+# fill .npmrc with access token
+echo "//registry.npmjs.org/:_authToken=${NPM_TOKEN}" > ~/.npmrc
+# publish to npm
 exe npm publish 
 
+# build qooxdoo server package
 cd $BASE_DIR/component/standalone/server 
 exe $GENERATE distclean
-echo "Building server SDK..."
 exe $GENERATE build
 exe $GENERATE npm-package-copy
 exe $GENERATE npm-package-test


### PR DESCRIPTION
Did some reworking, found npm error: We need a newer version to use access tokens.
Test with private qooxdoo repository works.
