### PR TITLE
fix regression causing circular load time dependency

### DIFF
--- a/framework/source/class/qx/Bootstrap.js
+++ b/framework/source/class/qx/Bootstrap.js
@@ -212,7 +212,30 @@ qx.Bootstrap = {
     }
 
     return clazz;
+  },
+  
+  /**
+   * Tests whether an object is an instance of qx.core.Object without using instanceof - this
+   * is only for certain low level instances which would otherwise cause a circular, load time 
+   * dependency
+   * 
+   * @param object {Object?} the object to test
+   * @return {Boolean} true if object is an instance of qx.core.Object
+   */
+  isQxCoreObject: function(object) {
+    if (object === object.constructor) {
+      return false;
+    }
+    var clz = object.constructor;
+    while (clz) {
+      if (clz.classname === "qx.core.Object") {
+        return true;
+      }
+      clz = clz.superclass;
+    }
+    return false;
   }
+
 };
 
 
@@ -335,6 +358,17 @@ qx.Bootstrap.define("qx.Bootstrap",
     define : qx.Bootstrap.define,
 
 
+    /**
+     * Tests whether an object is an instance of qx.core.Object without using instanceof - this
+     * is only for certain low level instances which would otherwise cause a circular, load time 
+     * dependency
+     * 
+     * @param object {Object?} the object to test
+     * @return {Boolean} true if object is an instance of qx.core.Object
+     */
+    isQxCoreObject: qx.Bootstrap.isQxCoreObject,
+    
+    
     /**
      * Sets the display name of the given function
      *

--- a/framework/source/class/qx/Class.js
+++ b/framework/source/class/qx/Class.js
@@ -1224,7 +1224,7 @@ qx.Bootstrap.define("qx.Class",
       }
       
       if (qx.core.Environment.get("qx.debug")) {
-        if (properties instanceof qx.core.Object) {
+        if (qx.Bootstrap.isQxCoreObject(properties)) {
           throw new Error("Invalid 'properties' for " + clazz.classname);
         }
       }

--- a/framework/source/class/qx/log/Logger.js
+++ b/framework/source/class/qx/log/Logger.js
@@ -578,22 +578,7 @@ qx.Bootstrap.define("qx.log.Logger",
       // Add relation fields
       if (object)
       {
-        // Do not explicitly check for instanceof qx.core.Object, in order not
-        // to introduce an unwanted load-time dependency
-        function isQxCoreObject(object) {
-          if (object === object.constructor) {
-            return false;
-          }
-          var clz = object.constructor;
-          while (clz) {
-            if (clz.classname === "qx.core.Object") {
-              return true;
-            }
-            clz = clz.superclass;
-          }
-          return false;
-        }
-        if (isQxCoreObject(object)) {
+        if (qx.Bootstrap.isQxCoreObject(object)) {
           entry.object = object.toHashCode();
         }
         if (object.$$type) {


### PR DESCRIPTION
fixes a bug in the last commit where the generator will complain about circular dependencies:

```
>>> Collecting classes  /
  - Warning: Detected circular dependency between: qx.event.Manager and qx.core.Object
<type 'exceptions.RuntimeError'> :
Circular class dependencies
```