### PR TITLE
urgent: fix missing type in compile.json. 

### DIFF
--- a/compile.json
+++ b/compile.json
@@ -20,7 +20,7 @@
     {
       "class": "qx.application.Native",
       "name": "qx_server",
-	  "theme": "",
+	  "type": "node",
       "environment": {
         "qx.debug": false
       },


### PR DESCRIPTION
Default is "web", with this…the npm package will not work!
We should merge this as soon as possible.