### PR TITLE
Knobless splitpane

### DIFF
--- a/framework/source/class/qx/ui/splitpane/Pane.js
+++ b/framework/source/class/qx/ui/splitpane/Pane.js
@@ -102,6 +102,13 @@ qx.Class.define("qx.ui.splitpane.Pane",
       init  : "horizontal",
       check : [ "horizontal", "vertical" ],
       apply : "_applyOrientation"
+    },
+
+    displaySplitter :
+    {
+      init: true,
+      check: "Boolean",
+      apply: "_applyDisplaySplitter"
     }
   },
 
@@ -187,7 +194,7 @@ qx.Class.define("qx.ui.splitpane.Pane",
       // is removed.
       splitter.addListener("resize", function(e) {
         var bounds = e.getData();
-        if (bounds.height == 0 || bounds.width == 0) {
+        if (this.getDisplaySplitter() && (bounds.height == 0 || bounds.width == 0)) {
           this.__blocker.hide();
         } else {
           this.__blocker.show();
@@ -269,6 +276,9 @@ qx.Class.define("qx.ui.splitpane.Pane",
       this.__setBlockerPosition();
     },
 
+    _applyDisplaySplitter : function(value, old) {
+      this.getChildControl("splitter").getChildControl("knob").setVisibility(value ? "visible" : "excluded");
+    },
 
     /**
      * Helper for setting the blocker to the right position, which depends on
@@ -299,11 +309,11 @@ qx.Class.define("qx.ui.splitpane.Pane",
         }
         var left = bounds && bounds.left;
 
-        if (width) {
+        if (width || !this.getDisplaySplitter()) {
           if (isNaN(left)) {
             left = qx.bom.element.Location.getPosition(splitterElem).left;
           }
-          this.__blocker.setWidth(offset, width);
+          this.__blocker.setWidth(offset, width || 6);
           this.__blocker.setLeft(offset, left);
         }
 
@@ -318,11 +328,11 @@ qx.Class.define("qx.ui.splitpane.Pane",
         }
         var top =  bounds && bounds.top;
 
-        if (height) {
+        if (height || !this.getDisplaySplitter()) {
           if (isNaN(top)) {
             top = qx.bom.element.Location.getPosition(splitterElem).top;
           }
-          this.__blocker.setHeight(offset, height);
+          this.__blocker.setHeight(offset, height || 6);
           this.__blocker.setTop(offset, top);
         }
       }
@@ -411,10 +421,17 @@ qx.Class.define("qx.ui.splitpane.Pane",
       // Synchronize slider to splitter size and show it
       var slider = this.getChildControl("slider");
       var splitterBounds = splitter.getBounds();
-      slider.setUserBounds(
-        splitterBounds.left, splitterBounds.top,
-        splitterBounds.width, splitterBounds.height
-      );
+      if (this.getOrientation() === "vertical") {
+        slider.setUserBounds(
+          splitterBounds.left, splitterBounds.top,
+          splitterBounds.width, splitterBounds.height || 6
+        );
+      } else if (this.getOrientation() === "horizontal") {
+        slider.setUserBounds(
+          splitterBounds.left, splitterBounds.top,
+          splitterBounds.width || 6, splitterBounds.height
+        );
+      }
 
       slider.setZIndex(splitter.getZIndex() + 1);
       slider.show();

--- a/framework/source/class/qx/ui/splitpane/Pane.js
+++ b/framework/source/class/qx/ui/splitpane/Pane.js
@@ -102,17 +102,6 @@ qx.Class.define("qx.ui.splitpane.Pane",
       init  : "horizontal",
       check : [ "horizontal", "vertical" ],
       apply : "_applyOrientation"
-    },
-
-    /**
-     * The visibility of the splitter.
-     * Allows to remove the splitter in favor of other visual separation means like background color differences.
-     */
-    splitterVisible :
-    {
-      init: true,
-      check: "Boolean",
-      apply: "_applySplitterVisible"
     }
   },
 
@@ -198,7 +187,7 @@ qx.Class.define("qx.ui.splitpane.Pane",
       // is removed.
       splitter.addListener("resize", function(e) {
         var bounds = e.getData();
-        if (this.getSplitterVisible() && (bounds.height == 0 || bounds.width == 0)) {
+        if (this.getChildControl("splitter").getVisible() && (bounds.height == 0 || bounds.width == 0)) {
           this.__blocker.hide();
         } else {
           this.__blocker.show();
@@ -280,10 +269,6 @@ qx.Class.define("qx.ui.splitpane.Pane",
       this.__setBlockerPosition();
     },
 
-    _applySplitterVisible : function(value, old) {
-      this.getChildControl("splitter").getChildControl("knob").setVisibility(value ? "visible" : "excluded");
-    },
-
     /**
      * Helper for setting the blocker to the right position, which depends on
      * the offset, orientation and the current position of the splitter.
@@ -313,7 +298,7 @@ qx.Class.define("qx.ui.splitpane.Pane",
         }
         var left = bounds && bounds.left;
 
-        if (width || !this.getSplitterVisible()) {
+        if (width || !this.getChildControl("splitter").getVisible()) {
           if (isNaN(left)) {
             left = qx.bom.element.Location.getPosition(splitterElem).left;
           }
@@ -332,7 +317,7 @@ qx.Class.define("qx.ui.splitpane.Pane",
         }
         var top =  bounds && bounds.top;
 
-        if (height || !this.getSplitterVisible()) {
+        if (height || !this.getChildControl("splitter").getVisible()) {
           if (isNaN(top)) {
             top = qx.bom.element.Location.getPosition(splitterElem).top;
           }

--- a/framework/source/class/qx/ui/splitpane/Pane.js
+++ b/framework/source/class/qx/ui/splitpane/Pane.js
@@ -421,17 +421,10 @@ qx.Class.define("qx.ui.splitpane.Pane",
       // Synchronize slider to splitter size and show it
       var slider = this.getChildControl("slider");
       var splitterBounds = splitter.getBounds();
-      if (this.getOrientation() === "vertical") {
-        slider.setUserBounds(
-          splitterBounds.left, splitterBounds.top,
-          splitterBounds.width, splitterBounds.height || 6
-        );
-      } else if (this.getOrientation() === "horizontal") {
-        slider.setUserBounds(
-          splitterBounds.left, splitterBounds.top,
-          splitterBounds.width || 6, splitterBounds.height
-        );
-      }
+      slider.setUserBounds(
+        splitterBounds.left, splitterBounds.top,
+        splitterBounds.width || 6, splitterBounds.height || 6
+      );
 
       slider.setZIndex(splitter.getZIndex() + 1);
       slider.show();

--- a/framework/source/class/qx/ui/splitpane/Pane.js
+++ b/framework/source/class/qx/ui/splitpane/Pane.js
@@ -104,11 +104,11 @@ qx.Class.define("qx.ui.splitpane.Pane",
       apply : "_applyOrientation"
     },
 
-    displaySplitter :
+    splitterVisible :
     {
       init: true,
       check: "Boolean",
-      apply: "_applyDisplaySplitter"
+      apply: "_applySplitterVisible"
     }
   },
 
@@ -194,7 +194,7 @@ qx.Class.define("qx.ui.splitpane.Pane",
       // is removed.
       splitter.addListener("resize", function(e) {
         var bounds = e.getData();
-        if (this.getDisplaySplitter() && (bounds.height == 0 || bounds.width == 0)) {
+        if (this.getSplitterVisible() && (bounds.height == 0 || bounds.width == 0)) {
           this.__blocker.hide();
         } else {
           this.__blocker.show();
@@ -276,7 +276,7 @@ qx.Class.define("qx.ui.splitpane.Pane",
       this.__setBlockerPosition();
     },
 
-    _applyDisplaySplitter : function(value, old) {
+    _applySplitterVisible : function(value, old) {
       this.getChildControl("splitter").getChildControl("knob").setVisibility(value ? "visible" : "excluded");
     },
 
@@ -309,7 +309,7 @@ qx.Class.define("qx.ui.splitpane.Pane",
         }
         var left = bounds && bounds.left;
 
-        if (width || !this.getDisplaySplitter()) {
+        if (width || !this.getSplitterVisible()) {
           if (isNaN(left)) {
             left = qx.bom.element.Location.getPosition(splitterElem).left;
           }
@@ -328,7 +328,7 @@ qx.Class.define("qx.ui.splitpane.Pane",
         }
         var top =  bounds && bounds.top;
 
-        if (height || !this.getDisplaySplitter()) {
+        if (height || !this.getSplitterVisible()) {
           if (isNaN(top)) {
             top = qx.bom.element.Location.getPosition(splitterElem).top;
           }

--- a/framework/source/class/qx/ui/splitpane/Pane.js
+++ b/framework/source/class/qx/ui/splitpane/Pane.js
@@ -104,6 +104,10 @@ qx.Class.define("qx.ui.splitpane.Pane",
       apply : "_applyOrientation"
     },
 
+    /**
+     * The visibility of the splitter.
+     * Allows to remove the splitter in favor of other visual separation means like background color differences.
+     */
     splitterVisible :
     {
       init: true,

--- a/framework/source/class/qx/ui/splitpane/Splitter.js
+++ b/framework/source/class/qx/ui/splitpane/Splitter.js
@@ -56,7 +56,9 @@ qx.Class.define("qx.ui.splitpane.Splitter",
     }
 
     // create knob child control
-    this._createChildControl("knob");
+    if (this.getVisible()) {
+      this._createChildControl("knob");
+    }
   },
 
 
@@ -81,6 +83,17 @@ qx.Class.define("qx.ui.splitpane.Splitter",
     {
       refine : true,
       init : false
+    },
+    /**
+     * The visibility of the splitter.
+     * Allows to remove the splitter in favor of other visual separation means like background color differences.
+     */
+    visible :
+    {
+      init: true,
+      check: "Boolean",
+      themeable: true,
+      apply: "_applyVisible"
     }
   },
 
@@ -110,6 +123,10 @@ qx.Class.define("qx.ui.splitpane.Splitter",
       }
 
       return control || this.base(arguments, id);
+    },
+
+    _applyVisible: function(visible, old) {
+      this.getChildControl("knob").setVisibility(visible ? "visible" : "excluded");
     }
   }
 });


### PR DESCRIPTION
Allows the user to set a ``splitterVisible`` property in the splitpane to remove the splitter, still being able to resize the panes.
It is possible to set the visibility of the splitter in the theme:
```
"splitpane/splitter": {
   style: function(states) {
      return {
         visible: false
      };
   }
}
```
or programatically:
```
const splitpane = new qx.ui.splitpane.Pane("horizontal");
splitpane.getChildControl("splitter").setVisible(false);
```
![invisible-splitter](https://user-images.githubusercontent.com/4764217/55140853-55718700-5139-11e9-84d0-c8cab67e6ae9.gif)
In the screencast it might look that there is a splitter at the beginning, but it is actually just the padding for the inner content widget if that view.