### PR TITLE
Subscriber list can be altered mid-stream.

### DIFF
--- a/framework/source/class/qx/event/message/Bus.js
+++ b/framework/source/class/qx/event/message/Bus.js
@@ -337,11 +337,21 @@ qx.Class.define("qx.event.message.Bus",
     /**
      * Call subscribers with passed message.
      *
+     * Each currently-subscribed subscriber function will be called in
+     * turn. Any requests to unsubscribe a subscriber from the list, while
+     * processing the currently-subscribed subscriber functions, will take
+     * effect after all currently-subscribed subscriber functions have been
+     * processed.
+     *
      * @param subscribers {Map} subscribers to call
      * @param msg {qx.event.message.Message} message for subscribers
      */
     __callSubscribers : function(subscribers, msg)
     {
+      // (Shallow) clone the subscribers array in case one of them alters the
+      // list, e.g., by unsubscribing
+      subscribers = subscribers.slice();
+
       for (var i=0; i<subscribers.length; i++)
       {
         var subscriber = subscribers[i].subscriber;

--- a/framework/source/class/qx/event/message/Bus.js
+++ b/framework/source/class/qx/event/message/Bus.js
@@ -343,7 +343,7 @@ qx.Class.define("qx.event.message.Bus",
      * effect after all currently-subscribed subscriber functions have been
      * processed.
      *
-     * @param subscribers {Map} subscribers to call
+     * @param subscribers {Array} subscribers to call
      * @param msg {qx.event.message.Message} message for subscribers
      */
     __callSubscribers : function(subscribers, msg)


### PR DESCRIPTION
The message bus subscriber list is iterated, and each subscribed function is
called in turn. If one of them unsubscribes itself, the subscriber list
decreased in length, and the loop failed to iterate over all original
subscribers. With this change, the subscriber list is cloned at the beginning,
and each subscribed function is called properly.

This fixes a real bug. A subscriber unsubscribing himself would cause later
subscribers in the list to never be called. This *may*, however, also be a
backward compatability breakage, in the rare case that an early subscriber
unsubscribes a later subscriber. Formerly, that later subscriber would not
have been called during this loop iteration. In the current implementation,
all subscribers originally in the list will be called.