### PR TITLE
Change jsonrpc default protocol to "2.0"

### DIFF
--- a/framework/source/class/qx/io/remote/Rpc.js
+++ b/framework/source/class/qx/io/remote/Rpc.js
@@ -390,7 +390,7 @@ qx.Class.define("qx.io.remote.Rpc",
      */
     protocol :
     {
-      init : "qx1",
+      init : "2.0",
       check : function(val) { return val == "qx1" || val == "2.0"; }
     }
   },


### PR DESCRIPTION
This is BC because anyone who still uses the original "qx1" protocol can switch back by setting the "protocol" property accordingly.