### PR TITLE
Added warning when an object in the property chain has a property but no corresponding event

### DIFF
--- a/framework/source/class/qx/data/SingleValueBinding.js
+++ b/framework/source/class/qx/data/SingleValueBinding.js
@@ -150,19 +150,29 @@ qx.Class.define("qx.data.SingleValueBinding",
       try {
         // go through all property names
         for (var i = 0; i < propertyNames.length; i++) {
+          var propertyName = propertyNames[i];
+
           // check for the array
           if (arrayIndexValues[i] !== "") {
             // push the array change event
             eventNames.push("change");
           } else {
-            var eventName = this.__getEventNameForProperty(source, propertyNames[i]);
+            var eventName = this.__getEventNameForProperty(source, propertyName);
             if (!eventName) {
               if (i == 0) { // the root property can not change --> error
                 throw new qx.core.AssertionError(
-                  "Binding property " + propertyNames[i] + " of object " + source +
-                  " not possible: No event available. "
+                  "Binding property " + propertyName + " of object " + source +
+                  " not possible: No event available. Full property chain: " + sourcePropertyChain
                 );
               }
+
+              if (source instanceof qx.core.Object && qx.Class.hasProperty(source.constructor, propertyName)) {
+                qx.log.Logger.warn(
+                  "Binding property " + propertyName + " of object " + source +
+                  " not possible: No event available. Full property chain: " + sourcePropertyChain
+                );
+              }
+
               // call the converter if no event could be found on binding creation
               initialPromise = this.__setInitialValue(undefined, targetObject, targetPropertyChain, options, sourceObject);
               break;


### PR DESCRIPTION
When binding a source object to a target using a property chain, and a source in that chain has the correct property, but does not have an event defined for it, this PR will make sure a warning gets logged. This saves a lot of time debugging.

This problem surfaced because I was missing an event for a property that was used in a VirtualTree. The VirtualTree uses the labelPath that was set, to bind the label of the item to the VirtualTreeItem label. It uses a property chain like: `[0].labelPath` where `labelPath` would be set by your own code.