### PR TITLE
Make qx.ui.table.pane.Scroller work with IE

### DIFF
--- a/framework/source/class/qx/ui/table/pane/Scroller.js
+++ b/framework/source/class/qx/ui/table/pane/Scroller.js
@@ -891,7 +891,8 @@ qx.Class.define("qx.ui.table.pane.Scroller",
       var rowHeight = this.getTable().getRowHeight();
       var delta = e.getData() - e.getOldData();
       if ((Math.abs(delta) > 1) && (Math.abs(delta) < rowHeight)) {
-        delta = e.getOldData() + Math.sign(delta) * rowHeight;
+          delta = (delta < 0) ? e.getOldData() - rowHeight
+                              : e.getOldData() + rowHeight;
         if (delta>=0&&delta<=scrollbar.getMaximum()) {
           scrollbar.setPosition(delta);
         }

--- a/framework/source/class/qx/ui/table/pane/Scroller.js
+++ b/framework/source/class/qx/ui/table/pane/Scroller.js
@@ -891,8 +891,8 @@ qx.Class.define("qx.ui.table.pane.Scroller",
       var rowHeight = this.getTable().getRowHeight();
       var delta = e.getData() - e.getOldData();
       if ((Math.abs(delta) > 1) && (Math.abs(delta) < rowHeight)) {
-          delta = (delta < 0) ? e.getOldData() - rowHeight
-                              : e.getOldData() + rowHeight;
+        delta = (delta < 0) ? e.getOldData() - rowHeight
+                            : e.getOldData() + rowHeight;
         if (delta>=0&&delta<=scrollbar.getMaximum()) {
           scrollbar.setPosition(delta);
         }


### PR DESCRIPTION
`Math.sign()` is not supported by IE. Replace with ternary statement.
This is the only place in the framework where `Math.sign()` is used (introduced recently).