### PR TITLE
[ci skip] Update documentation

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -58,7 +58,7 @@ code.
 $ mkdir myapp
 $ cd myapp
 $ npm init
-$ npm install --save-dev @qooxdoo/compiler @qooxdoo/framework
+$ npm install --save-dev @qooxdoo/compiler
 $ ls
 node_modules      package-lock.json package.json
 ```

--- a/docs/README.md
+++ b/docs/README.md
@@ -35,7 +35,7 @@ or you can install it globally.
 ### Global installation
 
 The following command line installs the qooxdoo compiler so that it becomes
-available via your path settings.
+available anywhere via your path settings.
 
 ```bash
 $ npm install -g @qooxdoo/compiler
@@ -60,7 +60,7 @@ $ cd myapp
 $ npm init
 $ npm install --save-dev @qooxdoo/compiler
 $ ls
-node_modules      package-lock.json package.json
+node_modules package-lock.json package.json
 ```
 
 To start the qooxdoo compiler type


### PR DESCRIPTION
Installing framework package explicitly is not necessary since compiler does it implicitly