### PR TITLE
fix for Issue #9627

### DIFF
--- a/framework/source/class/qx/core/MEvent.js
+++ b/framework/source/class/qx/core/MEvent.js
@@ -129,7 +129,7 @@ qx.Mixin.define("qx.core.MEvent",
           qx.lang.Array.removeAt(listener.$$wrapped_callbacks_ids[type + this.$$hash], i);
           if (listener.$$wrapped_callbacks_ids[type + this.$$hash].length === 0) {
             delete listener.$$wrapped_callbacks_ids[type + this.$$hash];
-            if (Object.keys(listener.$$wrapped_callbacks_ids).lenght === 0) {
+            if (Object.keys(listener.$$wrapped_callbacks_ids).length === 0) {
               delete listener.$$wrapped_callbacks_ids;
             }
           }
@@ -137,10 +137,7 @@ qx.Mixin.define("qx.core.MEvent",
           return this.__Registration.removeListenerById(this, id);
         }
       }
-      // store the call for each type in case the listener is
-      // used for more than one type [BUG #8038]
-      listener.$$wrapped_callback[type + this.toHashCode()] = callback;
-      return this.addListener(type, callback, context, capture);
+      return false;
     },
 
 

--- a/framework/source/class/qx/core/MEvent.js
+++ b/framework/source/class/qx/core/MEvent.js
@@ -77,10 +77,8 @@ qx.Mixin.define("qx.core.MEvent",
       var callback = function(e)
       {
         this.__removeOnceListenerOnceById(type, id, listener);
-        listener.call(self||this, e);
+        listener.call(context, e);
       };
-      // to get actual id
-      callback = callback.bind(this);
 
       // check for wrapped callbacks storage
       if (!listener.$$wrapped_callbacks_ids) {

--- a/framework/source/class/qx/core/MEvent.js
+++ b/framework/source/class/qx/core/MEvent.js
@@ -88,7 +88,9 @@ qx.Mixin.define("qx.core.MEvent",
         listener.$$wrapped_callbacks_ids[type + this.$$hash] = [];
 
       } else if (listener.$$wrapped_callbacks_ids.hasOwnProperty(type + this.$$hash)) {
-        if (qx.core.Environment.get("qx.debug") && listener.$$wrapped_callbacks_ids[type + this.$$hash].length)
+        if (    qx.core.Environment.get("qx.debug")
+             && listener.$$wrapped_callbacks_ids[type + this.$$hash]
+             && listener.$$wrapped_callbacks_ids[type + this.$$hash].length)
         {
           qx.log.Logger.warn("This listener '" + listener.name + "' of current object '" + this.$$hash +
             (this.name ? " (" + this.name + ")" : "") + "' on event with '" +

--- a/framework/source/class/qx/core/MEvent.js
+++ b/framework/source/class/qx/core/MEvent.js
@@ -80,6 +80,9 @@ qx.Mixin.define("qx.core.MEvent",
         listener.call(context, e);
       };
 
+      // register hash code
+      qx.core.ObjectRegistry.toHashCode(this);
+
       // check for wrapped callbacks storage
       if (!listener.$$wrapped_callbacks_ids) {
         listener.$$wrapped_callbacks_ids = {};


### PR DESCRIPTION
store listener unique ids added in addListenerOnce 
store listener unique ids added in addListenerOnce to remove all listeners correctly.

Bug in MEvent.addListenerOnce() for multiple times call with same args qooxdoo#9627

Taken from https://github.com/fortooon/qooxdoo/pull/2/commits/0ddde1efeedf721881e1466b715cd0b48f16cbd6