### PR TITLE
Remove deploy-to-website job

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -82,10 +82,6 @@ jobs:
       before_install: ./.travis/check-github-label ci-skip-browser-tests && exit 0 || true
       script: ../.travis/test EdgeSL
 
-    - stage: Deploy
-      name: Deploy to website
-      addons:
-      script: ../.travis/deploy_website
     - # parallel
       name: Deploy to npm
       addons:


### PR DESCRIPTION
It is no longer required since we are not updating the old website any more.  Deployment of new website can be found here: https://github.com/qooxdoo/website/blob/master/.github/workflows/deploy_website.yml