### PR TITLE
Scale default delay in async test methods

### DIFF
--- a/framework/source/class/qx/dev/unit/AsyncWrapper.js
+++ b/framework/source/class/qx/dev/unit/AsyncWrapper.js
@@ -41,14 +41,21 @@ qx.Class.define("qx.dev.unit.AsyncWrapper",
    */
   construct : function(delay, deferredFunction, context)
   {
-    for (var i=0; i<2; i++) {
-      if (qx.lang.Type.isFunction(arguments[i])) {
-        this.setDeferredFunction(arguments[i]);
-      } else if (qx.lang.Type.isNumber(arguments[i])) {
-        if (qx.core.Environment.get("qx.test.delay.scale")) {
-          this.setDelay(arguments[i] * parseInt(qx.core.Environment.get("qx.test.delay.scale"), 10));
-        } else {
-          this.setDelay(arguments[i]);
+    if (delay === undefined && deferredFunction === undefined) {
+      // scale default delay if wait() is called without arguments
+      if (qx.core.Environment.get("qx.test.delay.scale")) {
+        this.setDelay(this.getDelay() * parseInt(qx.core.Environment.get("qx.test.delay.scale"), 10));
+      }
+    } else {
+      for (var i=0; i<2; i++) {
+        if (qx.lang.Type.isFunction(arguments[i])) {
+          this.setDeferredFunction(arguments[i]);
+        } else if (qx.lang.Type.isNumber(arguments[i])) {
+          if (qx.core.Environment.get("qx.test.delay.scale")) {
+            this.setDelay(arguments[i] * parseInt(qx.core.Environment.get("qx.test.delay.scale"), 10));
+          } else {
+            this.setDelay(arguments[i]);
+          }
         }
       }
     }

--- a/framework/source/class/qx/dev/unit/TestResult.js
+++ b/framework/source/class/qx/dev/unit/TestResult.js
@@ -190,7 +190,7 @@ qx.Class.define("qx.dev.unit.TestResult",
               var defaultTimeoutFunction = function() {
                 throw new qx.core.AssertionError(
                   "Asynchronous Test Error in setUp",
-                  "Timeout reached before resume() was called."
+                  "Timeout of " + ex.getDelay() + " ms reached before resume() was called."
                 );
               };
               var timeoutFunc = (ex.getDeferredFunction() ? ex.getDeferredFunction() : defaultTimeoutFunction);
@@ -252,7 +252,7 @@ qx.Class.define("qx.dev.unit.TestResult",
             var defaultTimeoutFunction = function() {
               throw new qx.core.AssertionError(
                 "Asynchronous Test Error",
-                "Timeout reached before resume() was called."
+                "Timeout of " + ex.getDelay() + " ms reached before resume() was called."
               );
             };
             var timeoutFunc = (ex.getDeferredFunction() ? ex.getDeferredFunction() : defaultTimeoutFunction);


### PR DESCRIPTION
the Unit test runner [calls `wait()` with no arguments for async functions](https://github.com/qooxdoo/qooxdoo/blob/master/framework/source/class/qx/dev/unit/TestFunction.js#L126-L138)  which means that [the default timeout of 10000ms](https://github.com/qooxdoo/qooxdoo/blob/master/framework/source/class/qx/dev/unit/AsyncWrapper.js#L82) is applied, without the possibility of changing this timeout programmatically. This PR allows to scale the default timeout using the `qx.test.delay.scale` environment setting in the same way a given `delay` value would be scaled. 