### PR TITLE
fix the chrome transition bug

### DIFF
--- a/framework/source/class/qx/ui/decoration/MTransition.js
+++ b/framework/source/class/qx/ui/decoration/MTransition.js
@@ -93,9 +93,10 @@ qx.Mixin.define("qx.ui.decoration.MTransition",
       if (qx.bom.client.Browser.getName() === "chrome" && qx.bom.client.Browser.getVersion() >= 71) {
         // chrome has a repaint problem ... as suggested in
         // https://stackoverflow.com/a/21947628/235990 we are setting
-        // a transform ... if we were to use transforms for ui animation
-        // then this will have to be revisited, but for now it should work fine
-        styles.transform = "translateZ(0)";
+        // a transform ...
+        if (!styles.transform) {
+          styles.transform = "translateZ(0)";
+        }
       }
 
       propName = qx.bom.Style.getCssName(propName.name);

--- a/framework/source/class/qx/ui/decoration/MTransition.js
+++ b/framework/source/class/qx/ui/decoration/MTransition.js
@@ -28,7 +28,7 @@
  * * Opera 12.10+
  * * Chrome 26+
  *
- * It is possible to define transitions by setting an 
+ * It is possible to define transitions by setting an
  * array containing the needed values as the property value.
  * In case multiple values are specified, the values of the properties
  * are repeated until all match in length.
@@ -89,6 +89,13 @@ qx.Mixin.define("qx.ui.decoration.MTransition",
       if (!propName ||
           this.getTransitionDuration() == null ){
         return;
+      }
+      if (qx.bom.client.Browser.getName() === "chrome" && qx.bom.client.Browser.getVersion() >= 71) {
+        // chrome has a repaint problem ... as suggested in
+        // https://stackoverflow.com/a/21947628/235990 we are setting
+        // a transform ... if we were to use transforms for ui animation
+        // then this will have to be revisited, but for now it should work fine
+        styles.transform = "translateZ(0)";
       }
 
       propName = qx.bom.Style.getCssName(propName.name);


### PR DESCRIPTION
there is a bug (?) with redrawing content in transitioned containers. as shown in the playground <a href="http://www.qooxdoo.org/qxl.playground/#%7B%22code%22%3A%22var%2520height%2520%253D%2520280%253B%250A%250Avar%2520transitionDeco%2520%253D%2520new%2520qx.ui.decoration.Decorator().set(%257B%250A%2520%2520transitionProperty%253A%2520%2522height%2522%252C%250A%2520%2520transitionDuration%253A%2520%25220.2s%2522%252C%250A%2520%2520transitionTimingFunction%253A%2520%2522ease-out%2522%252C%250A%2520%2520width%253A%25201%252C%250A%2520%2520style%253A%2520%2522solid%2522%252C%250A%2520%2520color%253A%2520%2522black%2522%250A%257D)%253B%250A%250Avar%2520box%2520%253D%2520new%2520qx.ui.container.Composite(new%2520qx.ui.layout.Canvas()).set(%257B%250A%2520%2520decorator%253A%2520transitionDeco%252C%250A%2520%2520width%253A%2520340%252C%250A%2520%2520height%253A%2520height%252C%250A%2520%2520minHeight%253A%25200%250A%257D)%253B%250A%250Avar%2520rawData%2520%253D%2520%255B%255D%253B%250Afor%2520(var%2520i%2520%253D%25200%253B%2520i%2520%253C%253D%252025%253B%2520i%252B%252B)%2520%257B%250A%2520%2520rawData%255Bi%255D%2520%253D%2520%257B%250A%2520%2520%2520%2520label%253A%2520%2522Item%2520No%2520%2522%2520%252B%2520i%252C%250A%2520%2520%257D%250A%257D%250A%250Avar%2520model%2520%253D%2520qx.data.marshal.Json.createModel(rawData)%253B%250A%250A%250A%252F%252F%2520Creates%2520the%2520list%2520and%2520configures%2520it%250Avar%2520list%2520%253D%2520this.__configList%2520%253D%2520new%2520qx.ui.list.List(model).set(%257B%250A%2520%2520height%253A%2520height-20%252C%250A%2520%2520width%253A%2520150%252C%250A%2520%2520labelPath%253A%2520%2522label%2522%250A%257D)%253B%250A%250A%252F%252F%2520Document%2520is%2520the%2520application%2520root%250Avar%2520doc%2520%253D%2520this.getRoot()%253B%250A%250A%252F%252F%2520Add%2520button%2520to%2520document%2520at%2520fixed%2520coordinates%250Abox.add(list%252C%250A%257B%250A%2520%2520left%2520%253A%252010%252C%250A%2520%2520top%2520%2520%253A%252010%250A%257D)%253B%250A%250Avar%2520oList%2520%253D%2520new%2520qx.ui.form.List().set(%257B%2520%250A%2520%2520height%253A%2520height-20%252C%2520%250A%2520%2520width%253A%2520150%257D)%253B%250A%250Avar%2520item%253B%250Afor(%2520var%2520i%253D1%253B%2520i%253C%253D25%253B%2520i%252B%252B%2520)%250A%257B%250A%2520%2520item%2520%253D%2520new%2520qx.ui.form.ListItem(%2522Item%2520No%2520%2522%2520%252B%2520i)%253B%250A%2520%2520oList.add(item)%253B%250A%257D%250A%250Abox.add(oList%252C%250A%257B%250A%2520%2520left%2520%253A%2520170%252C%250A%2520%2520top%2520%2520%253A%252010%250A%257D)%253B%250A%250A%250Abox.addListenerOnce(%2522appear%2522%252Cfunction()%257B%250A%2520%2520let%2520el%2520%253D%2520box.getContentElement().getDomElement()%253B%250A%2520%2520el.style.transform%2520%253D%2520%2522translateZ(0)%2522%253B%250A%2520%2520el.addEventListener(%2522transitionend%2522%252C()%253D%253E%2520%257B%250A%2520%2520%2520%2520console.log(%2522transition%2520complete%2522)%250A%2520%2520%257D)%253B%250A%257D)%253B%250A%250A%250Adoc.add(box%252C%257B%250A%2520%2520top%253A%252050%252C%2520left%253A%252080%250A%257D)%253B%250A%250Avar%2520btn%2520%253D%2520new%2520qx.ui.form.ToggleButton(%2522Toggle%2520Size%2522)%253B%250A%250A%252F%252F%2520Add%2520an%2520event%2520listener%250A%250Abtn.addListener(%2522execute%2522%252C%2520function(e)%2520%257B%250A%2520%2520box.setHeight(btn.getValue()%2520%253F%25200%253Aheight)%253B%250A%257D)%253B%250A%250A%250Adoc.add(btn%252C%2520%257B%250A%2520%2520left%253A%252080%252C%250A%2520%2520top%253A%252010%250A%257D)%253B%250A%22%2C%20%22mode%22%3A%22ria%22%7D">example</a>. The bug is resolved by setting a `"translateZ(0)"` transform on the transitioning dom element.