### PR TITLE
remove chrome beta from test:

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -52,7 +52,7 @@ jobs:
       script: ../.travis/test Chrome_travis_ci      
     - stage: SL-Brower-Tests
       name: SL Chrome
-      script: ../.travis/test ChromeSL,ChromeBetaSL
+      script: ../.travis/test ChromeSL
     - #
       name: SL Firefox
       script: ../.travis/test FirefoxSL


### PR DESCRIPTION
....................09 04 2019 12:25:53.879:ERROR [launcher.sauce]: Can not start chrome beta (Windows 10)

[init({"version":"beta","platform":"Windows 10","tags":[],"name":"Qooxdoo Unit-Tests","tunnel-identifier":"1572.5","record-video":false,"record-screenshots":false,"device-orientation":null,"disable-popup-handler":true,"build":"1572","public":"public","commandTimeout":300,"idleTimeout":90,"maxDuration":1800,"customData":{},"base":"SauceLabs","browserName":"chrome"})] The environment you requested was unavailable.

session not created: Chrome version must be between 70 and 73

(Driver info: chromedriver=2.45.615291 (ec3682e3c9061c10f26ea9e5cdcf3c53f3f74387),platform=Windows NT 10.0.10586 x86_64)

{"status": 33, "sessionId": "3790b55863784e5f9f26d00c7a21c7a9", "value": {"message": "session not created: Chrome version must be between 70 and 73\n (Driver info: chromedriver=2.45.615291 (ec3682e3c9061c10f26ea9e5cdcf3c53f3f74387),platform=Windows NT 10.0.10586 x86_64)", "webdriver.remote.sessionid": "3790b55863784e5f9f26d00c7a21c7a9", "hasMetadata": true}}