### PR TITLE
Fix double click on close button.

### DIFF
--- a/framework/source/class/qx/ui/window/Window.js
+++ b/framework/source/class/qx/ui/window/Window.js
@@ -1112,7 +1112,7 @@ qx.Class.define("qx.ui.window.Window",
      */
     _onCaptionPointerDblTap : function(e)
     {
-      if (this.getAllowMaximize()) {
+      if (this.getAllowMaximize() && e.getTarget() === this) {
         this.isMaximized() ? this.restore() : this.maximize();
       }
     },


### PR DESCRIPTION
Double clicking the close button causes the form to also maximize.