### PR TITLE
Virtual list page scroll

### DIFF
--- a/framework/source/class/qx/ui/table/columnmodel/Basic.js
+++ b/framework/source/class/qx/ui/table/columnmodel/Basic.js
@@ -290,7 +290,9 @@ qx.Class.define("qx.ui.table.columnmodel.Basic",
 
 
     /**
-     * Sets the header renderer of a column.
+     * Sets the header renderer of a column. Use setHeaderCellRenderers
+     * instead of this method if you want to set the header renderer of many
+     * columns.
      *
      * @param col {Integer} the model index of the column.
      * @param renderer {qx.ui.table.IHeaderRenderer} the new header renderer the column
@@ -311,9 +313,47 @@ qx.Class.define("qx.ui.table.columnmodel.Basic",
       }
 
       this.__columnDataArr[col].headerRenderer = renderer;
-      this.fireDataEvent("headerCellRendererChanged", {col:col});
+      if (! this.__internalChange) {
+        this.fireDataEvent("headerCellRendererChanged", {col:col});
+      }
     },
 
+
+    /**
+     * Sets the header renderer of one or more columns. Use this method, in
+     * favor of setHeaderCellRenderer, if you want to set the header renderer
+     * of many columns. This method fires the "headerCellRendererChanged"
+     * event only once, after setting all renderers, whereas
+     * setHeaderCellRenderer fires it for each changed renderer which can be
+     * slow with many columns.
+     *
+     * @param renderers {Map}
+     *   Map, where the keys are column numbers and values are the renderers,
+     *   implementing qx.ui.table.IHeaderRenderer, of the the new header
+     *   renderers for that column
+     */
+    setHeaderCellRenderers : function(renderers)
+    {
+      var col;
+
+      // Prevent firing "headerCellRendererChanged" for each column. Instead,
+      // we'll fire it once at the end.
+      this.__internalChange = true;
+
+      // For each listed column...
+      for (col in renderers)
+      {
+        // ... set that column's renderer
+        this.setHeaderCellRenderer(+col, renderers[col]);
+      }
+
+      // Turn off the internal-change flag so operation returns to normal
+      this.__internalChange = false;
+
+      // Now we can fire the event once. The data indicates which columns
+      // changed. Internally to qooxdoo, nothing cares about the event data.
+      this.fireDataEvent("headerCellRendererChanged", { cols: Object.keys(renderers) });
+    },
 
     /**
      * Returns the header renderer of a column.

--- a/framework/source/class/qx/ui/table/columnmodel/Basic.js
+++ b/framework/source/class/qx/ui/table/columnmodel/Basic.js
@@ -290,9 +290,7 @@ qx.Class.define("qx.ui.table.columnmodel.Basic",
 
 
     /**
-     * Sets the header renderer of a column. Use setHeaderCellRenderers
-     * instead of this method if you want to set the header renderer of many
-     * columns.
+     * Sets the header renderer of a column.
      *
      * @param col {Integer} the model index of the column.
      * @param renderer {qx.ui.table.IHeaderRenderer} the new header renderer the column
@@ -313,47 +311,9 @@ qx.Class.define("qx.ui.table.columnmodel.Basic",
       }
 
       this.__columnDataArr[col].headerRenderer = renderer;
-      if (! this.__internalChange) {
-        this.fireDataEvent("headerCellRendererChanged", {col:col});
-      }
+      this.fireDataEvent("headerCellRendererChanged", {col:col});
     },
 
-
-    /**
-     * Sets the header renderer of one or more columns. Use this method, in
-     * favor of setHeaderCellRenderer, if you want to set the header renderer
-     * of many columns. This method fires the "headerCellRendererChanged"
-     * event only once, after setting all renderers, whereas
-     * setHeaderCellRenderer fires it for each changed renderer which can be
-     * slow with many columns.
-     *
-     * @param renderers {Map}
-     *   Map, where the keys are column numbers and values are the renderers,
-     *   implementing qx.ui.table.IHeaderRenderer, of the the new header
-     *   renderers for that column
-     */
-    setHeaderCellRenderers : function(renderers)
-    {
-      var col;
-
-      // Prevent firing "headerCellRendererChanged" for each column. Instead,
-      // we'll fire it once at the end.
-      this.__internalChange = true;
-
-      // For each listed column...
-      for (col in renderers)
-      {
-        // ... set that column's renderer
-        this.setHeaderCellRenderer(+col, renderers[col]);
-      }
-
-      // Turn off the internal-change flag so operation returns to normal
-      this.__internalChange = false;
-
-      // Now we can fire the event once. The data indicates which columns
-      // changed. Internally to qooxdoo, nothing cares about the event data.
-      this.fireDataEvent("headerCellRendererChanged", { cols: Object.keys(renderers) });
-    },
 
     /**
      * Returns the header renderer of a column.

--- a/framework/source/class/qx/ui/virtual/selection/Row.js
+++ b/framework/source/class/qx/ui/virtual/selection/Row.js
@@ -167,7 +167,6 @@ qx.Class.define("qx.ui.virtual.selection.Row",
       var paneSize;
       var scrollY;
       var newItem;
-      var oldItem;
       var rowConfig = this._pane.getRowConfig();
 
       // Determine the height of the pane

--- a/framework/source/class/qx/ui/virtual/selection/Row.js
+++ b/framework/source/class/qx/ui/virtual/selection/Row.js
@@ -164,11 +164,32 @@ qx.Class.define("qx.ui.virtual.selection.Row",
     // overridden
     _getPage : function(lead, up)
     {
+      var paneSize;
+      var scrollY;
+      var newItem;
+      var oldItem;
+      var rowConfig = this._pane.getRowConfig();
+
+      // Determine the height of the pane
+      paneSize = this._pane.getInnerSize();
+
+      // Determine our current y position
+      scrollY = this._pane.getScrollY();
+
+      // Scroll to the new page
       if (up) {
-        return this._getFirstSelectable();
+        // Add item size so we include the immediately previous item, i.e., so
+        // that pageDown followed by pageUp returns to the same location
+        this._pane.setScrollY(scrollY - paneSize.height + rowConfig.getDefaultItemSize());
       } else {
-        return this._getLastSelectable();
+        this._pane.setScrollY(scrollY + paneSize.height);
       }
+
+      // Determine new y position, and from that, what row we moved to
+      scrollY = this._pane.getScrollY();
+      newItem = rowConfig.getItemAtPosition(scrollY);
+
+      return newItem.index;
     },
 
 


### PR DESCRIPTION
Enable PageUp and PageDown to operate by pages. (Was never really implemented)

PageUp and PageDown were "implemented" as moving to the first or last
selectable item in the list. This implements proper full-pane paging when
PageUp or PageDown are pressed.

Suggest squash when merging.