### PR TITLE
Allow not throwing an error when non-focusable widgets are focused/blurred

### DIFF
--- a/framework/source/class/qx/ui/core/Widget.js
+++ b/framework/source/class/qx/ui/core/Widget.js
@@ -856,6 +856,9 @@ qx.Class.define("qx.ui.core.Widget",
     /** Whether the widget should print out hints and debug messages */
     DEBUG : false,
 
+    /** Whether to throw an error on focus/blur if the widget is unfocusable */
+    UNFOCUSABLE_WIDGET_FOCUS_BLUR_ERROR : true,
+
     /**
      * Returns the widget, which contains the given DOM element.
      *
@@ -3356,7 +3359,7 @@ qx.Class.define("qx.ui.core.Widget",
     {
       if (this.isFocusable()) {
         this.getFocusElement().focus();
-      } else {
+      } else if (qx.ui.core.Widget.UNFOCUSABLE_WIDGET_FOCUS_BLUR_ERROR) {
         throw new Error("Widget is not focusable!");
       }
     },
@@ -3370,7 +3373,7 @@ qx.Class.define("qx.ui.core.Widget",
     {
       if (this.isFocusable()) {
         this.getFocusElement().blur();
-      } else {
+      } else if (qx.ui.core.Widget.UNFOCUSABLE_WIDGET_FOCUS_BLUR_ERROR) {
         throw new Error("Widget is not focusable!");
       }
     },


### PR DESCRIPTION
In certain cases, Windows need be made unfocusable, yet internal qooxdoo code,
in the bowels of Promise-based code, tries to focus or blur them. These focus
and blur calls can be safely ignored, when nothing is expecting the focus or
blur to have an effect, yet display of the thrown error could not be
prevented.

This is done on a static, global basis. Applications that require it know that
they require it (few do, but when you need it, you really need it!), and can
change from the default, which remains as it was previously, for backward
compatibility. I don't see any reason for this to be a property. Having a
property would require *also* having a way to specify the default value of the
property.