### PR TITLE
Fix bind length from data array (BZ#8169) #8197

### DIFF
--- a/framework/source/class/qx/data/SingleValueBinding.js
+++ b/framework/source/class/qx/data/SingleValueBinding.js
@@ -373,7 +373,7 @@ qx.Class.define("qx.data.SingleValueBinding",
         // if its the last property
         if (j == context.propertyNames.length - 1) {
           // if its an array
-          if (qx.Class.implementsInterface(source, qx.data.IListData) && context.arrayIndexValues[i] !== "") {
+          if (qx.Class.implementsInterface(source, qx.data.IListData) && context.arrayIndexValues[j] !== "") {
             // set the initial value
             var itemIndex = context.arrayIndexValues[j] === "last" ?
               source.length - 1 : context.arrayIndexValues[j];

--- a/framework/source/class/qx/data/SingleValueBinding.js
+++ b/framework/source/class/qx/data/SingleValueBinding.js
@@ -373,7 +373,7 @@ qx.Class.define("qx.data.SingleValueBinding",
         // if its the last property
         if (j == context.propertyNames.length - 1) {
           // if its an array
-          if (qx.Class.implementsInterface(source, qx.data.IListData)) {
+          if (qx.Class.implementsInterface(source, qx.data.IListData) && context.arrayIndexValues[i] !== "") {
             // set the initial value
             var itemIndex = context.arrayIndexValues[j] === "last" ?
               source.length - 1 : context.arrayIndexValues[j];


### PR DESCRIPTION
Fix issue #8197

When you bind on the length of an array and the array instance is replaced by another in the object holding the array the bind isn't correctly updated to the new length but bind on array[0] instead.

This is because __chainListener incorrectly assume that if qx.Class.implementsInterface(source, qx.data.IListData) is true, it is always binding on an item.