### PR TITLE
add option to disable tab navigation, activated by default.

### DIFF
--- a/framework/source/class/qx/ui/core/FocusHandler.js
+++ b/framework/source/class/qx/ui/core/FocusHandler.js
@@ -43,6 +43,20 @@ qx.Class.define("qx.ui.core.FocusHandler",
   },
 
 
+  /*
+  ***********************************************
+    PROPERTIES
+  ***********************************************
+  */
+  properties: {
+    /**
+     * Activate changing focus with the tab key (default: true)
+     */
+    useTabNavigation: {
+      check: 'Boolean',
+      init: true
+    }
+  },
 
 
   /*
@@ -237,7 +251,7 @@ qx.Class.define("qx.ui.core.FocusHandler",
      */
     __onKeyPress : function(e)
     {
-      if (e.getKeyIdentifier() != "Tab") {
+      if (e.getKeyIdentifier() != "Tab" || !this.isUseTabNavigation()) {
         return;
       }
 


### PR DESCRIPTION
We are using the monaco text editor to edit Text files. With this new option you can avoid the behavior that the editor is loosing focus when you press the tab key.