### PR TITLE
fixes a bug with mixins when added via `qx.Class.patch`

### DIFF
--- a/framework/source/class/qx/Class.js
+++ b/framework/source/class/qx/Class.js
@@ -1633,50 +1633,6 @@ qx.Bootstrap.define("qx.Class",
 
 
     /**
-     * Checks if the constructor needs to be wrapped.
-     *
-     * @param base {Class} The base class.
-     * @param mixins {Mixin[]} All mixins which should be included.
-     * @param type {String} the type of the class
-     * @return {Boolean} true, if the constructor needs to be wrapped.
-     */
-    __needsConstructorWrapper : function(base, mixins, type)
-    {
-      if (qx.core.Environment.get("qx.debug")) {
-        if (type === "abstract" || type === "singleton") {
-          return true;
-        }
-      }
-      
-      // Check for base class mixin constructors
-      if (base && base.$$includes)
-      {
-        var baseMixins=base.$$flatIncludes;
-        for (var i=0, l=baseMixins.length; i<l; i++)
-        {
-          if (baseMixins[i].$$constructor) {
-            return true;
-          }
-        }
-      }
-
-      // check for direct mixin constructors
-      if (mixins)
-      {
-        var flatMixins = qx.Mixin.flatten(mixins);
-        for (var i=0, l=flatMixins.length; i<l; i++)
-        {
-          if (flatMixins[i].$$constructor) {
-            return true;
-          }
-        }
-      }
-
-      return false;
-    },
-
-
-    /**
      * Generate a wrapper of the original class constructor in order to enable
      * some of the advanced OO features (e.g. abstract class, singleton, mixins)
      *

--- a/framework/source/class/qx/test/Mixin.js
+++ b/framework/source/class/qx/test/Mixin.js
@@ -303,13 +303,34 @@ qx.Class.define("qx.test.Mixin",
       this.assertArrayEquals([ "root", "base", "mixin-one", "mixin-two", "derived" ], objPatched.state);
       this.assertEquals("mixin-one:derived", objPatched.getSomething());
       
+      var objBaseBoth = new qx.test.testclasses.BaseClassBoth();
+      this.assertArrayEquals([ "root", "base", "mixin-one", "mixin-two" ], objBaseBoth.state);
+      this.assertEquals("mixin-one", objBaseBoth.getSomething());
+      
       var objBoth = new qx.test.testclasses.DerivedClassBoth();
       this.assertArrayEquals([ "root", "base", "mixin-one", "mixin-two", "derived" ], objBoth.state);
       this.assertEquals("mixin-one:derived", objBoth.getSomething());
       
+      this.assertTrue(objBaseIncluded.constructor === qx.test.testclasses.BaseClassIncluded);
       this.assertTrue(objIncluded.constructor === qx.test.testclasses.DerivedClassIncluded);
+      this.assertTrue(objBasePatched.constructor === qx.test.testclasses.BaseClassPatched);
       this.assertTrue(objPatched.constructor === qx.test.testclasses.DerivedClassPatched);
+      this.assertTrue(objBaseBoth.constructor === qx.test.testclasses.BaseClassBoth);
       this.assertTrue(objBoth.constructor === qx.test.testclasses.DerivedClassBoth);
+      
+      this.assertTrue(objBaseIncluded instanceof qx.test.testclasses.BaseClassIncluded);
+      this.assertTrue(objIncluded instanceof qx.test.testclasses.DerivedClassIncluded);
+      this.assertTrue(objIncluded instanceof qx.test.testclasses.BaseClassIncluded);
+      this.assertTrue(objBasePatched instanceof qx.test.testclasses.BaseClassPatched);
+      this.assertTrue(objPatched instanceof qx.test.testclasses.BaseClassPatched);
+      this.assertTrue(objPatched instanceof qx.test.testclasses.DerivedClassPatched);
+      this.assertTrue(objBaseBoth instanceof qx.test.testclasses.BaseClassBoth);
+      this.assertTrue(objBoth instanceof qx.test.testclasses.BaseClassBoth);
+      this.assertTrue(objBoth instanceof qx.test.testclasses.DerivedClassBoth);
+      
+      this.assertTrue(objBaseIncluded instanceof qx.test.testclasses.RootClass);
+      this.assertTrue(objBaseBoth instanceof qx.test.testclasses.RootClass);
+      this.assertTrue(objPatched instanceof qx.test.testclasses.RootClass);
     }
   }
 });

--- a/framework/source/class/qx/test/Mixin.js
+++ b/framework/source/class/qx/test/Mixin.js
@@ -277,6 +277,39 @@ qx.Class.define("qx.test.Mixin",
       this.assertEquals("++bar__foo", o.foo());
       o.__b.dispose();
       o.dispose();
+    },
+    
+    testPatchConstructors: function() {
+      this.assertTrue(qx.test.testclasses.BaseClassIncluded.constructor === qx.test.testclasses.BaseClassIncluded);
+      this.assertTrue(qx.test.testclasses.BaseClassPatched.constructor === qx.test.testclasses.BaseClassPatched);
+      this.assertTrue(qx.test.testclasses.BaseClassBoth.constructor === qx.test.testclasses.BaseClassBoth);
+      this.assertTrue(qx.test.testclasses.DerivedClassIncluded.constructor === qx.test.testclasses.DerivedClassIncluded);
+      this.assertTrue(qx.test.testclasses.DerivedClassPatched.constructor === qx.test.testclasses.DerivedClassPatched);
+      this.assertTrue(qx.test.testclasses.DerivedClassBoth.constructor === qx.test.testclasses.DerivedClassBoth);
+
+      var objBaseIncluded = new qx.test.testclasses.BaseClassIncluded();
+      this.assertArrayEquals([ "root", "base", "mixin-one", "mixin-two" ], objBaseIncluded.state);
+      this.assertEquals("mixin-one", objBaseIncluded.getSomething());
+
+      var objIncluded = new qx.test.testclasses.DerivedClassIncluded();
+      this.assertArrayEquals([ "root", "base", "mixin-one", "mixin-two", "derived" ], objIncluded.state);
+      this.assertEquals("mixin-one:derived", objIncluded.getSomething());
+
+      var objBasePatched = new qx.test.testclasses.BaseClassPatched();
+      this.assertArrayEquals([ "root", "base", "mixin-one", "mixin-two" ], objBasePatched.state);
+      this.assertEquals("mixin-one", objBasePatched.getSomething());
+      
+      var objPatched = new qx.test.testclasses.DerivedClassPatched();
+      this.assertArrayEquals([ "root", "base", "mixin-one", "mixin-two", "derived" ], objPatched.state);
+      this.assertEquals("mixin-one:derived", objPatched.getSomething());
+      
+      var objBoth = new qx.test.testclasses.DerivedClassBoth();
+      this.assertArrayEquals([ "root", "base", "mixin-one", "mixin-two", "derived" ], objBoth.state);
+      this.assertEquals("mixin-one:derived", objBoth.getSomething());
+      
+      this.assertTrue(objIncluded.constructor === qx.test.testclasses.DerivedClassIncluded);
+      this.assertTrue(objPatched.constructor === qx.test.testclasses.DerivedClassPatched);
+      this.assertTrue(objBoth.constructor === qx.test.testclasses.DerivedClassBoth);
     }
   }
 });

--- a/framework/source/class/qx/test/testclasses/BaseClassBoth.js
+++ b/framework/source/class/qx/test/testclasses/BaseClassBoth.js
@@ -1,0 +1,13 @@
+qx.Class.define("qx.test.testclasses.BaseClassBoth", {
+  extend: qx.test.testclasses.RootClass,
+  include: [ qx.test.testclasses.MMixinOne ],
+  
+  construct: function() {
+    this.base(arguments);
+    this.state.push("base");
+  },
+  
+  defer: function() {
+    qx.Class.patch(qx.test.testclasses.BaseClassBoth, qx.test.testclasses.MMixinTwo);
+  }
+});

--- a/framework/source/class/qx/test/testclasses/BaseClassIncluded.js
+++ b/framework/source/class/qx/test/testclasses/BaseClassIncluded.js
@@ -1,0 +1,10 @@
+qx.Class.define("qx.test.testclasses.BaseClassIncluded", {
+  extend: qx.test.testclasses.RootClass,
+  include: [ qx.test.testclasses.MMixinOne, qx.test.testclasses.MMixinTwo ],
+  
+  construct: function() {
+    this.base(arguments);
+    this.state.push("base");
+  }
+  
+});

--- a/framework/source/class/qx/test/testclasses/BaseClassPatched.js
+++ b/framework/source/class/qx/test/testclasses/BaseClassPatched.js
@@ -1,0 +1,13 @@
+qx.Class.define("qx.test.testclasses.BaseClassPatched", {
+  extend: qx.test.testclasses.RootClass,
+  
+  construct: function() {
+    this.base(arguments);
+    this.state.push("base");
+  },
+  
+  defer: function() {
+    qx.Class.patch(qx.test.testclasses.BaseClassPatched, qx.test.testclasses.MMixinOne);
+    qx.Class.patch(qx.test.testclasses.BaseClassPatched, qx.test.testclasses.MMixinTwo);
+  }
+});

--- a/framework/source/class/qx/test/testclasses/DerivedClassBoth.js
+++ b/framework/source/class/qx/test/testclasses/DerivedClassBoth.js
@@ -1,0 +1,14 @@
+qx.Class.define("qx.test.testclasses.DerivedClassBoth", {
+  extend: qx.test.testclasses.BaseClassBoth,
+  
+  construct: function() {
+    this.base(arguments);
+    this.state.push("derived");
+  },
+  
+  members: {
+    getSomething: function() {
+      return this.base(arguments) + ":derived";
+    }
+  }
+});

--- a/framework/source/class/qx/test/testclasses/DerivedClassIncluded.js
+++ b/framework/source/class/qx/test/testclasses/DerivedClassIncluded.js
@@ -1,0 +1,14 @@
+qx.Class.define("qx.test.testclasses.DerivedClassIncluded", {
+  extend: qx.test.testclasses.BaseClassIncluded,
+  
+  construct: function() {
+    this.base(arguments);
+    this.state.push("derived");
+  },
+  
+  members: {
+    getSomething: function() {
+      return this.base(arguments) + ":derived";
+    }
+  }
+});

--- a/framework/source/class/qx/test/testclasses/DerivedClassPatched.js
+++ b/framework/source/class/qx/test/testclasses/DerivedClassPatched.js
@@ -1,0 +1,14 @@
+qx.Class.define("qx.test.testclasses.DerivedClassPatched", {
+  extend: qx.test.testclasses.BaseClassPatched,
+  
+  construct: function() {
+    this.base(arguments);
+    this.state.push("derived");
+  },
+  
+  members: {
+    getSomething: function() {
+      return this.base(arguments) + ":derived";
+    }
+  }
+});

--- a/framework/source/class/qx/test/testclasses/MMixinOne.js
+++ b/framework/source/class/qx/test/testclasses/MMixinOne.js
@@ -1,0 +1,12 @@
+qx.Mixin.define("qx.test.testclasses.MMixinOne", {
+  construct: function() {
+    qx.core.Assert.assertTrue(this.state !== null);
+    this.state.push("mixin-one");
+  },
+  
+  members: {
+    getSomething: function() {
+      return "mixin-one";
+    }
+  }
+});

--- a/framework/source/class/qx/test/testclasses/MMixinTwo.js
+++ b/framework/source/class/qx/test/testclasses/MMixinTwo.js
@@ -1,0 +1,6 @@
+qx.Mixin.define("qx.test.testclasses.MMixinTwo", {
+  construct: function() {
+    qx.core.Assert.assertTrue(this.state !== null);
+    this.state.push("mixin-two");
+  }
+});

--- a/framework/source/class/qx/test/testclasses/RootClass.js
+++ b/framework/source/class/qx/test/testclasses/RootClass.js
@@ -1,0 +1,17 @@
+qx.Class.define("qx.test.testclasses.RootClass", {
+  extend: qx.core.Object,
+  
+  construct: function() {
+    this.base(arguments);
+    qx.core.Assert.assertTrue(this.state === null);
+    this.state = [ "root" ];
+  },
+  
+  members: {
+    state: null,
+    
+    getSomething: function() {
+      return "root";
+    }
+  }
+});


### PR DESCRIPTION
This PR fixes a tricky problem with `qx.Class.patch` where mixin constructors are not called; worse, it did not occur in `qx.debug` builds because qx.debug would enable a shortcut that accidentally avoided the bug (this shortcut has now been removed).  Another confusion was that it depends on dependency orders whether the problem occurs at all, and this could also lead to different behaviour between generator and compiler.

The test for this bug would be that after patching, this assert would fail (it should never fail):

```
qx.Class.patch(abc.MyClass, xyz.SomeMixin);

// *** This assert should never fail***
qx.core.Assert.assertTrue(abc.MyClass.constructor === abc.MyClass);
```

The problem comes down to the need for `qx.Class.patch` to sometimes have to wrap the class’ constructor if the mixin has a constructor and the class’ constructor has not previously been wrapped (this is another reason why the non-debug build can exhibit different behaviour).  The wrapping is necessary to automatically call constructors.  However, because the class instance is the `constructor` property (ie `qx.core.Object === qx.core.Object.constructor`) this means that wrapping constructor means changing the class instance as well, and this causes issues where the class instance has been held onto.

EG:
```
var tmp = abc.MyClass;
qx.Class.patch(tmp, xyz.SomeMixin);

// *** Do not use this assert, it will (legitimately) not always be true ***
qx.core.Assert.assertTrue(tmp === abc.MyClass);
```

The framework was holding onto class definitions, ie it was effectively falling foul of this `var tmp = …` example above, and this would cause `defer` to be given the old (wrong) class.

This is the correct way:
```
var tmp = abc.MyClass;
tmp = qx.Class.patch(tmp, xyz.SomeMixin);
// This assert is safe and will always be true
qx.core.Assert.assertTrue(tmp === abc.MyClass);
```
