### PR TITLE
Allows to customize the label suffix (default " :") and the required …

### DIFF
--- a/framework/source/class/qx/ui/form/renderer/AbstractRenderer.js
+++ b/framework/source/class/qx/ui/form/renderer/AbstractRenderer.js
@@ -52,29 +52,31 @@ qx.Class.define("qx.ui.form.renderer.AbstractRenderer",
   },
 
   properties :
+  {
+    /**
+     * A string that is appended to the label if it is not empty.
+     * Defaults to " :"
+     */
+    labelSuffix :
     {
-      /**
-       * A string that is appended to the label if it is not empty
-       */
-      labelSuffix :
-        {
-          check : "String",
-          init : " :",
-          event : "changeLabelSuffix",
-          nullable : true
-        },
-
-      /**
-       * A string that is appended to the label if it is not empty
-       */
-      requiredSuffix :
-        {
-          check : "String",
-          init : " <span style='color:red'>*</span> ",
-          event : "changeRequiredSuffix",
-          nullable : false
-        }
+      check : "String",
+      init : " :",
+      event : "changeLabelSuffix",
+      nullable : true
     },
+
+    /**
+     * A string that is appended to the label and the label suffix if the corresponding
+     * form field is mandatory. Defaults to space plus a red asterisk.
+     */
+    requiredSuffix :
+    {
+      check : "String",
+      init : " <span style='color:red'>*</span> ",
+      event : "changeRequiredSuffix",
+      nullable : false
+    }
+  },
 
 
   members :

--- a/framework/source/class/qx/ui/form/renderer/AbstractRenderer.js
+++ b/framework/source/class/qx/ui/form/renderer/AbstractRenderer.js
@@ -51,6 +51,31 @@ qx.Class.define("qx.ui.form.renderer.AbstractRenderer",
     form.addListener("change", this._onFormChange, this);
   },
 
+  properties :
+    {
+      /**
+       * A string that is appended to the label if it is not empty
+       */
+      labelSuffix :
+        {
+          check : "String",
+          init : " :",
+          event : "changeLabelSuffix",
+          nullable : true
+        },
+
+      /**
+       * A string that is appended to the label if it is not empty
+       */
+      requiredSuffix :
+        {
+          check : "String",
+          init : " <span style='color:red'>*</span> ",
+          event : "changeRequiredSuffix",
+          nullable : false
+        }
+    },
+
 
   members :
   {
@@ -141,14 +166,14 @@ qx.Class.define("qx.ui.form.renderer.AbstractRenderer",
      */
     _createLabelText : function(name, item)
     {
-      var required = "";
+      var requiredSuffix = "";
       if (item.getRequired()) {
-       required = " <span style='color:red'>*</span> ";
+        requiredSuffix = this.getRequiredSuffix();
       }
 
-      // Create the label. Append a colon only if there's text to display.
-      var colon = name.length > 0 || item.getRequired() ? " :" : "";
-      return name + required + colon;
+      // Create the label. Append a suffix only if there's text to display.
+      var labelSuffix = name.length > 0 || item.getRequired() ? this.getLabelSuffix() : "";
+      return name + requiredSuffix + labelSuffix;
     },
 
 


### PR DESCRIPTION
…suffix (default: red asterisk) in the form renderer by refining the values of two new properties.

This time, without the merge commits!