### PR TITLE
add testtapper to qooxdoo

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -40,4 +40,4 @@
 node_modules/
 npm-debug.log
 
-
+.nyc*

--- a/compile.json
+++ b/compile.json
@@ -116,7 +116,22 @@
       "name": "mobileshowcase",
       "bootPath": "source/boot",
       "theme": ""
-   }
+    },
+    {
+      "class": "qxl.testtapper.Application",
+      "name": "testtapper",
+      "theme": "qx.theme.Simple",
+      "title": "Qooxdoo TestTAPper",
+      "environment": {
+        "qx.icontheme": "Tango",
+        "testtapper.testNameSpace": "qx.test"
+      },
+      "include": [
+        "qx.test.*"
+      ],
+      "exclude": [
+      ]
+    }
   ],
   "sass": {
     "compiler": "legacy"

--- a/qx-lock.json
+++ b/qx-lock.json
@@ -26,11 +26,11 @@
     },
     {
       "library_name": "DemoBrowser",
-      "library_version": "1.0.0-beta.13",
-      "path": "qx_packages/qooxdoo_qxl_demobrowser_v1_0_0-beta_13",
+      "library_version": "1.0.0-beta.14",
+      "path": "qx_packages/qooxdoo_qxl_demobrowser_v1_0_0-beta_14",
       "uri": "qooxdoo/qxl.demobrowser",
       "repo_name": "qooxdoo/qxl.demobrowser",
-      "repo_tag": "v1.0.0-beta.13"
+      "repo_tag": "v1.0.0-beta.14"
     },
     {
       "library_name": "Qooxdoo API Viewer",
@@ -71,6 +71,14 @@
       "uri": "qooxdoo/qxl.datademo",
       "repo_name": "qooxdoo/qxl.datademo",
       "repo_tag": "v1.0.0-beta.2"
+    },
+    {
+      "library_name": "Commandline Testrunner for Qooxdoo Apps",
+      "library_version": "0.4.7",
+      "path": "qx_packages/qooxdoo_qxl_testtapper_v0_4_7",
+      "uri": "qooxdoo/qxl.testtapper",
+      "repo_name": "qooxdoo/qxl.testtapper",
+      "repo_tag": "v0.4.7"
     }
   ],
   "version": "2.1.0"


### PR DESCRIPTION
so that you can run qx test in qooxdoo drectory.

Here is the result:

