### PR TITLE
Fix for #9719...

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,3 +3,5 @@
 ## Breaking changes
 
 * [qx.bom.Cookie] Previous versions of qooxoo use `escape()` and `unescape()` functions. Since those functions are deprecated, then now qooxdoo use `encodeURIComponent()` and `decodeURIComponent()` functions. This may break some cookies. There are no issues with special characters like `~!@#$%^&*(){}[]=:/,;?+\'"\\` but some unicode characters like `äëíöü` (etc) are encoded different by `escape()` and `encodeURIComponent()`, so you must take care of this change if you use unicode characters.
+
+* [qx.ui.splitpane.Splitter] New Property `knobVisible` toggles visibility of the splitter's button. Property `visible` toggles visibility of the whole splitte widget (no change from v5.0.x).

--- a/framework/source/class/qx/ui/splitpane/Pane.js
+++ b/framework/source/class/qx/ui/splitpane/Pane.js
@@ -187,7 +187,7 @@ qx.Class.define("qx.ui.splitpane.Pane",
       // is removed.
       splitter.addListener("resize", function(e) {
         var bounds = e.getData();
-        if (this.getChildControl("splitter").getVisible() && (bounds.height == 0 || bounds.width == 0)) {
+        if (this.getChildControl("splitter").isKnobVisible() && (bounds.height == 0 || bounds.width == 0)) {
           this.__blocker.hide();
         } else {
           this.__blocker.show();
@@ -298,7 +298,7 @@ qx.Class.define("qx.ui.splitpane.Pane",
         }
         var left = bounds && bounds.left;
 
-        if (width || !this.getChildControl("splitter").getVisible()) {
+        if (width || !this.getChildControl("splitter").isKnobVisible()) {
           if (isNaN(left)) {
             left = qx.bom.element.Location.getPosition(splitterElem).left;
           }
@@ -317,7 +317,7 @@ qx.Class.define("qx.ui.splitpane.Pane",
         }
         var top =  bounds && bounds.top;
 
-        if (height || !this.getChildControl("splitter").getVisible()) {
+        if (height || !this.getChildControl("splitter").isKnobVisible()) {
           if (isNaN(top)) {
             top = qx.bom.element.Location.getPosition(splitterElem).top;
           }

--- a/framework/source/class/qx/ui/splitpane/Splitter.js
+++ b/framework/source/class/qx/ui/splitpane/Splitter.js
@@ -56,7 +56,7 @@ qx.Class.define("qx.ui.splitpane.Splitter",
     }
 
     // create knob child control
-    if (this.getVisible()) {
+    if (this.isKnobVisible()) {
       this._createChildControl("knob");
     }
   },
@@ -84,16 +84,19 @@ qx.Class.define("qx.ui.splitpane.Splitter",
       refine : true,
       init : false
     },
+
+
     /**
-     * The visibility of the splitter.
-     * Allows to remove the splitter in favor of other visual separation means like background color differences.
+     * The visibility of the splitter button.
+     * Allows to remove the splitter button in favor of other visual separation
+     * means like background color differences.
      */
-    visible :
+    knobVisible :
     {
-      init: true,
-      check: "Boolean",
-      themeable: true,
-      apply: "_applyVisible"
+      check     : "Boolean",
+      init      : true,
+      themeable : true,
+      apply     : "_applyKnobVisible"
     }
   },
 
@@ -125,8 +128,10 @@ qx.Class.define("qx.ui.splitpane.Splitter",
       return control || this.base(arguments, id);
     },
 
-    _applyVisible: function(visible, old) {
-      this.getChildControl("knob").setVisibility(visible ? "visible" : "excluded");
+
+    // property apply
+    _applyKnobVisible : function (value, old) {
+      this.getChildControl("knob").setVisibility(value ? "visible" : "excluded");
     }
   }
 });


### PR DESCRIPTION
`Conflicting property method qx.ui.splitpane.Splitter.isVisible with qx.ui.core.Widget`.
Property `visible` is for the whole widget (_as like all other widgets_),
property `knobVisible` is for the knob.