### PR TITLE
Make qx.ui.layout.Grid spanned column width adaption configurable and per default BC

### DIFF
--- a/docs/desktop/layout/grid.md
+++ b/docs/desktop/layout/grid.md
@@ -37,7 +37,6 @@ Layout properties
 -   **column** *(Integer)*: The column of the cell the widget should occupy. Each cell can only contain one widget. This layout property is mandatory.
 -   **rowSpan** *(Integer)*: The number of rows, the widget should span, starting from the row specified in the `row` property. The cells in the spanned rows must be empty as well. (defaults to `1`)
 -   **colSpan** *(Integer)*: The number of columns, the widget should span, starting from the column specified in the `column` property. The cells in the spanned columns must be empty as well. (defaults to `1`)
--   **allowGrowSpannedCellWidth** *(Boolean)*: Allow growing of spanning cells' widths beyond the cumulated widths of the columns. The default behavior is that the width of the spanning cell is determined by the accumulated width of the columns (plus spacing). Setting this property to true lets the cell width grow as needed to show the widget in the spanning cell, which also enlarges the width of the spanned columns. (defaults to `true`)
 
 Alternative Names
 -----------------

--- a/docs/desktop/layout/grid.md
+++ b/docs/desktop/layout/grid.md
@@ -37,7 +37,7 @@ Layout properties
 -   **column** *(Integer)*: The column of the cell the widget should occupy. Each cell can only contain one widget. This layout property is mandatory.
 -   **rowSpan** *(Integer)*: The number of rows, the widget should span, starting from the row specified in the `row` property. The cells in the spanned rows must be empty as well. (defaults to `1`)
 -   **colSpan** *(Integer)*: The number of columns, the widget should span, starting from the column specified in the `column` property. The cells in the spanned columns must be empty as well. (defaults to `1`)
--   **allowGrowSpannedCellWidth** *(Boolean)*: Allow growing of spanning cells widths beyond the cumulated widths of the columns. The default behavior is that the width of the the spanning cell is determined by the cumulated width of the columns (plus spacing). Setting this property to true lets the cell width grow as needed to show the widget in the spanning cell, which also enlarges the width of the spanned columns. (defaults to `true`)
+-   **allowGrowSpannedCellWidth** *(Boolean)*: Allow growing of spanning cells' widths beyond the cumulated widths of the columns. The default behavior is that the width of the spanning cell is determined by the accumulated width of the columns (plus spacing). Setting this property to true lets the cell width grow as needed to show the widget in the spanning cell, which also enlarges the width of the spanned columns. (defaults to `true`)
 
 Alternative Names
 -----------------

--- a/docs/desktop/layout/grid.md
+++ b/docs/desktop/layout/grid.md
@@ -37,6 +37,7 @@ Layout properties
 -   **column** *(Integer)*: The column of the cell the widget should occupy. Each cell can only contain one widget. This layout property is mandatory.
 -   **rowSpan** *(Integer)*: The number of rows, the widget should span, starting from the row specified in the `row` property. The cells in the spanned rows must be empty as well. (defaults to `1`)
 -   **colSpan** *(Integer)*: The number of columns, the widget should span, starting from the column specified in the `column` property. The cells in the spanned columns must be empty as well. (defaults to `1`)
+-   **allowGrowSpannedCellWidth** *(Boolean)*: Allow growing of spanning cells widths beyond the cumulated widths of the columns. The default behavior is that the width of the the spanning cell is determined by the cumulated width of the columns (plus spacing). Setting this property to true lets the cell width grow as needed to show the widget in the spanning cell, which also enlarges the width of the spanned columns. (defaults to `true`)
 
 Alternative Names
 -----------------

--- a/framework/source/class/qx/test/ui/layout/Grid.js
+++ b/framework/source/class/qx/test/ui/layout/Grid.js
@@ -89,9 +89,10 @@ qx.Class.define("qx.test.ui.layout.Grid",
       w3.dispose();
     },
 
