### PR TITLE
ignore native objects to avoid warnings

### DIFF
--- a/framework/source/class/qx/bom/client/Plugin.js
+++ b/framework/source/class/qx/bom/client/Plugin.js
@@ -45,6 +45,8 @@ qx.Bootstrap.define("qx.bom.client.Plugin",
      *
      * @internal
      * @return {Boolean} <code>true</code> if ActiveX is available
+     *
+     * @ignore(window.ActiveXObject)
      */
     getActiveX : function()
     {

--- a/framework/source/class/qx/bom/request/Xhr.js
+++ b/framework/source/class/qx/bom/request/Xhr.js
@@ -730,6 +730,8 @@ qx.Bootstrap.define("qx.bom.request.Xhr",
      * Create XMLHttpRequest (or equivalent).
      *
      * @return {Object} XMLHttpRequest or equivalent.
+     *
+     * @ignore(XMLHttpRequest)
      */
     _createNativeXhr: function() {
       var xhr = qx.core.Environment.get("io.xhr");

--- a/framework/source/class/qx/xml/Document.js
+++ b/framework/source/class/qx/xml/Document.js
@@ -72,6 +72,8 @@ qx.Bootstrap.define("qx.xml.Document",
      * @param namespaceUri {String ? null} The namespace URI of the document element to create or null.
      * @param qualifiedName {String ? null} The qualified name of the document element to be created or null.
      * @return {Document} empty XML object
+     *
+     * @ignore(ActiveXObject)
      */
     create : function(namespaceUri, qualifiedName)
     {
@@ -116,6 +118,8 @@ qx.Bootstrap.define("qx.xml.Document",
      * @param str {String} the string to be parsed
      * @return {Document} XML document with given content
      * @signature function(str)
+     *
+     * @ignore(DOMParser)
      */
     fromString : function(str)
     {


### PR DESCRIPTION
I am seeing these warnings in an application that doesn't (explicitly) use these classes. This should squelch the warnings... but should the compiler be ignoring these native types?