### PR TITLE
Reset user data of objects returned to the ObjectPool.

### DIFF
--- a/framework/source/class/qx/util/ObjectPool.js
+++ b/framework/source/class/qx/util/ObjectPool.js
@@ -185,6 +185,10 @@ qx.Class.define("qx.util.ObjectPool",
         return;
       }
 
+      // Reset all user data when the object is returned to the pool.
+      // The next consumer should expect a clean object.
+      obj.resetUserData();
+      
       obj.$$pooled = true;
       pool.push(obj);
     }


### PR DESCRIPTION
If an app uses the ObjectPool to pool objects when getting an instance out of the pool the consumer should expect a clean object. A case in point would to use setUserData() on an event to handle custom information in a propagation chain. When the object is pooled and reused for the next event the user data should be empty.