### PR TITLE
fix bug where you can't edit the first cell in a table until the focused cell has changed

### DIFF
--- a/framework/source/class/qx/ui/table/pane/Scroller.js
+++ b/framework/source/class/qx/ui/table/pane/Scroller.js
@@ -683,7 +683,11 @@ qx.Class.define("qx.ui.table.pane.Scroller",
       {
         this.updateVerScrollBarMaximum();
 
-        if (this.getFocusedRow() >= rowCount)
+        if (this.getFocusedRow() === null)
+        {
+          this.setFocusedCell(this.getFocusedColumn()||0, 0);
+        } 
+        else if (this.getFocusedRow() >= rowCount)
         {
           if (rowCount == 0) {
             this.setFocusedCell(null, null);

--- a/framework/source/class/qx/ui/table/pane/Scroller.js
+++ b/framework/source/class/qx/ui/table/pane/Scroller.js
@@ -678,12 +678,13 @@ qx.Class.define("qx.ui.table.pane.Scroller",
     {
       this.__tablePane.onTableModelDataChanged(firstRow, lastRow, firstColumn, lastColumn);
       var rowCount = this.getTable().getTableModel().getRowCount();
+      var colCount = this.__table.getTableColumnModel().getOverallColumnCount();
 
       if (rowCount != this.__lastRowCount)
       {
         this.updateVerScrollBarMaximum();
 
-        if (this.getFocusedRow() === null)
+        if (this.getFocusedRow() === null && rowCount > 0 && colCount > 0)
         {
           this.setFocusedCell(this.getFocusedColumn()||0, 0);
         } 


### PR DESCRIPTION
What happens is that the table.startEditing() is called by the tap handler, but the scroller still has it's focused row/col properties set to null even though the table's focused row/col is at `0`.  Because of coercion the scroller does not update its value from `null` to `0`, but later on refuses to allow editing because it has a `null` focus.  