### PR TITLE
Fix failed attempt to add symlink to current docs

### DIFF
--- a/.travis/deploy_website
+++ b/.travis/deploy_website
@@ -44,9 +44,9 @@ if [ $CURRENT = 1 ]; then
   rm -f current
   ln -s "$TARGET" current
 fi
-# global /docs reflects master
+# global /docs shows documentation of current master
 rm -f docs 
-ln -s "$TARGET"/docs docs
+ln -s deploy/$(cat ./version.txt)/docs docs
 
 
 touch .nojekyll


### PR DESCRIPTION
I had linked to the python framework folder before. Thanks to @hkollmann for pointing this out!