### PR TITLE
Resizing columns with liveResize=false can break the layout

### DIFF
--- a/framework/source/class/qx/ui/table/pane/Scroller.js
+++ b/framework/source/class/qx/ui/table/pane/Scroller.js
@@ -961,8 +961,6 @@ qx.Class.define("qx.ui.table.pane.Scroller",
         var columnModel = table.getTableColumnModel();
         columnModel.setColumnWidth(this.__resizeColumn, newWidth, true);
       } else {
-        this.__header.setColumnWidth(this.__resizeColumn, newWidth, true);
-
         var paneModel = this.getTablePaneModel();
         this._showResizeLine(paneModel.getColumnLeft(this.__resizeColumn) + newWidth);
       }


### PR DESCRIPTION
When the column scroller is scrolled to the right and resizing a column makes the scroll are smaller, the header gets messed up because it's trying to update it live while the columns are not. When live resize is false it's better not to live resize the header.

See video using qooxdoo online demo browser.

[qooxdoo » Demo Browser » Table » Table.zip](https://github.com/qooxdoo/qooxdoo/files/3952060/qooxdoo.Demo.Browser.Table.Table.zip)
