### PR TITLE
Level420 patch manifest version mismatch

### DIFF
--- a/Manifest.json
+++ b/Manifest.json
@@ -90,6 +90,6 @@
   },
   "requires": {
     "@qooxdoo/compiler": "^1.0.0-beta",
-    "@qooxdoo/framework": "^6.0.0-alpha"
+    "@qooxdoo/framework": "^6.0.0-beta"
   }
 }


### PR DESCRIPTION
Both version and required version should be the same.