### PR TITLE
qooxdoo npm source package should live under source.

### DIFF
--- a/.travis/deploy_npm
+++ b/.travis/deploy_npm
@@ -40,6 +40,8 @@ exe npx qx --version
 exe npm update --no-save @qooxdoo/compiler 
 exe npx qx --version
 exe npx qx compile -v
+exe mkdir source
+exe cp -rf ./framework/source/* ./source
 
 
 # fill .npmrc with access token

--- a/package.json
+++ b/package.json
@@ -18,12 +18,14 @@
     "Manifest.json",
     "lib/qx_server",
     "lib/resource",
-    "framework/source",
+    "source/class",
+    "source/resource",
+    "source/translation",
     "tool/data/cldr",
     "docs"
   ],
   "devDependencies": {
-    "@qooxdoo/compiler": "^1.0.0-beta.20190521-1557",
+    "@qooxdoo/compiler": "^1.0.0-beta",
     "remark-cli": "^6.0.1",
     "remark-lint-no-dead-urls": "^0.4.1",
     "remark-preset-lint-recommended": "^3.0.2",


### PR DESCRIPTION
 like all other packages.

This will copy framework/source to source while building package.
See https://github.com/qooxdoo/qooxdoo-compiler/issues/450