### PR TITLE
Firefox 66 handles keypress key/charCode the same way as other browsers

### DIFF
--- a/framework/source/class/qx/event/handler/Keyboard.js
+++ b/framework/source/class/qx/event/handler/Keyboard.js
@@ -446,10 +446,18 @@ qx.Class.define("qx.event.handler.Keyboard",
 
       "gecko" : function(domEvent)
       {
-        var charCode = domEvent.charCode;
-        var type = domEvent.type;
+        if(qx.core.Environment.get("engine.version") < 66) {
+          var charCode = domEvent.charCode;
+          var type = domEvent.type;
 
-        return this._idealKeyHandler(domEvent.keyCode, charCode, type, domEvent);
+           return this._idealKeyHandler(domEvent.keyCode, charCode, type, domEvent);
+        } else {
+          if (this._charCode2KeyCode[domEvent.keyCode]) {
+            return this._idealKeyHandler(this._charCode2KeyCode[domEvent.keyCode], 0, domEvent.type, domEvent);
+          } else {
+            return this._idealKeyHandler(0, domEvent.keyCode, domEvent.type, domEvent);
+          }
+        }
       },
 
       "webkit" : function(domEvent)
@@ -629,8 +637,7 @@ qx.Class.define("qx.event.handler.Keyboard",
     // register at the event handler
     qx.event.Registration.addHandler(statics);
 
-    if ((qx.core.Environment.get("engine.name") == "mshtml") ||
-      qx.core.Environment.get("engine.name") == "webkit")
+    if ((qx.core.Environment.get("engine.name") !== "opera"))
     {
       members._charCode2KeyCode =
       {


### PR DESCRIPTION
Firefox 66 handles keypress key/charCode the same way as other browsers. Fix for #9643 