### PR TITLE
use image size for Boolean table cell render, up to max (and default) 11x11

### DIFF
--- a/framework/source/class/qx/ui/table/cellrenderer/Boolean.js
+++ b/framework/source/class/qx/ui/table/cellrenderer/Boolean.js
@@ -131,12 +131,39 @@ qx.Class.define("qx.ui.table.cellrenderer.Boolean",
     // overridden
     _identifyImage : function(cellInfo)
     {
-      var imageHints =
+      var w;
+      var h;
+      var rm;
+      var id;
+      var ids;
+      var imageHints;
+
+      // Retrieve the ID
+      rm = qx.util.ResourceManager.getInstance();
+      ids = rm.getIds(this.__iconUrlTrue);
+
+      // If ID was found, we'll use its first (likely only) element here.
+      if (ids)
       {
-        imageWidth  : 11,
-        imageHeight : 11
+        id = ids[0];
+
+        // Get the natural size of the image
+        w = rm.getImageWidth(id);
+        h = rm.getImageHeight(id);
+      }
+
+      // Create the size portion of the hint.
+      //
+      // The traditional (fixed) size of the image was 11x11px. Use that if we
+      // weren't able to retrieve the actual size of the image, and never
+      // exceed that size.
+      imageHints =
+      {
+        imageWidth  : w ? Math.min(w, 11) : 11,
+        imageHeight : h ? Math.min(h, 11) : 11
       };
 
+      // Add the URL portion of the hint
       switch(cellInfo.value)
       {
         case true:


### PR DESCRIPTION
Fixes #9646. An image in the Boolean cell renderer was traditionally placed in an 11x11px box regardless of actual image size, and placed starting at the top-right corner of that 11x11px box. With the recent changes proposed in #9610 and merged in #9625, images smaller than 11x11 used in the Boolean cell renderer were stretched to fit the 11x11 box, causing a backward-compatibility break.

This change attempts to retrieve the actual image size, and use that size for the Boolean indication. If the actual image size can't be determined, as might be the case with an unmanaged image, the original 11x11 size is used.