### PR TITLE
ECMAScript BigInt environment checks

### DIFF
--- a/framework/source/class/qx/bom/client/EcmaScript.js
+++ b/framework/source/class/qx/bom/client/EcmaScript.js
@@ -303,8 +303,36 @@ qx.Bootstrap.define("qx.bom.client.EcmaScript",
     getStringTrim : function() {
       return typeof String.prototype.trim === "function";
     },
-    
-    
+
+
+    /**
+     * Checks if 'BigInt' type is supported.
+     * @internal
+     * @ignore(BigInt)
+     * @return {Boolean} <code>true</code>, if BigInt is available.
+     */
+    getBigInt : function() {
+      return typeof BigInt != "undefined";
+    },
+
+
+    /**
+     * Checks if 'toLocaleString' is supported on the BigInt object and whether
+     * it actually works
+     * @internal
+     * @ignore(BigInt)
+     * @ignore(BigInt.prototype.toLocaleString)
+     * @return {Boolean} <code>true</code>, if the method is supported and
+     *   works at least rudimentary.
+     */
+    getBigIntToLocaleString : function()
+    {
+      return typeof BigInt != "undefined"                          // BigInt type supported...
+          && typeof BigInt.prototype.toLocaleString === "function"// ...method is present...
+          && (BigInt(1234).toLocaleString("de-DE") === "1,234"); // ...and works as expected
+    },
+
+
     /**
      * Checks whether Native promises are available
      */
@@ -365,6 +393,10 @@ qx.Bootstrap.define("qx.bom.client.EcmaScript",
 
     // MutationObserver
     qx.core.Environment.add("ecmascript.mutationobserver", statics.getMutationObserver);
+
+    // BigInt
+    qx.core.Environment.add("ecmascript.bigint", statics.getBigInt);
+    qx.core.Environment.add("ecmascript.bigint.tolocalestring", statics.getBigIntToLocaleString);
 
     // Promises
     qx.core.Environment.add("ecmascript.promise.native", statics.getPromiseNative);

--- a/framework/source/class/qx/bom/client/EcmaScript.js
+++ b/framework/source/class/qx/bom/client/EcmaScript.js
@@ -312,7 +312,7 @@ qx.Bootstrap.define("qx.bom.client.EcmaScript",
      * @return {Boolean} <code>true</code>, if BigInt is available.
      */
     getBigInt : function() {
-      return typeof BigInt != "undefined";
+      return typeof BigInt !== "undefined";
     },
 
 
@@ -327,7 +327,7 @@ qx.Bootstrap.define("qx.bom.client.EcmaScript",
      */
     getBigIntToLocaleString : function()
     {
-      return typeof BigInt != "undefined"                          // BigInt type supported...
+      return typeof BigInt !== "undefined"                         // BigInt type supported...
           && typeof BigInt.prototype.toLocaleString === "function"// ...method is present...
           && (BigInt(1234).toLocaleString("de-DE") === "1,234"); // ...and works as expected
     },

--- a/framework/source/class/qx/core/Environment.js
+++ b/framework/source/class/qx/core/Environment.js
@@ -234,6 +234,14 @@
  *       <td>{@link qx.bom.client.EcmaScript#getMutationObserver}</td>
  *     </tr>
  *     <tr>
+ *       <td>ecmascript.bigint</td><td><i>Boolean</i></td><td><code>true</code></td>
+ *       <td>{@link qx.bom.client.EcmaScript#getBigInt}</td>
+ *     </tr>
+ *     <tr>
+ *       <td>ecmascript.bigint.tolocalestring</td><td><i>Boolean</i></td><td><code>true</code></td>
+ *       <td>{@link qx.bom.client.EcmaScript#getBigIntToLocaleString}</td>
+ *     </tr>
+ *     <tr>
  *       <td>ecmascript.array.indexof<td><i>Boolean</i></td><td><code>true</code></td>
  *       <td>{@link qx.bom.client.EcmaScript#getArrayIndexOf}</td>
  *     </tr>


### PR DESCRIPTION
As I found that the ECMAScript `BigInt` object[1] is getting supported by the current major desktop browsers[2], I think environment checks for it could be nice.

While using `BigInt` in my code, I found that `toLocaleString` does not work on current FF[3], so I added an additional check for that, too.


------
[1] ECMAScript NEXT
[2] https://kangax.github.io/compat-table/esnext/#test-BigInt
[3] Firefox Quantum 68.0.2 (32-bit)