### PR TITLE
Fix qx.test.core.Property test

### DIFF
--- a/framework/source/class/qx/test/Part.js
+++ b/framework/source/class/qx/test/Part.js
@@ -177,7 +177,7 @@ qx.Class.define("qx.test.Part",
       partLoader.preload("juhu");
 
       var part = partLoader.getParts()["juhu"];
-
+      var self = this;
       part.getPackages()[0].loadClosure = function() {
         self.resume(function() {
           self.fail("load called twice!");

--- a/framework/source/class/qx/test/core/Property.js
+++ b/framework/source/class/qx/test/core/Property.js
@@ -328,68 +328,78 @@ qx.Class.define("qx.test.core.Property",
     testWrongPropertyDefinitions : function()
     {
       if (qx.core.Environment.get("qx.debug")) {
+
+        // class config maps must be separately defined to not produce compiler errors
+
         // date
         this.assertException(function() {
-          qx.Class.define("qx.test.clName", {
+          var config = {
             extend : qx.core.Object,
             properties : new Date()
-          });
+          };
+          qx.Class.define("qx.test.clName", config);
         }, Error, new RegExp(".*Invalid.*"), "123");
         delete qx.test.clName;
 
         // array
         this.assertException(function() {
-          qx.Class.define("qx.test.clName", {
+          var config = {
             extend : qx.core.Object,
             properties : [1,2,3]
-          });
+          };
+          qx.Class.define("qx.test.clName", config);
         }, Error, new RegExp(".*Invalid.*"), "123");
         delete qx.test.clName;
 
         // qooxdoo class
         var o = new qx.core.Object();
         this.assertException(function() {
-          qx.Class.define("qx.test.clName", {
+          var config = {
             extend : qx.core.Object,
             properties : o
-          });
+          };
+          qx.Class.define("qx.test.clName", config);
         }, Error, new RegExp(".*Invalid.*"), "123");
         delete qx.test.clName;
         o.dispose();
 
         // RegExp
         this.assertException(function() {
-          qx.Class.define("qx.test.clName", {
+          var config = {
             extend : qx.core.Object,
             properties : new RegExp()
-          });
+          };
+          qx.Class.define("qx.test.clName", config);
         }, Error, new RegExp(".*Invalid.*"), "123");
         delete qx.test.clName;
 
         // null
         this.assertException(function() {
-          qx.Class.define("qx.test.clName", {
+          var config = {
             extend : qx.core.Object,
             properties : null
-          });
+          };
+          qx.Class.define("qx.test.clName", config);
         }, Error, new RegExp(".*Invalid.*"), "123");
         delete qx.test.clName;
 
         // boolean
         this.assertException(function() {
-          qx.Class.define("qx.test.clName", {
+          var config = {
             extend : qx.core.Object,
             properties : true
-          });
+          };
+          qx.Class.define("qx.test.clName", config);
         }, Error, new RegExp(".*Invalid.*"), "123");
         delete qx.test.clName;
 
         // number
         this.assertException(function() {
-          qx.Class.define("qx.test.clName", {
+          var config = {
             extend : qx.core.Object,
             properties : 123
-          });
+          };
+          qx.Class.define("qx.test.clName", config);
         }, Error, new RegExp(".*Invalid.*"), "123");
         delete qx.test.clName;
       }
@@ -893,8 +903,8 @@ qx.Class.define("qx.test.core.Property",
 
       object.dispose();
     },
-    
-    
+
+
     testTransform : function ()
     {
       qx.Class.define("qx.TestProperty", {


### PR DESCRIPTION
class config maps must be separately defined to not produce compiler errors