-    testColSpanWithoutFlex : function() {
-      // test with spacing
+    testColSpanWithoutFlexAllowGrowTrue : function() {
+      
       this._gridLayout.setSpacingX(6);
+      this._gridLayout.setAllowGrowSpannedCellWidth(true);
 
       var w1 = new qx.test.ui.layout.LayoutItem(100, 100);
       this._gridWidget.add(w1, {row: 1, column: 0});
@@ -107,6 +108,71 @@ qx.Class.define("qx.test.ui.layout.Grid",
 
       this.flush();
       this.assertEquals(300, this._gridWidget.bounds.width);
+
+      this._gridLayout.resetAllowGrowSpannedCellWidth();
+      
+      w1.dispose();
+      w2.dispose();
+      w3.dispose();
+    },
+
+    testColSpanWithoutFlexAllowGrowFalse : function() {
+      
+      this._gridLayout.setSpacingX(6);
+      this._gridLayout.setAllowGrowSpannedCellWidth(false);
+
+      var w1 = new qx.test.ui.layout.LayoutItem(100, 100);
+      this._gridWidget.add(w1, {row: 1, column: 0});
+
+      var w2 = new qx.test.ui.layout.LayoutItem(100, 100);
+      this._gridWidget.add(w2, {row: 1, column: 1});
+      
+      this.flush();
+      this.assertEquals(206, this._gridWidget.bounds.width);
+      
+      var w3 = new qx.test.ui.layout.LayoutItem(300, 100);
+      w3.setAllowShrinkX(true);
+      
+      this._gridWidget.add(w3, {row: 0, column: 0, colSpan: 2});
+
+      this.flush();
+      this.assertEquals(206, this._gridWidget.bounds.width);
+
+      this._gridLayout.resetAllowGrowSpannedCellWidth();
+
+      w1.dispose();
+      w2.dispose();
+      w3.dispose();
+    },
+
+    testColSpanWithoutFlexAllowGrowFalseChangeToTrue : function() {
+      
+      this._gridLayout.setSpacingX(6);
+      this._gridLayout.setAllowGrowSpannedCellWidth(false);
+
+      var w1 = new qx.test.ui.layout.LayoutItem(100, 100);
+      this._gridWidget.add(w1, {row: 1, column: 0});
+
+      var w2 = new qx.test.ui.layout.LayoutItem(100, 100);
+      this._gridWidget.add(w2, {row: 1, column: 1});
+      
+      this.flush();
+      this.assertEquals(206, this._gridWidget.bounds.width);
+
+      var w3 = new qx.test.ui.layout.LayoutItem(300, 100);
+      w3.setAllowShrinkX(true);
+      
+      this._gridWidget.add(w3, {row: 0, column: 0, colSpan: 2});
+
+      this.flush();
+      this.assertEquals(206, this._gridWidget.bounds.width);
+
+      this._gridLayout.setAllowGrowSpannedCellWidth(true);
+
+      this.flush();
+      this.assertEquals(300, this._gridWidget.bounds.width);
+
+      this._gridLayout.resetAllowGrowSpannedCellWidth();
 
       w1.dispose();
       w2.dispose();

--- a/framework/source/class/qx/ui/layout/Grid.js
+++ b/framework/source/class/qx/ui/layout/Grid.js
@@ -51,6 +51,12 @@
  *   widget should span, starting from the column specified in the <code>column</code>
  *   property. The cells in the spanned columns must be empty as well.
  * </li>
+ * <li><strong>allowGrowSpannedCellWidth</strong> <em>(Boolean)</em>: Allow growing 
+ * of spanning cells widths beyond the cumulated widths of the columns. The default behavior 
+ * is that the width of the the spanning cell is determined by the cumulated width of the
+ * columns (plus spacing). Setting this property to true lets the cell width grow as needed to
+ * show the widget in the spanning cell, which also enlarges the width of the spanned columns.
+ * </li>
  * </ul>
  *
  * *Example*
@@ -93,8 +99,10 @@ qx.Class.define("qx.ui.layout.Grid",
    *     Sets {@link #spacingX}.
    * @param spacingY {Integer?0} The vertical spacing between grid cells.
    *     Sets {@link #spacingY}.
+   * @param allowGrowSpannedCellWidth {Boolean?false} Allow growing of spanning cell widths beyond the cumulated widths of the columns.
+   *     Sets {@link #allowGrowSpannedCellWidth}.
    */
-  construct : function(spacingX, spacingY)
+  construct : function(spacingX, spacingY, allowGrowSpannedCellWidth)
   {
     this.base(arguments);
 
@@ -107,6 +115,10 @@ qx.Class.define("qx.ui.layout.Grid",
 
     if (spacingY) {
       this.setSpacingY(spacingY);
+    }
+    
+    if(allowGrowSpannedCellWidth === true || allowGrowSpannedCellWidth === false) {
+      this.setAllowGrowSpannedCellWidth(allowGrowSpannedCellWidth);
     }
   },
 
@@ -139,6 +151,17 @@ qx.Class.define("qx.ui.layout.Grid",
     {
       check : "Integer",
       init : 0,
+      apply : "_applyLayoutChange"
+    },
+    
+    
+    /**
+     * Allow growing of spanning cell widths beyond the cumulated widths of the columns.
+     */
+    allowGrowSpannedCellWidth :
+    {
+      check : "Boolean",
+      init : false,
       apply : "_applyLayoutChange"
     }
   },
@@ -995,7 +1018,11 @@ qx.Class.define("qx.ui.layout.Grid",
         // increment the preferred column sizes.
         if (prefSpanWidth < hint.width)
         {
-          if (!qx.lang.Object.isEmpty(colFlexes)) {
+          // Do not adapt column widths to the width
+          // of the spanning cell if allowGrowSpannedCellWidth property
+          // is set to false
+          // See https://github.com/qooxdoo/qooxdoo/issues/9871
+          if (this.getAllowGrowSpannedCellWidth() === false || !qx.lang.Object.isEmpty(colFlexes)) {
             var colIncrements = qx.ui.layout.Util.computeFlexOffsets(
               colFlexes, hint.width, prefSpanWidth
             );

--- a/framework/source/class/qx/ui/layout/Grid.js
+++ b/framework/source/class/qx/ui/layout/Grid.js
@@ -51,12 +51,6 @@
  *   widget should span, starting from the column specified in the <code>column</code>
  *   property. The cells in the spanned columns must be empty as well.
  * </li>
- * <li><strong>allowGrowSpannedCellWidth</strong> <em>(Boolean)</em>: Allow growing 
- * of spanning cells widths beyond the cumulated widths of the columns. The default behavior 
- * is that the width of the the spanning cell is determined by the cumulated width of the
- * columns (plus spacing). Setting this property to true lets the cell width grow as needed to
- * show the widget in the spanning cell, which also enlarges the width of the spanned columns.
- * </li>
  * </ul>
  *
  * *Example*
@@ -99,10 +93,8 @@ qx.Class.define("qx.ui.layout.Grid",
    *     Sets {@link #spacingX}.
    * @param spacingY {Integer?0} The vertical spacing between grid cells.
    *     Sets {@link #spacingY}.
-   * @param allowGrowSpannedCellWidth {Boolean?false} Allow growing of spanning cell widths beyond the cumulated widths of the columns.
-   *     Sets {@link #allowGrowSpannedCellWidth}.
    */
-  construct : function(spacingX, spacingY, allowGrowSpannedCellWidth)
+  construct : function(spacingX, spacingY)
   {
     this.base(arguments);
 
@@ -115,10 +107,6 @@ qx.Class.define("qx.ui.layout.Grid",
 
     if (spacingY) {
       this.setSpacingY(spacingY);
-    }
-    
-    if(allowGrowSpannedCellWidth === true || allowGrowSpannedCellWidth === false) {
-      this.setAllowGrowSpannedCellWidth(allowGrowSpannedCellWidth);
     }
   },
 
@@ -156,7 +144,7 @@ qx.Class.define("qx.ui.layout.Grid",
     
     
     /**
-     * Allow growing of spanning cell widths beyond the cumulated widths of the columns.
+     * Allow growing of spanning cells' widths beyond the accumulated widths of the columns.
      */
     allowGrowSpannedCellWidth :
     {
@@ -1022,7 +1010,7 @@ qx.Class.define("qx.ui.layout.Grid",
           // of the spanning cell if allowGrowSpannedCellWidth property
           // is set to false
           // See https://github.com/qooxdoo/qooxdoo/issues/9871
-          if (this.getAllowGrowSpannedCellWidth() === false || !qx.lang.Object.isEmpty(colFlexes)) {
+          if (!this.getAllowGrowSpannedCellWidth() || !qx.lang.Object.isEmpty(colFlexes)) {
             var colIncrements = qx.ui.layout.Util.computeFlexOffsets(
               colFlexes, hint.width, prefSpanWidth
             );

--- a/framework/source/class/qx/ui/layout/Grid.js
+++ b/framework/source/class/qx/ui/layout/Grid.js
@@ -144,7 +144,7 @@ qx.Class.define("qx.ui.layout.Grid",
     
     
     /**
-     * Allow growing of spanning cells widths beyond the accumulated widths of the columns.
+     * Allow growing of spanning cells' widths beyond the accumulated widths of the columns.
      * The default behavior (init value false) is that the width of the spanning cell is 
      * determined by the accumulated width of the columns (plus spacing). 
      * Setting this property to true lets the cell width grow as needed to show 

--- a/framework/source/class/qx/ui/layout/Grid.js
+++ b/framework/source/class/qx/ui/layout/Grid.js
@@ -144,7 +144,7 @@ qx.Class.define("qx.ui.layout.Grid",
     
     
     /**
-     * Allow growing of spanning cells' widths beyond the accumulated widths of the columns.
+     * Allow growing of spanning cells widths beyond the accumulated widths of the columns.
      * The default behavior (init value false) is that the width of the spanning cell is 
      * determined by the accumulated width of the columns (plus spacing). 
      * Setting this property to true lets the cell width grow as needed to show 

--- a/framework/source/class/qx/ui/layout/Grid.js
+++ b/framework/source/class/qx/ui/layout/Grid.js
@@ -145,6 +145,10 @@ qx.Class.define("qx.ui.layout.Grid",
     
     /**
      * Allow growing of spanning cells' widths beyond the accumulated widths of the columns.
+     * The default behavior (init value false) is that the width of the spanning cell is 
+     * determined by the accumulated width of the columns (plus spacing). 
+     * Setting this property to true lets the cell width grow as needed to show 
+     * the widget in the spanning cell, which also enlarges the width of the spanned columns.
      */
     allowGrowSpannedCellWidth :
     {


### PR DESCRIPTION
This PR adds the property allowGrowSpannedCellWidth (default false) which allows to determine the behavior of spanning cells when the widget within a spanning cell needs more place than the width cumulated widths of the spanned columns.

Default false of the new property ensures backwards compatibility. True enables the new behavior introduced with #9860 

Fixes #9871 
