### PR TITLE
Reset this._userInteraction

### DIFF
--- a/framework/source/class/qx/ui/core/selection/Abstract.js
+++ b/framework/source/class/qx/ui/core/selection/Abstract.js
@@ -1023,6 +1023,7 @@ qx.Class.define("qx.ui.core.selection.Abstract",
       }
 
       // Cleanup operation
+      this._userInteraction = false;      
       this._cleanup();
     },
 


### PR DESCRIPTION
In some cases it gets stuck to true and prevents the programmatic selection of some items. It is reset to false on all cases except this one.