### PR TITLE
#9623 added tab key to emulateKeyPress 

### DIFF
--- a/framework/source/class/qx/event/handler/Keyboard.js
+++ b/framework/source/class/qx/event/handler/Keyboard.js
@@ -554,6 +554,10 @@ qx.Class.define("qx.event.handler.Keyboard",
         9: true,
         27: true
       },
+	  
+	  "gecko" : {
+		9: true
+	  },
 
       "default" : {}
     }),


### PR DESCRIPTION
Since Firefox 65 the Tab key is considered an unprintable key.  Therefore a simulated "keypress" event is necessary.    