### PR TITLE
Use background-size only when hi-res image is used.

### DIFF
--- a/framework/source/class/qx/ui/table/cellrenderer/AbstractImage.js
+++ b/framework/source/class/qx/ui/table/cellrenderer/AbstractImage.js
@@ -232,15 +232,15 @@ qx.Class.define("qx.ui.table.cellrenderer.AbstractImage",
     _getContentHtml : function(cellInfo)
     {
       var content = "<div></div>";
-
-      // background size is critical for high-resolution images
-      var backgroundSize = this.__imageData.width + "px " + this.__imageData.height + "px";
+      var backgroundSize = "auto auto";
 
       var srcUrl = this.__imageData.url;
       if (this.__imageData.url !== null)
       {
         var highResolutionSource = qx.util.ResourceManager.getInstance().findHighResolutionSource (this.__imageData.url);
         if (highResolutionSource) {
+          // background size is critical for high-resolution images
+          backgroundSize = this.__imageData.width + "px " + this.__imageData.height + "px";
           srcUrl = highResolutionSource;
         }
       }

--- a/framework/source/class/qx/ui/table/cellrenderer/AbstractImage.js
+++ b/framework/source/class/qx/ui/table/cellrenderer/AbstractImage.js
@@ -229,37 +229,29 @@ qx.Class.define("qx.ui.table.cellrenderer.AbstractImage",
 
 
     // overridden
-    _getContentHtml : function(cellInfo)
-    {
+    _getContentHtml : function(cellInfo) {
       var content = "<div></div>";
-      var backgroundSize = "auto auto";
-
-      var srcUrl = this.__imageData.url;
-      if (this.__imageData.url !== null)
-      {
-        var highResolutionSource = qx.util.ResourceManager.getInstance().findHighResolutionSource (this.__imageData.url);
-        if (highResolutionSource) {
-          // background size is critical for high-resolution images
-          backgroundSize = this.__imageData.width + "px " + this.__imageData.height + "px";
-          srcUrl = highResolutionSource;
-        }
-      }
-
       // set image
       if (this.__imageData.url) {
-        content = qx.bom.element.Decoration.create(
-          srcUrl,
-          this.getRepeat(),
-          {
+        var srcUrl = this.__imageData.url;
+        var highResolutionSource = qx.util.ResourceManager.getInstance().findHighResolutionSource(this.__imageData.url);
+        if (highResolutionSource) {
+          srcUrl = highResolutionSource;
+        }
+        var style = {
           width: this.__imageData.width + "px",
           height: this.__imageData.height + "px",
-          "background-size": backgroundSize,
           display: qx.core.Environment.get("css.inlineblock"),
           verticalAlign: "top",
           position: "static"
-        });
-      };
-      return content;    
+        }
+        if (qx.util.ResourceManager.getInstance().getCombinedFormat(this.__imageData.url) === "") {
+          // background size is critical for high-resolution images but breaks combined images
+          style["background-size"] = this.__imageData.width + "px " + this.__imageData.height + "px";
+        }
+        content = qx.bom.element.Decoration.create(srcUrl, this.getRepeat(), style);
+      }
+      return content;
     },
 
 


### PR DESCRIPTION
fixes issue #9653 
background-size was added while implementing support for high res images (to avoid clipped images?), so I guess it is safe to only add the exact size when a high res source is found.