### PR TITLE
Named parameter string format translation

### DIFF
--- a/docs/_to_be_done/development/internationalization.md
+++ b/docs/_to_be_done/development/internationalization.md
@@ -111,6 +111,11 @@ Marks the string `Hello` for translation and returns the string unmodified.
 
 Since sentences in different languages can have different structures, it is always better to prefer a format string over string concatenation to compose messages. This is why the methods above all support format strings like `Copied %1 files` as messages and a variable number of additional arguments. The additional arguments are converted to strings and inserted into the original message. `%` is used as an escape character and the number following `%` references the corresponding additional argument.
 
+You can use, if you prefer, named arguments in your string. We use the `%` symbol to begin an argument and we use curly braces to indicate the name like this : `Copied %{numberOfCopy} files. %{myName}`. With this type of formating you should give to your translation function an object, with your named argument as key. Example:
+
+    this.tr("Copied %{numberOfCopy} files. %{myName}", { numberOfCopy: 2, myName: "Kevin" });
+
+
 ### Extract the Messages
 
 After the source code has been prepared, the desired languages of the application may be specified in `config.json`, in the `LOCALES` macro within the global `let` section, for example

--- a/framework/source/class/qx/lang/String.js
+++ b/framework/source/class/qx/lang/String.js
@@ -296,6 +296,10 @@ qx.Bootstrap.define("qx.lang.String",
     {
       var str = pattern;
       var regexp = /%(\d+)|%\${(\S*)}/g;
+      if (!Array.isArray(args)) {
+        args = [args];
+      }
+
       var argsIsObject = (args.length === 1 && typeof args[0] === "object");
 
       str = str.replace(regexp, function(matchedSubString, numberArgument, namedArgument) {

--- a/framework/source/class/qx/lang/String.js
+++ b/framework/source/class/qx/lang/String.js
@@ -285,8 +285,12 @@ qx.Bootstrap.define("qx.lang.String",
     /**
      * Print a list of arguments using a format string
      * In the format string occurrences of %n are replaced by the n'th element of the args list.
+     * You can give an object as argument.
+     * In this case you should specify namedArgument in your string with %{namedArgument}.
+     * The named argument will be replace by the value of the property of the object named "namedArgument"
      * Example:
      * <pre class='javascript'>qx.lang.String.format("Hello %1, my name is %2", ["Egon", "Franz"]) == "Hello Egon, my name is Franz"</pre>
+     * <pre class='javascript'>qx.lang.String.format("Hello %{yourName}, my name is %{myName}", {yourName: "Egon", myName: "Franz"}) == "Hello Egon, my name is Franz"</pre>
      *
      * @param pattern {String} format string
      * @param args {Array} array of arguments to insert into the format string
@@ -295,7 +299,7 @@ qx.Bootstrap.define("qx.lang.String",
     format : function(pattern, args)
     {
       var str = pattern;
-      var regexp = /%(\d+)|%\${(\S*)}/g;
+      var regexp = /%(\d+)|%{(\S*)}/g;
       if (!Array.isArray(args)) {
         args = [args];
       }

--- a/framework/source/class/qx/lang/String.js
+++ b/framework/source/class/qx/lang/String.js
@@ -295,13 +295,25 @@ qx.Bootstrap.define("qx.lang.String",
     format : function(pattern, args)
     {
       var str = pattern;
-      var i = args.length;
+      var regexp = /%(\d+)|%\${(\S*)}/g;
+      var argsIsObject = (args.length === 1 && typeof args[0] === "object");
 
-      while (i--) {
-        // be sure to always use a string for replacement.
-        str = str.replace(new RegExp("%" + (i + 1), "g"), function(){return args[i] + "";});
-      }
+      str = str.replace(regexp, function(matchedSubString, numberArgument, namedArgument) {
+        if (namedArgument) {
+          if (argsIsObject) {
+            return args[0][namedArgument];
+          }
 
+          return namedArgument;
+        }
+
+        if (numberArgument && numberArgument > 0 && args.length >= numberArgument) {
+          var index = numberArgument - 1;
+          return args[index];
+        }
+
+        return matchedSubString;
+      });
       return str;
     },
 

--- a/framework/source/class/qx/locale/Manager.js
+++ b/framework/source/class/qx/locale/Manager.js
@@ -72,8 +72,7 @@ qx.Class.define("qx.locale.Manager",
      */
     tr : function(messageId, varargs)
     {
-      var args = qx.lang.Array.fromArguments(arguments);
-      args.splice(0, 1);
+      var args = qx.lang.Array.fromArguments(arguments, 1);
 
       return qx.locale.Manager.getInstance().translate(messageId, args);
     },

--- a/framework/source/class/qx/test/locale/Locale.js
+++ b/framework/source/class/qx/test/locale/Locale.js
@@ -77,7 +77,7 @@ qx.Class.define("qx.test.locale.Locale",
       this.assertEquals("test Hello Fabian!", hello);
 
       // tr(): format string with namedArg
-      var hello = this.tr("test Hello %${firstName} %${lastName}!", { firstName: "Fabian", lastName: "Jonny"});
+      var hello = this.tr("test Hello %{firstName} %{lastName}!", { firstName: "Fabian", lastName: "Jonny"});
       this.assertEquals("test Hello Fabian Jonny!", hello);
 
       // tr(): format string with translated arguments

--- a/framework/source/class/qx/test/locale/Locale.js
+++ b/framework/source/class/qx/test/locale/Locale.js
@@ -76,6 +76,10 @@ qx.Class.define("qx.test.locale.Locale",
       var hello = this.tr("test Hello %1!", "Fabian");
       this.assertEquals("test Hello Fabian!", hello);
 
+      // tr(): format string with namedArg
+      var hello = this.tr("test Hello %${firstName} %${lastName}!", { firstName: "Fabian", lastName: "Jonny"});
+      this.assertEquals("test Hello Fabian Jonny!", hello);
+
       // tr(): format string with translated arguments
       var hiJonny = this.tr("test Hello %1!", this.tr("test Jonny"));
       this.assertEquals("test Hello test Jonny!", hiJonny);


### PR DESCRIPTION
add the posibility to use named parameter in translation.

The current format for translation is: 

this.tr("test %1 , with %2", ["me", "fantastic ideas"]);

You can now also use : 

this.tr("test %{subject} , with %{idea}", {subject: "me", idea: "fantastic ideas"});

The way it works with number isn't impacted. 
I tested it with testtapper without problem.