### PR TITLE
Fix check if there is requestData to send

### DIFF
--- a/framework/source/class/qx/io/request/Xhr.js
+++ b/framework/source/class/qx/io/request/Xhr.js
@@ -254,7 +254,7 @@ qx.Class.define("qx.io.request.Xhr",
       }
 
       // By default, set content-type urlencoded for requests with body
-      if (this.getRequestData() !== "null" && isAllowsBody) {
+      if (this.getRequestData() && isAllowsBody) {
         headers["Content-Type"] = "application/x-www-form-urlencoded";
       }
 


### PR DESCRIPTION
the former comparison with "null" as string doesn't really make sense.