### PR TITLE
add support for breaking within words in labels

### DIFF
--- a/framework/source/class/qx/bom/Label.js
+++ b/framework/source/class/qx/bom/Label.js
@@ -37,7 +37,8 @@ qx.Bootstrap.define("qx.bom.Label",
       fontSize : 1,
       fontWeight : 1,
       fontStyle : 1,
-      lineHeight : 1
+      lineHeight : 1,
+      wordBreak : 1
     },
 
 

--- a/framework/source/class/qx/ui/basic/Label.js
+++ b/framework/source/class/qx/ui/basic/Label.js
@@ -123,6 +123,21 @@ qx.Class.define("qx.ui.basic.Label",
       init : true,
       apply : "_applyWrap"
     },
+    
+    
+    /**
+     * Controls whether line wrapping can occur in the middle of a word; this is
+     * typically only useful when there is a restricted amount of horizontal space
+     * and words would otherwise overflow beyond the width of the element.  Words
+     * are typically considered as separated by spaces, so "abc/def/ghi" is a 11 
+     * character word that would not be split without `breakWithWords` set to true. 
+     */
+    breakWithinWords :
+    {
+      check : "Boolean",
+      init : false,
+      apply : "_applyBreakWithinWords"
+    },
 
 
     /**
@@ -391,6 +406,9 @@ qx.Class.define("qx.ui.basic.Label",
       if (this.__webfontListenerId) {
         this.__fixEllipsis();
       }
+      if (rich && this.getBreakWithinWords()) {
+        styles.wordBreak = "break-all";
+      }
 
       return rich ?
         Label.getHtmlSize(content, styles, width) :
@@ -485,6 +503,13 @@ qx.Class.define("qx.ui.basic.Label",
         // to wrap if wrap is set to false [BUG #3732]
         var whiteSpace = value ? "normal" : "nowrap";
         this.getContentElement().setStyle("whiteSpace", whiteSpace);
+      }
+    },
+    
+    // property apply
+    _applyBreakWithinWords : function(value, old) {
+      if (this.isRich()) {
+        this.getContentElement().setStyle("wordBreak", value ? "break-all" : "normal");
       }
     },
 


### PR DESCRIPTION
If you have a label with very little horizontal space (eg a table of some kind) and a user keys in a long bit of text, label will word wrap and calculate the height including the word wrap; however, words are space delimited, and users can enter values like "Netherlands/Belgium/Germany" and the  browser will not wrap because there are no spaces - instead the label is truncated at maximum width.

This PR add a property to label `breakWithinWords` which allows words to be broken; it defaults to `false` to avoid BC issues.

