### PR TITLE
Do not touch Content-Type when submitting FormData

### DIFF
--- a/framework/source/class/qx/io/request/Xhr.js
+++ b/framework/source/class/qx/io/request/Xhr.js
@@ -241,7 +241,8 @@ qx.Class.define("qx.io.request.Xhr",
     // overridden
     _getConfiguredRequestHeaders: function() {
       var headers = {},
-          isAllowsBody = qx.util.Request.methodAllowsRequestBody(this.getMethod());
+          isAllowsBody = qx.util.Request.methodAllowsRequestBody(this.getMethod()),
+          isFormData = (qx.Bootstrap.getClass(this.getRequestData()) == "FormData");
 
       // Follow convention to include X-Requested-With header when same origin
       if (!qx.util.Request.isCrossDomain(this.getUrl())) {
@@ -254,7 +255,7 @@ qx.Class.define("qx.io.request.Xhr",
       }
 
       // By default, set content-type urlencoded for requests with body
-      if (this.getRequestData() && isAllowsBody) {
+      if (this.getRequestData() && isAllowsBody && !isFormData) {
         headers["Content-Type"] = "application/x-www-form-urlencoded";
       }
 


### PR DESCRIPTION
When using XMLHttpRequest with FormData the Content-Type gets set automatically to `multipart/form-data` with an appropriate boundary.  But this will only work when the Content-Type has not been set already. Prevent qooxdoo from breaking this :)