### PR TITLE
Add qx.command.bindEnabled option

### DIFF
--- a/framework/source/class/qx/core/Environment.js
+++ b/framework/source/class/qx/core/Environment.js
@@ -914,7 +914,8 @@ qx.Bootstrap.define("qx.core.Environment",
       "qx.automaticMemoryManagement": true,
       "qx.promise": true,
       "qx.promise.warnings": true,
-      "qx.promise.longStackTraces": true
+      "qx.promise.longStackTraces": true,
+      "qx.command.bindEnabled": false
     },
 
     /**

--- a/framework/source/class/qx/test/ui/command/Command.js
+++ b/framework/source/class/qx/test/ui/command/Command.js
@@ -86,19 +86,21 @@ qx.Class.define("qx.test.ui.command.Command",
 
     testEnabled : function()
     {
-      this.skip("Skipped because not relevant anymore");
+      if (qx.core.Environment.get("qx.command.bindEnabled")) {
+        // set disabled
+        this.__cmd.setEnabled(false);
+        this.assertEquals(this.__cmd.getEnabled(), this.__button.getEnabled());
+        this.assertEquals(this.__cmd.getEnabled(), this.__toolbarButton.getEnabled());
+        this.assertEquals(this.__cmd.getEnabled(), this.__menuButton.getEnabled());
 
-      // set disabled
-      this.__cmd.setEnabled(false);
-      this.assertEquals(this.__cmd.getEnabled(), this.__button.getEnabled());
-      this.assertEquals(this.__cmd.getEnabled(), this.__toolbarButton.getEnabled());
-      this.assertEquals(this.__cmd.getEnabled(), this.__menuButton.getEnabled());
-
-      // set enabled
-      this.__cmd.setEnabled(true);
-      this.assertEquals(this.__cmd.getEnabled(), this.__button.getEnabled());
-      this.assertEquals(this.__cmd.getEnabled(), this.__toolbarButton.getEnabled());
-      this.assertEquals(this.__cmd.getEnabled(), this.__menuButton.getEnabled());
+        // set enabled
+        this.__cmd.setEnabled(true);
+        this.assertEquals(this.__cmd.getEnabled(), this.__button.getEnabled());
+        this.assertEquals(this.__cmd.getEnabled(), this.__toolbarButton.getEnabled());
+        this.assertEquals(this.__cmd.getEnabled(), this.__menuButton.getEnabled());
+      } else {
+        this.skip("Skipped because binding the Enabled property has been deprecated");
+      }
     },
 
 

--- a/framework/source/class/qx/ui/core/MExecutable.js
+++ b/framework/source/class/qx/ui/core/MExecutable.js
@@ -80,15 +80,23 @@ qx.Mixin.define("qx.ui.core.MExecutable",
      *
      * @lint ignoreReferenceField(_bindableProperties)
      */
-    _bindableProperties :
-    [
-      "label",
-      "icon",
-      "toolTipText",
-      "value",
-      "menu"
-    ],
-
+    _bindableProperties : qx.core.Environment.select("qx.command.bindEnabled", {
+      "true": [
+          "enabled",
+          "label",
+          "icon",
+          "toolTipText",
+          "value",
+          "menu"
+        ],
+      "false": [
+          "label",
+          "icon",
+          "toolTipText",
+          "value",
+          "menu"
+        ]
+    }),
 
     /**
      * Initiate the execute action.


### PR DESCRIPTION
With the submission of PR https://github.com/qooxdoo/qooxdoo/pull/9275, the enabled property of a Command button was no longer bound to the buttons to which the Command had been associated. This PR adds a "qx.command.bindEnabled" option such that the legacy behaviour of binding the enabled property of buttons to command objects can be re-enabled if so desired.