### PR TITLE
Disable building of apps  - temporary fix

### DIFF
--- a/.travis/deploy_npm
+++ b/.travis/deploy_npm
@@ -43,10 +43,10 @@ exe npx qx --version
 exe npx qx pkg install -v 
 #compile everything
 exe npx qx compile --config-file=compileServer.json --target=build 
-exe npx qx compile --config-file=compile.json       --target=build 
+#exe npx qx compile --config-file=compile.json       --target=build 
 #remove unnecessary stuff
-exe find ./apps/transpiled -type f -name '*.map' -delete
-exe find ./apps/transpiled -type f -name '*.js'  -delete
+#exe find ./apps/transpiled -type f -name '*.map' -delete
+#exe find ./apps/transpiled -type f -name '*.js'  -delete
 #copy source
 exe mkdir -p source
 exe cp -rf ./framework/source/* ./source


### PR DESCRIPTION
Any problem in any of the apps' build chain currently breaks the deployment of the qooxdoo framework package to NPM (`@qooxdoo/framework`). This PR disables the building of the apps for the local qx server, since they are not necessary for its functioning, until a better fix is available. 