### PR TITLE
Keep qx from focussing non focusable widgets

### DIFF
--- a/framework/source/class/qx/ui/core/Blocker.js
+++ b/framework/source/class/qx/ui/core/Blocker.js
@@ -274,7 +274,7 @@ qx.Class.define("qx.ui.core.Blocker",
         activeWidget.deactivate();
       }
 
-      if (focusedWidget) {
+      if (focusedWidget && focusedWidget.isFocusable()) {
         focusedWidget.blur();
       }
     },


### PR DESCRIPTION
Setting a TextField to 'readonly' sets focusable to false on qx widget
side, but in the DOM, the widget *is* focussed. The changed code does
not check whether the widget is focussable at all which leads to a
crash.

Got introduced by https://github.com/qooxdoo/qooxdoo/pull/9555 .