### PR TITLE
Fix sidebar

### DIFF
--- a/docs/_sidebar.md
+++ b/docs/_sidebar.md
@@ -4,31 +4,33 @@
   - [Qooxdoo Apps](/apps.md)
   - [About](/about.md)
 
-- [**Qooxdoo Core**](/core/)
-
-  - [Introduction](/core/oo_introduction.md)
+- Qooxdoo Core
+  - [Overview](/core/)
+  - [Introduction into OO](/core/oo_introduction.md)
   - [Feature summary](/core/oo_feature_summary.md)
   
   - Object Orientation
-    - [Classes](/core/classes.md)
-      - [Quickref](/core/class_quickref.md)
-    - [Interfaces](/core/interfaces.md)
-      - [Quickref](/core/interface_quickref.md)
-    - [Mixins](/core/mixins.md)
-      - [Quickref](/core/mixin_quickref.md)
+    - [Classes](/core/classes.md)     
+    - [Interfaces](/core/interfaces.md) 
+    - [Mixins](/core/mixins.md) 
     - [Annotations](/core/annotations.md)
     - [Arrays](/core/array.md)
     - [Data binding](/core/data_binding/)
     - [Promises](/core/promises.md)
+    - Class system quickrefs:
+        - [Classes](/core/class_quickref.md)
+        - [Interfaces](/core/interface_quickref.md)
+        - [Mixins](/core/mixin_quickref.md)
 
   - Properties
-    - [Properties](/core/understanding_properties.md)
-      - [Quickref](/core/properties_quickref.md)
+    - [Overview](/core/understanding_properties.md)
     - [Defining properties](/core/defining_properties.md)
     - [Behavior](/core/property_behavior.md)
     - [Features](/core/property_features.md)
+    - [Property Quickref](/core/properties_quickref.md)
   
-  - [Environment](/core/environment.md)
+  - Environment
+    - [Overview](/core/environment.md)
   
   - Interaction Events
     - [Pointer](/core/pointer.md)
@@ -69,7 +71,6 @@
     - [HTML element handling](/desktop/gui/html.md)
     - [Focus handling](/desktop/gui/focus.md)  
 
-
 - Qooxdoo for Node
   - [Introduction](/server/)
   - [Getting Started](/server/getting_started.md)
@@ -86,18 +87,15 @@
   - [Resolution and Pixel Density](/mobile/resolution.md)
   - [Theming](/mobile/theming.md)
 
-
 - Communication
-
+  - [Overview](/communication/)
   - [REST](/communication/rest.md)
-  - [Server Writer Guide](/communication/rpc_server_writer_guide.md)
-  - [Fake Server](/communication/fake_server.md)
   - [Remote IO](/communication/remote_io.md)
   - [Request IO](/communication/request_io.md)
   - [JSON RPC](/communication/rpc.md)
 
-
 - Development
+  - [Migrating to the `qx` toolchain](/compiler/migration.md)
   - ["qx" CLI commands](/compiler/cli/commands.md)
   - [Package system](/compiler/cli/packages.md)
   - [Compiler Configuration](/compiler/configuration/overview.md)
@@ -105,12 +103,13 @@
     - [compile.json](/compiler/configuration/compile.md)
     - [API](/compiler/configuration/api.md)
   - [Advanced compiler topics](/compiler/internals/)
-  - [Migrating from Python to qx toolchain](/compiler/migration.md)
-
-- [**Testing**](/compiler/cli/testing.md)
+  - [Testing](/development/testing/)
+    - [Unit Testing](/development/testing/unit_testing.md)
+    - [Using qx test](/compiler/cli/testing.md)
+    - [Fake Server](/development/testing/fake_server.md)
+    - [Testing qooxdoo forks](/development/testing/framework_tests.md)
 
 - Deployment (tbd)
-
 
 - Tutorials
 

--- a/docs/development/testing/README.md
+++ b/docs/development/testing/README.md
@@ -6,6 +6,7 @@ and a standalone testrunner which runs in the browser or as a node application.
 Until there is more exensive documentation,
 please refer to the following resources:
 
+ - [Unit Testing](unit_testing.md)
  - [Testrunner](../../../compiler/cli/testing.md)
  - [Framework Tests](framework_tests.md)
  - [Fake Server](fake_server.md)

--- a/docs/index.html
+++ b/docs/index.html
@@ -16,12 +16,15 @@
     markdown: {
       gfm: true, tables: true
     },
+    alias: {
+      '/.*/_sidebar.md': '/_sidebar.md',
+    },
     name: '@qooxdoo/framework',
     repo: 'https://github.com/qooxdoo/qooxdoo',
     loadSidebar: '_sidebar.md',
     coverpage: true,
     auto2top: true,
-    subMaxLevel: 2,
+    subMaxLevel: 3,
     mergeNavbar: false,
     namespace: 'qx-manual',
     relativePath: true,
@@ -61,5 +64,6 @@
 <script src="_media/prism-bash.min.js"></script>
 <script src="_media/prism-json.min.js"></script>
 <script src="_media/sidecar.v1.js"></script>
+<script src="_media/docsify-sidebar-collapse.min.js">
 </body>
 </html>

--- a/docs/index.html
+++ b/docs/index.html
@@ -16,15 +16,12 @@
     markdown: {
       gfm: true, tables: true
     },
-    alias: {
-      '/.*/_sidebar.md': '/_sidebar.md',
-    },
     name: '@qooxdoo/framework',
     repo: 'https://github.com/qooxdoo/qooxdoo',
     loadSidebar: '_sidebar.md',
     coverpage: true,
     auto2top: true,
-    subMaxLevel: 3,
+    subMaxLevel: 2,
     mergeNavbar: false,
     namespace: 'qx-manual',
     relativePath: true,
@@ -64,6 +61,5 @@
 <script src="_media/prism-bash.min.js"></script>
 <script src="_media/prism-json.min.js"></script>
 <script src="_media/sidecar.v1.js"></script>
-<script src="_media/docsify-sidebar-collapse.min.js">
 </body>
 </html>


### PR DESCRIPTION
This fixes broken links and a few layout problems in the sidebar. For example, if a heading is annotated with a URL, it is no longer formatted as a heading. This ultimately needs to be fixed in the CSS, of course, but I have no time for that and removing the link and moving it to an "Overview" sub-page seems like an adequate fix. 