### PR TITLE
Blocker.forceUnblock() doesn't unblock in some cases

### DIFF
--- a/framework/source/class/qx/ui/core/Blocker.js
+++ b/framework/source/class/qx/ui/core/Blocker.js
@@ -364,7 +364,9 @@ qx.Class.define("qx.ui.core.Blocker",
      */
     _block : function(zIndex, blockContent) {
       if (!this._isRoot && !this._widget.getLayoutParent()) {
-        this.__appearListener = this._widget.addListenerOnce("appear", this._block.bind(this, zIndex));
+        if (!this.__appearListener) {
+          this.__appearListener = this._widget.addListenerOnce("appear", this._block.bind(this, zIndex));
+        }
         return;
       }
 
@@ -425,6 +427,7 @@ qx.Class.define("qx.ui.core.Blocker",
     {
       if (this.__appearListener) {
         this._widget.removeListenerById(this.__appearListener);
+        this.__appearListener = null;
       }
 
       if (!this.isBlocked()){
@@ -445,6 +448,11 @@ qx.Class.define("qx.ui.core.Blocker",
      */
     forceUnblock : function()
     {
+      if (this.__appearListener) {
+        this._widget.removeListenerById(this.__appearListener);
+        this.__appearListener = null;
+      }
+
       if (!this.isBlocked()){
         return;
       }


### PR DESCRIPTION
If forceUnblock() is called before the blocker is shown it doesn't detach the "appear" handler and the blocker is shown anyway, unlike unblock().

If block() is called multiple times before the element is shown, the "appear" handler is re-registered losing the previous id, so if the app calls unblock() it cannot unregister the "appear" handler and the blocker is shown anyway.