Web server started, please browse to http://localhost:8080
CALL http://localhost:8080/apps/testtapper/
not ok 14 - qx.test.Bootstrap:test: superclass calls aka basecalls (constructor and methods) - Expected 'bmw' but found ''undefined''!
not ok 108 - qx.test.ui.basic.Image:testHighResImageWithDecoratorAndSourceInConstructor - Error in property decorator of class qx.ui.basic.Image in method $$setDecoratorImpl with incoming value 'toolbar-part': Is invalid!
not ok 109 - qx.test.ui.basic.Image:testHighResImageWithDecoratorAndSourceInSetter - Error in property decorator of class qx.ui.basic.Image in method $$setDecoratorImpl with incoming value 'toolbar-part': Is invalid!
not ok 145 - qx.test.ui.core.AbstractScrollArea:test default behaviour - tearDown failed: Cannot read property 'prototype' of undefined
not ok 146 - qx.test.ui.core.AbstractScrollArea:test smaller widget than container - setUp failed: Cannot read property 'setUp' of undefined
not ok 147 - qx.test.ui.core.AbstractScrollArea:test bigger widget than container - setUp failed: Cannot read property 'setUp' of undefined
not ok 148 - qx.test.ui.core.AbstractScrollArea:test bigger preferred widget than container - setUp failed: Cannot read property 'setUp' of undefined
not ok 149 - qx.test.ui.core.AbstractScrollArea:test bigger widget than smaller preferred container - setUp failed: Cannot read property 'setUp' of undefined
not ok 310 - qx.test.ui.form.Form:testValidSpinner - Cannot read property 'indexOf' of null
not ok 313 - qx.test.ui.form.Form:testValidTextField - Cannot read property 'focus' of null
not ok 315 - qx.test.ui.form.Form:testValidTextArea - Cannot read property 'focus' of undefined
not ok 319 - qx.test.ui.form.Form:testValidSelectBox - Cannot read property 'focus' of undefined
not ok 320 - qx.test.ui.form.Form:testValidSelectBox - resume() called before wait()
not ok 325 - qx.test.ui.form.Form:testRequiredRadioButton - resume() called before wait()
not ok 329 - qx.test.ui.form.Form:testValidRadioGroupBox - resume() called before wait()
not ok 343 - qx.test.ui.form.Form:testRedefineItem - resume() called before wait()
not ok 344 - qx.test.ui.form.Form:testRedefineItem - Cannot read property 'indexOf' of null
not ok 345 - qx.test.ui.form.Form:testRedefineItem - resume() called before wait()
not ok 346 - qx.test.ui.form.Form:testRedefineItem - Cannot read property 'focus' of null
not ok 470 - qx.test.ui.form.Form:testValidSlider - Timeout reached before resume() was called.
not ok 471 - qx.test.ui.form.Form:testValidPasswordField - Timeout reached before resume() was called.
not ok 472 - qx.test.ui.form.Form:testValidComboBox - Timeout reached before resume() was called.
not ok 473 - qx.test.ui.form.Placeholder:testFocusDateField - Called assertTrue with 'false'
not ok 478 - qx.test.ui.form.Form:testValidList - Timeout reached before resume() was called.
not ok 479 - qx.test.ui.form.Form:testValidTree - Timeout reached before resume() was called.
not ok 481 - qx.test.ui.form.Form:testValidDateField - Timeout reached before resume() was called.
not ok 482 - qx.test.ui.form.Form:testValidDateChooser - Timeout reached before resume() was called.
not ok 499 - qx.test.ui.form.Slider:testKnobPositionAfterBlur - Expected '25px' but found '24px'!
not ok 502 - qx.test.ui.form.Spinner:testCorrectLocaleUsed - Expected '1,23' but found '1.23'!
not ok 839 - qx.test.ui.toolbar.OverflowHandling:testShowItem - Event (showItem) not fired.
not ok 841 - qx.test.ui.toolbar.OverflowHandling:testShowItemPriority - Event (showItem) not fired.
not ok 842 - qx.test.ui.toolbar.OverflowHandling:testHideIndicator - resume() called before wait()
not ok 843 - qx.test.ui.toolbar.OverflowHandling:testShowIndicatorHuge - resume() called before wait()
not ok 844 - qx.test.ui.toolbar.OverflowHandling:testHideItemRemoved - Event (hideItem) was fired.
not ok 845 - qx.test.ui.toolbar.OverflowHandling:testShowItemRemoved - Event (showItem) not fired.
not ok 1109 - qx.test.ui.toolbar.OverflowHandling:testShowIndicator - Timeout reached before resume() was called.
not ok 1185 - qx.test.Class:testOverridePropertyMethod - Cannot read property 'prototype' of undefined
not ok 1187 - qx.test.Class:testSuperClassCall - Expected '4' but found ''undefined''!
not ok 1243 - qx.test.io.part.Package:test: delay the first file - test load order - Expected '["file1","file2","file3"]' but found '["file2","file3"]'!
not ok 1244 - qx.test.io.part.Package:test: loading a closure package with load() should execute the closure - Expected '["file1-closure"]' but found '["file1","file1-closure"]'!
not ok 1245 - qx.test.io.part.Package:test: loading a non existing file with loadClosure() should timeout - Expected 'error' but found 'cached'!
not ok 1247 - qx.test.io.part.Package:test: loading a non existing file with loadClosure() should timeout - resume() called before wait()
not ok 1256 - qx.test.io.remote.RequestIframe:testAsynchronous - Expected '10' but found '0'!
not ok 1259 - qx.test.io.part.Package:test: loading a non existing file with loadClosure() should timeout - Expected 'cached' but found 'error'!
not ok 1260 - qx.test.io.remote.RequestIframe:testAbortedOnException - Timeout reached before resume() was called.
not ok 1261 - qx.test.io.part.Package:test: if one of the files fails to load, no load event should be fired - Timeout reached before resume() was called.
not ok 1262 - qx.test.io.part.Package:test: loading a closure package with loadClosure() should not execute the closure - Timeout reached before resume() was called.
not ok 1263 - qx.test.io.remote.RequestXhr:testSynchronousAndAsynchronousMix - Called assertTrue with 'false'
not ok 1264 - qx.test.io.remote.RequestIframe:testAbortedOnException - resume() called before wait()
not ok 1265 - qx.test.io.remote.RequestXhr:testAsynchronous - Expected 'kinners' but found 'null'!
not ok 1275 - qx.test.io.remote.RequestXhr:testGetResponseHeader - Timeout reached before resume() was called.
not ok 1276 - qx.test.io.remote.transport.Iframe:testGetIframeHtmlContent - Timeout reached before resume() was called.
not ok 1277 - qx.test.io.remote.transport.XmlHttp:testSetHeader - Unexpected token < in JSON at position 0
not ok 1283 - qx.test.io.remote.transport.XmlHttp:testGetResponseHeader - Expected 'kinners' but found 'null'!
not ok 1326 - qx.test.io.request.JsonpWithRemote:test: fetch json - Expected value to be typeof object but found null!
not ok 1417 - qx.test.io.request.XhrWithRemote:test: timeout - Timeout reached before resume() was called.
not ok 1455 - qx.test.io.rest.Resource:test: invoke action ignores invalid check in production - Expected value to be a regular expression but found !
not ok 1483 - qx.test.io.request.XhrWithRemote:test: timeout with header call - Timeout reached before resume() was called.
not ok 1484 - qx.test.io.rest.ResourceWithRemote:test: invoke action and handle response - Timeout reached before resume() was called.
not ok 1486 - qx.test.io.rest.ResourceWithRemote:test: long poll - Called assert with 'false'
not ok 1516 - qx.test.Theme:testExtendTheme - Unable to resolve decorator 'qx-main'.
not ok 1517 - qx.test.Theme:testIncludeTheme - Unable to resolve decorator 'qx-main'.
not ok 1518 - qx.test.Theme:testIncludeInvalidTheme - Unable to resolve decorator 'qx-main'.
not ok 1519 - qx.test.Theme:testPatchTheme - Unable to resolve decorator 'qx-main'.
not ok 1520 - qx.test.Theme:testPatchInvalidTheme - Unable to resolve decorator 'qx-main'.
not ok 1521 - qx.test.Theme:testIncludeThemeWithIncludes - Unable to resolve decorator 'qx-main'.
not ok 1522 - qx.test.Theme:testDoubleExtend - Unable to resolve decorator 'qx-main'.
not ok 1523 - qx.test.Theme:testExtendThemeWithIncludes - Unable to resolve decorator 'qx-main'.
not ok 1556 - qx.test.io.rest.ResourceWithRemote:test: invoke action and handle failure - Timeout reached before resume() was called.
not ok 1599 - qx.test.bom.Font:testColorAtWidget - Expected 'rgb(26, 26, 26)' but found 'black'!
not ok 1757 - qx.test.bom.media.Audio:test Play Event - Timeout reached before resume() was called.
not ok 1772 - qx.test.bom.media.Video:test Play Event - Timeout reached before resume() was called.
not ok 1977 - qx.test.bom.rest.Resource:test: invoke action ignores invalid check in production - Expected value to be a regular expression but found !
not ok 2006 - qx.test.bom.rest.Resource:test: dispose request on loadEnd - resume() called before wait()
not ok 2008 - qx.test.bom.rest.Resource:test: fire started - Timeout reached before resume() was called.
not ok 2009 - qx.test.bom.rest.ResourceWithRemote:test: poll action - Timeout reached before resume() was called.
not ok 2013 - qx.test.bom.rest.ResourceWithRemote:test: long poll - Called assert with 'false'
not ok 2565 - qx.test.dev.StackTrace:testFilenameConverterDefault - The String ') [as testFilenameConverterDefault] (http://localhost:8080/apps/testtapper/part-boot-bundle-1.js:174225:18' does not match the regular expression '/((?:test\.dev\.StackTrace)|(?:dev\.unit)|(?:testrunner\.js)|(?:tests\.js)|(?:qooxdoo-adapter\.js))/'!
not ok 2654 - qx.test.event.Timer:testStartStop - Called assertFalse with 'true'
not ok 2815 - qx.test.lang.normalize.Date:test parse() - Expected '-377736727708000' (identical) but found '-377736728100000'!
not ok 2825 - qx.test.locale.Date:testDayNames - Expected '["So.","Mo.","Di.","Mi.","Do.","Fr.","Sa."]' but found '["Sun","Mon","Tue","Wed","Thu","Fri","Sat"]'!
not ok 2829 - qx.test.locale.Locale:testMacCtrl - Expected 'Links' but found 'Left'!
not ok 3010 - qx.test.performance.decorator.Beveled:testCreate - No such property: outerColor
not ok 3011 - qx.test.performance.decorator.Beveled:testRender - No such property: outerColor
not ok 3012 - qx.test.performance.decorator.Beveled:testResize - No such property: outerColor
not ok 3013 - qx.test.performance.decorator.Grid:testCreate - No such property: baseImage
not ok 3014 - qx.test.performance.decorator.Grid:testRender - No such property: baseImage
not ok 3015 - qx.test.performance.decorator.Grid:testResize - No such property: baseImage
not ok 3061 - qx.test.theme.manager.Decoration:testAlias - Unable to resolve decorator 'qx-main'.
not ok 3062 - qx.test.theme.manager.Decoration:testAliasExtend - Unable to resolve decorator 'qx-main'.
not ok 3063 - qx.test.theme.manager.Decoration:testAliasOverride - Unable to resolve decorator 'qx-main'.
not ok 3064 - qx.test.theme.manager.Decoration:testChangeThemeEventFired - Unable to resolve decorator 'qx-main'.
not ok 3065 - qx.test.theme.manager.Decoration:testAddCssClass - Unable to resolve decorator 'qx-main'.
not ok 3072 - qx.test.theme.manager.Meta:testColorThemeManagerChanged - Error in property innerColorTop of class qx.ui.decoration.Decorator in method $$setInnerColorTopImpl with incoming value 'window-border-inner': Is invalid!
not ok 3073 - qx.test.theme.manager.Meta:testDecoratorThemeManagerChanged - Expected '0px' but found '10px'!
not ok 3074 - qx.test.theme.manager.Meta:testAppearanceThemeManagerChanged - Expected '0px' but found '30px 80px'!
not ok 3075 - qx.test.theme.manager.Meta:testColorThemeChanged - Error in property innerColorTop of class qx.ui.decoration.Decorator in method $$setInnerColorTopImpl with incoming value 'window-border-inner': Is invalid!
not ok 3236 - qx.test.util.Function:testDebounce - Called fail().
not ok 3238 - qx.test.util.Function:testImmediateDebounce - Called fail().
not ok 3242 - qx.test.util.NumberFormat:testNumberFormat - Expected '1.000.000' but found '1,000,000'!
not ok 3243 - qx.test.util.NumberFormat:testNumberParse - Number string '-0,02' does not match the number format
not ok 3244 - qx.test.util.NumberFormat:testLocaleSwitch - The function did not raise an exception!
not ok 3246 - qx.test.util.NumberFormat:testParseWithPrefixOrPostfix - Expected '$ 1,23 €' but found '$ 0.00 €'!
not ok 3248 - qx.test.util.PropertyUtil:testGetThemeValue - Expected 'true' but found ''undefined''!
DONE testing 3262 ok, 104 not ok
writing coverage information ...


