### PR TITLE
Fix docs: framework does not need to be installed

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -38,7 +38,7 @@ The following command line installs the qooxdoo compiler so that it becomes
 available via your path settings.
 
 ```bash
-$ npm install -g @qooxdoo/compiler @qooxdoo/framework
+$ npm install -g @qooxdoo/compiler
 ```
 
 To start the qooxdoo compiler type


### PR DESCRIPTION
... when installing the compiler, since the compiler comes with its own copy of the framework