### PR TITLE
Fix CheckGroupBox enabled consistency (closes #9350, refs #5519)

### DIFF
--- a/framework/source/class/qx/test/ui/groupbox/CheckGroupBox.js
+++ b/framework/source/class/qx/test/ui/groupbox/CheckGroupBox.js
@@ -1,0 +1,71 @@
+/* ************************************************************************
+
+   qooxdoo - the new era of web development
+
+   http://qooxdoo.org
+
+   Copyright:
+     2018 The Qooxdoo Project
+
+   License:
+     MIT: https://opensource.org/licenses/MIT
+     See the LICENSE file in the project's top-level directory for details.
+
+************************************************************************ */
+qx.Class.define("qx.test.ui.groupbox.CheckGroupBox",
+{
+  extend : qx.test.ui.LayoutTestCase,
+
+  members :
+  {
+    _checkGroupBox : null,
+    _label : null,
+
+    setUp : function()
+    {
+      this.base(arguments);
+
+      var groupBox = this._checkGroupBox = new qx.ui.groupbox.CheckGroupBox;
+      this.getRoot().add(groupBox);
+      groupBox.setLayout(new qx.ui.layout.HBox);
+      this._label = new qx.ui.basic.Label;
+      groupBox.add(this._label);
+
+      this.flush();
+    },
+
+    tearDown : function()
+    {
+      this.base(arguments);
+      this._disposeObjects("_checkGroupBox");
+    },
+
+    /**
+     * Tests whether 'enabled' is in consistent state for both groupbox content widgets
+     * and groupbox parent, i.e. after groupbox legend is unchecked and then checked
+     * again, disabling groupbox parent must disable groupbox content widgets (see [1]).
+     * 1. https://github.com/qooxdoo/qooxdoo/issues/9350
+     */
+    testEnabledConsistencyBetweenContentAndParent : function()
+    {
+      this.assertTrue(this._checkGroupBox.isEnabled());
+      this.assertTrue(this._label.isEnabled());
+
+      // Uncheck/check legend
+      this._checkGroupBox.setValue(false);
+      this.assertFalse(this._label.isEnabled());
+      this._checkGroupBox.setValue(true);
+      this.assertTrue(this._label.isEnabled());
+
+      // Disable parent, content label must switch to disabled
+      this._checkGroupBox.getLayoutParent().setEnabled(false);
+      this.assertFalse(this._checkGroupBox.isEnabled());
+      this.assertFalse(this._label.isEnabled());
+
+      // Enable parent, content label must switch to enabled
+      this._checkGroupBox.getLayoutParent().setEnabled(true);
+      this.assertTrue(this._checkGroupBox.isEnabled());
+      this.assertTrue(this._label.isEnabled());
+    }
+  }
+});

--- a/framework/source/class/qx/test/ui/groupbox/__init__.js
+++ b/framework/source/class/qx/test/ui/groupbox/__init__.js
@@ -1,0 +1,4 @@
+/**
+ * qx.test.ui.groupbox package
+ *
+ */

--- a/framework/source/class/qx/ui/groupbox/CheckGroupBox.js
+++ b/framework/source/class/qx/ui/groupbox/CheckGroupBox.js
@@ -80,6 +80,15 @@ qx.Class.define("qx.ui.groupbox.CheckGroupBox",
     },
 
 
+    // overridden
+    _applyEnabled : function(value, old) {
+      this.base(arguments, value, old);
+
+      this.getChildrenContainer().setEnabled(value && this.getValue());
+    },
+
+
+
 
 
     /*


### PR DESCRIPTION
This PR fixes bug reported in #9350 which is identical to #5519 (already fixed in 53e335a486fb4c2b00e3a1072a078ed50bc98ebf).
Fix is effectively a copy-paste of this piece of code:
https://github.com/qooxdoo/qooxdoo/blob/263f2cc988fd5c66a560ad7396c9113210c9f33b/framework/source/class/qx/ui/groupbox/RadioGroupBox.js#L110-L115
I'm aware this violates [DRY principle](https://en.wikipedia.org/wiki/Don%27t_repeat_yourself) but there is already a substantial amount of code duplication between `CheckGroupBox` and `RadioGroupBox` so I decided not to touch it for now. Just yell at me if I should DRY it out.