### PR TITLE
Rename methods to avoid name conflicts

### DIFF
--- a/framework/source/class/qx/core/Id.js
+++ b/framework/source/class/qx/core/Id.js
@@ -31,16 +31,16 @@ qx.Class.define("qx.core.Id", {
     /*
      * @Override
      */
-    _createObject: function(id) {
+    _createQxObject: function(id) {
       // Create the object, but don't add it to the list of owned objects
-      var result = this._createObjectImpl(id);
+      var result = this._createQxObjectImpl(id);
       return result;
     },
     
     /*
      * @Override
      */
-    _createObjectImpl: function(id) {
+    _createQxObjectImpl: function(id) {
       if (this.__registeredObjects) {
         var obj = this.__registeredObjects[id];
         if (obj !== undefined) {
@@ -58,7 +58,7 @@ qx.Class.define("qx.core.Id", {
     
     /**
      * Returns an object path which can be used to locate an object anywhere in the application
-     * with a call to `qx.core.Id.getObject()`.
+     * with a call to `qx.core.Id.getQxObject()`.
      * 
      * This will return null if it is not possible to calculate a path because one of the
      * ancestors has a null `qxObjectId`.
@@ -133,7 +133,7 @@ qx.Class.define("qx.core.Id", {
       }
       this.__registeredObjects[id] = obj;
       this.__registeredIdHashes[obj.toHashCode()] = id;
-      obj._cascadeObjectIdChanges();
+      obj._cascadeQxObjectIdChanges();
     },
     
     /**
@@ -162,7 +162,7 @@ qx.Class.define("qx.core.Id", {
       if (obj) {
         delete this.__registeredObjects[id];
         delete this.__registeredIdHashes[obj.toHashCode()];
-        obj._cascadeObjectIdChanges();
+        obj._cascadeQxObjectIdChanges();
         return true;
       }
       
@@ -178,8 +178,8 @@ qx.Class.define("qx.core.Id", {
      * @param id {String} the ID to look for
      * @return {qx.core.Object?} the object
      */
-    getObject: function(id) {
-      return this.getInstance().getObject(id);
+    getQxObject: function(id) {
+      return this.getInstance().getQxObject(id);
     },
     
     /**

--- a/framework/source/class/qx/core/MObjectId.js
+++ b/framework/source/class/qx/core/MObjectId.js
@@ -19,9 +19,9 @@
 /**
  * A mixin providing objects by ID and owners.
  * 
- * The typical use of IDs is to override the `_createObjectImpl` method and create
+ * The typical use of IDs is to override the `_createQxObjectImpl` method and create
  * new instances on demand; all code should access these instances by calling
- * `getObject`.
+ * `getQxObject`.
  */
 qx.Mixin.define("qx.core.MObjectId", {
   
@@ -59,14 +59,14 @@ qx.Mixin.define("qx.core.MObjectId", {
 
   members: {
     
-    __ownedObjects: null,
-    __changingOwner: false,
+    __ownedQxObjects: null,
+    __changingQxOwner: false,
 
     /**
      * Apply owner
      */
     _applyQxOwner : function(value, oldValue) {
-      if (!this.__changingOwner) {
+      if (!this.__changingQxOwner) {
         throw new Error("Please use API methods to change owner, not the property");
       }
     },
@@ -75,12 +75,12 @@ qx.Mixin.define("qx.core.MObjectId", {
      * Apply objectId
      */
     _applyQxObjectId : function(value, oldValue) {
-      if (!this.__changingOwner) {
+      if (!this.__changingQxOwner) {
         var owner = this.getQxOwner();
         if (owner) {
           owner.__onOwnedObjectIdChange(this, value, oldValue);
         }
-        this._cascadeObjectIdChanges();
+        this._cascadeQxObjectIdChanges();
       }
     },
     
@@ -88,23 +88,23 @@ qx.Mixin.define("qx.core.MObjectId", {
      * Called when a child's objectId changes
      */
     __onOwnedObjectIdChange: function(obj, newId, oldId) {
-      delete this.__ownedObjects[oldId];
-      this.__ownedObjects[newId] = obj;
+      delete this.__ownedQxObjects[oldId];
+      this.__ownedQxObjects[newId] = obj;
     },
     
     /**
      * Reflect changes to IDs or owners
      */
-    _cascadeObjectIdChanges: function() {
+    _cascadeQxObjectIdChanges: function() {
       if (typeof this.getContentElement == "function") {
         var contentElement = this.getContentElement();
         if (contentElement) {
           contentElement.updateObjectId();
         }
       }
-      if (this.__ownedObjects) {
-        for (var name in this.__ownedObjects) {
-          this.__ownedObjects[name]._cascadeObjectIdChanges();
+      if (this.__ownedQxObjects) {
+        for (var name in this.__ownedQxObjects) {
+          this.__ownedQxObjects[name]._cascadeQxObjectIdChanges();
         }
       }
     },
@@ -116,9 +116,9 @@ qx.Mixin.define("qx.core.MObjectId", {
      *          {String} ID of the object
      * @return {qx.core.Object?} the found object
      */
-    getObject: function(id) {
-      if (this.__ownedObjects) {
-        var obj = this.__ownedObjects[id];
+    getQxObject: function(id) {
+      if (this.__ownedQxObjects) {
+        var obj = this.__ownedQxObjects[id];
         if (obj !== undefined) {
           return obj;
         }
@@ -145,7 +145,7 @@ qx.Mixin.define("qx.core.MObjectId", {
           if (!target) {
             return false;
           }
-          var tmp = target.getObject(seg);
+          var tmp = target.getQxObject(seg);
           if (tmp !== undefined) {
             target = tmp;
             return true;
@@ -157,7 +157,7 @@ qx.Mixin.define("qx.core.MObjectId", {
         
       } else {
         // No object, creating the object
-        result = this._createObject(id);
+        result = this._createQxObject(id);
       }
       
       if (result && controlId) {
@@ -170,29 +170,29 @@ qx.Mixin.define("qx.core.MObjectId", {
     
     /**
      * Creates the object and adds it to a list; most classes are expected to
-     * override `_createObjectImpl` NOT this method.
+     * override `_createQxObjectImpl` NOT this method.
      * 
      * @param id {String} ID of the object
      * @return {qx.core.Object?} the created object
      */
-    _createObject: function(id) {
-      var result = this._createObjectImpl(id);
+    _createQxObject: function(id) {
+      var result = this._createQxObjectImpl(id);
       if (result !== undefined) {
-        this.addOwnedObject(result, id);
+        this.addOwnedQxObject(result, id);
       }
       return result;
     },
     
     /**
      * Creates the object, intended to be overridden. Null is a valid return
-     * value and will be cached by `getObject`, however `undefined` is NOT a
-     * valid value and so will not be cached meaning that `_createObjectImpl`
+     * value and will be cached by `getQxObject`, however `undefined` is NOT a
+     * valid value and so will not be cached meaning that `_createQxObjectImpl`
      * will be called multiple times until a valid value is returned.
      * 
      * @param id {String} ID of the object
      * @return {qx.core.Object?} the created object
      */
-    _createObjectImpl: function(id) {
+    _createQxObjectImpl: function(id) {
       return undefined;
     },
     
@@ -202,18 +202,18 @@ qx.Mixin.define("qx.core.MObjectId", {
      * @param obj {qx.core.Object} the object to register
      * @param id {String?} the id to set when registering the object
      */
-    addOwnedObject: function(obj, id) {
-      if (!this.__ownedObjects) {
-        this.__ownedObjects = {};
+    addOwnedQxObject: function(obj, id) {
+      if (!this.__ownedQxObjects) {
+        this.__ownedQxObjects = {};
       }
       var thatOwner = obj.getQxOwner();
       if (thatOwner === this) {
         return;
       }
-      obj.__changingOwner = true;
+      obj.__changingQxOwner = true;
       try {
         if (thatOwner) {
-          thatOwner.__removeOwnedObjectImpl(obj);
+          thatOwner.__removeOwnedQxObjectImpl(obj);
         }
         if (id === undefined) {
           id = obj.getQxObjectId();
@@ -221,7 +221,7 @@ qx.Mixin.define("qx.core.MObjectId", {
         if (!id) {
           throw new Error("Cannot register an object that has no ID, obj=" + obj);
         }
-        if (this.__ownedObjects[id]) {
+        if (this.__ownedQxObjects[id]) {
           throw new Error("Cannot register an object with ID '" + id + "' because that ID is already in use, this=" + this + ", obj=" + obj);
         }
         if (obj.getQxOwner() != null) {
@@ -229,11 +229,11 @@ qx.Mixin.define("qx.core.MObjectId", {
         }
         obj.setQxOwner(this);
         obj.setQxObjectId(id);
-        obj._cascadeObjectIdChanges();
+        obj._cascadeQxObjectIdChanges();
       } finally {
-        obj.__changingOwner = false;
+        obj.__changingQxOwner = false;
       }
-      this.__ownedObjects[id] = obj;
+      this.__ownedQxObjects[id] = obj;
     },
 
     /**
@@ -242,8 +242,8 @@ qx.Mixin.define("qx.core.MObjectId", {
      * 
      * @param args {String|Object} the ID of the object to discard, or the object itself
      */
-    removeOwnedObject: function(args) {
-      if (!this.__ownedObjects) {
+    removeOwnedQxObject: function(args) {
+      if (!this.__ownedQxObjects) {
         throw new Error("Cannot discard object because it is not owned by this, this=" + this + ", object=" + obj);
       }
       
@@ -254,34 +254,39 @@ qx.Mixin.define("qx.core.MObjectId", {
           throw new Error("Cannot discard owned objects based on a path");
         }
         id = args;
-        obj = this.__ownedObjects[id];
+        obj = this.__ownedQxObjects[id];
         if (obj === undefined) {
           return;
         }
       } else {
         obj = args;
         id = obj.getQxObjectId();
-        if (this.__ownedObjects[id] !== obj) {
+        if (this.__ownedQxObjects[id] !== obj) {
           throw new Error("Cannot discard object because it is not owned by this, this=" + this + ", object=" + obj);
         }
       }
 
       if (obj !== null) {
-        obj.__changingOwner = true;
+        obj.__changingQxOwner = true;
         try {
-          this.__removeOwnedObjectImpl(obj);
-          obj._cascadeObjectIdChanges();
+          this.__removeOwnedQxObjectImpl(obj);
+          obj._cascadeQxObjectIdChanges();
         } finally {
-          obj.__changingOwner = false;
+          obj.__changingQxOwner = false;
         }
       }
     },
     
-    __removeOwnedObjectImpl: function(obj) {
+    /**
+     * Removes an owned object
+     * 
+     * @param obj {qx.core.Object} the object
+     */
+    __removeOwnedQxObjectImpl: function(obj) {
       if (obj !== null) {
         var id = obj.getQxObjectId();
         obj.setQxOwner(null);
-        delete this.__ownedObjects[id];
+        delete this.__ownedQxObjects[id];
       }
     },
 
@@ -291,8 +296,8 @@ qx.Mixin.define("qx.core.MObjectId", {
      * 
      * @return {Array}
      */    
-    getOwnedObjects : function(){
-      return this.__ownedObjects ? Object.values(this.__ownedObjects) : [];
+    getOwnedQxObjects : function(){
+      return this.__ownedQxObjects ? Object.values(this.__ownedQxObjects) : [];
     }
   }
 });

--- a/framework/source/class/qx/test/core/ObjectId.js
+++ b/framework/source/class/qx/test/core/ObjectId.js
@@ -28,7 +28,7 @@ qx.Class.define("qx.test.core.ObjectId", {
       var clazz = qx.Class.define("demo.MyClass", {
         extend: qx.core.Object,
         members: {
-          _createObjectImpl: function(id) {
+          _createQxObjectImpl: function(id) {
             switch(id) {
             case "txt":
               return new qx.ui.form.TextField();
@@ -41,28 +41,28 @@ qx.Class.define("qx.test.core.ObjectId", {
       var obj = new demo.MyClass();
       var Id = qx.core.Id.getInstance();
       Id.register(obj, "test");
-      var txt = obj.getObject("txt");
-      this.assertTrue(txt === obj.getObject("txt"));
+      var txt = obj.getQxObject("txt");
+      this.assertTrue(txt === obj.getQxObject("txt"));
       this.assertTrue(txt.getQxObjectId() === "txt");
-      this.assertTrue(Id.getObject("test") === obj);
-      this.assertTrue(Id.getObject("test/txt") === txt);
+      this.assertTrue(Id.getQxObject("test") === obj);
+      this.assertTrue(Id.getQxObject("test/txt") === txt);
       
-      obj.removeOwnedObject(txt);
-      var txt2 = obj.getObject("txt");
+      obj.removeOwnedQxObject(txt);
+      var txt2 = obj.getQxObject("txt");
       this.assertTrue(txt !== txt2);
-      this.assertTrue(txt2 === obj.getObject("txt"));
+      this.assertTrue(txt2 === obj.getQxObject("txt"));
       
       txt.setQxObjectId("txt-orig");
-      obj.addOwnedObject(txt);
-      this.assertTrue(txt === obj.getObject("txt-orig"));
+      obj.addOwnedQxObject(txt);
+      this.assertTrue(txt === obj.getQxObject("txt-orig"));
 
       var obj2 = new demo.MyClass();
-      obj2.addOwnedObject(txt);
-      this.assertTrue(obj.getObject("txt-orig") === undefined);
-      this.assertTrue(obj2.getObject("txt-orig") === txt);
+      obj2.addOwnedQxObject(txt);
+      this.assertTrue(obj.getQxObject("txt-orig") === undefined);
+      this.assertTrue(obj2.getQxObject("txt-orig") === txt);
       
       Id.unregister("test");
-      this.assertTrue(!Id.getObject("test"));
+      this.assertTrue(!Id.getQxObject("test"));
     }
   }
 });

--- a/uitests/objectid/source/class/objectid/Application.js
+++ b/uitests/objectid/source/class/objectid/Application.js
@@ -48,8 +48,8 @@ qx.Class.define("objectid.Application", {
           "console.log(edtName.$$widgetObject.getValue());\n",
         readOnly: true, width: 600, height: 85 }), 
         { left: 100, top: 80 });
-      root.add(this.getObject("btnRunTest"), { left: 100, top: 200 });
-      root.add(this.getObject("lblTestResult"), { left: 250, top: 200 });
+      root.add(this.getQxObject("btnRunTest"), { left: 100, top: 200 });
+      root.add(this.getQxObject("lblTestResult"), { left: 250, top: 200 });
 
       var model = qx.data.marshal.Json.createModel([
         { name: "Mr" },
@@ -57,15 +57,15 @@ qx.Class.define("objectid.Application", {
         { name: "Mrs" },
         { name: "Rev" }
       ]);
-      this.getObject("exampleEditor/ctlrTitle").setModel(model);
+      this.getQxObject("exampleEditor/ctlrTitle").setModel(model);
 
-      root.add(this.getObject("exampleEditor/container"), { left: 100, top: 250 });
+      root.add(this.getQxObject("exampleEditor/container"), { left: 100, top: 250 });
       
       var button_panel = new qx.ui.toolbar.ToolBar();
       
       var btnPushMe = new qx.ui.toolbar.Button("Push Me (Tests #2)").set({ qxObjectId: "pushMe" });
       btnPushMe.addListener("appear", function() {
-        button_panel.addOwnedObject(btnPushMe);
+        button_panel.addOwnedQxObject(btnPushMe);
         button_panel.setQxObjectId("buttons");
         qx.core.Id.getInstance().register(button_panel);
       });
@@ -73,7 +73,7 @@ qx.Class.define("objectid.Application", {
       
       var btnSomeButton = new qx.ui.toolbar.Button("Some Button").set({ qxObjectId: "someButton" });
       btnSomeButton.addListener("appear", function() {
-        button_panel.addOwnedObject(btnSomeButton);
+        button_panel.addOwnedQxObject(btnSomeButton);
       });
       button_panel.add(btnSomeButton);
       
@@ -84,16 +84,16 @@ qx.Class.define("objectid.Application", {
       btnPushMe.addListener("execute", function() {
         btnPushMe.setEnabled(false); // run once, this test is destructive
         
-        A.assertTrue(button_panel === Id.getObject("buttons"));
-        A.assertTrue(btnPushMe === Id.getObject("buttons/pushMe"));
+        A.assertTrue(button_panel === Id.getQxObject("buttons"));
+        A.assertTrue(btnPushMe === Id.getQxObject("buttons/pushMe"));
         
-        A.assertTrue(Id.getObject("buttons/pushMe#label") === btnPushMe.getChildControl("label"));
+        A.assertTrue(Id.getQxObject("buttons/pushMe#label") === btnPushMe.getChildControl("label"));
         
         var id = btnPushMe.getContentElement().getAttribute("data-qx-object-id");
         A.assertTrue(id === "buttons/pushMe");
         
         button_panel.setQxObjectId("buttons_renamed");
-        A.assertTrue(button_panel === Id.getObject("buttons"));
+        A.assertTrue(button_panel === Id.getQxObject("buttons"));
         id = btnPushMe.getContentElement().getAttribute("data-qx-object-id");
         A.assertTrue(id === "buttons/pushMe");
         
@@ -101,7 +101,7 @@ qx.Class.define("objectid.Application", {
         id = btnPushMe.getContentElement().getAttribute("data-qx-object-id");
         A.assertTrue(id === "buttons/pushMeToo");
         
-        button_panel.removeOwnedObject(btnPushMe);
+        button_panel.removeOwnedQxObject(btnPushMe);
         id = btnPushMe.getContentElement().getAttribute("data-qx-object-id");
         A.assertTrue(!id);
         
@@ -120,7 +120,7 @@ qx.Class.define("objectid.Application", {
       }, this);
     },
     
-    _createObjectImpl: function(id) {
+    _createQxObjectImpl: function(id) {
       switch(id) {
       case "exampleEditor":
         return new objectid.ExampleEditor();
@@ -128,7 +128,7 @@ qx.Class.define("objectid.Application", {
       case "btnRunTest":
         var btn = new qx.ui.form.Button("Run Test");
         btn.addListener("execute", () => {
-          var edt = qx.core.Id.getObject("application/exampleEditor/edtName");
+          var edt = qx.core.Id.getQxObject("application/exampleEditor/edtName");
           edt.setValue("John Smith");
           
           var A = qx.core.Assert;
@@ -140,7 +140,7 @@ qx.Class.define("objectid.Application", {
           A.assertTrue(!!dom);
           var widget = qx.ui.core.Widget.getWidgetByElement(dom);
           A.assertTrue(widget === edt);
-          this.getObject("lblTestResult").setValue("Tests completed OK");
+          this.getQxObject("lblTestResult").setValue("Tests completed OK");
         });
         return btn;
         

--- a/uitests/objectid/source/class/objectid/ExampleEditor.js
+++ b/uitests/objectid/source/class/objectid/ExampleEditor.js
@@ -2,23 +2,23 @@ qx.Class.define("objectid.ExampleEditor", {
   extend: qx.core.Object,
   
   members: {
-    _createObjectImpl: function(id) {
+    _createQxObjectImpl: function(id) {
       switch(id) {
       case "container":
         var comp = new qx.ui.container.Composite(new qx.ui.layout.Grid(5, 2));
         
         comp.add(new qx.ui.basic.Label("Title"), { row: 0, column: 0 });
-        comp.add(this.getObject("cboTitle"), { row: 0, column: 1 });
+        comp.add(this.getQxObject("cboTitle"), { row: 0, column: 1 });
         
         comp.add(new qx.ui.basic.Label("Name"), { row: 1, column: 0 });
-        comp.add(this.getObject("edtName"), { row: 1, column: 1 });
+        comp.add(this.getQxObject("edtName"), { row: 1, column: 1 });
         return comp;
         
       case "cboTitle":
         return new qx.ui.form.SelectBox();
         
       case "ctlrTitle":
-        var ctlr = new qx.data.controller.List(null, this.getObject("cboTitle"), "name");
+        var ctlr = new qx.data.controller.List(null, this.getQxObject("cboTitle"), "name");
         return ctlr;
         
       case "edtName":


### PR DESCRIPTION
This is (hopefully) a last PR on this subject, made to try and ensure that there are no possible side effects or name collisions with existing code belonging to users.  The naming convention has been changed so that the "object" part is always "Qx Object", meaning that we talk about properties like `qxObjectId` and `getQxObject` etc

One change that I've made here which is different to recent discussions on gitter with @cboulanger and @derrell is that `qx.core.MObject.getObject` has been renamed to `.getQxObject` and *not* `.getObjectByQxObjectId` - the reason for this is that the design pattern of `_createObjectImpl` is specifically intended to allow user interface widgets (and other objects) to be routinely accessed by `.getQxObject`, and for this to be used so frequently brevity seems essential, but this PR still used the "QX" convention

For example, see https://github.com/johnspackman/qooxdoo/blob/add-qx-prefix-to-objectid-2/uitests/objectid/source/class/objectid/ExampleEditor.js#L11-L14.