### PR TITLE
Double clicking on buttons in the captionbar should not maximize the dialog.

### DIFF
--- a/framework/source/class/qx/ui/window/Window.js
+++ b/framework/source/class/qx/ui/window/Window.js
@@ -1112,7 +1112,7 @@ qx.Class.define("qx.ui.window.Window",
      */
     _onCaptionPointerDblTap : function(e)
     {
-      if (this.getAllowMaximize()) {
+      if (this.getAllowMaximize() && (e.getTarget() === this.getChildControl("captionbar") || e.getTarget() === this.getChildControl("title"))) {
         this.isMaximized() ? this.restore() : this.maximize();
       }
     },


### PR DESCRIPTION
This fix should be the good one. It lets double clicks on the "title" and "captionbar" widgets maximize/normalize the dialog. Double clicks on any button in the  "captionbar" are handled by the button only.