### PR TITLE
ObjectID fixes and updates for UI testing framework

### DIFF
--- a/framework/source/class/qx/bom/element/Attribute.js
+++ b/framework/source/class/qx/bom/element/Attribute.js
@@ -323,6 +323,9 @@ qx.Bootstrap.define("qx.bom.element.Attribute",
             element.removeAttribute(name);
           }
         }
+        else if (value === null) {
+          element.removeAttribute(name);
+        }
         else {
           element.setAttribute(name, value);
         }

--- a/framework/source/class/qx/core/Id.js
+++ b/framework/source/class/qx/core/Id.js
@@ -57,16 +57,14 @@ qx.Class.define("qx.core.Id", {
      * 
      * This will also return null if the top-most ancestor is not one of the globals registered
      * with `registerObject` or a known global (such as the application); however, by passing
-     * `false` as the `mustBeRegistered` parameter, this restriction is removed and a path will
-     * still be returned (it's just that in this case, you will have to know the the root object
-     * to query and `qx.core.Id.getObject` will not work on that path)  
+     * `true` as the `suppressWarnings` parameter, this will prevent errors from appearing in 
+     * the console when this happens  
      * 
      * @param obj {qx.core.Object} the object
-     * @param mustBeRegistered {Boolean} default: true; whether the function is allowed to return
-     *  a path that cannot be accessed via `qx.core.Id.getObject()`
+     * @param suppressWarnings {Boolean?} default: false; silently returns null if an ID cannot be created 
      * @return {String} full path to the object
      */
-    getAbsoluteIdOf: function(obj, mustBeRegistered) {
+    getAbsoluteIdOf: function(obj, suppressWarnings) {
       if (this.__registeredIdHashes && this.__registeredIdHashes[obj.toHashCode()]) {
         return obj.getObjectId();
       }
@@ -75,7 +73,9 @@ qx.Class.define("qx.core.Id", {
       while (obj) {
         var id = obj.getObjectId();
         if (!id) {
-          this.error("Cannot determine an absolute Object ID because one of the ancestor ObjectID's is null (got as far as " + segs.join('/') + ")");
+          if (!suppressWarnings) {
+            this.error("Cannot determine an absolute Object ID because one of the ancestor ObjectID's is null (got as far as " + segs.join('/') + ")");
+          }
           return null;
         }
         segs.unshift(id);
@@ -95,10 +95,9 @@ qx.Class.define("qx.core.Id", {
             break;
           }
         } else {
-          if (mustBeRegistered === false) {
-            break;
+          if (!suppressWarnings) {
+            this.error("Cannot determine a global absolute Object ID because the topmost object is not registered");
           }
-          this.error("Cannot determine a global absolute Object ID because the topmost object is not registered");
           return null;
         }
         obj = owner;
@@ -126,22 +125,39 @@ qx.Class.define("qx.core.Id", {
       }
       this.__registeredObjects[id] = obj;
       this.__registeredIdHashes[obj.toHashCode()] = id;
+      obj._cascadeObjectIdChanges();
     },
     
     /**
      * Unregisters a previously registered object with an ID
      * 
-     * @param id {String} the ID to unregister the object
+     * @param data {Object|String} the object to unregister, or the ID of the object
+     * @return {Boolean} whether there was an object to unregister
      */
-    unregister: function(id) {
-      if (this.__registeredObjects) {
-        var obj = this.__registeredObjects[id];
-        if (obj) {
-          delete this.__registeredObjects[id];
-          delete this.__registeredIdHashes[obj.toHashCode()];
-        }
+    unregister: function(data) {
+      if (!this.__registeredObjects) {
+        return false;
       }
-      this.removeOwnedObject(id);
+      
+      var id;
+      if (typeof data == "string") {
+        id = data;
+      } else {
+        var hash = data.toHashCode();
+        id = this.__registeredIdHashes[hash];
+        if (!id)
+          return false;
+      }
+      
+      var obj = this.__registeredObjects[id];
+      if (obj) {
+        delete this.__registeredObjects[id];
+        delete this.__registeredIdHashes[obj.toHashCode()];
+        obj._cascadeObjectIdChanges();
+        return true;
+      }
+      
+      return false;
     }
   },
   
@@ -161,10 +177,11 @@ qx.Class.define("qx.core.Id", {
      * Helper for `qx.core.Id.getAbsoluteIdOf`
      * 
      * @param obj {qx.core.Object} the object
+     * @param suppressWarnings {Boolean?} default: false; silently returns null if an ID cannot be created 
      * @return {String} full path to the object
      */
-    getAbsoluteIdOf: function(obj) {
-      return this.getInstance().getAbsoluteIdOf(obj);
+    getAbsoluteIdOf: function(obj, suppressWarnings) {
+      return this.getInstance().getAbsoluteIdOf(obj, suppressWarnings);
     }
   }
 });

--- a/framework/source/class/qx/core/Id.js
+++ b/framework/source/class/qx/core/Id.js
@@ -145,8 +145,9 @@ qx.Class.define("qx.core.Id", {
       } else {
         var hash = data.toHashCode();
         id = this.__registeredIdHashes[hash];
-        if (!id)
+        if (!id) {
           return false;
+        }
       }
       
       var obj = this.__registeredObjects[id];

--- a/framework/source/class/qx/core/Id.js
+++ b/framework/source/class/qx/core/Id.js
@@ -32,6 +32,15 @@ qx.Class.define("qx.core.Id", {
     /*
      * @Override
      */
+    _createObject: function(id) {
+      // Create the object, but don't add it to the list of owned objects
+      var result = this._createObjectImpl(id);
+      return result;
+    },
+    
+    /*
+     * @Override
+     */
     _createObjectImpl: function(id) {
       if (this.__registeredObjects) {
         var obj = this.__registeredObjects[id];

--- a/framework/source/class/qx/core/MObjectId.js
+++ b/framework/source/class/qx/core/MObjectId.js
@@ -157,10 +157,7 @@ qx.Mixin.define("qx.core.MObjectId", {
         
       } else {
         // No object, creating the object
-        result = this._createObjectImpl(id);
-        if (result !== undefined) {
-          this.addOwnedObject(result, id);
-        }
+        result = this._createObject(id);
       }
       
       if (result && controlId) {
@@ -168,6 +165,21 @@ qx.Mixin.define("qx.core.MObjectId", {
         return childControl;
       }
       
+      return result;
+    },
+    
+    /**
+     * Creates the object and adds it to a list; most classes are expected to
+     * override `_createObjectImpl` NOT this method.
+     * 
+     * @param id {String} ID of the object
+     * @return {qx.core.Object?} the created object
+     */
+    _createObject: function(id) {
+      var result = this._createObjectImpl(id);
+      if (result !== undefined) {
+        this.addOwnedObject(result, id);
+      }
       return result;
     },
     
@@ -181,7 +193,7 @@ qx.Mixin.define("qx.core.MObjectId", {
      * @return {qx.core.Object?} the created object
      */
     _createObjectImpl: function(id) {
-      return;  // Return undefined
+      return undefined;
     },
     
     /**

--- a/framework/source/class/qx/core/MObjectId.js
+++ b/framework/source/class/qx/core/MObjectId.js
@@ -123,6 +123,16 @@ qx.Mixin.define("qx.core.MObjectId", {
         }
       }
       
+      // Separate out the child control ID
+      var controlId = null;
+      var pos = id.indexOf('#');
+      if (pos > -1) {
+        controlId = id.substring(pos + 1);
+        id = id.substring(0, pos);
+      }
+      
+      var result = undefined;
+      
       // Handle paths
       if (id.indexOf('/') > -1) {
         var segs = id.split('/');
@@ -140,16 +150,23 @@ qx.Mixin.define("qx.core.MObjectId", {
             return true;
           }
         });
-        return found ? target : undefined;
+        if (found)
+          result = target;
+        
+      } else {
+        // No object, creating the object
+        result = this._createObjectImpl(id);
+        if (result !== undefined) {
+          this.addOwnedObject(result, id);
+        }
       }
       
-      // No object, creating the object
-      var obj = this._createObjectImpl(id);
-      if (obj !== undefined) {
-        this.addOwnedObject(obj, id);
+      if (result && controlId) {
+        var childControl = result.getChildControl(controlId);
+        return childControl;
       }
       
-      return obj;
+      return result;
     },
     
     /**

--- a/framework/source/class/qx/core/MObjectId.js
+++ b/framework/source/class/qx/core/MObjectId.js
@@ -103,8 +103,9 @@ qx.Mixin.define("qx.core.MObjectId", {
         }
       }
       if (this.__ownedObjects) {
-        for (var name in this.__ownedObjects)
+        for (var name in this.__ownedObjects) {
           this.__ownedObjects[name]._cascadeObjectIdChanges();
+        }
       }
     },
     
@@ -150,8 +151,9 @@ qx.Mixin.define("qx.core.MObjectId", {
             return true;
           }
         });
-        if (found)
+        if (found) {
           result = target;
+        }
         
       } else {
         // No object, creating the object

--- a/framework/source/class/qx/event/Manager.js
+++ b/framework/source/class/qx/event/Manager.js
@@ -100,6 +100,30 @@ qx.Class.define("qx.event.Manager",
      */
     getNextUniqueId : function() {
       return (this.__lastUnique++) + "";
+    },
+    
+    
+    /** @type {Function} global event monitor, called with parameters of target and event */
+    __globalEventMonitor: null,
+    
+    
+    /**
+     * Returns the global event monitor
+     * 
+     * @return {Function?} the global monitor function
+     */
+    getGlobalEventMonitor: function() {
+      return this.__globalEventMonitor;
+    },
+    
+    
+    /**
+     * Sets the global event monitor
+     * 
+     * @param cb {Function?} the global monitor function
+     */
+    setGlobalEventMonitor: function(cb) {
+      this.__globalEventMonitor = cb;
     }
   },
 
@@ -855,6 +879,18 @@ qx.Class.define("qx.event.Manager",
         qx.core.Assert.assertNotUndefined(target, msg + "Invalid event target.");
         qx.core.Assert.assertNotNull(target, msg + "Invalid event target.");
         qx.core.Assert.assertInstance(event, qx.event.type.Event, msg + "Invalid event object.");
+      }
+      
+      if (qx.event.Manager.__globalEventMonitor) {
+        try {
+          var preventDefault = event.getDefaultPrevented();
+          qx.event.Manager.__globalEventMonitor(target, event);
+          if (preventDefault != event.getDefaultPrevented()) {
+            qx.log.Logger.error("Unexpected change by GlobalEventMonitor, modifications to events: ");
+          }
+        }catch (ex) {
+          qx.log.Logger.error("Error in GlobalEventMonitor: " + ex);
+        }
       }
 
       // Preparations

--- a/framework/source/class/qx/html/Element.js
+++ b/framework/source/class/qx/html/Element.js
@@ -801,7 +801,7 @@ qx.Class.define("qx.html.Element",
       if (qx.core.Environment.get("module.objectid")) {
         var id = null;
         if (this.__widget && this.__widget.getObjectId()) {
-          id = qx.core.Id.getAbsoluteIdOf(this.__widget, false) || null;
+          id = qx.core.Id.getAbsoluteIdOf(this.__widget, true) || null;
         }
         this.setAttribute("data-qx-object-id", id, true);
       }

--- a/uitests/objectid/source/class/objectid/Application.js
+++ b/uitests/objectid/source/class/objectid/Application.js
@@ -78,17 +78,20 @@ qx.Class.define("objectid.Application", {
       root.add(button_panel, { left: 100, top: 300 });
       
       var A = qx.core.Assert;
+      var Id = qx.core.Id;
       btnPushMe.addListener("execute", function() {
         btnPushMe.setEnabled(false); // run once, this test is destructive
         
-        A.assertTrue(button_panel === qx.core.Id.getObject("buttons"));
-        A.assertTrue(btnPushMe === qx.core.Id.getObject("buttons/pushMe"));
+        A.assertTrue(button_panel === Id.getObject("buttons"));
+        A.assertTrue(btnPushMe === Id.getObject("buttons/pushMe"));
+        
+        A.assertTrue(Id.getObject("buttons/pushMe#label") === btnPushMe.getChildControl("label"));
         
         var id = btnPushMe.getContentElement().getAttribute("data-qx-object-id");
         A.assertTrue(id === "buttons/pushMe");
         
         button_panel.setObjectId("buttons_renamed");
-        A.assertTrue(button_panel === qx.core.Id.getObject("buttons"));
+        A.assertTrue(button_panel === Id.getObject("buttons"));
         id = btnPushMe.getContentElement().getAttribute("data-qx-object-id");
         A.assertTrue(id === "buttons/pushMe");
         
@@ -106,7 +109,7 @@ qx.Class.define("objectid.Application", {
         
         id = btnSomeButton.getContentElement().getAttribute("data-qx-object-id");
         A.assertTrue(id === "buttons/someButton");
-        qx.core.Id.getInstance().unregister(button_panel);
+        Id.getInstance().unregister(button_panel);
         id = btnSomeButton.getContentElement().getAttribute("data-qx-object-id");
         A.assertTrue(!id);
         

--- a/uitests/objectid/source/class/objectid/Application.js
+++ b/uitests/objectid/source/class/objectid/Application.js
@@ -25,6 +25,11 @@ qx.Class.define("objectid.Application", {
         qx.log.appender.Native;
         qx.log.appender.Console;
       }
+      
+      var numGlobalEvents = 0;
+      qx.event.Manager.setGlobalEventMonitor(function(target, event) {
+        numGlobalEvents++;
+      });
 
       var root = this.getRoot();
       
@@ -104,6 +109,8 @@ qx.Class.define("objectid.Application", {
         qx.core.Id.getInstance().unregister(button_panel);
         id = btnSomeButton.getContentElement().getAttribute("data-qx-object-id");
         A.assertTrue(!id);
+        
+        A.assertTrue(numGlobalEvents > 0);
         
       }, this);
     },

--- a/uitests/objectid/source/class/objectid/Application.js
+++ b/uitests/objectid/source/class/objectid/Application.js
@@ -30,6 +30,8 @@ qx.Class.define("objectid.Application", {
       qx.event.Manager.setGlobalEventMonitor(function(target, event) {
         numGlobalEvents++;
       });
+      
+      new qx.test.core.ObjectId().testGetObject();
 
       var root = this.getRoot();
       

--- a/uitests/objectid/source/class/objectid/Application.js
+++ b/uitests/objectid/source/class/objectid/Application.js
@@ -29,12 +29,12 @@ qx.Class.define("objectid.Application", {
       var root = this.getRoot();
       
       root.add(new qx.ui.basic.Label("Use the DOM Elements inspector to look at the widgets, " +
-      		"check out the 'data-object-id' attributes.<br>\n" +
+      		"check out the 'data-qx-object-id' attributes.<br>\n" +
       		"<br>\n" +
       		"Click the 'Run Test' button and then try this code in console:")
         .set({ rich: true }), { left: 100, top: 20 });
       root.add(new qx.ui.form.TextArea().set({ 
-        value: "var edtName = $(\"input[data-object-id='application/exampleEditor/edtName']\");\n" +
+        value: "var edtName = $(\"input[data-qx-object-id='application/exampleEditor/edtName']\");\n" +
         		"console.log(edtName);\n" +
           "console.log(edtName.$$widgetObject);\n" +
           "console.log(edtName.$$widgetObject.classname);\n" +
@@ -55,12 +55,57 @@ qx.Class.define("objectid.Application", {
       root.add(this.getObject("exampleEditor/container"), { left: 100, top: 250 });
       
       var button_panel = new qx.ui.toolbar.ToolBar();
-      button_panel.add(new qx.ui.toolbar.Button("Push Me"));
-      root.add(button_panel, { left: 100, top: 300 });
-      qx.core.Id.getInstance().register(button_panel, "buttons");
-      button_panel.setObjectId("buttons");
       
-      qx.core.Assert.assertTrue(button_panel === qx.core.Id.getObject("buttons"));
+      var btnPushMe = new qx.ui.toolbar.Button("Push Me (Tests #2)").set({ objectId: "pushMe" });
+      btnPushMe.addListener("appear", function() {
+        button_panel.addOwnedObject(btnPushMe);
+        button_panel.setObjectId("buttons");
+        qx.core.Id.getInstance().register(button_panel);
+      });
+      button_panel.add(btnPushMe);
+      
+      var btnSomeButton = new qx.ui.toolbar.Button("Some Button").set({ objectId: "someButton" });
+      btnSomeButton.addListener("appear", function() {
+        button_panel.addOwnedObject(btnSomeButton);
+      });
+      button_panel.add(btnSomeButton);
+      
+      root.add(button_panel, { left: 100, top: 300 });
+      
+      var A = qx.core.Assert;
+      btnPushMe.addListener("execute", function() {
+        btnPushMe.setEnabled(false); // run once, this test is destructive
+        
+        A.assertTrue(button_panel === qx.core.Id.getObject("buttons"));
+        A.assertTrue(btnPushMe === qx.core.Id.getObject("buttons/pushMe"));
+        
+        var id = btnPushMe.getContentElement().getAttribute("data-qx-object-id");
+        A.assertTrue(id === "buttons/pushMe");
+        
+        button_panel.setObjectId("buttons_renamed");
+        A.assertTrue(button_panel === qx.core.Id.getObject("buttons"));
+        id = btnPushMe.getContentElement().getAttribute("data-qx-object-id");
+        A.assertTrue(id === "buttons/pushMe");
+        
+        btnPushMe.setObjectId("pushMeToo");
+        id = btnPushMe.getContentElement().getAttribute("data-qx-object-id");
+        A.assertTrue(id === "buttons/pushMeToo");
+        
+        button_panel.removeOwnedObject(btnPushMe);
+        id = btnPushMe.getContentElement().getAttribute("data-qx-object-id");
+        A.assertTrue(!id);
+        
+        btnPushMe.setObjectId(null);
+        id = btnPushMe.getContentElement().getAttribute("data-qx-object-id");
+        A.assertTrue(!id);
+        
+        id = btnSomeButton.getContentElement().getAttribute("data-qx-object-id");
+        A.assertTrue(id === "buttons/someButton");
+        qx.core.Id.getInstance().unregister(button_panel);
+        id = btnSomeButton.getContentElement().getAttribute("data-qx-object-id");
+        A.assertTrue(!id);
+        
+      }, this);
     },
     
     _createObjectImpl: function(id) {
@@ -76,10 +121,10 @@ qx.Class.define("objectid.Application", {
           
           var A = qx.core.Assert;
           
-          var id = edt.getContentElement().getAttribute("data-object-id");
+          var id = edt.getContentElement().getAttribute("data-qx-object-id");
           A.assertTrue(id === "application/exampleEditor/edtName");
           
-          var dom = qx.bom.Selector.query("input[data-object-id='application/exampleEditor/edtName']")[0]
+          var dom = qx.bom.Selector.query("input[data-qx-object-id='application/exampleEditor/edtName']")[0]
           A.assertTrue(!!dom);
           var widget = qx.ui.core.Widget.getWidgetByElement(dom);
           A.assertTrue(widget === edt);


### PR DESCRIPTION
This makes some improvements to the object id mechanism, fixing some bugs and adding support for @cboulanger 's new testing framework:

* Adds global event monitor so that all events can be recorded for automatic test script generation
* Adds `#` to the ID path, to select child controls from the target widget
* Fixes a bug in `qx.html.Attribute` where `data-` attributes are not deleted properly
* Fixes warning suppression
* Fixes bug where changes to owner object IDs are not cascaded down, onto DOM objects
