### PR TITLE
Virtual DOM and JSX support

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -126,7 +126,7 @@ qx.Class.define("myapp.Application", {
 If you have worked with javascript before you may find that it looks like
 javascript but also different from most javascript you have seen to date. This
 is because qooxdoo introduces both a rich set of widgets as well as class based
-object orientation into the language. There is quote a lot of documentation on
+object orientation into the language. There is quite a lot of documentation on
 these toppics in the next few sections.
 
 And yes, this is the complete program, there is neither HTML nor CSS. The
@@ -137,14 +137,12 @@ your application a distinctive look.
 Try editing the file a bit. You will notice that the server detects your
 modifications and recompiles the application automatically.
 
-If you look at the files that are created by the compiler (in the `compiled/` directory), 
+If you look at the files that are created by the compiler (in the `compiled/source` directory), 
 you might notice that the resulting code is quite large in size. This is because even
 the tiniest application makes use of qooxdoo's core classes, and the compiler produces
-a large number of artefacts that are needed for quick recompilation, but not for the
-functioning of your app. What you will finally deploy is much smaller (in our case, it is
-in the `compiled/source/myapp` folder). As your app grows, the size of that folder will grow 
-linearly with your new code (and with whatever additional features of qooxdoo 
-your code uses).
+a large number of artefacts that are needed for quick recompilation and debugging.
+The compiler can also produce a deployable version of your app wich will be much smaller
+and not contain any of the debugging support. More on that later.
 
 ## Reading on
 

--- a/docs/_sidebar.md
+++ b/docs/_sidebar.md
@@ -1,6 +1,7 @@
 - Overview
   - [Contents](/contents.md)
   - [Getting Started](/?id=getting-started)
+  - [Qooxdoo Tutorials](/tutorials.md)
   - [Qooxdoo Apps](/apps.md)
   - [About](/about.md)
 

--- a/docs/core/data_binding/data_binding.md
+++ b/docs/core/data_binding/data_binding.md
@@ -165,7 +165,7 @@ What if you want to to bring your own code to the generated model classes or if 
 -   Add your code as a mixin to the created model classes.
 -   Use your own class instead of the created model classes.
 
-Take a look at the API-Documentation of the [qx.data.store.IStoreDelegate](apps://apiviewer/index.html#qx.data.store.IStoreDelegate) to see the available methods and how to implement them.
+Take a look at the API-Documentation of the [qx.data.store.IStoreDelegate](apps://apiviewer/#qx.data.store.IStoreDelegate) to see the available methods and how to implement them.
 
 ## Controller Component
 

--- a/docs/core/gestures.md
+++ b/docs/core/gestures.md
@@ -4,18 +4,18 @@ Based on the `low-level pointer events pointer.md#pointer_events`,
 the following gesture events are available in all three of qooxdoo's GUI
 toolkits (qx.Desktop, qx.Mobile and qx.Website):
 
-  - [tap](apps://apiviewer/index.html#qx.event.type.Tap):
+  - [tap](apps://apiviewer/#qx.event.type.Tap):
     A brief finger/stylus tap or mouse click
-  - [longtap](apps://apiviewer/index.html#qx.event.type.Tap):
+  - [longtap](apps://apiviewer/#qx.event.type.Tap):
     A tap that is held down for 500 milliseconds
-  - [dbltap](apps://apiviewer/index.html#qx.event.type.Tap):
+  - [dbltap](apps://apiviewer/#qx.event.type.Tap):
     Two taps in quick succession
-  - [swipe](apps://apiviewer/index.html#qx.event.type.Swipe):
+  - [swipe](apps://apiviewer/#qx.event.type.Swipe):
     Horizontal or vertical swipe motion
-  - [rotate](apps://apiviewer/index.html#qx.event.type.Rotate):
+  - [rotate](apps://apiviewer/#qx.event.type.Rotate):
     Two contact points (e.g. fingers) rotating around a central point
-  - [pinch](apps://apiviewer/index.html#qx.event.type.Pinch):
+  - [pinch](apps://apiviewer/#qx.event.type.Pinch):
     Two contact points moving towards or away from each other
-  - [track](apps://apiviewer/index.html#qx.event.type.Track):
+  - [track](apps://apiviewer/#qx.event.type.Track):
     Cross-device equivalent to mouse drag (fired only between
     pointerdown and pointerup)

--- a/docs/core/pointer.md
+++ b/docs/core/pointer.md
@@ -31,7 +31,7 @@ The following events are available in all of qooxdoo's GUI toolkits:
   - pointercancel
 
 [Pointer event API
-documentation](apps://apiviewer/index.html#qx.event.type.Pointer)
+documentation](apps://apiviewer/#qx.event.type.Pointer)
 
 Note that not all events mentioned in the specification are listed here.
 We chose to only implement the event types required for qooxdoo's

--- a/docs/desktop/gui/html.md
+++ b/docs/desktop/gui/html.md
@@ -87,7 +87,6 @@ qx.Class.define("mypackage.MySignupForm", {
   
   construct() {
     this.base(arguments, "div");
-    this.setCaption("Login");
     let body = this.getBody();
     body.add(<h1>Welcome to My Corporate Website</h1>);
     body.add(

--- a/docs/desktop/gui/html.md
+++ b/docs/desktop/gui/html.md
@@ -76,7 +76,7 @@ an HTML string which the server can pass to the client; this is useful because i
 defining and manipulating the DOM before it reaches the browser.
 
 However, rather than simply creating instances of `qx.html.Element`, you can derive classes from it and this has a  
-particular advantage in that you code can be used on the client and the server, and will be able to connect to the
+particular advantage in that your code can be used on the client and the server and will be able to connect to the
 browser's "real" DOM nodes.
 
 For example, consider this class:
@@ -171,4 +171,3 @@ Even things like focus handling or scrolling may be queued. It depends on if the
 determine whether these are queued. `focus` often makes more sense when it is directly executed, as the following code 
 may make assumptions that the changes are applied already. Generally Qooxdoo allows it to apply most changes without 
 the queue, as well, using a `direct` flag which is part of most setters offered by `qx.html.Element`.
-

--- a/docs/desktop/gui/html.md
+++ b/docs/desktop/gui/html.md
@@ -132,6 +132,9 @@ qx.Class.define("mypackage.MySignupForm", {
 });
 ```
 
+(The above example uses JSX to embed HTML inside Javascript - this will not work with the Python toolchain, you *must*
+use the new compiler)
+
 Note that this class does *not* use the `qx.ui.*` classes - it is just about manipulating the DOM, and is
 the sort of lightweight code you might use as part of the interaction with a user long before they are able to start
 a full blown Desktop or Mobile Qooxdoo application. 

--- a/docs/desktop/gui/pointer.md
+++ b/docs/desktop/gui/pointer.md
@@ -19,6 +19,6 @@ The following events are available in all of qooxdoo's GUI toolkits:
 -   pointerup
 -   pointercancel
 
-[Pointer event API documentation](apps://apiviewer/index.html#qx.event.type.Pointer)
+[Pointer event API documentation](apps://apiviewer/#qx.event.type.Pointer)
 
 Note that not all events mentioned in the specification are listed here. We chose to only implement the event types required for qooxdoo's widgets, which is one reason why we don't like to call this implementation a polyfill, even if in most areas it conforms to the the spec and is quite broad in scope.

--- a/docs/desktop/gui/window_management.md
+++ b/docs/desktop/gui/window_management.md
@@ -80,5 +80,5 @@ windows to a root widget.
 
 ## Demos and API
 
-To find out more, you can check the [desktop demo](apps://demobrowser/index.html#widget~Desktop.html)
-and the [API reference](apps://apiviewer/index.html#qx.ui.window).
+To find out more, you can check the [desktop demo](apps://demobrowser/#widget~Desktop.html)
+and the [API reference](apps://apiviewer/#qx.ui.window).

--- a/docs/desktop/layout/basic.md
+++ b/docs/desktop/layout/basic.md
@@ -48,4 +48,4 @@ API
 ---
 
 Here is a link to the API of the layout manager:
-[qx.ui.layout.Basic](apps://apiviewer/index.html#qx.ui.layout.Basic)
+[qx.ui.layout.Basic](apps://apiviewer/#qx.ui.layout.Basic)

--- a/docs/desktop/layout/box.md
+++ b/docs/desktop/layout/box.md
@@ -72,5 +72,5 @@ API
 
 Here is a link to the API of the layout manager:
 
-[qx.ui.layout.HBox](apps://apiviewer/index.html#qx.ui.layout.HBox)
-[qx.ui.layout.VBox](apps://apiviewer/index.html#qx.ui.layout.VBox)
+[qx.ui.layout.HBox](apps://apiviewer/#qx.ui.layout.HBox)
+[qx.ui.layout.VBox](apps://apiviewer/#qx.ui.layout.VBox)

--- a/docs/desktop/layout/canvas.md
+++ b/docs/desktop/layout/canvas.md
@@ -53,4 +53,4 @@ API
 ---
 
 Here is a link to the API of the layout manager:
-[qx.ui.layout.Canvas](apps://apiviewer/index.html#qx.ui.layout.Canvas)
+[qx.ui.layout.Canvas](apps://apiviewer/#qx.ui.layout.Canvas)

--- a/docs/desktop/layout/dock.md
+++ b/docs/desktop/layout/dock.md
@@ -57,4 +57,4 @@ API
 ---
 
 Here is a link to the API of the layout manager:
-[qx.ui.layout.Dock](apps://apiviewer/index.html#qx.ui.layout.Dock)
+[qx.ui.layout.Dock](apps://apiviewer/#qx.ui.layout.Dock)

--- a/docs/desktop/layout/flow.md
+++ b/docs/desktop/layout/flow.md
@@ -51,4 +51,4 @@ API
 ---
 
 Here is a link to the API of the layout manager:
-[qx.ui.layout.Flow](apps://apiviewer/index.html#qx.ui.layout.Flow)
+[qx.ui.layout.Flow](apps://apiviewer/#qx.ui.layout.Flow)

--- a/docs/desktop/layout/grid.md
+++ b/docs/desktop/layout/grid.md
@@ -59,4 +59,4 @@ API
 ---
 
 Here is a link to the API of the layout manager:
-[qx.ui.layout.Grid](apps://apiviewer/index.html#qx.ui.layout.Grid)
+[qx.ui.layout.Grid](apps://apiviewer/#qx.ui.layout.Grid)

--- a/docs/desktop/layout/grow.md
+++ b/docs/desktop/layout/grow.md
@@ -28,4 +28,4 @@ API
 ---
 
 Here is a link to the API of the layout manager:
-[qx.ui.layout.Grow](apps://apiviewer/index.html#qx.ui.layout.Grow)
+[qx.ui.layout.Grow](apps://apiviewer/#qx.ui.layout.Grow)

--- a/docs/desktop/widget/button.md
+++ b/docs/desktop/widget/button.md
@@ -32,4 +32,4 @@ API
 ---
 
 Here is a link to the API of the Widget:
-[qx.ui.form.Button](apps://apiviewer/index.html#qx.ui.form.Button)
+[qx.ui.form.Button](apps://apiviewer/#qx.ui.form.Button)

--- a/docs/desktop/widget/canvas.md
+++ b/docs/desktop/widget/canvas.md
@@ -36,10 +36,10 @@ Demos
 
 Here are some links that demonstrate the usage of the widget:
 
--   [Canvas demo](apps://demobrowser/index.html#widget-Canvas.html)
+-   [Canvas demo](apps://demobrowser/#widget-Canvas.html)
 
 API
 ---
 
 Here is a link to the API of the Widget:
-[Canvas API](apps://apiviewer/index.html#qx.ui.embed.Canvas)
+[Canvas API](apps://apiviewer/#qx.ui.embed.Canvas)

--- a/docs/desktop/widget/composite.md
+++ b/docs/desktop/widget/composite.md
@@ -27,4 +27,4 @@ API
 ---
 
 Here is a link to the API of the Widget:
-[qx.ui.container.Composite](apps://apiviewer/index.html#qx.ui.container.Composite)
+[qx.ui.container.Composite](apps://apiviewer/#qx.ui.container.Composite)

--- a/docs/desktop/widget/html.md
+++ b/docs/desktop/widget/html.md
@@ -32,10 +32,10 @@ Demos
 
 Here are some links that demonstrate the usage of the widget:
 
--   [HTML embed demo](apps://demobrowser/index.html#widget-HtmlEmbed.html)
+-   [HTML embed demo](apps://demobrowser/#widget-HtmlEmbed.html)
 
 API
 ---
 
 Here is a link to the API of the Widget:
-[HTML Embed API](apps://apiviewer/index.html#qx.ui.embed.Html)
+[HTML Embed API](apps://apiviewer/#qx.ui.embed.Html)

--- a/docs/desktop/widget/iframe.md
+++ b/docs/desktop/widget/iframe.md
@@ -25,10 +25,10 @@ Demos
 
 Here are some links that demonstrate the usage of the widget:
 
--   [Iframe demo](apps://demobrowser/index.html#widget-Iframe.html)
+-   [Iframe demo](apps://demobrowser/#widget-Iframe.html)
 
 API
 ---
 
 Here is a link to the API of the Widget:
-[API for Iframe](apps://apiviewer/index.html#qx.ui.embed.Iframe)
+[API for Iframe](apps://apiviewer/#qx.ui.embed.Iframe)

--- a/docs/desktop/widget/label.md
+++ b/docs/desktop/widget/label.md
@@ -34,4 +34,4 @@ API
 ---
 
 Here is a link to the API of the Widget:
-[qx.ui.basic.Label](apps://apiviewer/index.html#qx.ui.basic.Label)
+[qx.ui.basic.Label](apps://apiviewer/#qx.ui.basic.Label)

--- a/docs/desktop/widget/resizer.md
+++ b/docs/desktop/widget/resizer.md
@@ -31,4 +31,4 @@ API
 ---
 
 Here is a link to the API of the Widget:
-[qx.ui.container.Resizer](apps://apiviewer/index.html#qx.ui.container.Resizer)
+[qx.ui.container.Resizer](apps://apiviewer/#qx.ui.container.Resizer)

--- a/docs/desktop/widget/scroll.md
+++ b/docs/desktop/widget/scroll.md
@@ -35,4 +35,4 @@ API
 ---
 
 Here is a link to the API of the Widget:
-[qx.ui.container.Scroll](apps://apiviewer/index.html#qx.ui.container.Scroll)
+[qx.ui.container.Scroll](apps://apiviewer/#qx.ui.container.Scroll)

--- a/docs/desktop/widget/scrollbar.md
+++ b/docs/desktop/widget/scrollbar.md
@@ -23,12 +23,12 @@ Demos
 
 Here are some links that demonstrate the usage of the widget:
 
--   [Scroll bar demo](apps://demobrowser/index.html#widget~ScrollBar.html)
+-   [Scroll bar demo](apps://demobrowser/#widget~ScrollBar.html)
 -   [A simple scroll container demo](apps://demobrowser/#ui~ScrollContainer_Simple.html)
 
 API
 ---
 
 Here is a link to the API of the Widget:
-[qx.ui.core.ScrollBar](apps://apiviewer/index.html#qx.ui.core.scroll.ScrollBar)
-[qx.ui.core.NativeScrollBar](apps://apiviewer/index.html#qx.ui.core.scroll.NativeScrollBar)
+[qx.ui.core.ScrollBar](apps://apiviewer/#qx.ui.core.scroll.ScrollBar)
+[qx.ui.core.NativeScrollBar](apps://apiviewer/#qx.ui.core.scroll.NativeScrollBar)

--- a/docs/desktop/widget/slidebar.md
+++ b/docs/desktop/widget/slidebar.md
@@ -24,10 +24,10 @@ Demos
 
 Here are some links that demonstrate the usage of the widget:
 
--   [SlideBar demo](apps://demobrowser/index.html#widget-SlideBar.html)
+-   [SlideBar demo](apps://demobrowser/#widget-SlideBar.html)
 
 API
 ---
 
 Here is a link to the API of the Widget:
-[qx.ui.container.SlideBar](apps://apiviewer/index.html#qx.ui.container.SlideBar)
+[qx.ui.container.SlideBar](apps://apiviewer/#qx.ui.container.SlideBar)

--- a/docs/desktop/widget/spacer.md
+++ b/docs/desktop/widget/spacer.md
@@ -20,4 +20,4 @@ API
 ---
 
 Here is a link to the API of the Widget:
-[qx.ui.core.Spacer](apps://apiviewer/index.html#qx.ui.core.Spacer)
+[qx.ui.core.Spacer](apps://apiviewer/#qx.ui.core.Spacer)

--- a/docs/desktop/widget/splitpane.md
+++ b/docs/desktop/widget/splitpane.md
@@ -26,10 +26,10 @@ Demos
 
 Here are some links that demonstrate the usage of the widget:
 
--   [SplitPane that can toggle its orientation and hide/show panes](apps://demobrowser/index.html#widget-SplitPane.html)
+-   [SplitPane that can toggle its orientation and hide/show panes](apps://demobrowser/#widget-SplitPane.html)
 
 API
 ---
 
 Here is a link to the API of the Widget:
-[qx.ui.splitpane](apps://apiviewer/index.html#qx.ui.splitpane)
+[qx.ui.splitpane](apps://apiviewer/#qx.ui.splitpane)

--- a/docs/desktop/widget/stack.md
+++ b/docs/desktop/widget/stack.md
@@ -26,4 +26,4 @@ API
 ---
 
 Here is a link to the API of the Widget:
-[qx.ui.container.Stack](apps://apiviewer/index.html#qx.ui.container.Stack)
+[qx.ui.container.Stack](apps://apiviewer/#qx.ui.container.Stack)

--- a/docs/desktop/widget/tabview.md
+++ b/docs/desktop/widget/tabview.md
@@ -36,10 +36,10 @@ Demos
 
 Here are some links that demonstrate the usage of the widget:
 
--   [Horizontal and vertical TabViews with a different amount of pages](apps://demobrowser/index.html#widget~TabView.html)
+-   [Horizontal and vertical TabViews with a different amount of pages](apps://demobrowser/#widget~TabView.html)
 
 API
 ---
 
 Here is a link to the API of the Widget:
-[qx.ui.tabview](apps://apiviewer/index.html#qx.ui.tabview)
+[qx.ui.tabview](apps://apiviewer/#qx.ui.tabview)

--- a/docs/desktop/widget/toolbar.md
+++ b/docs/desktop/widget/toolbar.md
@@ -51,4 +51,4 @@ API
 ---
 
 Here is a link to the API of the Widget:
-[qx.ui.toolbar](apps://apiviewer/index.html#qx.ui.toolbar)
+[qx.ui.toolbar](apps://apiviewer/#qx.ui.toolbar)

--- a/docs/desktop/widget/tooltip.md
+++ b/docs/desktop/widget/tooltip.md
@@ -25,10 +25,10 @@ Demos
 
 Here are some links that demonstrate the usage of the widget:
 
--   [Demonstrates regular and shared ToolTips](apps://demobrowser/index.html#widget-Tooltip.html)
+-   [Demonstrates regular and shared ToolTips](apps://demobrowser/#widget-Tooltip.html)
 
 API
 ---
 
 Here is a link to the API of the Widget:
-[complete package and classname](apps://apiviewer/index.html#qx.ui.tooltip)
+[complete package and classname](apps://apiviewer/#qx.ui.tooltip)

--- a/docs/desktop/widget/widget.md
+++ b/docs/desktop/widget/widget.md
@@ -30,4 +30,4 @@ API
 ---
 
 Here is a link to the API of the Widget:
-[qx.ui.core.Widget](apps://apiviewer/index.html#qx.ui.core.Widget)
+[qx.ui.core.Widget](apps://apiviewer/#qx.ui.core.Widget)

--- a/docs/development/howto/internationalization.md
+++ b/docs/development/howto/internationalization.md
@@ -119,6 +119,10 @@ that setting if you plan to support locale switching during run time.
 If the string given to `tr` does not have a translation
 under the current locale, the string itself will be returned.
 
+If the string given to `tr` is the empty string, the header of the
+.po file is returned (which can be a bit confusing if done
+accidentally, but is correct according to the [PO specs](https://www.gnu.org/software/gettext/manual/html_node/PO-Files.html#PO-Files PO specs).
+
 There is one exception to the simple rule that all strings can just be
 replaced by wrapping them in an appropriate `this.tr()` function call:
 If init values of dynamic properties (core/understanding_properties)
@@ -215,7 +219,7 @@ of the application may be specified in `compile.json`, in the
 
 This would add a German and a French translation to
 the project. For a more exhaustive list of available
-locales see [here](http://unicode.org/cldr/apps/survey).
+locales see [here](http://cldr.unicode.org/index/survey-tool).
 
 A run of `npx qx compile --update-po-files` or its shorthand `npx qx
 compile -u` will generate a `.po` file for each configured locale,

--- a/docs/tutorial/README.md
+++ b/docs/tutorial/README.md
@@ -3,8 +3,14 @@
 Often the simplest way to learn about a new technology is to work through some
 tutorials.
 
-You may already have worked your way through the [getting
-started](?id=getting-started) one.
+You may already have worked your way through the [getting started](?id=getting-started) one.
 
-For a much more in depth encounter with qooxdoo, have a look at the
-comprehensive [tweets app tutorial](twitter/).
+For a much more in depth encounter with qooxdoo, we have some comprehensive tutorials: 
+
+- **qooxdoo tutorial app** ([App](http://www.qooxdoo.org/qxl.tutorial) [Code](https://github.com/qooxdoo/qxl.tutorial))
+- **tweets app tutorial** ([App](https://qooxdoo.org/qxl.tweet-tutorial) [Code](https://github.com/qooxdoo/qxl.tweet-tutorial))
+
+
+
+
+

--- a/docs/tutorial/twitter/README.md
+++ b/docs/tutorial/twitter/README.md
@@ -3,11 +3,34 @@ Tutorial: Tweets App
 
 This tutorial covers many practical aspects of developing desktop-like qooxdoo apps.
 
-As the headline of this tutorial says, we are building a simple tweets application. [identica](http://identi.ca) is a twitter-like service for reading and posting public short messages - called "tweets". It has a [twitter-compatible API](http://status.net/wiki/Twitter-compatible_API) for accessing data.
+As the headline of this tutorial says, we are building a simple tweets application. 
 
-[Twitter](http://twitter.com) itself made its authorization scheme more complex, as it starts requiring OAuth even to read public tweets. For this basic tutorial it would be too complex to handle such advanced authorization. If your are interested in OAuth, check out how you could handle that in a qooxdoo app by looking at the [Github demo](apps://demobrowser/#data~Github.html).
+[Twitter](http://twitter.com) itself made its authorization scheme more complex, as it started requiring OAuth even to read public tweets. For this basic tutorial it would be too complex to handle such advanced authorization. If your are interested in OAuth, check out how you could handle that in a qooxdoo app by looking at the [Github demo](apps://demobrowser/#data~Github.html).
 
-The following mockup shows you how the application should look like at the end.
+So we decided to provide a simple example which dellivers some static text.
+
+```javascript
+callback([
+  {
+    text: "Lorem ipsum dolor sit amet, consetetur sadipscing elitr, sed diam nonumy eirmod tempor invidunt ut labore", 
+    user: {profile_image_url : "http://www.gravatar.com/avatar/7c366401a0b7a57c50e5c38913ddc135.png"},
+    created_at: 1373541470150
+  },
+  {
+    text: "Lorem ipsum dolor sit amet, consetetur sadipscing elitr, sed diam", 
+    user: {profile_image_url : "http://www.gravatar.com/avatar/00000000000000000000000000000000.png"},
+    created_at: 1373541361356
+  },
+  {
+    text: "Lorem ipsum dolor sit amet, consetetur sadipscing elitr, sed diam nonumy eirmod tempor", 
+    user: {profile_image_url : "http://www.gravatar.com/avatar/74e78850f9d01ddce817dd5f83f3ac0d.png"},
+    created_at: 1373541270150
+  }
+]);
+```
+
+
+The following mockup shows you how the application should look at the end.
 
 ![image](identicamockup1.png)
 

--- a/docs/tutorial/twitter/tutorial-part-1.md
+++ b/docs/tutorial/twitter/tutorial-part-1.md
@@ -80,5 +80,6 @@ At this point, your application should look like this.
 
 ![step 1](step11.png)
 
-That's it for the first part. If you want to have the 
-[code from the tutorial](https://github.com/qooxdoo/qooxdoo/blob/master/docs/tutorial/twitter/tutorial-part-1.md), take a look at the project at Github and just fork the project. The next part of the tutorial will contain the building of the other parts of the UI. If you have feedback or want to see something special in further tutorials, just let us know!
+That's it for the first part. 
+If you want, you may take a [look at the code](https://github.com/qooxdoo/qxl.tweet-tutorial/tree/master/tweets/step1). 
+If you want to have the [code from the tutorial](https://github.com/qooxdoo/qxl.tweet-tutorial), take a look at the project at Github and just fork the project. The next part of the tutorial will contain the building of the other parts of the UI. If you have feedback or want to see something special in further tutorials, just let us know!

--- a/docs/tutorial/twitter/tutorial-part-2.md
+++ b/docs/tutorial/twitter/tutorial-part-2.md
@@ -41,7 +41,7 @@ var list = new qx.ui.form.List();
 this.add(list, {row: 1, column: 0});
 ```
 
-Now its time to see our work in the browser. But again, we have added new class dependencies so we need to invoke the generator with `./generate.py`. After that, we can see the result in the browser. I guess it's not the way we like it to be. You cannot see any toolbar, the list has too much padding against the window border and doesn't fit the whole window. That's something we should take care of now.
+Now its time to see our work in the browser. But again, we have added new class dependencies so we need to invoke the compiler with `npx qx serve`. After that, we can see the result in the browser. It's not quite the way we'd like it to look. You cannot see any toolbar, the list has too much padding against the window border and it doesn't fit the whole window. These are things we should take care of now.
 
 First, get rid of that padding we don't need. The window object has a default content padding which we just to set to `0`.
 
@@ -156,7 +156,7 @@ textarea.setPlaceholder("Enter your message here...");
 postButton.setToolTipText("Post this message on identi.ca");
 ```
 
-Another nice tweak could be a identica logo in the windows caption bar. Just download this [logo from identica](https://raw.github.com/qooxdoo/qooxdoo/%{release_tag}/component/tutorials/tweets/step2/source/resource/logo.png) and save it in the `source/resource/tweets` folder of your application. Adding the logo is easy because the window has also a property for an icon, which can be set in the constructor. Adding the reference to the icon in the base call should do the job.
+Another nice tweak could be an Identica logo in the windows caption bar. Just download this [logo](https://github.com/qooxdoo/qxl.tweet-tutorial/tree/master/tweets/step2/source/resource/qxl/tweets/logo.png) and save it in the `source/resource/tweets` folder of your application. Adding the logo is easy because the window also has a property for an icon, which can be set in the constructor. Adding the reference to the icon in the base call should do the job.
 
 ```javascript
 this.base(arguments, "tweets", "logo.png");
@@ -191,4 +191,4 @@ Now go back to the browser and test your new tweaks. It should look like this.
 
 ![step 2](step21.png)
 
-That's it for building the UI. Again, if you want to take a [look at the code](https://github.com/qooxdoo/qooxdoo/tree/%{release_tag}/component/tutorials/tweets/step2), fork the project on github. Next time we take care of getting the data. If you have feedback on this post, just let us know!
+That's it for building the UI. Again, if you want to take a [look at the code](https://github.com/qooxdoo/qxl.tweet-tutorial/tree/master/tweets/step2), fork the project on github. Next time we will take care of getting the data. If you have feedback on this post, just let us know!

--- a/docs/tutorial/twitter/tutorial-part-3.md
+++ b/docs/tutorial/twitter/tutorial-part-3.md
@@ -6,21 +6,41 @@ After we created the application and the main window in the first tutorial part 
 Pre-Evaluation
 --------------
 
-First, we need to specify what's the data we need to transfer. For that, we need to take a look what tasks our application can handle:
+First, we need to specify what data we need to transfer. For that, we need to take a look at what tasks our application can handle:
 
-1.  Show the public identica timeline.
+1.  Show the public timeline.
 2.  Post a message.
 
-So it's clear that we need to fetch the public timeline (that's how it is called by identica), and we need to post a message to identica. It's time to take a look at the [identica API](http://status.net/wiki/Twitter-compatible_API) so that we know what we need to do to communicate with the service. But keep in mind that we are still on a website so we can't just send some `POST` or `GET` requests due to cross-site scripting restrictions. The one thing we can and should do is take advantage of JSONP. If you have never heard of JSONP, take some time to read the [article on ajaxian](http://ajaxian.com/archives/jsonp-json-with-padding) to get further details. In this tutorial, we won't use the service itself due to API changes and availability of the service. Instead we use a simple JavaScript file which will fake the JSON-P call.
+So it's clear that we need to fetch the public timeline, and we need to post a message. It's time to take a look at the api so that we know what we need to do to communicate with the service. But keep in mind that we are still on a website so we can't just send some `POST` or `GET` requests due to cross-site scripting restrictions. The one thing we can and should do is take advantage of JSONP. If you have never heard of JSONP, take some time to read the [article on ajaxian](http://ajaxian.com/archives/jsonp-json-with-padding) to get further details. In this tutorial, we won't use the service itself. Instead we use a simple JavaScript file which will fake the JSON-P call.
 
 Creating the Data Access Class
 ------------------------------
 
-Now, that we know how we want to communicate, we can tackle the first task, fetching the public timeline. identica offers a [JSONP service for that](http://status.net/wiki/Twitter-compatible_API#Timeline_resources) which we can use. Luckily, there is no login process on the server side so we don't need to bother with that in the client. The following URL returns the public timeline wrapped in a JavaScript method call (that's what JSONP is about):
+Now, that we know how we want to communicate, we can tackle the first task: fetching the public timeline. The following URL returns the public timeline wrapped in a JavaScript method call (that's what JSONP is about):
 
-    https://raw.githubusercontent.com/qooxdoo/qooxdoo/%{release_tag}/component/tutorials/tweets/step4.5/source/resource/tweets/service.js
+```javascript
+callback([
+  {
+    text: "Lorem ipsum dolor sit amet, consetetur sadipscing elitr, sed diam nonumy eirmod tempor invidunt ut labore", 
+    user: {profile_image_url : "http://www.gravatar.com/avatar/7c366401a0b7a57c50e5c38913ddc135.png"},
+    created_at: 1373541470150
+  },
+  {
+    text: "Lorem ipsum dolor sit amet, consetetur sadipscing elitr, sed diam", 
+    user: {profile_image_url : "http://www.gravatar.com/avatar/00000000000000000000000000000000.png"},
+    created_at: 1373541361356
+  },
+  {
+    text: "Lorem ipsum dolor sit amet, consetetur sadipscing elitr, sed diam nonumy eirmod tempor", 
+    user: {profile_image_url : "http://www.gravatar.com/avatar/74e78850f9d01ddce817dd5f83f3ac0d.png"},
+    created_at: 1373541270150
+  }
+]);
+```
 
-Now we know how to get the data from identica. Its time for us to go back to the qooxdoo code. It is, like in the case of the UI, a good idea to create a separate class for the communication layer. Therefore, we create a class named `IdenticaService`. We don't want to inherit from any advanced qooxdoo class so we extend straight from `qx.core.Object`. The code for that class should looks like this:
+This service script is part of the projects resources and therefore acessible through the web server with `qx serve` and the url `http://localhost:8080/resource/qxl/tweets/service.js`.
+
+Now we know how to get the data. Its time for us to go back to the qooxdoo code. It is, like in the case of the UI, a good idea to create a separate class for the communication layer. Therefore, we create a class named `IdenticaService`. We don't want to inherit from any advanced qooxdoo class so we extend straight from `qx.core.Object`. The code for that class should looks like this:
 
 ```javascript
 qx.Class.define("tweets.IdenticaService",{
@@ -44,7 +64,7 @@ Now it's time to get this method working. But how do we load the data in qooxdoo
 
 ```javascript
 if (this.__store == null) {
-  var url = "https://raw.githubusercontent.com/qooxdoo/qooxdoo/%{release_tag}/component/tutorials/tweets/step4.5/source/resource/tweets/service.js";
+  var url = "http://localhost:8080/resource/qxl/tweets/service.js";
   this.__store = new qx.data.store.Jsonp();
   this.__store.setCallbackName("callback");
   this.__store.setUrl(url);
@@ -184,10 +204,8 @@ Now it should be the way we like it to be. Sure it's not perfect because it has 
 Posting tweets
 --------------
 
-As you have seen in the last paragraphs, creating the data access layer is not that hard using qooxdoo's data binding. That is why we want you to implement the rest of the application: Posting of tweets. But we will give you some hints so it does not take that much time for you.
+As you have seen previously, creating the data access layer is easy with qooxdoo's data binding. We believe, using what you learned of data binding, that you now have what you need to implement the remainder of the application: posting of tweets.
 
--   identica uses OAuth authentication for postings. Don't make yourself too much work by implementing the whole OAuth thing. Invoking an alert should be enough.
-
-That should be possible for you right now! If you need to take a look at an implementation, you can always take a look at the [code on github](https://github.com/qooxdoo/qooxdoo/tree/%{release_tag}/component/tutorials/tweets/step3) or fork the project.
+That should be possible for you right now! If you need to take a look at an implementation, you can always take a look at the [code on github](https://github.com/qooxdoo/qxl.tweet-tutorial/tree/master/tweets/step3) or fork the project.
 
 That's it for the third part of the tutorial. With this tutorial, the application should be ready and we can continue our next tutorial lines based on this state of the application. As always, if you have any feedback, please let us know!

--- a/docs/tutorial/twitter/tutorial-part-4.md
+++ b/docs/tutorial/twitter/tutorial-part-4.md
@@ -3,7 +3,7 @@ Tutorial Part 4: Handling Forms
 
 In the previous steps of this tutorial, we laid the groundwork for a tweets client application, gave it a neat UI and implemented a communication layer. One thing this application still lacks is a nice way for users to input their identica user name and password in order to post a status update. Fortunately, qooxdoo comes with a forms API that takes the pain out of creating form elements and handling user input.
 
-Before we get started, make sure you're working on the version of the tweets tutorial application tagged with ["Step 3" in the GitHub repository](https://github.com/qooxdoo/qooxdoo/tree/%{release_tag}/component/tutorials/tweets/step3). This includes the posting part of the communication layer that we'll be using in this tutorial.
+Before we get started, make sure you're working on the version of the tweets tutorial application tagged with ["Step 3" in the GitHub repository](https://github.com/qooxdoo/qxl.tweet-tutorial/tree/master/tweets/step3). This includes the posting part of the communication layer that we'll be using in this tutorial.
 
 The plan
 --------
@@ -13,7 +13,7 @@ We want to create a new window with user name and password fields that pops up w
 Creating the login window
 -------------------------
 
-We start by creating a new class called tweets.LoginWindow that inherits from [qx.ui.window.Window](apps://apiviewer/index.html#qx.ui.window.Window), similar to the MainWindow class from the first part of this tutorial:
+We start by creating a new class called tweets.LoginWindow that inherits from [qx.ui.window.Window](apps://apiviewer/#qx.ui.window.Window), similar to the MainWindow class from the first part of this tutorial:
 
 ```javascript
 qx.Class.define("tweets.LoginWindow", {
@@ -58,7 +58,7 @@ var controller = new qx.data.controller.Form(null, form);
 var model = controller.createModel();
 ```
 
-Just like in the previous tutorial, we create a [controller](apps://apiviewer/index.html#qx.data.controller.Form) without a model. Then, we ask the controller to create a model from the form's elements. This model will be used to serialize the form data.
+Just like in the previous tutorial, we create a [controller](apps://apiviewer/#qx.data.controller.Form) without a model. Then, we ask the controller to create a model from the form's elements. This model will be used to serialize the form data.
 
 The form still needs a "submit" button, so we'll add one, plus a "cancel" button to close the window:
 
@@ -73,14 +73,14 @@ cancelbutton.addListener("execute", function() {
 }, this);
 ```
 
-That's all the elements we need, let's get them displayed. We'll let one of qooxdoo's built-in [form renderer](apps://apiviewer/index.html#qx.ui.form.renderer) classes worry about the form's layout:
+That's all the elements we need, let's get them displayed. We'll let one of qooxdoo's built-in [form renderer](apps://apiviewer/#qx.ui.form.renderer) classes worry about the form's layout:
 
 ```javascript
 var renderer = new qx.ui.form.renderer.Single(form);
 this.add(renderer);
 ```
 
-The renderer is a widget, so we can just add it to the window. In addition to the standard renderers, it's fairly simple to create a custom renderer by subclassing [qx.ui.form.renderer.AbstractRenderer](apps://apiviewer/index.html#qx.ui.form.renderer.AbstractRenderer), though that's outside the scope of this tutorial.
+The renderer is a widget, so we can just add it to the window. In addition to the standard renderers, it's fairly simple to create a custom renderer by subclassing [qx.ui.form.renderer.AbstractRenderer](apps://apiviewer/#qx.ui.form.renderer.AbstractRenderer), though that's outside the scope of this tutorial.
 
 Accessing the form values
 -------------------------
@@ -138,4 +138,4 @@ OK, time to run `generate.py` and load the application in a browser to make sure
 
 Tweets client application with login window
 
-And that's it for the form handling chapter. As usual, you'll find the tutorial [code on GitHub](https://github.com/qooxdoo/qooxdoo/tree/%{release_tag}/component/tutorials/tweets/step4.1). Watch out for the next chapter, which will focus on developing your own custom widgets.
+And that's it for the form handling chapter. As usual, you'll find the tutorial [code on GitHub](https://github.com/qooxdoo/qxl.tweet-tutorial/tree/master/tweets/step4.1). Watch out for the next chapter, which will focus on developing your own custom widgets.

--- a/docs/tutorial/twitter/tutorial-part-5.md
+++ b/docs/tutorial/twitter/tutorial-part-5.md
@@ -11,7 +11,7 @@ You can see that one tweet consists of a photo, a text and a creation date, but 
 
 > **note**
 >
-> The code in this tutorial should also work when you haven't completed the 4.1 tutorial because it doesn't depend on the code changes from tutorial 4.1. But if you have any problems to run the tutorial, you can also checkout the code from tutorial 4.1 on [github](https://github.com/qooxdoo/qooxdoo/tree/%{release_tag}/component/tutorials/tweets/step4.1).
+> The code in this tutorial should also work when you haven't completed the 4.1 tutorial because it doesn't depend on the code changes from tutorial 4.1. But if you have any problems to run the tutorial, you can also checkout the code from tutorial 4.1 on [github](https://github.com/qooxdoo/qxl.tweet-tutorial/tree/master/tweets/step4.1).
 
 The plan
 --------
@@ -281,8 +281,8 @@ converter: function(data) {
 
 The converter method creates a date object from the given number (time in milliseconds). The `configureItem` method should be known from tutorial part 3 (tutorial-part-3), there are only some improvements to keep the same behavior as before.
 
-Great, now we've got it! Run `generate.py` to create the application.
+Great, now we've got it! Run `qx serve` to create and run the application.
 
 ![Step 4-2](step42.png)
 
-Again, if you want to take a [look at the code](https://github.com/qooxdoo/qooxdoo/tree/%{release_tag}/component/tutorials/tweets/step4.2), fork the project on github.
+Again, if you want to take a [look at the code](https://github.com/qooxdoo/qxl.tweet-tutorial/tree/master/tweets/step4.2), fork the project on github.

--- a/docs/tutorial/twitter/tutorial-part-6.md
+++ b/docs/tutorial/twitter/tutorial-part-6.md
@@ -1,7 +1,7 @@
 Tutorial Part 6: Theming
 ==================================
 
-This time, we continue with a very exciting topic for the tutorials: Theming. As you might already know, the theming system in qooxdoo is not based on CSS which means you, as an application developer, don't have to bother with cross browser CSS. The qooxdoo framework takes care of all that for you. As a base for theming an app, we use the already known tweets client we built in the former tutorials. On the left is a picture how it should look to get you started. The the code of the tutorial [on GitHub](https://github.com/qooxdoo/qooxdoo/tree/%{release_tag}/component/tutorials/tweets/step4.2.1).
+This time, we continue with a very exciting topic for the tutorials: Theming. As you might already know, the theming system in qooxdoo is not based on CSS, which means you, as an application developer, don't have to bother with cross browser CSS. The qooxdoo framework takes care of all that for you. As a base for theming an app, we use the already known tweets client we built in the former tutorials. On the left is a picture how it should look to get you started. The the code of the tutorial [on GitHub](https://github.com/qooxdoo/qxl.tweet-tutorial/tree/master/tweets/step4.2.1).
 
 ![image](step42.png)
 
@@ -110,4 +110,4 @@ Like in the former appearance we added, we define one property. In this case, we
 Job done
 --------
 
-With the last step, we have finally managed to change the three basic things we wanted to change. If you are interested in more details about the theming possibilities in qooxdoo, check out the manual for more information. As always, the code of the tutorial is [on GitHub](https://github.com/qooxdoo/qooxdoo/tree/%{release_tag}/component/tutorials/tweets/step4.2.1).
+With the last step, we have finally managed to change the three basic things we wanted to change. If you are interested in more details about the theming possibilities in qooxdoo, check out the manual for more information. As always, the code of the tutorial is [on GitHub](https://github.com/qooxdoo/qxl.tweet-tutorial/tree/master/tweets/step4.2.1).

--- a/docs/tutorial/twitter/tutorial-part-7.md
+++ b/docs/tutorial/twitter/tutorial-part-7.md
@@ -51,7 +51,7 @@ For the next step, we need to tell the compiler what languages we want to suppor
   ],
 ```
 
-The next time you generate your project the compiler will extract all the text strings you marked up and will put them into the `source/translation` folder. There you'll find the created files ending in `.po`. You may be familiar with that file format from [GNU gettext](http://en.wikipedia.org/wiki/GNU_gettext) which is quite popular.
+Then you have to generate the tranlation files with ```qx compile --update-po-files```. The compiler will extract all the text strings you marked up and will put them into the `source/translation` folder. There you'll find the created files ending in `.po`. You may be familiar with that file format from [GNU gettext](http://en.wikipedia.org/wiki/GNU_gettext) which is quite popular.
 
 You should see two files, one for the default language, English (`en.po`), and one for the language you added, in this case German (`de.po`). For now, we just need the file for our alternative language because English is already used in the application so this should work right out of the box. Opening the second file, you'll notice some details about it at the top of the document. The important part starts with the following text.
 
@@ -193,4 +193,4 @@ Now you can edit the `po` files again and add the new translations. Don't forget
 
 After compiling the application again you should be set up for testing and all should run as expected.
 
- As always, you can find the entire [code on GitHub](https://github.com/qooxdoo/qooxdoo/tree/%{release_tag}/component/tutorials/tweets/step4.3).
+ As always, you can find the entire [code on GitHub](https://github.com/qooxdoo/qxl.tweet-tutorial/tree/master/tweets/step4.3).

--- a/docs/tutorial/twitter/tutorial-part-8.md
+++ b/docs/tutorial/twitter/tutorial-part-8.md
@@ -1,7 +1,7 @@
 Tutorial Part 8: Unit Testing
 ===============================
 
-In this tutorial, we'll be taking a closer look at qooxdoo's integrated unit testing framework. Armed with this new knowledge, we'll then define a few unit tests for the tweets application created in previous tutorials, generate the test runner application, and watch the tests in action. As usual, the code can be found on [GitHub](https://github.com/qooxdoo/qooxdoo/tree/%{release_tag}/component/tutorials/tweets/step4.4).
+In this tutorial, we'll be taking a closer look at qooxdoo's integrated unit testing framework. Armed with this new knowledge, we'll then define a few unit tests for the tweets application created in previous tutorials, generate the test runner application, and watch the tests in action. As usual, the code can be found on [GitHub](https://github.com/qooxdoo/qxl.tweet-tutorial/tree/master/tweets/step4.4).
 
 Background
 ----------

--- a/docs/tutorial/twitter/tutorial-part-9.md
+++ b/docs/tutorial/twitter/tutorial-part-9.md
@@ -96,4 +96,4 @@ Now we only need to run the generator to resolve the new dependencies:
 
 ![image](tutorial_4_5-2.png)
 
-The virtual List supports some more features like grouping, for additional details have a look at the [virtual demos](apps://demobrowser/#virtual~List.html). As always, the [code of the tutorial](https://github.com/qooxdoo/qooxdoo/tree/%{release_tag}/component/tutorials/tweets/step4.5/) is on github.
+The virtual List supports some more features like grouping, for additional details have a look at the [virtual demos](apps://demobrowser/#virtual~List.html). As always, the [code of the tutorial](https://github.com/qooxdoo/qxl.tweet-tutorial/tree/master/tweets/step4.5) is on github.

--- a/framework/source/class/qx/bom/client/Html.js
+++ b/framework/source/class/qx/bom/client/Html.js
@@ -353,7 +353,7 @@ qx.Bootstrap.define("qx.bom.client.Html",
      * @ignore(Image)
      */
     getDataUrl : function(callback) {
-      var data = new Image();
+      var data = new window.Image();
       data.onload = data.onerror = function() {
         // wrap that into a timeout because IE might execute it synchronously
         window.setTimeout(function() {

--- a/framework/source/class/qx/bom/element/Attribute.js
+++ b/framework/source/class/qx/bom/element/Attribute.js
@@ -136,8 +136,8 @@ qx.Bootstrap.define("qx.bom.element.Attribute",
         $$elementObject : 1,
 
         // Used by qx.ui.core.Widget
-        $$widget        : 1,
-        $$widgetObject  : 1,
+        $$qxObjectHash  : 1,
+        $$qxObject      : 1,
 
         // Native properties
         checked     : 1,
@@ -156,8 +156,8 @@ qx.Bootstrap.define("qx.bom.element.Attribute",
 
       qxProperties :
       {
-        $$widget : 1,
-        $$widgetObject : 1,
+        $$qxObjectHash : 1,
+        $$qxObject : 1,
         $$element : 1,
         $$elementObject : 1
       },
@@ -318,7 +318,7 @@ qx.Bootstrap.define("qx.bom.element.Attribute",
           name.indexOf("data-") !== 0)
         {
           if (value === true) {
-          element.setAttribute(name, name);
+            element.setAttribute(name, name);
           } else if (value === false || value === null) {
             element.removeAttribute(name);
           }
@@ -329,6 +329,42 @@ qx.Bootstrap.define("qx.bom.element.Attribute",
         else {
           element.setAttribute(name, value);
         }
+      }
+    },
+
+
+    /**
+     * Serializes an HTML attribute into a writert
+     *
+     * @param writer {Function} The writer to serialize to
+     * @param name {String} Name of the attribute
+     * @param value {var} New value of the attribute
+     */
+    serialize : function(writer, name, value)
+    {
+      if (typeof value === "undefined") {
+        return;
+      }
+
+      var hints = this.__hints;
+
+      // Skip unserialization Qooxdoo state properties
+      if (hints.qxProperties[name]) {
+        return;
+      }
+
+      // respect booleans
+      if (hints.bools[name] && !qx.lang.Type.isBoolean(value)) {
+        value = qx.lang.Type.isString(value);
+      }
+
+      // apply attribute
+      if ((hints.bools[name] || value === null) && name.indexOf("data-") !== 0) {
+        if (value === true) {
+          writer(name, "=", name);
+        }
+      } else if (value !== null) {
+        writer(name, "=\"", value, "\"");
       }
     },
 

--- a/framework/source/class/qx/bom/element/Attribute.js
+++ b/framework/source/class/qx/bom/element/Attribute.js
@@ -334,7 +334,8 @@ qx.Bootstrap.define("qx.bom.element.Attribute",
 
 
     /**
-     * Serializes an HTML attribute into a writert
+     * Serializes an HTML attribute into a writer; the `writer` function accepts
+     *  an varargs, which can be joined with an empty string or streamed.
      *
      * @param writer {Function} The writer to serialize to
      * @param name {String} Name of the attribute
@@ -348,7 +349,7 @@ qx.Bootstrap.define("qx.bom.element.Attribute",
 
       var hints = this.__hints;
 
-      // Skip unserialization Qooxdoo state properties
+      // Skip serialization of hidden Qooxdoo state properties
       if (hints.qxProperties[name]) {
         return;
       }

--- a/framework/source/class/qx/bom/element/Attribute.js
+++ b/framework/source/class/qx/bom/element/Attribute.js
@@ -334,7 +334,8 @@ qx.Bootstrap.define("qx.bom.element.Attribute",
 
 
     /**
-     * Serializes an HTML attribute into a writert
+     * Serializes an HTML attribute into a writer; the `writer` function accepts
+     *  an varargs, which can be joined with an empty string or streamed.
      *
      * @param writer {Function} The writer to serialize to
      * @param name {String} Name of the attribute

--- a/framework/source/class/qx/core/BaseInit.js
+++ b/framework/source/class/qx/core/BaseInit.js
@@ -40,7 +40,7 @@ qx.Class.define("qx.core.BaseInit",
      * @return {qx.core.Object} The application instance.
      */
     getApplication : function() {
-      return this.__application || null;
+      return qx.core.BaseInit.__application || null;
     },
 
 
@@ -51,7 +51,7 @@ qx.Class.define("qx.core.BaseInit",
      */
     ready : function()
     {
-      if (this.__application) {
+      if (qx.core.BaseInit.__application) {
         return;
       }
 
@@ -72,14 +72,14 @@ qx.Class.define("qx.core.BaseInit",
 
       if (clazz)
       {
-        this.__application = new clazz;
+        qx.core.BaseInit.__application = new clazz;
 
         var start = new Date;
-        this.__application.main();
+        qx.core.BaseInit.__application.main();
         qx.log.Logger.debug(this, "Main runtime: " + (new Date - start) + "ms");
 
         var start = new Date;
-        this.__application.finalize();
+        qx.core.BaseInit.__application.finalize();
         qx.log.Logger.debug(this, "Finalize runtime: " + (new Date - start) + "ms");
         
         qx.event.handler.Application.onAppInstanceInitialized();
@@ -99,7 +99,7 @@ qx.Class.define("qx.core.BaseInit",
      */
     __close : function(e)
     {
-      var app = this.__application;
+      var app = qx.core.BaseInit.__application;
       if (app) {
         app.close();
       }
@@ -113,7 +113,7 @@ qx.Class.define("qx.core.BaseInit",
      */
     __shutdown : function()
     {
-      var app = this.__application;
+      var app = qx.core.BaseInit.__application;
 
       if (app) {
         app.terminate();

--- a/framework/source/class/qx/core/Environment.js
+++ b/framework/source/class/qx/core/Environment.js
@@ -765,6 +765,15 @@
  *       <td><i>default:</i> <code>true</code> {@link qx.event.GlobalError}</td>
  *     </tr>
  *     <tr>
+ *       <td>qx.headless</td><td><i>Boolean</i></td><td><code>false</code></td>
+ *       <td><i>default:</i> <code>false</code> Whether the environment is headless (ie rhino/nodejs); note that 
+ *        headless will still have some kind of DOM emulation - normally that would be quite basic, unless
+ *        <a href="https://www.npmjs.com/package/jsdom">https://www.npmjs.com/package/jsdom</a> has been installed.
+ *        The <code>qx.headless</code> allows code to detect whether there is an user interface, most typically 
+ *        whether to cater for input events.  This is set automatically by the compiler but would have to be
+ *        manually configured if you use the generator.</td>
+ *     </tr>
+ *     <tr>
  *       <td>qx.mobile.nativescroll</td><td><i>Boolean</i></td><td><code>false</code></td>
  *       <td>{@link qx.bom.client.Scroll#getNativeScroll}</td>
  *     </tr>
@@ -907,7 +916,8 @@ qx.Bootstrap.define("qx.core.Environment",
       "qx.promise": true,
       "qx.promise.warnings": true,
       "qx.promise.longStackTraces": true,
-      "qx.command.bindEnabled": false
+      "qx.command.bindEnabled": false,
+      "qx.headless": false
     },
 
     /**

--- a/framework/source/class/qx/core/GlobalError.js
+++ b/framework/source/class/qx/core/GlobalError.js
@@ -41,7 +41,10 @@ qx.Bootstrap.define("qx.core.GlobalError",
 
     var inst = Error.call(this, this.__failMessage);
     // map stack trace properties since they're not added by Error's constructor
-    if (inst.stack) {
+    if (exc && exc.stack) {
+      this.stack = exc.stack;
+    }
+    if (!this.stack && inst.stack) {
       this.stack = inst.stack;
     }
     if (inst.stacktrace) {

--- a/framework/source/class/qx/event/handler/Application.js
+++ b/framework/source/class/qx/event/handler/Application.js
@@ -270,7 +270,7 @@ qx.Class.define("qx.event.handler.Application",
           // Using native method supported by Mozilla, Webkit, Opera and IE >= 9
           qx.bom.Event.addNativeListener(this._window, "DOMContentLoaded", this._onNativeLoadWrapped);
         }
-        else {
+        else if (document) {
           var self = this;
 
           // Continually check to see if the document is ready

--- a/framework/source/class/qx/event/handler/Application.js
+++ b/framework/source/class/qx/event/handler/Application.js
@@ -269,8 +269,8 @@ qx.Class.define("qx.event.handler.Application",
         ) {
           // Using native method supported by Mozilla, Webkit, Opera and IE >= 9
           qx.bom.Event.addNativeListener(this._window, "DOMContentLoaded", this._onNativeLoadWrapped);
-        }
-        else if (document) {
+          
+        } else if (typeof document !== "undefined") {
           var self = this;
 
           // Continually check to see if the document is ready

--- a/framework/source/class/qx/event/handler/Element.js
+++ b/framework/source/class/qx/event/handler/Element.js
@@ -181,7 +181,7 @@ qx.Class.define("qx.event.handler.Element",
       }
 
       var eventData = events[eventId];
-      var isCancelable = this.constructor.CANCELABLE[eventData.type];
+      var isCancelable = nativeEvent.cancelable || this.constructor.CANCELABLE[eventData.type];
 
       qx.event.Registration.fireNonBubblingEvent(
         eventData.element, eventData.type,

--- a/framework/source/class/qx/event/handler/Focus.js
+++ b/framework/source/class/qx/event/handler/Focus.js
@@ -1063,8 +1063,9 @@ qx.Class.define("qx.event.handler.Focus",
           return focusedElement;
         }
         // Check compound widgets
-        var widget = qx.ui.core.Widget.getWidgetByElement(focusedElement),
-          textField = widget && widget.getChildControl && widget.getChildControl("textfield", true);
+        var Widget = qx.Class.getByName("qx.ui.core.Widget");
+        var widget = Widget && Widget.getWidgetByElement(focusedElement);
+        var textField = widget && widget.getChildControl && widget.getChildControl("textfield", true);
 
         if (textField) {
           return textField.getContentElement().getDomElement();

--- a/framework/source/class/qx/event/handler/GestureCore.js
+++ b/framework/source/class/qx/event/handler/GestureCore.js
@@ -277,8 +277,9 @@ qx.Bootstrap.define("qx.event.handler.GestureCore", {
         if(!this.__isMultiPointerGesture) {
           // Workaround for bug in Chrome where cancelling mousemove events will break text selection and possibly other
           //  mouse events.  See http://bugzilla.qooxdoo.org/show_bug.cgi?id=9218
-          if (domEvent._original && domEvent._original.type == "mousemove")
+          if (domEvent._original && domEvent._original.type == "mousemove") {
             domEvent.preventDefault = function(){};
+          }
           this.__fireTrack("track", domEvent, gesture.target);
           this._fireRoll(domEvent, "touch", gesture.target);
         }

--- a/framework/source/class/qx/event/handler/GestureCore.js
+++ b/framework/source/class/qx/event/handler/GestureCore.js
@@ -20,6 +20,11 @@
 /**
  * Listens for (native or synthetic) pointer events and fires events
  * for gestures like "tap" or "swipe"
+ * 
+ * qx.event.Timer and qx.util.Wheel are needed for very early DOM event handling; 
+ * EG scrolling the mouse during startup on MacOS 10.12
+ * @require(qx.event.Timer)
+ * @require(qx.util.Wheel)
  */
 qx.Bootstrap.define("qx.event.handler.GestureCore", {
   extend : Object,
@@ -270,6 +275,10 @@ qx.Bootstrap.define("qx.event.handler.GestureCore", {
         }
 
         if(!this.__isMultiPointerGesture) {
+          // Workaround for bug in Chrome where cancelling mousemove events will break text selection and possibly other
+          //  mouse events.  See http://bugzilla.qooxdoo.org/show_bug.cgi?id=9218
+          if (domEvent._original && domEvent._original.type == "mousemove")
+            domEvent.preventDefault = function(){};
           this.__fireTrack("track", domEvent, gesture.target);
           this._fireRoll(domEvent, "touch", gesture.target);
         }

--- a/framework/source/class/qx/event/handler/Mouse.js
+++ b/framework/source/class/qx/event/handler/Mouse.js
@@ -27,6 +27,7 @@
  *
  * @require(qx.event.handler.UserAction)
  * @ignore(qx.event.handler.DragDrop)
+ * @ignore(performance.now)
  */
 qx.Class.define("qx.event.handler.Mouse",
 {
@@ -203,10 +204,11 @@ qx.Class.define("qx.event.handler.Mouse",
         if (type == "mousewheel") {
           var end = (window.performance && performance.now) ? (performance.now() + qx.bom.AnimationFrame.__start) : Date.now();
           var diff = Math.round(end - start);
-          if (diff > 500)
+          if (diff > 500) {
             this.error("'mousewheel' event took " + diff + "ms - this may have a significant effect on UI experience");
-          else if (diff > 100)
+          } else if (diff > 100) {
             this.warn("'mousewheel' event took " + diff + "ms - consider refactoring for smoother UI experience");
+          }
         }
       }
     },

--- a/framework/source/class/qx/event/handler/Mouse.js
+++ b/framework/source/class/qx/event/handler/Mouse.js
@@ -183,7 +183,7 @@ qx.Class.define("qx.event.handler.Mouse",
       // an empty object as "srcElement"
       if (target && target.nodeType)
       {
-        var notPrevented = qx.event.Registration.fireEvent(
+        var prevented = !qx.event.Registration.fireEvent(
           target,
           type||domEvent.type,
           type == "mousewheel" ? qx.event.type.MouseWheel : qx.event.type.Mouse,
@@ -191,7 +191,7 @@ qx.Class.define("qx.event.handler.Mouse",
         );
         
         if (qx.core.Environment.get("qx.debug")) {
-          if (type == "mousewheel" && !notPrevented) {
+          if (type == "mousewheel" && prevented) {
             this.warn("'mousewheel' event was prevented, consider refactoring to allow for passive event handling");
           }
         }

--- a/framework/source/class/qx/html/Element.js
+++ b/framework/source/class/qx/html/Element.js
@@ -69,10 +69,11 @@ qx.Class.define("qx.html.Element",
     this.__styleValues = styles || null;
     this.__attribValues = attributes || null;
     if (attributes) {
-      for (var key in attributes)
+      for (var key in attributes) {
         if (!key) {
           throw new Error("Invalid unnamed attribute in " + this.classname);
         }
+      }
     }
     this.initCssClass();
     
@@ -549,7 +550,6 @@ qx.Class.define("qx.html.Element",
      */
     _serializeImpl: function(writer) {
       writer("<", this._nodeName);
-      var elem = this._domNode;
       
       // Copy attributes
       var data = this.__attribValues;
@@ -649,8 +649,9 @@ qx.Class.define("qx.html.Element",
         var Attribute = qx.bom.element.Attribute;
         if (fromMarkup) {
           var str = Attribute.get(elem, "class");
-          if (str instanceof window.SVGAnimatedString)
+          if (str instanceof window.SVGAnimatedString) {
             str = str.baseVal;
+          }
           var segs = str ? str.split(" ") : [];
           if (segs.length) {
             this.setCssClass(segs[0]);

--- a/framework/source/class/qx/html/Element.js
+++ b/framework/source/class/qx/html/Element.js
@@ -182,7 +182,7 @@ qx.Class.define("qx.html.Element",
           focusHandler.blur(focusedDomElement);
         }
   
-        // decativate elements, which will be removed
+        // deactivate elements, which will be removed
         var activeDomElement = focusHandler.getActive();
         if (activeDomElement && this.__willBecomeInvisible(activeDomElement)) {
           qx.bom.Element.deactivate(activeDomElement);
@@ -447,7 +447,7 @@ qx.Class.define("qx.html.Element",
      *
      * @param domElement {DOM} the DOM element
      * @return {qx.ui.core.Widget} the Widget that created the DOM element
-     * @deprecated {6.0} see qx.html.Node.fromDomNode
+     * @deprecated {6.1} see qx.html.Node.fromDomNode
      */
     fromDomElement: function(domElement) {
       return qx.html.Node.fromDomNode(domElement);
@@ -606,7 +606,7 @@ qx.Class.define("qx.html.Element",
      * remain associated until disposed or disconnectWidget is called
      *
      * @param widget {qx.ui.core.Widget} the widget to associate
-     * @deprecated {6.0} see connectObject
+     * @deprecated {6.1} see connectObject
      */
     connectWidget : function(widget) {
       return this.connectObject(widget);
@@ -617,7 +617,7 @@ qx.Class.define("qx.html.Element",
      * untouched, except that it can no longer be used to find the Widget.
      *
      * @param qxObject {qx.core.Object} the Widget
-     * @deprecated {6.0} see disconnectObject
+     * @deprecated {6.1} see disconnectObject
      */
     disconnectWidget: function(widget) {
       return this.disconnectObject(widget);
@@ -649,8 +649,10 @@ qx.Class.define("qx.html.Element",
         var Attribute = qx.bom.element.Attribute;
         if (fromMarkup) {
           var str = Attribute.get(elem, "class");
-          if (str instanceof window.SVGAnimatedString) {
-            str = str.baseVal;
+          if (!qx.core.Environment.get("qx.headless")) {
+            if (str instanceof window.SVGAnimatedString) {
+              str = str.baseVal;
+            }
           }
           var segs = str ? str.split(" ") : [];
           if (segs.length) {
@@ -821,7 +823,7 @@ qx.Class.define("qx.html.Element",
      * when the DOM element is directly needed to add content etc.
      *
      * @param elem {Element} Element to reuse
-     * @deprecated {6.0} see useNode
+     * @deprecated {6.1} see useNode
      */
     useElement : function(elem)
     {

--- a/framework/source/class/qx/html/Factory.js
+++ b/framework/source/class/qx/html/Factory.js
@@ -1,0 +1,123 @@
+/* ************************************************************************
+
+   qooxdoo - the new era of web development
+
+   http://qooxdoo.org
+
+   Copyright:
+     2019-2020 Zenesis Limited, https://www.zenesis.com
+
+   License:
+     MIT: https://opensource.org/licenses/MIT
+     See the LICENSE file in the project's top-level directory for details.
+
+   Authors:
+     * John Spackman (https://github.com/johnspackman, john.spackman@zenesis.com)
+
+************************************************************************ */
+
+/**
+ * Factory class used to create Virtual DOM instances by JSX support
+ */
+qx.Class.define("qx.html.Factory", {
+  extend: qx.core.Object,
+  type: "singleton",
+  
+  construct: function() {
+    this.base(arguments);
+    this.__factoriesByTagName = {};
+    this.registerFactory("#text", function(tagName, attributes, styles) {
+      return new qx.html.Text("");
+    });
+    this.registerFactory("img", qx.html.Image);
+    this.registerFactory("iframe", function(tagName, attributes, styles) {
+      return new qx.html.Iframe(attributes.src, attributes, styles);
+    });
+    this.registerFactory("input", function(tagName, attributes, styles) {
+      return new qx.html.Input(attributes.type||"text", attributes, styles);
+    });
+  },
+  
+  members: {
+    __factoriesByTagName: null,
+    
+    /**
+     * Registers a factory; a factory is either a class, or a function which is 
+     * called with the parameters (tagName {String}, styles{Map?}, attributes {Map?}), and
+     * which is expected to return an {Element}
+     * 
+     * @param tagName {String} the name of the tag
+     * @param factory {Class|Function} the function used to create instances for that tagName
+     */
+    registerFactory: function(tagName, factory) {
+      tagName = tagName.toLowerCase();
+      if (this.__factoriesByTagName[tagName] === undefined)
+        this.__factoriesByTagName[tagName] = [];
+      this.__factoriesByTagName[tagName].push(factory);
+    },
+    
+    /**
+     * Called to create an {Element}
+     * 
+     * @param tagName {String} the name of the tag
+     * @param attributes {Map?} the attributes to create (including style etc)
+     * @return {qx.html.Node}
+     */
+    createElement: function(tagName, attributes) {
+      tagName = tagName.toLowerCase();
+      
+      if (attributes) {
+        if (window.NamedNodeMap && attributes instanceof window.NamedNodeMap) {
+          var newAttrs = {};
+          for(var i = attributes.length - 1; i >= 0; i--) {
+            newAttrs[attributes[i].name] = attributes[i].value;
+          }
+          attributes = newAttrs;
+        }
+        
+        var styles = {};
+        if (attributes.style) {
+          attributes.style.split(/;/).forEach(function(seg) {
+            var pos = seg.indexOf(":");
+            var key = seg.substring(0, pos);
+            var value = seg.substring(pos + 1).trim();
+            if (key)
+              styles[key] = value;
+          });
+          delete attributes.style;
+        }
+        
+        var classname = attributes["data-qx-classname"];
+        if (classname) {
+          var clazz = qx.Class.getByName(classname);
+          if (qx.core.Environment.get("qx.debug")) {
+            this.assertTrue(clazz && qx.Class.isSubClassOf(clazz, qx.html.Element));
+            return new clazz(tagName, styles, attributes);
+          }
+        }
+      }
+      
+      var factories = this.__factoriesByTagName[tagName];
+      if (factories) {
+        for (var i = factories.length - 1; i > -1; i++) {
+          var factory = factories[i];
+          if (factory.classname && qx.Class.getByName(factory.classname) === factory) {
+            return new factory(tagName, styles, attributes);
+          }
+          
+          if (qx.core.Environment.get("qx.debug")) {
+            this.assertTrue(typeof factory == "function");
+          }
+          var element = factory(tagName, styles, attributes);
+          if (element) {
+            return element;
+          }
+        }
+      }
+      
+      return new qx.html.Element(tagName, styles, attributes);
+    }
+  
+  }
+});
+

--- a/framework/source/class/qx/html/Factory.js
+++ b/framework/source/class/qx/html/Factory.js
@@ -51,8 +51,9 @@ qx.Class.define("qx.html.Factory", {
      */
     registerFactory: function(tagName, factory) {
       tagName = tagName.toLowerCase();
-      if (this.__factoriesByTagName[tagName] === undefined)
+      if (this.__factoriesByTagName[tagName] === undefined) {
         this.__factoriesByTagName[tagName] = [];
+      }
       this.__factoriesByTagName[tagName].push(factory);
     },
     
@@ -81,8 +82,9 @@ qx.Class.define("qx.html.Factory", {
             var pos = seg.indexOf(":");
             var key = seg.substring(0, pos);
             var value = seg.substring(pos + 1).trim();
-            if (key)
+            if (key) {
               styles[key] = value;
+            }
           });
           delete attributes.style;
         }

--- a/framework/source/class/qx/html/Iframe.js
+++ b/framework/source/class/qx/html/Iframe.js
@@ -44,6 +44,8 @@ qx.Class.define("qx.html.Iframe",
   {
     this.base(arguments, "iframe", styles, attributes);
 
+    this.registerProperty("source", null, this._setSourceProperty);
+    
     this.setSource(url);
     this.addListener("navigate", this.__onNavigate, this);
 
@@ -96,27 +98,26 @@ qx.Class.define("qx.html.Iframe",
       ELEMENT API
     ---------------------------------------------------------------------------
     */
+    
+    /**
+     * Implementation of setter for the "source" property
+     * 
+     * @param value {String?} value to set
+     */
+    _setSourceProperty: function(value) {
+      var element = this.getDomElement();
+      var currentUrl = qx.bom.Iframe.queryCurrentUrl(element);
 
-    // overridden
-    _applyProperty : function(name, value)
-    {
-      this.base(arguments, name, value);
-
-      if (name == "source") {
-        var element = this.getDomElement();
-        var currentUrl = qx.bom.Iframe.queryCurrentUrl(element);
-
-        // Skip if frame is already on URL.
-        //
-        // When URL of Iframe and source property get out of sync, the source
-        // property needs to be updated [BUG #4481]. This is to make sure the
-        // same source is not set twice on the BOM level.
-        if (value === currentUrl) {
-          return;
-        }
-
-        qx.bom.Iframe.setSource(element, value);
+      // Skip if frame is already on URL.
+      //
+      // When URL of Iframe and source property get out of sync, the source
+      // property needs to be updated [BUG #4481]. This is to make sure the
+      // same source is not set twice on the BOM level.
+      if (value === currentUrl) {
+        return;
       }
+
+      qx.bom.Iframe.setSource(element, value);
     },
 
     // overridden

--- a/framework/source/class/qx/html/Iframe.js
+++ b/framework/source/class/qx/html/Iframe.js
@@ -122,7 +122,7 @@ qx.Class.define("qx.html.Iframe",
 
     // overridden
     _createDomElement : function() {
-      return qx.bom.Iframe.create(this._content);
+      return qx.bom.Iframe.create();
     },
 
 

--- a/framework/source/class/qx/html/Image.js
+++ b/framework/source/class/qx/html/Image.js
@@ -23,6 +23,17 @@
 qx.Class.define("qx.html.Image",
 {
   extend : qx.html.Element,
+  
+  /**
+   * Creates a new Image
+   *
+   * @see constructor for {Element}
+   */
+  construct: function(tagName, styles, attributes) {
+    this.base(arguments, tagName, styles, attributes);
+    this.registerProperty("source", null, this._setSourceProperty);
+    this.registerProperty("scale", null, this._setScaleProperty);
+  },
 
 
 
@@ -69,43 +80,44 @@ qx.Class.define("qx.html.Image",
       ELEMENT API
     ---------------------------------------------------------------------------
     */
+    
+    /**
+     * Implementation of setter for the "source" property
+     * 
+     * @param value {String?} value to set
+     */
+    _setSourceProperty: function(value) {
+      var elem = this.getDomElement();
 
-    // overridden
-    _applyProperty : function(name, value)
-    {
-      this.base(arguments, name, value);
+      // To prevent any wrong background-position or -repeat it is necessary
+      // to reset those styles whenever a background-image is updated.
+      // This is only necessary if any backgroundImage was set already.
+      // See bug #3376 for details
+      var styles = this.getAllStyles();
 
-      if (name === "source")
-      {
-        var elem = this.getDomElement();
-
-        // To prevent any wrong background-position or -repeat it is necessary
-        // to reset those styles whenever a background-image is updated.
-        // This is only necessary if any backgroundImage was set already.
-        // See bug #3376 for details
-        var styles = this.getAllStyles();
-
-        if (this.getNodeName() == "div" && this.getStyle("backgroundImage"))
-        {
-          styles.backgroundRepeat = null;
-        }
-
-        var source = this._getProperty("source");
-        var scale = this._getProperty("scale");
-        var repeat = scale ? "scale" : "no-repeat";
-
-        // Source can be null in certain circumstances.
-        // See bug #3701 for details.
-        if (source != null) {
-          // Normalize "" to null
-          source = source || null;
-
-          styles.paddingTop = this.__paddingTop;
-          styles.paddingLeft = this.__paddingLeft;
-
-          qx.bom.element.Decoration.update(elem, source, repeat, styles);
-        }
+      if (this.getNodeName() == "div" && this.getStyle("backgroundImage")) {
+        styles.backgroundRepeat = null;
       }
+
+      var source = this._getProperty("source");
+      var scale = this._getProperty("scale");
+      var repeat = scale ? "scale" : "no-repeat";
+
+      // Source can be null in certain circumstances.
+      // See bug #3701 for details.
+      if (source != null) {
+        // Normalize "" to null
+        source = source || null;
+
+        styles.paddingTop = this.__paddingTop;
+        styles.paddingLeft = this.__paddingLeft;
+
+        qx.bom.element.Decoration.update(elem, source, repeat, styles);
+      }
+    },
+    
+    _setScaleProperty: function(value) {
+      // Nothing
     },
 
     // overridden
@@ -147,8 +159,8 @@ qx.Class.define("qx.html.Image",
 
     // overridden
     // be sure that style attributes are merged and not overwritten
-    _copyData : function(fromMarkup) {
-      return this.base(arguments, true);
+    _copyData : function(fromMarkup, propertiesFromDom) {
+      return this.base(arguments, true, propertiesFromDom);
     },
 
 

--- a/framework/source/class/qx/html/Input.js
+++ b/framework/source/class/qx/html/Input.js
@@ -44,8 +44,7 @@ qx.Class.define("qx.html.Input",
    * @param attributes {Map?null} optional map of element attributes, where the
    *    key is the name of the attribute and the value is the value to use.
    */
-  construct : function(type, styles, attributes)
-  {
+  construct : function(type, styles, attributes) {
     // Update node name correctly
     if (type === "select" || type === "textarea") {
       var nodeName = type;
@@ -56,6 +55,9 @@ qx.Class.define("qx.html.Input",
     this.base(arguments, nodeName, styles, attributes);
 
     this.__type = type;
+    
+    this.registerProperty("value", this._getValueProperty, this._setValueProperty);
+    this.registerProperty("wrap", null, this._setWrapProperty);
   },
 
 
@@ -80,34 +82,55 @@ qx.Class.define("qx.html.Input",
       ELEMENT API
     ---------------------------------------------------------------------------
     */
+    
+    _useNodeImpl: function(domNode, newChildren) {
+      this.base(arguments, domNode, newChildren);
+      domNode.addEventListener('input', () => console.log("Changing INPUT Value"));
+    },
 
     //overridden
     _createDomElement : function() {
       return qx.bom.Input.create(this.__type);
     },
-
-
-    // overridden
-    _applyProperty : function(name, value)
-    {
-      this.base(arguments, name, value);
+    
+    /**
+     * Implementation of setter for the "value" property
+     * 
+     * @param value {String?} value to set
+     */
+    _setValueProperty(value) {
       var element = this.getDomElement();
-
-      if (name === "value") {
-        qx.bom.Input.setValue(element, value);
-      } else if (name === "wrap") {
-        qx.bom.Input.setWrap(element, value);
-
-        // qx.bom.Input#setWrap has the side-effect that the CSS property
-        // overflow is set via DOM methods, causing queue and DOM to get
-        // out of sync. Mirror all overflow properties to handle the case
-        // when group and x/y property differ.
-        this.setStyle("overflow", element.style.overflow, true);
-        this.setStyle("overflowX", element.style.overflowX, true);
-        this.setStyle("overflowY", element.style.overflowY, true);
-      }
+      qx.bom.Input.setValue(element, value);
     },
+    
+    /**
+     * Implementation of getter for the "value" property
+     * 
+     * @return {String?} value on the dom
+     */
+    _getValueProperty() {
+      var element = this.getDomElement();
+      var value = qx.bom.Input.getValue(element);
+      return value;
+    },
+    
+    /**
+     * Implementation of setter for the "wrap" property
+     * 
+     * @param value {String?} value to set
+     */
+    _setWrapProperty(value) {
+      var element = this.getDomElement();
+      qx.bom.Input.setWrap(element, value);
 
+      // qx.bom.Input#setWrap has the side-effect that the CSS property
+      // overflow is set via DOM methods, causing queue and DOM to get
+      // out of sync. Mirror all overflow properties to handle the case
+      // when group and x/y property differ.
+      this.setStyle("overflow", element.style.overflow, true);
+      this.setStyle("overflowX", element.style.overflowX, true);
+      this.setStyle("overflowY", element.style.overflowY, true);
+    },
 
     /**
      * Set the input element enabled / disabled.
@@ -173,19 +196,17 @@ qx.Class.define("qx.html.Input",
       INPUT API
     ---------------------------------------------------------------------------
     */
-
+    
     /**
      * Sets the value of the input element.
      *
      * @param value {var} the new value
      * @return {qx.html.Input} This instance for for chaining support.
      */
-    setValue : function(value)
-    {
+    setValue : function(value) {
       var element = this.getDomElement();
 
-      if (element)
-      {
+      if (element) {
         // Do not overwrite when already correct (on input events)
         // This is needed to keep caret position while typing.
         if (element.value != value) {
@@ -204,8 +225,7 @@ qx.Class.define("qx.html.Input",
      *
      * @return {String} The element's current value.
      */
-    getValue : function()
-    {
+    getValue : function() {
       var element = this.getDomElement();
 
       if (element) {
@@ -226,8 +246,7 @@ qx.Class.define("qx.html.Input",
      *  directly when possible
      * @return {qx.html.Input} This instance for for chaining support.
      */
-    setWrap : function(wrap, direct)
-    {
+    setWrap : function(wrap, direct) {
       if (this.__type === "textarea") {
         this._setProperty("wrap", wrap, direct);
       } else {
@@ -245,8 +264,7 @@ qx.Class.define("qx.html.Input",
      *
      * @return {Boolean} Whether wrapping is enabled or disabled.
      */
-    getWrap : function()
-    {
+    getWrap : function() {
       if (this.__type === "textarea") {
         return this._getProperty("wrap");
       } else {

--- a/framework/source/class/qx/html/Input.js
+++ b/framework/source/class/qx/html/Input.js
@@ -85,7 +85,6 @@ qx.Class.define("qx.html.Input",
     
     _useNodeImpl: function(domNode, newChildren) {
       this.base(arguments, domNode, newChildren);
-      domNode.addEventListener('input', () => console.log("Changing INPUT Value"));
     },
 
     //overridden
@@ -98,7 +97,7 @@ qx.Class.define("qx.html.Input",
      * 
      * @param value {String?} value to set
      */
-    _setValueProperty(value) {
+    _setValueProperty: function(value) {
       var element = this.getDomElement();
       qx.bom.Input.setValue(element, value);
     },
@@ -108,7 +107,7 @@ qx.Class.define("qx.html.Input",
      * 
      * @return {String?} value on the dom
      */
-    _getValueProperty() {
+    _getValueProperty: function() {
       var element = this.getDomElement();
       var value = qx.bom.Input.getValue(element);
       return value;
@@ -119,7 +118,7 @@ qx.Class.define("qx.html.Input",
      * 
      * @param value {String?} value to set
      */
-    _setWrapProperty(value) {
+    _setWrapProperty: function(value) {
       var element = this.getDomElement();
       qx.bom.Input.setWrap(element, value);
 

--- a/framework/source/class/qx/html/Jsx.js
+++ b/framework/source/class/qx/html/Jsx.js
@@ -1,0 +1,189 @@
+/* ************************************************************************
+
+   qooxdoo - the new era of web development
+
+   http://qooxdoo.org
+
+   Copyright:
+     2019 Zenesis Ltd http://www.zenesis.com
+
+   License:
+     MIT: https://opensource.org/licenses/MIT
+     See the LICENSE file in the project's top-level directory for details.
+
+   Authors:
+     * John Spackman (https://github.com/johnspackman)
+     * Alexander Lopez (https://github.com/alecsgone)
+
+   This class includes work from on https://github.com/alecsgone/jsx-render; at the time of writing, 
+   the https://github.com/alecsgone/jsx-render repo is available under an MIT license.
+  
+************************************************************************ */
+
+/**
+ * This class includes work from on https://github.com/alecsgone/jsx-render; at the time of writing, 
+ * the https://github.com/alecsgone/jsx-render repo is available under an MIT license. 
+ */
+qx.Class.define("qx.html.Jsx", {
+  extend: qx.core.Object,
+  
+  statics: {
+    /**
+     * Creates an element.
+     * 
+     * Fragments are supported if the tagname is `qx.html.Jsx.FRAGMENT`; but in this case,
+     * an `qx.data.Array` is returned.
+     * 
+     * @param tagname {String} the name of the tag
+     * @param attributes {Map?} map of attribute values
+     * @param ...children {qx.html.Node[]} array of children
+     * @return {qx.html.Element | qx.data.Array}
+     */
+    createElement(tagname, attributes, ...children) {
+      if (typeof tagname === "function") { 
+        throw new Error("Custom tags are not supported");
+      }
+      if (tagname == qx.html.Jsx.FRAGMENT) {
+        var arr = new qx.data.Array();
+        const addChildren = children => {
+          children.forEach(child => {
+            if (child instanceof qx.data.Array || qx.lang.Type.isArray(child))
+              addChildren(child);
+            else
+              arr.push(child);
+          });
+        }
+        addChildren(children);
+        return arr;
+      }
+      let newAttrs = {};
+      let eventHandlers = {};
+      let innerHtml = null;
+      let refs = [];
+      
+      if (attributes) {
+        const RENAME = {
+            "className": "class",
+            "htmlFor": "for",
+            "xlinkHref": "xlink:href"
+        };
+        
+        Object.keys(attributes).forEach(prop => {
+          let renameTo = RENAME[prop];
+          if (renameTo) {
+            newAttrs[renameTo] = attributes[prop]; 
+            return;
+          }
+          
+          if (prop === "ref") {
+            if (attributes.ref instanceof qx.html.JsxRef || typeof attributes.ref === "function") {
+              refs.push(attributes.ref);
+            } else {
+              this.warn("Unsupported type of `ref` argument: " + typeof attributes.ref);
+            }
+            
+          } else if (prop === "dangerouslySetInnerHTML") {
+            // eslint-disable-next-line no-underscore-dangle
+            innerHtml = attributes[prop].__html;
+            
+          } else if (qx.html.Jsx.SYNTETIC_EVENTS[prop]) {
+            const eventName = prop.replace(/^on/, "").toLowerCase();
+            eventHandlers[eventName] = attributes[prop];
+            
+          } else {
+            // any other prop will be set as attribute
+            newAttrs[prop] = attributes[prop];
+          }
+        });
+      }
+      
+      let element = qx.html.Factory.getInstance().createElement(tagname, newAttrs);
+      if (children) {
+        const addChildren = children => {
+          children.forEach(child => {
+            if (child instanceof qx.data.Array || qx.lang.Type.isArray(child)) {
+              addChildren(child);
+              
+            } else if (typeof child == "string") {
+              element.add(new qx.html.Text(child));
+              
+            } else {
+              element.add(child);
+            }
+          });
+        };
+        addChildren(children);
+      }
+      if (innerHtml) {
+        element.setProperty("innerHtml", innerHtml);
+      }
+      for (let eventName in eventHandlers) {
+        element.addListener(eventName, eventHandlers[eventName]);
+      }
+      refs.forEach(ref => {
+        if (ref instanceof qx.html.JsxRef) {
+          ref.setValue(element);
+        } else { 
+          ref(element, attributes);
+        }
+      });
+      
+      return element;
+    },
+    
+    /** @type {Map} map of event names, all values are `true` */
+    SYNTETIC_EVENTS: null,
+
+    /** @type {String} tagname for fragments */
+    FRAGMENT: "$$fragment"
+  },
+  
+  defer(statics) {
+    const MOUSE_EVENTS = [
+      "onClick",
+      "onContextMenu",
+      "onDoubleClick",
+      "onDrag",
+      "onDragEnd",
+      "onDragEnter",
+      "onDragExit",
+      "onDragLeave",
+      "onDragOver",
+      "onDragStart",
+      "onDrop",
+      "onMouseDown",
+      "onMouseEnter",
+      "onMouseLeave",
+      "onMouseMove",
+      "onMouseOut",
+      "onMouseOver",
+      "onMouseUp",
+    ];
+
+    const TOUCH_EVENTS = ["onTouchCancel", "onTouchEnd", "onTouchMove", "onTouchStart"];
+
+    const KEYBOARD_EVENTS = ["onKeyDown", "onKeyPress", "onKeyUp"];
+
+    const FOCUS_EVENTS = ["onFocus", "onBlur"];
+
+    const FORM_EVENTS = ["onChange", "onInput", "onInvalid", "onSubmit"];
+
+    const UI_EVENTS = ["onScroll"];
+
+    const IMAGE_EVENTS = ["onLoad", "onError"];
+
+    const synteticEvents = [
+      ...MOUSE_EVENTS,
+      ...TOUCH_EVENTS,
+      ...KEYBOARD_EVENTS,
+      ...FOCUS_EVENTS,
+      ...FORM_EVENTS,
+      ...UI_EVENTS,
+      ...IMAGE_EVENTS,
+    ];
+    
+    let SYNTETIC_EVENTS = qx.html.Jsx.SYNTETIC_EVENTS = {};
+    synteticEvents.forEach(key => SYNTETIC_EVENTS[key] = true);
+    
+  }
+});

--- a/framework/source/class/qx/html/Jsx.js
+++ b/framework/source/class/qx/html/Jsx.js
@@ -36,40 +36,43 @@ qx.Class.define("qx.html.Jsx", {
      * 
      * @param tagname {String} the name of the tag
      * @param attributes {Map?} map of attribute values
-     * @param ...children {qx.html.Node[]} array of children
+     * @param children {qx.html.Node[]} array of children
      * @return {qx.html.Element | qx.data.Array}
      */
-    createElement(tagname, attributes, ...children) {
+    createElement: function(tagname, attributes) {
+      var children = qx.lang.Array.fromArguments(arguments, 2);
+      var self = this;
       if (typeof tagname === "function") { 
         throw new Error("Custom tags are not supported");
       }
       if (tagname == qx.html.Jsx.FRAGMENT) {
         var arr = new qx.data.Array();
-        const addChildren = children => {
-          children.forEach(child => {
-            if (child instanceof qx.data.Array || qx.lang.Type.isArray(child))
-              addChildren(child);
-            else
+        function addChildrenFragment(children) {
+          children.forEach(function(child) {
+            if (child instanceof qx.data.Array || qx.lang.Type.isArray(child)) {
+              addChildrenFragment(child);
+            } else {
               arr.push(child);
+            }
           });
         }
-        addChildren(children);
+        addChildrenFragment(children);
         return arr;
       }
-      let newAttrs = {};
-      let eventHandlers = {};
-      let innerHtml = null;
-      let refs = [];
+      var newAttrs = {};
+      var eventHandlers = {};
+      var innerHtml = null;
+      var refs = [];
       
       if (attributes) {
-        const RENAME = {
+        var RENAME = {
             "className": "class",
             "htmlFor": "for",
             "xlinkHref": "xlink:href"
         };
         
-        Object.keys(attributes).forEach(prop => {
-          let renameTo = RENAME[prop];
+        Object.keys(attributes).forEach(function(prop) {
+          var renameTo = RENAME[prop];
           if (renameTo) {
             newAttrs[renameTo] = attributes[prop]; 
             return;
@@ -79,7 +82,7 @@ qx.Class.define("qx.html.Jsx", {
             if (attributes.ref instanceof qx.html.JsxRef || typeof attributes.ref === "function") {
               refs.push(attributes.ref);
             } else {
-              this.warn("Unsupported type of `ref` argument: " + typeof attributes.ref);
+              self.warn("Unsupported type of `ref` argument: " + typeof attributes.ref);
             }
             
           } else if (prop === "dangerouslySetInnerHTML") {
@@ -87,7 +90,7 @@ qx.Class.define("qx.html.Jsx", {
             innerHtml = attributes[prop].__html;
             
           } else if (qx.html.Jsx.SYNTETIC_EVENTS[prop]) {
-            const eventName = prop.replace(/^on/, "").toLowerCase();
+            var eventName = prop.replace(/^on/, "").toLowerCase();
             eventHandlers[eventName] = attributes[prop];
             
           } else {
@@ -97,10 +100,10 @@ qx.Class.define("qx.html.Jsx", {
         });
       }
       
-      let element = qx.html.Factory.getInstance().createElement(tagname, newAttrs);
+      var element = qx.html.Factory.getInstance().createElement(tagname, newAttrs);
       if (children) {
-        const addChildren = children => {
-          children.forEach(child => {
+        function addChildren(children) {
+          children.forEach(function(child) {
             if (child instanceof qx.data.Array || qx.lang.Type.isArray(child)) {
               addChildren(child);
               
@@ -117,10 +120,10 @@ qx.Class.define("qx.html.Jsx", {
       if (innerHtml) {
         element.setProperty("innerHtml", innerHtml);
       }
-      for (let eventName in eventHandlers) {
+      for (var eventName in eventHandlers) {
         element.addListener(eventName, eventHandlers[eventName]);
       }
-      refs.forEach(ref => {
+      refs.forEach(function(ref) {
         if (ref instanceof qx.html.JsxRef) {
           ref.setValue(element);
         } else { 
@@ -138,8 +141,8 @@ qx.Class.define("qx.html.Jsx", {
     FRAGMENT: "$$fragment"
   },
   
-  defer(statics) {
-    const MOUSE_EVENTS = [
+  defer: function(statics) {
+    var MOUSE_EVENTS = [
       "onClick",
       "onContextMenu",
       "onDoubleClick",
@@ -160,30 +163,34 @@ qx.Class.define("qx.html.Jsx", {
       "onMouseUp",
     ];
 
-    const TOUCH_EVENTS = ["onTouchCancel", "onTouchEnd", "onTouchMove", "onTouchStart"];
+    var TOUCH_EVENTS = ["onTouchCancel", "onTouchEnd", "onTouchMove", "onTouchStart"];
 
-    const KEYBOARD_EVENTS = ["onKeyDown", "onKeyPress", "onKeyUp"];
+    var KEYBOARD_EVENTS = ["onKeyDown", "onKeyPress", "onKeyUp"];
 
-    const FOCUS_EVENTS = ["onFocus", "onBlur"];
+    var FOCUS_EVENTS = ["onFocus", "onBlur"];
 
-    const FORM_EVENTS = ["onChange", "onInput", "onInvalid", "onSubmit"];
+    var FORM_EVENTS = ["onChange", "onInput", "onInvalid", "onSubmit"];
 
-    const UI_EVENTS = ["onScroll"];
+    var UI_EVENTS = ["onScroll"];
 
-    const IMAGE_EVENTS = ["onLoad", "onError"];
+    var IMAGE_EVENTS = ["onLoad", "onError"];
 
-    const synteticEvents = [
-      ...MOUSE_EVENTS,
-      ...TOUCH_EVENTS,
-      ...KEYBOARD_EVENTS,
-      ...FOCUS_EVENTS,
-      ...FORM_EVENTS,
-      ...UI_EVENTS,
-      ...IMAGE_EVENTS,
+    var synteticEvents = [
+      MOUSE_EVENTS,
+      TOUCH_EVENTS,
+      KEYBOARD_EVENTS,
+      FOCUS_EVENTS,
+      FORM_EVENTS,
+      UI_EVENTS,
+      IMAGE_EVENTS,
     ];
     
-    let SYNTETIC_EVENTS = qx.html.Jsx.SYNTETIC_EVENTS = {};
-    synteticEvents.forEach(key => SYNTETIC_EVENTS[key] = true);
+    var SYNTETIC_EVENTS = qx.html.Jsx.SYNTETIC_EVENTS = {};
+    synteticEvents.forEach(function(arr) {
+      arr.forEach(function(key) {
+        SYNTETIC_EVENTS[key] = true;
+      });
+    });
     
   }
 });

--- a/framework/source/class/qx/html/JsxRef.js
+++ b/framework/source/class/qx/html/JsxRef.js
@@ -1,0 +1,38 @@
+/* ************************************************************************
+
+   qooxdoo - the new era of web development
+
+   http://qooxdoo.org
+
+   Copyright:
+     2019 Zenesis Ltd http://www.zenesis.com
+
+   License:
+     MIT: https://opensource.org/licenses/MIT
+     See the LICENSE file in the project's top-level directory for details.
+
+   Authors:
+     * John Spackman (https://github.com/johnspackman)
+  
+************************************************************************ */
+
+/**
+ * This class provides encapsulation for a JSX reference
+ */
+qx.Class.define("qx.html.JsxRef", {
+  extend: qx.core.Object,
+  
+  properties: {
+    value: {
+      init: null,
+      nullable: true,
+      check: "qx.html.Element",
+      event: "changeValue"
+    }
+  },
+  
+  members: {
+    
+  }
+});
+

--- a/framework/source/class/qx/html/Label.js
+++ b/framework/source/class/qx/html/Label.js
@@ -29,6 +29,16 @@ qx.Class.define("qx.html.Label",
 {
   extend : qx.html.Element,
 
+  /**
+   * Creates a new Image
+   *
+   * @see constructor for {Element}
+   */
+  construct: function(tagName, styles, attributes) {
+    this.base(arguments, tagName, styles, attributes);
+    this.registerProperty("value", null, this._setValueProperty);
+  },
+
 
 
   /*
@@ -47,19 +57,16 @@ qx.Class.define("qx.html.Label",
       ELEMENT API
     ---------------------------------------------------------------------------
     */
-
-    // overridden
-    _applyProperty : function(name, value)
-    {
-      this.base(arguments, name, value);
-
-      if (name == "value")
-      {
-        var element = this.getDomElement();
-        qx.bom.Label.setValue(element, value);
-      }
+    
+    /**
+     * Implementation of setter for the "value" property
+     * 
+     * @param value {String?} value to set
+     */
+    _setValueProperty: function(value) {
+      var element = this.getDomElement();
+      qx.bom.Label.setValue(element, value);
     },
-
 
     // overridden
     _createDomElement : function()
@@ -73,8 +80,8 @@ qx.Class.define("qx.html.Label",
 
     // overridden
     // be sure that style attributes are merged and not overwritten
-    _copyData : function(fromMarkup) {
-      return this.base(arguments, true);
+    _copyData : function(fromMarkup, propertiesFromDom) {
+      return this.base(arguments, true, propertiesFromDom);
     },
 
 

--- a/framework/source/class/qx/html/Node.js
+++ b/framework/source/class/qx/html/Node.js
@@ -1,0 +1,1852 @@
+/* ************************************************************************
+
+   qooxdoo - the new era of web development
+
+   http://qooxdoo.org
+
+   Copyright:
+     2004-2008 1&1 Internet AG, Germany, http://www.1und1.de
+
+   License:
+     MIT: https://opensource.org/licenses/MIT
+     See the LICENSE file in the project's top-level directory for details.
+
+   Authors:
+     * Sebastian Werner (wpbasti)
+     * John Spackman (https://github.com/johnspackman)
+
+************************************************************************ */
+
+/**
+ * High-performance, high-level DOM element creation and management.
+ *
+ * Mirrors the DOM structure of Node (see also Element and Text) so to provide 
+ * DOM insertion and modification with advanced logic to reduce the real transactions.
+ *
+ * Each child itself also has got some powerful methods to control its
+ * position:
+ * {@link #getParent}, {@link #free},
+ * {@link #insertInto}, {@link #insertBefore}, {@link #insertAfter},
+ * {@link #moveTo}, {@link #moveBefore}, {@link #moveAfter},
+ *
+ * NOTE: Instances of this class must be disposed of after use
+ *
+ * @require(qx.module.Animation)
+ */
+qx.Class.define("qx.html.Node",
+{
+  extend : qx.core.Object,
+  implement : [ qx.core.IDisposable ],
+  
+  
+  /**
+   * Creates a new Element
+   *
+   * @param nodeName {String} name of the node; will be a tag name for Elements, otherwise it's a reserved
+   * name eg "#text"
+   */
+  construct : function(nodeName)
+  {
+    this.base(arguments);
+    this._nodeName = nodeName;
+  },
+
+
+
+
+
+  /*
+  *****************************************************************************
+     STATICS
+  *****************************************************************************
+  */
+
+  statics :
+  {
+
+    /**
+     * Finds the Widget for a given DOM element
+     *
+     * @param domElement {DOM} the DOM element
+     * @return {qx.ui.core.Widget} the Widget that created the DOM element
+     */
+    fromDomNode: function(domNode) {
+    	if (qx.core.Environment.get("qx.debug")) {
+    		qx.core.Assert.assertTrue((!domNode.$$element && !domNode.$$elementObject) ||
+    				domNode.$$element === domNode.$$elementObject.toHashCode());
+    	}
+      return domNode.$$elementObject;
+    }
+
+  },
+
+
+
+  /*
+  *****************************************************************************
+     PROPERTIES
+  *****************************************************************************
+  */
+
+  properties : {
+    /**
+     * Controls whether the element is visible which means that a previously applied
+     * CSS style of display=none gets removed and the element will inserted into the DOM, 
+     * when this had not already happened before.
+     * 
+     * If the element already exists in the DOM then it will kept in DOM, but configured 
+     * hidden using a CSS style of display=none.
+     * 
+     * Please note: This does not control the visibility or parent inclusion recursively.
+     * 
+     * @type {Boolean} Whether the element should be visible in the render result
+     */
+    visible: {
+      init: true,
+      nullable: true,
+      check: "Boolean",
+      apply: "_applyVisible"
+    }
+  },
+
+
+
+
+  /*
+  *****************************************************************************
+     MEMBERS
+  *****************************************************************************
+  */
+
+  members :
+  {
+    /*
+    ---------------------------------------------------------------------------
+      PROTECTED HELPERS/DATA
+    ---------------------------------------------------------------------------
+    */
+
+    /** @type {String} the name of the node */
+    _nodeName : null,
+
+    /** @type {Node} DOM node of this object */
+    _domNode : null,
+
+    /** @type {qx.html.Element} parent element */
+    _parent : null,
+    
+    /** @type {qx.core.Object} the Qooxdoo object this node is attached to */
+    _qxObject : null,
+
+    /** @type {Boolean} Whether the element should be included in the render result */
+    _included : true,
+
+    _children : null,
+    _modifiedChildren : null,
+
+    _propertyJobs : null,
+    _properties : null,
+
+
+    /**
+     * Connects a widget to this element, and to the DOM element in this Element.  They
+     * remain associated until disposed or disconnectObject is called
+     *
+     * @param qxObject {qx.core.Object} the object to associate
+     */
+    connectObject: function(qxObject) {
+    	if (qx.core.Environment.get("qx.debug")) {
+      	qx.core.Assert.assertTrue(!this._qxObject || this._qxObject === qxObject);
+    	}
+
+    	this._qxObject = qxObject;
+    	if (this._domNode) {
+      	if (qx.core.Environment.get("qx.debug")) {
+          qx.core.Assert.assertTrue((!this._domNode.$$qxObjectHash && !this._domNode.$$qxObject) ||
+              (this._domNode.$$qxObject === qxObject && this._domNode.$$qxObjectHash === qxObject.toHashCode()));
+      	}
+
+        this._domNode.$$qxObjectHash = qxObject.toHashCode();
+        this._domNode.$$qxObject = qxObject;
+    	}
+
+      if (qx.core.Environment.get("module.objectid")) {
+        this.updateObjectId();
+      }
+    },
+
+
+    /**
+     * Disconnects a widget from this element and the DOM element.  The DOM element remains
+     * untouched, except that it can no longer be used to find the Widget.
+     *
+     * @param qxObject {qx.core.Object} the Widget
+     */
+    disconnectObject: function(qxObject) {
+    	if (qx.core.Environment.get("qx.debug")) {
+      	qx.core.Assert.assertTrue(this._qxObject === qxObject);
+    	}
+
+    	delete this._qxObject;
+    	if (this._domNode) {
+      	if (qx.core.Environment.get("qx.debug")) {
+          qx.core.Assert.assertTrue((!this._domNode.$$qxObjectHash && !this._domNode.$$qxObject) ||
+              (this._domNode.$$qxObject === qxObject && this._domNode.$$qxObjectHash === qxObject.toHashCode()));
+      	}
+
+        this._domNode.$$qxObjectHash = "";
+        delete this._domNode.$$qxObject;
+    	}
+    	
+      if (qx.core.Environment.get("module.objectid")) {
+        this.updateObjectId();
+      }
+    },
+
+    /**
+     * Internal helper to generate the DOM element
+     *
+     * @return {Element} DOM element
+     */
+    _createDomElement : function() {
+      throw new Error("No implementation for " + this.classname + "._createDomElement");
+    },
+    
+    /**
+     * Serializes the virtual DOM element to a writer; the `writer` function accepts
+     *  an varargs, which can be joined with an empty string or streamed.
+     *  
+     * If writer is null, the element will be serialised to a string which is returned;
+     * note that if writer is not null, the return value will be null
+     * 
+     * @param writer {Function?} the writer
+     * @return {String?} the serialised version if writer is null
+     */
+    serialize: function(writer) {
+      var temporaryQxObjectId = !this.getQxObjectId();
+      if (temporaryQxObjectId) {
+        this.setQxObjectId(this.classname);
+      }
+      var id = qx.core.Id.getAbsoluteIdOf(this, true);
+      var isIdRoot = !id;
+      if (isIdRoot) {
+        qx.core.Id.getInstance().register(this);
+      }
+      
+      var result = undefined;
+      if (writer) {
+        this._serializeImpl(writer);
+      } else {
+        var buffer = [];
+        this._serializeImpl(function() {
+          var args = qx.lang.Array.fromArguments(arguments);
+          qx.lang.Array.append(buffer, args);
+        });
+        result = buffer.join(""); 
+      }
+      
+      if (isIdRoot) {
+        qx.core.Id.getInstance().unregister(this);
+      }
+      if (temporaryQxObjectId) {
+        this.setQxObjectId(null);
+      }
+      
+      return result;
+    },
+
+    /**
+     * Serializes the virtual DOM element to a writer; the `writer` function accepts
+     *  an varargs, which can be joined with an empty string or streamed.
+     * 
+     * @param writer {Function} the writer
+     */
+    _serializeImpl: function(writer) {
+      throw new Error("No implementation for " + this.classname + ".serializeImpl");
+    },
+
+    /**
+     * Uses an existing element instead of creating one. This may be interesting
+     * when the DOM element is directly needed to add content etc.
+     *
+     * @param domNode {Node} DOM Node to reuse
+     */
+    useNode: function(domNode) {
+      var temporaryQxObjectId = !this.getQxObjectId();
+      if (temporaryQxObjectId) {
+        this.setQxObjectId(this.classname);
+      }
+      var id = qx.core.Id.getAbsoluteIdOf(this, true);
+      var isIdRoot = !id;
+      if (isIdRoot) {
+        qx.core.Id.getInstance().register(this);
+      }
+      
+      /*
+       * When merging children, we want to keep the original DOM nodes in
+       * domNode no matter what - however, where the DOM nodes have a qxObjectId
+       * we must reuse the original instances.
+       * 
+       * The crucial thing is that the qxObjectId hierarchy and the DOM hierarchy
+       * are not the same (although they are often similar, the DOM will often have
+       * extra Nodes).
+       * 
+       * However, because the objects in the qxObjectId space will typically already 
+       * exist (eg accessed via the constructor) we do not want to discard the original
+       * instance of qx.html.Element because there are probably references to them in 
+       * code.
+       * 
+       * In the code below, we map the DOM heirarchy into a temporary Javascript
+       * hierarchy, where we can either use existing qx.html.Element instances (found
+       * by looking up the qxObjectId) or fabricate new ones.
+       * 
+       * Once the temporary hierarchy is ready, we go back and synchronise each
+       * qx.html.Element with the DOM node and our new array of children.
+       * 
+       * The only rule to this is that if you are going to call this `useNode`, then
+       * you must not keep references to objects *unless* you also access them via
+       * the qxObjectId mechanism.
+       */
+      
+      var self = this;
+      function convert(domNode) {
+        var children = qx.lang.Array.fromCollection(domNode.childNodes);
+        children = children
+          .map(function(domChild) {
+            var child = null;
+            if (domChild.nodeType == window.Node.ELEMENT_NODE) {
+              var id = domChild.getAttribute("data-qx-object-id");
+              if (domChild.nodeName == "INPUT") {
+                console.log("Convert INPUT: " + id);
+              }
+              if (id) {
+                var owningQxObjectId = null;
+                var qxObjectId = null;
+                var owningQxObject = null;
+                var pos = id.lastIndexOf('/');
+                if (pos > -1) {
+                  owningQxObjectId = id.substring(0, pos);
+                  qxObjectId = id.substring(pos + 1);
+                  owningQxObject = qx.core.Id.getQxObject(owningQxObjectId);
+                  child = owningQxObject.getQxObject(qxObjectId);
+                } else {
+                  qxObjectId = id;
+                  owningQxObject = self;
+                  child = self.getQxObject(id);
+                }
+              }
+            }
+            if (!child)
+              child = qx.html.Factory.getInstance().createElement(domChild.nodeName, domChild.attributes);
+            return {
+              htmlNode: child,
+              domNode: domChild,
+              children: convert(domChild)
+            };
+          });
+        return children;
+      }
+      
+      function install(map) {
+        var htmlChildren = map.children.map(function(mapEntry) {
+          install(mapEntry);
+          return mapEntry.htmlNode;
+        });
+        if (map.domNode.nodeName == "INPUT") {
+          console.log("Install INPUT: " + map.domNode.getAttribute("data-qx-object-id"));
+        }
+        map.htmlNode._useNodeImpl(map.domNode, htmlChildren);
+      }
+      
+      var rootMap = {
+          htmlNode: this,
+          domNode: domNode,
+          children: convert(domNode)
+      };
+      
+      install(rootMap);
+      
+      this.flush();
+      this._insertChildren();
+      
+      if (isIdRoot) {
+        qx.core.Id.getInstance().unregister(this);
+      }
+      if (temporaryQxObjectId) {
+        this.setQxObjectId(null);
+      }
+    },
+    
+    /**
+     * Called internally to complete the connection to an existing DOM node
+     * 
+     * @param domNode {DOMNode} the node we're syncing to 
+     * @param newChildren {qx.html.Node[]} the new children
+     */
+    _useNodeImpl: function(domNode, newChildren) {
+      if (this._domNode) {
+        throw new Error("Could not overwrite existing element!");
+      }
+
+      // Use incoming element
+      this._connectDomNode(domNode);
+      
+      // Copy currently existing data over to element
+      this._copyData(true, true);
+      
+      // Add children
+      var lookup = {};
+      var oldChildren = this._children ? qx.lang.Array.clone(this._children) : null;
+      newChildren.forEach(function(child) {
+        lookup[child.toHashCode()] = child;
+      });
+      this._children = newChildren;
+      
+      // Make sure that unused children are disconnected
+      if (oldChildren) {
+        oldChildren.forEach(function(child) {
+          if (!lookup[child.toHashCode()]) {
+            if (child._domNode && child._domNode.parentElement)
+              child._domNode.parentElement.removeChild(child._domNode);
+            child._parent = null;
+          }
+        });
+      }
+      
+      var self = this;
+      this._children.forEach(function(child) {
+        child._parent = self;
+        if (child._domNode && child._domNode.parentElement !== self._domNode) {
+          child._domNode.parentElement.removeChild(child._domNode);
+          if (this._domNode) {
+            this._domNode.appendChild(child._domNode);
+          }
+        }
+      });
+      
+      if (this._domNode) {
+        this._scheduleChildrenUpdate();
+      }
+    },
+
+    /**
+     * Connects a DOM element to this Node; if this Node is already connected to a Widget
+     * then the Widget is also connected.
+     *
+     * @param domNode {DOM} the DOM Node to associate
+     */
+    _connectDomNode: function(domNode) {
+    	if (qx.core.Environment.get("qx.debug")) {
+    		qx.core.Assert.assertTrue(!this._domNode || this._domNode === domNode);
+        qx.core.Assert.assertTrue((domNode.$$elementObject === this && domNode.$$element === this.toHashCode()) ||
+            (!domNode.$$elementObject && !domNode.$$element));
+    	};
+
+    	this._domNode = domNode;
+    	domNode.$$elementObject = this;
+    	domNode.$$element = this.toHashCode();
+    	if (this._qxObject) {
+      	domNode.$$qxObjectHash = this._qxObject.toHashCode();
+      	domNode.$$qxObject = this._qxObject;
+    	}
+    },
+    
+    
+    /**
+     * Detects whether the DOM node has been created and is in the document
+     * 
+     * @return {Boolean}
+     */
+    isInDocument: function() {
+      if (document.body) {
+        for (var domNode = this._domNode; domNode != null; domNode = domNode.parentElement) {
+          if (domNode === document.body) {
+            return true;
+          }
+        }
+      }
+      return false;
+    },
+    
+    
+    /**
+     * Updates the Object ID on the element to match the QxObjectId
+     */
+    updateObjectId: function() {
+      // Copy Object Id
+      if (qx.core.Environment.get("module.objectid")) {
+        var id = null;
+        
+        if (!this._qxObject && this.getQxObjectId()) {
+          id = qx.core.Id.getAbsoluteIdOf(this, true) || null;
+        } else if (this._qxObject && this._qxObject.getQxObjectId()) {
+          id = qx.core.Id.getAbsoluteIdOf(this._qxObject, true) || null;
+        }
+        
+        this.setAttribute("data-qx-object-id", id, true);
+      }
+    },
+    
+    _cascadeQxObjectIdChanges: function() {
+      if (qx.core.Environment.get("module.objectid")) {
+        this.updateObjectId();
+      }
+      this.base(arguments);
+    },
+
+
+    /*
+    ---------------------------------------------------------------------------
+      FLUSH OBJECT
+    ---------------------------------------------------------------------------
+    */
+
+    /**
+     * Add the element to the global modification list.
+     *
+     */
+    _scheduleChildrenUpdate : function()
+    {
+      if (this._modifiedChildren) {
+        return;
+      }
+
+      this._modifiedChildren = true;
+
+      qx.html.Element._modified[this.toHashCode()] = this;
+      qx.html.Element._scheduleFlush("element");
+    },
+
+
+    /**
+     * Syncs data of an HtmlElement object to the DOM.
+     * 
+     * This is just a public wrapper around `flush`, because the scope has changed
+     * 
+     * @deprecated {6.0} Please use `.flush()` instead
+     */
+    _flush : function() {
+      this.flush();
+    },
+
+
+    /**
+     * Syncs data of an HtmlElement object to the DOM.
+     *
+     */
+    flush : function()
+    {
+      if (qx.core.Environment.get("qx.debug"))
+      {
+        if (this.DEBUG) {
+          this.debug("Flush: " + this.getAttribute("id"));
+        }
+      }
+
+      var length;
+      var children = this._children;
+      if (children)
+      {
+        length = children.length;
+        var child;
+        for (var i=0; i<length; i++)
+        {
+          child = children[i];
+
+          if (child.isVisible() && child._included && !child._domNode) {
+            child.flush();
+          }
+        }
+      }
+
+      if (!this._domNode)
+      {
+        this._connectDomNode(this._createDomElement());
+
+        this._copyData(false, false);
+
+        if (children && length > 0) {
+          this._insertChildren();
+        }
+      }
+      else
+      {
+        this._syncData();
+
+        if (this._modifiedChildren) {
+          this._syncChildren();
+        }
+      }
+
+      delete this._modifiedChildren;
+    },
+
+    /**
+     * Returns this element's root flag
+     * 
+     * @return {Boolean}
+     */
+    isRoot : function() {
+      throw new Error("No implementation for " + this.classname + ".isRoot");
+    },
+
+    /**
+     * Detects whether this element is inside a root element
+     * 
+     * @return {Boolean}
+     */
+    isInRoot: function() {
+      var tmp = this;
+      while (tmp) {
+        if (tmp.isRoot())
+          return true;
+        tmp = tmp._parent;
+      }
+      return false;
+    },
+
+    /**
+     * Walk up the internal children hierarchy and
+     * look if one of the children is marked as root.
+     *
+     * This method is quite performance hungry as it
+     * really walks up recursively.
+     * @return {Boolean} <code>true</code> if the element will be seeable
+     */
+    _willBeSeeable : function()
+    {
+      if (!qx.html.Element._hasRoots) {
+        return false;
+      }
+      var pa = this;
+
+      // Any chance to cache this information in the parents?
+      while(pa)
+      {
+        if (pa.isRoot()) {
+          return true;
+        }
+
+        if (!pa._included || !pa.isVisible()) {
+          return false;
+        }
+
+        pa = pa._parent;
+      }
+
+      return false;
+    },
+
+
+
+
+
+    /*
+    ---------------------------------------------------------------------------
+      SUPPORT FOR CHILDREN FLUSH
+    ---------------------------------------------------------------------------
+    */
+
+    /**
+     * Append all child nodes to the DOM
+     * element. This function is used when the element is initially
+     * created. After this initial apply {@link #_syncChildren} is used
+     * instead.
+     *
+     */
+    _insertChildren : function()
+    {
+      var children = this._children;
+      if (!children) {
+        return;
+      }
+      var length = children.length;
+      var child;
+
+      if (length > 2)
+      {
+        var domElement = document.createDocumentFragment();
+        for (var i=0; i<length; i++)
+        {
+          child = children[i];
+          if (child._domNode && child._included) {
+            domElement.appendChild(child._domNode);
+          }
+        }
+
+        this._domNode.appendChild(domElement);
+      }
+      else
+      {
+        var domElement = this._domNode;
+        for (var i=0; i<length; i++)
+        {
+          child = children[i];
+          if (child._domNode && child._included) {
+            domElement.appendChild(child._domNode);
+          }
+        }
+      }
+    },
+
+
+    /**
+     * Synchronize internal children hierarchy to the DOM. This is used
+     * for further runtime updates after the element has been created
+     * initially.
+     *
+     */
+    _syncChildren : function()
+    {
+      var dataChildren = this._children||[];
+      var dataLength = dataChildren.length;
+      var dataChild;
+      var dataEl;
+
+      var domParent = this._domNode;
+      var domChildren = domParent.childNodes;
+      var domPos = 0;
+      var domEl;
+
+      if (qx.core.Environment.get("qx.debug")) {
+        var domOperations = 0;
+      }
+
+      // Remove children from DOM which are excluded or remove first
+      for (var i=domChildren.length-1; i>=0; i--)
+      {
+        domEl = domChildren[i];
+        dataEl = qx.html.Node.fromDomNode(domEl);
+
+        if (!dataEl || !dataEl._included || dataEl._parent !== this)
+        {
+          domParent.removeChild(domEl);
+
+          if (qx.core.Environment.get("qx.debug")) {
+            domOperations++;
+          }
+        }
+      }
+
+      // Start from beginning and bring DOM in sync
+      // with the data structure
+      for (var i=0; i<dataLength; i++)
+      {
+        dataChild = dataChildren[i];
+
+        // Only process visible childs
+        if (dataChild._included)
+        {
+          dataEl = dataChild._domNode;
+          domEl = domChildren[domPos];
+
+          if (!dataEl) {
+            continue;
+          }
+
+          // Only do something when out of sync
+          // If the data element is not there it may mean that it is still
+          // marked as visible=false
+          if (dataEl != domEl)
+          {
+            if (domEl) {
+              domParent.insertBefore(dataEl, domEl);
+            } else {
+              domParent.appendChild(dataEl);
+            }
+
+            if (qx.core.Environment.get("qx.debug")) {
+              domOperations++;
+            }
+          }
+
+          // Increase counter
+          domPos++;
+        }
+      }
+
+      // User feedback
+      if (qx.core.Environment.get("qx.debug"))
+      {
+        if (qx.html.Element.DEBUG) {
+          this.debug("Synced DOM with " + domOperations + " operations");
+        }
+      }
+    },
+    
+    
+    /**
+     * Copies data between the internal representation and the DOM. This
+     * simply copies all the data and only works well directly after
+     * element creation. After this the data must be synced using {@link #_syncData}
+     *
+     * @param fromMarkup {Boolean} Whether the copy should respect styles
+     *   given from markup
+     * @param propertiesFromDom {Boolean} whether the copy should respect the property
+     *  values in the dom
+     */
+    _copyData : function(fromMarkup, propertiesFromDom)
+    {
+      var elem = this._domNode;
+      
+      // Copy properties
+      if (this._properties) {
+        for (var key in this._properties) {
+          var prop = this._properties[key];
+          if (propertiesFromDom) {
+            if (prop.get) {
+              prop.value = prop.get.call(this, key);
+            }
+          } else if (prop.value !== undefined) {
+            prop.set.call(this, prop.value, key);
+          }
+        }
+      }
+
+      // Attach events
+      var data = this.__eventValues;
+      if (data)
+      {
+        // Import listeners
+        qx.event.Registration.getManager(elem).importListeners(elem, data);
+
+        // Cleanup event map
+        // Events are directly attached through event manager
+        // after initial creation. This differs from the
+        // handling of styles and attributes where queuing happens
+        // through the complete runtime of the application.
+        delete this.__eventValues;
+      }
+    },
+
+
+    /**
+     * Synchronizes data between the internal representation and the DOM. This
+     * is the counterpart of {@link #_copyData} and is used for further updates
+     * after the element has been created.
+     *
+     */
+    _syncData : function()
+    {
+      var elem = this._domNode;
+
+      // Sync misc
+      var jobs = this._propertyJobs;
+      if (jobs && this._properties) {
+        for (var key in jobs) {
+          var prop = this._properties[key];
+          if (prop.value !== undefined) {
+            prop.set.call(this, prop.value, key);
+          }
+        }
+
+        this._propertyJobs = null;
+      }
+    },
+
+
+
+
+
+
+
+
+    /*
+    ---------------------------------------------------------------------------
+      PRIVATE HELPERS/DATA
+    ---------------------------------------------------------------------------
+    */
+
+    /**
+     * Internal helper for all children addition needs
+     *
+     * @param child {var} the element to add
+     * @throws {Error} if the given element is already a child
+     *     of this element
+     */
+    __addChildHelper : function(child)
+    {
+      if (child._parent === this) {
+        throw new Error("Child is already in: " + child);
+      }
+
+      if (child.__root) {
+        throw new Error("Root elements could not be inserted into other ones.");
+      }
+
+      // Remove from previous parent
+      if (child._parent) {
+        child._parent.remove(child);
+      }
+
+      // Convert to child of this object
+      child._parent = this;
+
+      // Prepare array
+      if (!this._children) {
+        this._children = [];
+      }
+
+      // Schedule children update
+      if (this._domNode) {
+        this._scheduleChildrenUpdate();
+      }
+    },
+
+
+    /**
+     * Internal helper for all children removal needs
+     *
+     * @param child {qx.html.Element} the removed element
+     * @throws {Error} if the given element is not a child
+     *     of this element
+     */
+    __removeChildHelper : function(child)
+    {
+      if (child._parent !== this) {
+        throw new Error("Has no child: " + child);
+      }
+
+      // Schedule children update
+      if (this._domNode) {
+        this._scheduleChildrenUpdate();
+      }
+
+      // Remove reference to old parent
+      delete child._parent;
+    },
+
+
+    /**
+     * Internal helper for all children move needs
+     *
+     * @param child {qx.html.Element} the moved element
+     * @throws {Error} if the given element is not a child
+     *     of this element
+     */
+    __moveChildHelper : function(child)
+    {
+      if (child._parent !== this) {
+        throw new Error("Has no child: " + child);
+      }
+
+      // Schedule children update
+      if (this._domNode) {
+        this._scheduleChildrenUpdate();
+      }
+    },
+
+
+
+
+    /*
+    ---------------------------------------------------------------------------
+      CHILDREN MANAGEMENT (EXECUTED ON THE PARENT)
+    ---------------------------------------------------------------------------
+    */
+
+    /**
+     * Returns a copy of the internal children structure.
+     *
+     * Please do not modify the array in place. If you need
+     * to work with the data in such a way make yourself
+     * a copy of the data first.
+     *
+     * @return {Array} the children list
+     */
+    getChildren : function() {
+      return this._children || null;
+    },
+
+
+    /**
+     * Get a child element at the given index
+     *
+     * @param index {Integer} child index
+     * @return {qx.html.Element|null} The child element or <code>null</code> if
+     *     no child is found at that index.
+     */
+    getChild : function(index)
+    {
+      var children = this._children;
+      return children && children[index] || null;
+    },
+
+
+    /**
+     * Returns whether the element has any child nodes
+     *
+     * @return {Boolean} Whether the element has any child nodes
+     */
+    hasChildren : function()
+    {
+      var children = this._children;
+      return children && children[0] !== undefined;
+    },
+
+
+    /**
+     * Find the position of the given child
+     *
+     * @param child {qx.html.Element} the child
+     * @return {Integer} returns the position. If the element
+     *     is not a child <code>-1</code> will be returned.
+     */
+    indexOf : function(child)
+    {
+      var children = this._children;
+      return children ? children.indexOf(child) : -1;
+    },
+
+
+    /**
+     * Whether the given element is a child of this element.
+     *
+     * @param child {qx.html.Element} the child
+     * @return {Boolean} Returns <code>true</code> when the given
+     *    element is a child of this element.
+     */
+    hasChild : function(child)
+    {
+      var children = this._children;
+      return children && children.indexOf(child) !== -1;
+    },
+
+
+    /**
+     * Append all given children at the end of this element.
+     *
+     * @param varargs {qx.html.Element} elements to insert
+     * @return {qx.html.Element} this object (for chaining support)
+     */
+    add : function(varargs) {
+      var self = this;
+      function addImpl(arr) {
+        arr.forEach(function(child) {
+          if (child instanceof qx.data.Array || qx.lang.Type.isArray(child)) {
+            addImpl(child);
+          } else {
+            self.__addChildHelper(child);
+            self._children.push(child);
+          }
+        });
+      }
+      addImpl(qx.lang.Array.fromArguments(arguments));
+
+      // Chaining support
+      return this;
+    },
+
+
+    /**
+     * Inserts a new element into this element at the given position.
+     *
+     * @param child {qx.html.Element} the element to insert
+     * @param index {Integer} the index (starts at 0 for the
+     *     first child) to insert (the index of the following
+     *     children will be increased by one)
+     * @return {qx.html.Element} this object (for chaining support)
+     */
+    addAt : function(child, index)
+    {
+      this.__addChildHelper(child);
+      qx.lang.Array.insertAt(this._children, child, index);
+
+      // Chaining support
+      return this;
+    },
+
+
+    /**
+     * Removes all given children
+     *
+     * @param childs {qx.html.Element} children to remove
+     * @return {qx.html.Element} this object (for chaining support)
+     */
+    remove : function(childs) {
+      var children = this._children;
+      if (!children) {
+        return this;
+      }
+
+      var self = this;
+      function removeImpl(arr) {
+        arr.forEach(function(child) {
+          if (child instanceof qx.data.Array || qx.lang.Type.isArray(child)) {
+            removeImpl(child);
+          } else {
+            self.__removeChildHelper(child);
+            qx.lang.Array.remove(children, child);
+          }
+        });
+      }
+      removeImpl(qx.lang.Array.fromArguments(arguments));
+      
+      // Chaining support
+      return this;
+    },
+
+
+    /**
+     * Removes the child at the given index
+     *
+     * @param index {Integer} the position of the
+     *     child (starts at 0 for the first child)
+     * @return {qx.html.Element} this object (for chaining support)
+     */
+    removeAt : function(index)
+    {
+      var children = this._children;
+      if (!children) {
+        throw new Error("Has no children!");
+      }
+
+      var child = children[index];
+      if (!child) {
+        throw new Error("Has no child at this position!");
+      }
+
+      this.__removeChildHelper(child);
+      qx.lang.Array.removeAt(this._children, index);
+
+      // Chaining support
+      return this;
+    },
+
+
+    /**
+     * Remove all children from this element.
+     *
+     * @return {qx.html.Element} A reference to this.
+     */
+    removeAll : function()
+    {
+      var children = this._children;
+      if (children)
+      {
+        for (var i=0, l=children.length; i<l; i++) {
+          this.__removeChildHelper(children[i]);
+        }
+
+        // Clear array
+        children.length = 0;
+      }
+
+      // Chaining support
+      return this;
+    },
+
+
+
+
+
+
+    /*
+    ---------------------------------------------------------------------------
+      CHILDREN MANAGEMENT (EXECUTED ON THE CHILD)
+    ---------------------------------------------------------------------------
+    */
+
+    /**
+     * Returns the parent of this element.
+     *
+     * @return {qx.html.Element|null} The parent of this element
+     */
+    getParent : function() {
+      return this._parent || null;
+    },
+
+
+    /**
+     * Insert self into the given parent. Normally appends self to the end,
+     * but optionally a position can be defined. With index <code>0</code> it
+     * will be inserted at the begin.
+     *
+     * @param parent {qx.html.Element} The new parent of this element
+     * @param index {Integer?null} Optional position
+     * @return {qx.html.Element} this object (for chaining support)
+     */
+    insertInto : function(parent, index)
+    {
+      parent.__addChildHelper(this);
+
+      if (index == null) {
+        parent._children.push(this);
+      } else {
+        qx.lang.Array.insertAt(this._children, this, index);
+      }
+
+      return this;
+    },
+
+
+    /**
+     * Insert self before the given (related) element
+     *
+     * @param rel {qx.html.Element} the related element
+     * @return {qx.html.Element} this object (for chaining support)
+     */
+    insertBefore : function(rel)
+    {
+      var parent = rel._parent;
+
+      parent.__addChildHelper(this);
+      qx.lang.Array.insertBefore(parent._children, this, rel);
+
+      return this;
+    },
+
+
+    /**
+     * Insert self after the given (related) element
+     *
+     * @param rel {qx.html.Element} the related element
+     * @return {qx.html.Element} this object (for chaining support)
+     */
+    insertAfter : function(rel)
+    {
+      var parent = rel._parent;
+
+      parent.__addChildHelper(this);
+      qx.lang.Array.insertAfter(parent._children, this, rel);
+
+      return this;
+    },
+
+
+    /**
+     * Move self to the given index in the current parent.
+     *
+     * @param index {Integer} the index (starts at 0 for the first child)
+     * @return {qx.html.Element} this object (for chaining support)
+     * @throws {Error} when the given element is not child
+     *      of this element.
+     */
+    moveTo : function(index)
+    {
+      var parent = this._parent;
+
+      parent.__moveChildHelper(this);
+
+      var oldIndex = parent._children.indexOf(this);
+
+      if (oldIndex === index) {
+        throw new Error("Could not move to same index!");
+      } else if (oldIndex < index) {
+        index--;
+      }
+
+      qx.lang.Array.removeAt(parent._children, oldIndex);
+      qx.lang.Array.insertAt(parent._children, this, index);
+
+      return this;
+    },
+
+
+    /**
+     * Move self before the given (related) child.
+     *
+     * @param rel {qx.html.Element} the related child
+     * @return {qx.html.Element} this object (for chaining support)
+     */
+    moveBefore : function(rel)
+    {
+      var parent = this._parent;
+      return this.moveTo(parent._children.indexOf(rel));
+    },
+
+
+    /**
+     * Move self after the given (related) child.
+     *
+     * @param rel {qx.html.Element} the related child
+     * @return {qx.html.Element} this object (for chaining support)
+     */
+    moveAfter : function(rel)
+    {
+      var parent = this._parent;
+      return this.moveTo(parent._children.indexOf(rel) + 1);
+    },
+
+
+    /**
+     * Remove self from the current parent.
+     *
+     * @return {qx.html.Element} this object (for chaining support)
+     */
+    free : function()
+    {
+      var parent = this._parent;
+      if (!parent) {
+        throw new Error("Has no parent to remove from.");
+      }
+
+      if (!parent._children) {
+        return this;
+      }
+
+      parent.__removeChildHelper(this);
+      qx.lang.Array.remove(parent._children, this);
+
+      return this;
+    },
+
+
+
+
+
+
+    /*
+    ---------------------------------------------------------------------------
+      DOM ELEMENT ACCESS
+    ---------------------------------------------------------------------------
+    */
+
+    /**
+     * Returns the DOM element (if created). Please use this with caution.
+     * It is better to make all changes to the object itself using the public
+     * API rather than to the underlying DOM element.
+     * 
+     * @param create {Boolean?} if true, the DOM node will be created if it does
+     * not exist
+     * @return {Element|null} The DOM element node, if available.
+     */
+    getDomElement : function(create) {
+      if (create && !this._domNode) {
+        this.flush();
+      }
+      return this._domNode || null;
+    },
+
+
+    /**
+     * Returns the nodeName of the DOM element.
+     *
+     * @return {String} The node name
+     */
+    getNodeName : function() {
+      return this._nodeName;
+    },
+
+    /**
+     * Sets the nodeName of the DOM element.
+     *
+     * @param name {String} The node name
+     */
+    setNodeName : function(name) {
+      this._nodeName = name;
+    },
+
+
+
+
+
+    /*
+    ---------------------------------------------------------------------------
+      EXCLUDE SUPPORT
+    ---------------------------------------------------------------------------
+    */
+
+    /**
+     * Marks the element as included which means it will be moved into
+     * the DOM again and synced with the internal data representation.
+     *
+     * @return {Node} this object (for chaining support)
+     */
+    include : function()
+    {
+      if (this._included) {
+        return this;
+      }
+
+      delete this._included;
+
+      if (this._parent) {
+        this._parent._scheduleChildrenUpdate();
+      }
+
+      return this;
+    },
+
+
+    /**
+     * Marks the element as excluded which means it will be removed
+     * from the DOM and ignored for updates until it gets included again.
+     *
+     * @return {qx.html.Element} this object (for chaining support)
+     */
+    exclude : function()
+    {
+      if (!this._included) {
+        return this;
+      }
+
+      this._included = false;
+
+      if (this._parent) {
+        this._parent._scheduleChildrenUpdate();
+      }
+
+      return this;
+    },
+
+
+    /**
+     * Whether the element is part of the DOM
+     *
+     * @return {Boolean} Whether the element is part of the DOM.
+     */
+    isIncluded : function() {
+      return this._included === true;
+    },
+    
+    /**
+     * Apply method for visible property
+     */
+    _applyVisible: function(value) {
+      // Nothing - to be overridden
+    },
+
+
+
+    /*
+    ---------------------------------------------------------------------------
+      PROPERTY SUPPORT
+    ---------------------------------------------------------------------------
+    */
+
+    /**
+     * Registers a property and the implementations used to read the property value
+     * from the DOM and to set the property value onto the DOM.  This allows the element
+     * to have a simple `setProperty` method that knows how to read and write the value.
+     * 
+     * You do not have to specify a getter or a setter - by default the setter will use
+     * `_applyProperty` for backwards compatibility, and there is no getter implementation.
+     * 
+     * The functions are called with `this` set to this Element.  The getter takes
+     * the property name as a parameter and is expected to return a value, the setter takes
+     * the property name and value as parameters, and returns nothing. 
+     * 
+     * @param key {String} the property name
+     * @param getter {Function?} function to read from the DOM
+     * @param setter {Function?} function to copy to the DOM
+     * @param serialize {Function?} function to serialize the value to HTML
+     */
+    registerProperty: function(key, get, set, serialize) {
+      if (!this._properties) {
+        this._properties = {};
+      }
+      if (this._properties[key]) {
+        this.debug("Overridding property " + key + " in " + this + "[" + this.classname + "]");
+      }
+      if (!set) {
+        set = qx.lang.Function.bind(function(value, key) {
+          this._applyProperty(key, value);
+        }, this);
+        qx.log.Logger.deprecatedMethodWarning(this._applyProperty, "The method '_applyProperty' is deprecated.  Please use `registerProperty` instead (property '" + key + "' in " + this.classname + ")");
+      }
+      this._properties[key] = {
+          get: get,
+          set: set,
+          serialize: serialize,
+          value: undefined
+      }
+    },
+
+
+    
+    /**
+     * Applies a special property with the given value.
+     *
+     * This property apply routine can be easily overwritten and
+     * extended by sub classes to add new low level features which
+     * are not easily possible using styles and attributes.
+     * 
+     * Note that this implementation is for backwards compatibility and
+     * implementations 
+     *
+     * @param name {String} Unique property identifier
+     * @param value {var} Any valid value (depends on the property)
+     * @return {qx.html.Element} this object (for chaining support)
+     * @abstract
+     * @deprecated {6.0} please use `registerProperty` instead
+     */
+    _applyProperty : function(name, value) {
+      // empty implementation
+    },
+
+
+    /**
+     * Set up the given property.
+     *
+     * @param key {String} the name of the property
+     * @param value {var} the value
+     * @param direct {Boolean?false} Whether the value should be applied
+     *    directly (without queuing)
+     * @return {qx.html.Element} this object (for chaining support)
+     */
+    _setProperty : function(key, value, direct) {
+      if (!this._properties || !this._properties[key]) {
+        this.registerProperty(key, null, null);
+      }
+
+      if (this._properties[key].value == value) {
+        return this;
+      }
+
+      this._properties[key].value = value;
+
+      // Uncreated elements simply copy all data
+      // on creation. We don't need to remember any
+      // jobs. It is a simple full list copy.
+      if (this._domNode) {
+        // Omit queuing in direct mode
+        if (direct) {
+          this._properties[key].set.call(this, value, key);
+          return this;
+        }
+
+        // Dynamically create if needed
+        if (!this._propertyJobs) {
+          this._propertyJobs = {};
+        }
+
+        // Store job info
+        this._propertyJobs[key] = true;
+
+        // Register modification
+        qx.html.Element._modified[this.toHashCode()] = this;
+        qx.html.Element._scheduleFlush("element");
+      }
+
+      return this;
+    },
+
+
+    /**
+     * Removes the given misc
+     *
+     * @param key {String} the name of the misc
+     * @param direct {Boolean?false} Whether the value should be removed
+     *    directly (without queuing)
+     * @return {qx.html.Element} this object (for chaining support)
+     */
+    _removeProperty : function(key, direct) {
+      return this._setProperty(key, null, direct);
+    },
+
+
+    /**
+     * Get the value of the given misc.
+     *
+     * @param key {String} name of the misc
+     * @param direct {Boolean?false} Whether the value should be obtained directly (without queuing)
+     * @return {var} the value of the misc
+     */
+    _getProperty : function(key, direct) {
+      if (!this._properties || !this._properties[key]) {
+        return null;
+      }
+      
+      var value = this._properties[key].value;
+      if (this._domNode) {
+        if (direct || value === undefined) {
+          var fn = this._properties[key].get;
+          if (fn) {
+            this._properties[key].value = value = fn.call(this, key);
+          }
+        }
+      }
+
+      return value === undefined || value == null ? null : value;
+    },
+
+
+
+
+
+    /*
+    ---------------------------------------------------------------------------
+      EVENT SUPPORT
+    ---------------------------------------------------------------------------
+    */
+
+    /**
+     * Adds an event listener to the element.
+     *
+     * @param type {String} Name of the event
+     * @param listener {Function} Function to execute on event
+     * @param self {Object ? null} Reference to the 'this' variable inside
+     *         the event listener. When not given, the corresponding dispatcher
+     *         usually falls back to a default, which is the target
+     *         by convention. Note this is not a strict requirement, i.e.
+     *         custom dispatchers can follow a different strategy.
+     * @param capture {Boolean ? false} Whether capturing should be enabled
+     * @return {var} An opaque id, which can be used to remove the event listener
+     *         using the {@link #removeListenerById} method.
+     */
+    addListener : function(type, listener, self, capture)
+    {
+      if (this.$$disposed) {
+        return null;
+      }
+
+      if (qx.core.Environment.get("qx.debug")) {
+        var msg = "Failed to add event listener for type '" + type + "'" +
+          " to the target '" + this + "': ";
+
+        this.assertString(type, msg + "Invalid event type.");
+        this.assertFunction(listener, msg + "Invalid callback function");
+
+        if (self !== undefined) {
+          this.assertObject(self, "Invalid context for callback.");
+        }
+
+        if (capture !== undefined) {
+          this.assertBoolean(capture, "Invalid capture flag.");
+        }
+      }
+      
+      if (qx.Class.supportsEvent(this, type)) {
+        return this.base(arguments, type, listener, self, capture);
+      }
+
+      if (this._domNode) {
+        return qx.event.Registration.addListener(this._domNode, type, listener, self, capture);
+      }
+
+      if (!this.__eventValues) {
+        this.__eventValues = {};
+      }
+
+      if (capture == null) {
+        capture = false;
+      }
+
+      var unique = qx.event.Manager.getNextUniqueId();
+      var id = type + (capture ? "|capture|" : "|bubble|") + unique;
+
+      this.__eventValues[id] =
+      {
+        type : type,
+        listener : listener,
+        self : self,
+        capture : capture,
+        unique : unique
+      };
+
+      return id;
+    },
+
+
+    /**
+     * Removes an event listener from the element.
+     *
+     * @param type {String} Name of the event
+     * @param listener {Function} Function to execute on event
+     * @param self {Object} Execution context of given function
+     * @param capture {Boolean ? false} Whether capturing should be enabled
+     * @return {qx.html.Element} this object (for chaining support)
+     */
+    removeListener : function(type, listener, self, capture)
+    {
+      if (this.$$disposed) {
+        return null;
+      }
+
+      if (qx.core.Environment.get("qx.debug"))
+      {
+        var msg = "Failed to remove event listener for type '" + type + "'" +
+          " from the target '" + this + "': ";
+
+        this.assertString(type, msg + "Invalid event type.");
+        this.assertFunction(listener, msg + "Invalid callback function");
+
+        if (self !== undefined) {
+          this.assertObject(self, "Invalid context for callback.");
+        }
+
+        if (capture !== undefined) {
+          this.assertBoolean(capture, "Invalid capture flag.");
+        }
+      }
+
+      if (qx.Class.supportsEvent(this, type)) {
+        return this.base(arguments, type, listener, self, capture);
+      }
+
+      if (this._domNode)
+      {
+        if (listener.$$wrapped_callback && listener.$$wrapped_callback[type + this.toHashCode()]) {
+          var callback = listener.$$wrapped_callback[type + this.toHashCode()];
+          delete listener.$$wrapped_callback[type + this.toHashCode()];
+          listener = callback;
+        }
+        qx.event.Registration.removeListener(this._domNode, type, listener, self, capture);
+      }
+      else
+      {
+        var values = this.__eventValues;
+        var entry;
+
+        if (capture == null) {
+          capture = false;
+        }
+
+        for (var key in values)
+        {
+          entry = values[key];
+
+          // Optimized for performance: Testing references first
+          if (entry.listener === listener && entry.self === self && entry.capture === capture && entry.type === type)
+          {
+            delete values[key];
+            break;
+          }
+        }
+      }
+
+      return this;
+    },
+
+
+    /**
+     * Removes an event listener from an event target by an id returned by
+     * {@link #addListener}
+     *
+     * @param id {var} The id returned by {@link #addListener}
+     * @return {qx.html.Element} this object (for chaining support)
+     */
+    removeListenerById : function(id)
+    {
+      if (this.$$disposed) {
+        return null;
+      }
+
+      this.base(arguments, id);
+
+      if (this._domNode) {
+        qx.event.Registration.removeListenerById(this._domNode, id);
+      } else {
+        delete this.__eventValues[id];
+      }
+
+      return this;
+    },
+
+
+    /**
+     * Check if there are one or more listeners for an event type.
+     *
+     * @param type {String} name of the event type
+     * @param capture {Boolean ? false} Whether to check for listeners of
+     *         the bubbling or of the capturing phase.
+     * @return {Boolean} Whether the object has a listener of the given type.
+     */
+    hasListener : function(type, capture)
+    {
+      if (this.$$disposed) {
+        return false;
+      }
+
+      if (qx.Class.supportsEvent(this, type)) {
+        return this.base(arguments, type, capture);
+      }
+
+      if (this._domNode) {
+        if (qx.event.Registration.hasListener(this._domNode, type, capture))
+          return true;
+        
+      } else {
+        var values = this.__eventValues;
+        var entry;
+  
+        if (capture == null) {
+          capture = false;
+        }
+  
+        for (var key in values) {
+          entry = values[key];
+  
+          // Optimized for performance: Testing fast types first
+          if (entry.capture === capture && entry.type === type) {
+            return true;
+          }
+        }
+      }
+
+      return false;
+    },
+
+
+    /**
+     * Serializes and returns all event listeners attached to this element
+     * @return {Map[]} an Array containing a map for each listener. The maps
+     * have the following keys:
+     * <ul>
+     *   <li><code>type</code> (String): Event name</li>
+     *   <li><code>handler</code> (Function): Callback function</li>
+     *   <li><code>self</code> (Object): The callback's context</li>
+     *   <li><code>capture</code> (Boolean): If <code>true</code>, the listener is
+     * attached to the capturing phase</li>
+     * </ul>
+     */
+    getListeners : function() {
+      if (this.$$disposed) {
+        return null;
+      }
+
+      if (this._domNode) {
+        return qx.event.Registration.getManager(this._domNode).serializeListeners(this._domNode);
+      }
+
+      var listeners = [];
+      for (var id in this.__eventValues) {
+        var listenerData = this.__eventValues[id];
+        listeners.push({
+          type: listenerData.type,
+          handler: listenerData.listener,
+          self: listenerData.self,
+          capture: listenerData.capture
+        });
+      }
+
+      return listeners;
+    }
+  },
+
+
+
+
+
+  /*
+  *****************************************************************************
+     DESTRUCT
+  *****************************************************************************
+  */
+
+  destruct : function()
+  {
+    var el = this._domNode;
+    if (el)
+    {
+      qx.event.Registration.getManager(el).removeAllListeners(el);
+      el.$$element = "";
+      delete el.$$elementObject;
+      el.$$qxObjectHash = "";
+      delete el.$$qxObject;
+    }
+
+    if (!qx.core.ObjectRegistry.inShutDown)
+    {
+      var parent = this._parent;
+      if (parent && !parent.$$disposed) {
+        parent.remove(this);
+      }
+    }
+
+    this._disposeArray("_children");
+
+    this._properties = this._propertyJobs = this._domNode = this._parent = this.__eventValues = null;
+  }
+});

--- a/framework/source/class/qx/html/Node.js
+++ b/framework/source/class/qx/html/Node.js
@@ -146,6 +146,9 @@ qx.Class.define("qx.html.Node",
 
     _propertyJobs : null,
     _properties : null,
+    
+    /** @type {Map} map of event handlers */
+    __eventValues: null,
 
 
     /**
@@ -316,9 +319,6 @@ qx.Class.define("qx.html.Node",
             var child = null;
             if (domChild.nodeType == window.Node.ELEMENT_NODE) {
               var id = domChild.getAttribute("data-qx-object-id");
-              if (domChild.nodeName == "INPUT") {
-                console.log("Convert INPUT: " + id);
-              }
               if (id) {
                 var owningQxObjectId = null;
                 var qxObjectId = null;
@@ -336,8 +336,9 @@ qx.Class.define("qx.html.Node",
                 }
               }
             }
-            if (!child)
+            if (!child) {
               child = qx.html.Factory.getInstance().createElement(domChild.nodeName, domChild.attributes);
+            }
             return {
               htmlNode: child,
               domNode: domChild,
@@ -352,9 +353,6 @@ qx.Class.define("qx.html.Node",
           install(mapEntry);
           return mapEntry.htmlNode;
         });
-        if (map.domNode.nodeName == "INPUT") {
-          console.log("Install INPUT: " + map.domNode.getAttribute("data-qx-object-id"));
-        }
         map.htmlNode._useNodeImpl(map.domNode, htmlChildren);
       }
       
@@ -406,8 +404,9 @@ qx.Class.define("qx.html.Node",
       if (oldChildren) {
         oldChildren.forEach(function(child) {
           if (!lookup[child.toHashCode()]) {
-            if (child._domNode && child._domNode.parentElement)
+            if (child._domNode && child._domNode.parentElement) {
               child._domNode.parentElement.removeChild(child._domNode);
+            }
             child._parent = null;
           }
         });
@@ -598,8 +597,9 @@ qx.Class.define("qx.html.Node",
     isInRoot: function() {
       var tmp = this;
       while (tmp) {
-        if (tmp.isRoot())
+        if (tmp.isRoot()) {
           return true;
+        }
         tmp = tmp._parent;
       }
       return false;
@@ -828,8 +828,6 @@ qx.Class.define("qx.html.Node",
      */
     _syncData : function()
     {
-      var elem = this._domNode;
-
       // Sync misc
       var jobs = this._propertyJobs;
       if (jobs && this._properties) {
@@ -1754,8 +1752,9 @@ qx.Class.define("qx.html.Node",
       }
 
       if (this._domNode) {
-        if (qx.event.Registration.hasListener(this._domNode, type, capture))
+        if (qx.event.Registration.hasListener(this._domNode, type, capture)) {
           return true;
+        }
         
       } else {
         var values = this.__eventValues;

--- a/framework/source/class/qx/html/Root.js
+++ b/framework/source/class/qx/html/Root.js
@@ -48,7 +48,7 @@ qx.Class.define("qx.html.Root",
     this.base(arguments);
 
     if (elem != null) {
-      this.useElement(elem);
+      this.useNode(elem);
     }
   },
 
@@ -71,7 +71,7 @@ qx.Class.define("qx.html.Root",
      * @param elem {Element} the dom element to set
      * @throws {Error} if the element is assigned again
      */
-    useElement : function(elem)
+    useNode : function(elem)
     {
       // Base call
       this.base(arguments, elem);

--- a/framework/source/class/qx/html/Text.js
+++ b/framework/source/class/qx/html/Text.js
@@ -1,0 +1,165 @@
+/* ************************************************************************
+
+   qooxdoo - the new era of web development
+
+   http://qooxdoo.org
+
+   Copyright:
+     2019-2020 Zenesis Limited, https://www.zenesis.com
+
+   License:
+     MIT: https://opensource.org/licenses/MIT
+     See the LICENSE file in the project's top-level directory for details.
+
+   Authors:
+     * John Spackman (https://github.com/johnspackman, john.spackman@zenesis.com)
+
+************************************************************************ */
+
+/**
+ * DOM representation of Text nodes
+ */
+qx.Class.define("qx.html.Text", {
+  extend: qx.html.Node,
+
+  /*
+   * ****************************************************************************
+   * CONSTRUCTOR
+   * ****************************************************************************
+   */
+
+  /**
+   * Creates a new Text
+   * 
+   * @param value
+   *          {String?} the value of the text
+   */
+  construct: function(text) {
+    this.base(arguments, "#text");
+    if (text) {
+      this.__text = text;
+    }
+  },
+
+  /*
+   * ****************************************************************************
+   * MEMBERS
+   * ****************************************************************************
+   */
+
+  members: {
+    __text: null,
+
+    /*
+     * @Override
+     */
+    _createDomElement: function() {
+      return window.document.createTextNode(this.__text || "");
+    },
+
+    /*
+     * @Override
+     */
+    isRoot : function() {
+      return false;
+    },
+    
+    /*
+     * @Override
+     */
+    _copyData: function(fromMarkup, propertiesFromDom) {
+      this.base(arguments, fromMarkup, propertiesFromDom);
+      var elem = this._domNode;
+      elem.nodeValue = this.__text || "";
+    },
+    
+    /*
+     * @Override
+     */
+    _useNode: function(domNode) {
+      this.setText(domNode.nodeValue);
+    },
+
+    /*
+     * @Override
+     */
+    _useNodeImpl: function(domNode) {
+      this.setText(domNode.nodeValue);
+    },
+
+    /**
+     * @Override
+     */
+    _syncData : function() {
+      this.base(arguments);
+      var elem = this._domNode;
+      elem.nodeValue = this.__text || "";
+    },
+    
+    /*
+     * @Override
+     */
+    _serializeImpl: function(writer) {
+      if (this.__nodeValue !== null) {
+        writer(this.__text);
+      }
+    },
+    
+    /**
+     * @Override
+     */
+    useMarkup: function(html) {
+      throw new Error("Could not overwrite existing text node!");
+    },
+    
+    /**
+     * Sets the text value
+     * 
+     * @param value {String?} the text value of for the text node
+     * @param direct {Boolean?} whether to set the DOM node immediately if there is one 
+     */
+    setText: function(value, direct) {
+      this.__text = value;
+      if (direct && this._domNode) {
+        this._domNode.nodeValue = value;
+      } else {
+        qx.html.Element._modified[this.$$hash] = this;
+        qx.html.Element._scheduleFlush("element");
+      }
+    },
+    
+    /**
+     * Returns the value of the node
+     * 
+     * @return {String} the text node
+     */
+    getText: function() {
+      return this.__text;
+    }
+  },
+
+  /*
+   * ****************************************************************************
+   * DEFER
+   * ****************************************************************************
+   */
+
+  defer: function(statics) {
+    statics.__deferredCall = new qx.util.DeferredCall(statics.flush, statics);
+  },
+
+  /*
+   * ****************************************************************************
+   * DESTRUCT
+   * ****************************************************************************
+   */
+
+  destruct: function() {
+    if (this.toHashCode()) {
+      delete qx.html.Element._modified[this.toHashCode()];
+      delete qx.html.Element._scroll[this.toHashCode()];
+    }
+
+    this.__attribValues = this.__styleValues = this.__eventValues = this.__attribJobs = this.__styleJobs = this.__lazyScrollIntoViewX = this.__lazyScrollIntoViewY = null;
+  }
+});

--- a/framework/source/class/qx/html/Text.js
+++ b/framework/source/class/qx/html/Text.js
@@ -100,7 +100,7 @@ qx.Class.define("qx.html.Text", {
      * @Override
      */
     _serializeImpl: function(writer) {
-      if (this.__nodeValue !== null) {
+      if (this.__text !== null) {
         writer(this.__text);
       }
     },

--- a/framework/source/class/qx/locale/Manager.js
+++ b/framework/source/class/qx/locale/Manager.js
@@ -25,6 +25,9 @@
  * @require(qx.event.dispatch.Direct)
  * @require(qx.locale.LocalizedString)
  *
+ * Note: "translating" the empty string, e.g. tr("") will return the header
+ * of the respective .po file. See also https://www.gnu.org/software/gettext/manual/html_node/PO-Files.html#PO-Files
+ *
  * @cldr()
  */
 

--- a/framework/source/class/qx/test/TestPromise.js
+++ b/framework/source/class/qx/test/TestPromise.js
@@ -1,0 +1,100 @@
+qx.Class.define("qx.test.TestPromise", {
+  extend: qx.dev.unit.TestCase,
+  
+  members: {
+    
+    testResolve: function() {
+      var self = this;
+      var p = new qx.Promise(function(resolve, reject) {
+        setTimeout(function() {
+          resolve("ok");
+        });
+      }, this);
+      p.then(function(value) {
+        this.assertIdentical(this, self);
+        this.assertEquals(value, "ok");
+        this.resume();
+      }, function(err) {
+        this.assertTrue(false);
+        this.resume();
+      });
+      this.wait(1000);
+    },
+    
+    testReject: function() {
+      var self = this;
+      var p = new qx.Promise(function(resolve, reject) {
+        setTimeout(function() {
+          reject(new Error("oops"));
+        });
+      }, this);
+      p.then(function(value) {
+        this.assertTrue(false);
+        this.resume();
+      }, function(err) {
+        this.assertIdentical(this, self);
+        this.assertEquals(err.message, "oops");
+        this.resume();
+      });
+      this.wait(1000);
+    },
+    
+    testProperty: function() {
+      var t = this;
+      var Clazz = qx.Class.define(null, {
+        extend: qx.core.Object,
+        properties: {
+          alpha: {
+            init: null,
+            nullable: true
+          }
+        }
+      }); 
+      var obj = new Clazz();
+      var p = new qx.Promise(function(resolve) {
+        resolve(123);
+      });
+      obj.setAlpha(p).then(function() {
+        t.assertEquals(123, obj.getAlpha());
+        t.resume();
+      });
+      this.wait(1000);
+    },
+    
+    /*
+    testEach: function() {
+      var t = this;
+      var arr = new qx.data.Array();
+      arr.push("a");
+      arr.push("b");
+      arr.push("c");
+      var str = "";
+      qx.Promise.resolve(arr).each(function(elem) {
+        str += item;
+      }).then(function() {
+        t.assertEquals("abc", str);
+        t.resume();
+      });
+      t.wait(1000);
+    },
+    */
+    
+    testGlobalError: function() {
+      var t = this;
+      qx.event.GlobalError.setErrorHandler(function(ex) {
+        t.assertEquals(ex.message, "oops");
+        t.resume();
+      });
+      var self = this;
+      var p = new qx.Promise(function(resolve, reject) {
+        setTimeout(function() {
+          resolve("ok");
+        });
+      }, this);
+      p.then(function(value) {
+        throw new Error("oops");
+      });
+      this.wait(1000);
+    }
+  }
+});

--- a/framework/source/class/qx/test/html/Element.js
+++ b/framework/source/class/qx/test/html/Element.js
@@ -164,8 +164,59 @@ qx.Class.define("qx.test.html.Element",
          el.dispose();
       }, this);
     },
+    
+    
+    testText : function()
+    {
+      var el1 = new qx.html.Element();
+      el1.setAttribute("id", "el1");
+      var txt1 = new qx.html.Text();
+      txt1.setValue("Hello");
+      var txt2 = new qx.html.Text();
+      txt2.setValue(" World");
+      el1.add(txt1);
+      el1.add(txt2);
 
+      this._doc.add(el1);
+      qx.html.Element.flush();
+      var pa = document.getElementById("el1");
+      this.assertEquals(2, pa.childNodes.length);
+      this.assertEquals(pa.textContent, "Hello World");
+      txt1.setValue("Goodbye");
+      this.assertEquals(pa.textContent, "Hello World");
+      qx.html.Element.flush();
+      this.assertEquals(pa.textContent, "Goodbye World");
+      txt1.setValue("Hello Again", true);
+      this.assertEquals(pa.textContent, "Hello Again World");
+      
+      var buffer = "";
+      function writer() {
+        var args = qx.lang.Array.fromArguments(arguments);
+        buffer += args.join("");
+      }
+      el1.serialize(writer);
+      this.assertEquals("<div id=\"el1\">Hello Again World</div>", buffer);
+      el1.setAttribute("abc", 123);
+      el1.setAttribute("def", true);
+      el1.setAttribute("checked", true);
+      buffer = "";
+      el1.serialize(writer);
+      this.assertEquals("<div id=\"el1\" abc=\"123\" def=\"true\" checked=checked>Hello Again World</div>", buffer);
+      
+      var el2 = new qx.html.Element();
+      el2.setAttribute("id", "el2");
+      el1.addAt(el2, 1);
+      buffer = "";
+      el1.serialize(writer);
+      this.assertEquals("<div id=\"el1\" abc=\"123\" def=\"true\" checked=checked>Hello Again<div id=\"el2\"/> World</div>", buffer);
+      
+      el2.setProperty("innerHtml", "<b>Test</b>");
+      buffer = "";
+      el1.serialize(writer);
+      this.assertEquals("<div id=\"el1\" abc=\"123\" def=\"true\" checked=checked>Hello Again<div id=\"el2\"><b>Test</b></div> World</div>", buffer);
+    },
 
+    
     testBasics : function()
     {
       //

--- a/framework/source/class/qx/test/lang/Type.js
+++ b/framework/source/class/qx/test/lang/Type.js
@@ -227,7 +227,9 @@ qx.Class.define("qx.test.lang.Type",
       this.assertFalse(Type.isError(document.getElementById("ReturenedNull")));
     },
 
-    // @ignore(Promise)
+    /**
+     * @ignore(Promise)
+     */
     testIsPromise: function() {
       var Type = qx.lang.Type;
 

--- a/framework/source/class/qx/ui/basic/Image.js
+++ b/framework/source/class/qx/ui/basic/Image.js
@@ -417,7 +417,7 @@ qx.Class.define("qx.ui.basic.Image",
       }
 
       var element = new (clazz)(tagName);
-      element.connectWidget(this);
+      element.connectObject(this);
       element.setStyles({
         "overflowX": "hidden",
         "overflowY": "hidden",
@@ -432,7 +432,7 @@ qx.Class.define("qx.ui.basic.Image",
 
         if (qx.core.Environment.get("css.alphaimageloaderneeded")) {
           var wrapper = this.__wrapper = new qx.html.Element("div");
-          element.connectWidget(this);
+          element.connectObject(this);
           wrapper.setStyle("position", "absolute");
           wrapper.add(element);
           return wrapper;
@@ -1069,7 +1069,7 @@ qx.Class.define("qx.ui.basic.Image",
   destruct : function() {
     for (var mode in this.__contentElements) {
       if (this.__contentElements.hasOwnProperty(mode)) {
-        this.__contentElements[mode].disconnectWidget(this);
+        this.__contentElements[mode].disconnectObject(this);
       }
     }
 

--- a/framework/source/class/qx/ui/core/Widget.js
+++ b/framework/source/class/qx/ui/core/Widget.js
@@ -55,6 +55,7 @@ qx.Class.define("qx.ui.core.Widget",
   construct : function()
   {
     this.base(arguments);
+    qx.core.ObjectRegistry.register(this);
 
     // Create basic element
     this.__contentElement = this.__createContentElement();
@@ -872,10 +873,10 @@ qx.Class.define("qx.ui.core.Widget",
       while(element)
       {
       	if (qx.core.Environment.get("qx.debug")) {
-      		qx.core.Assert.assertTrue((!element.$$widget && !element.$$widgetObject) ||
-      				(element.$$widgetObject && element.$$widget && element.$$widgetObject.toHashCode() === element.$$widget));
+      		qx.core.Assert.assertTrue((!element.$$qxObjectHash && !element.$$qxObject) ||
+      				(element.$$qxObject && element.$$qxObjectHash && element.$$qxObject.toHashCode() === element.$$qxObjectHash));
       	}
-        var widget = element.$$widgetObject;
+        var widget = element.$$qxObject;
 
         // check for anonymous widgets
         if (widget) {
@@ -1633,7 +1634,7 @@ qx.Class.define("qx.ui.core.Widget",
     __createContentElement : function()
     {
       var el = this._createContentElement();
-      el.connectWidget(this);
+      el.connectObject(this);
 
       // make sure to allow all pointer events
       el.setStyles({"touch-action": "none", "-ms-touch-action" : "none"});
@@ -3912,7 +3913,7 @@ qx.Class.define("qx.ui.core.Widget",
       // Remove widget pointer from DOM
       var contentEl = this.getContentElement();
       if (contentEl) {
-      	contentEl.disconnectWidget(this);
+      	contentEl.disconnectObject(this);
       }
 
       // Clean up all child controls

--- a/framework/source/class/qx/ui/embed/Flash.js
+++ b/framework/source/class/qx/ui/embed/Flash.js
@@ -305,7 +305,7 @@ qx.Class.define("qx.ui.embed.Flash",
     // overridden
     _createContentElement : function() {
       var el = new qx.html.Flash();
-      el.connectWidget(this);
+      el.connectObject(this);
       return el;
     },
 

--- a/framework/source/class/qx/ui/form/TextArea.js
+++ b/framework/source/class/qx/ui/form/TextArea.js
@@ -346,7 +346,7 @@ qx.Class.define("qx.ui.form.TextArea",
 
       // Convert to qx.html Element
       cloneHtml = new qx.html.Input("textarea");
-      cloneHtml.useElement(cloneDom);
+      cloneHtml.useNode(cloneDom);
       clone = cloneHtml;
 
       // Push out of view

--- a/framework/source/class/qx/ui/root/Application.js
+++ b/framework/source/class/qx/ui/root/Application.js
@@ -152,7 +152,7 @@ qx.Class.define("qx.ui.root.Application",
       });
 
       // Store reference to the widget in the DOM element.
-      root.connectWidget(this);
+      root.connectObject(this);
 
       return root;
     },

--- a/framework/source/class/qx/ui/root/Inline.js
+++ b/framework/source/class/qx/ui/root/Inline.js
@@ -172,7 +172,7 @@ qx.Class.define("qx.ui.root.Inline",
       rootEl.style.position = "relative";
 
       // Store reference to the widget in the DOM element.
-      root.connectWidget(this);
+      root.connectObject(this);
 
       // fire event asynchronously, otherwise the browser will fire the event
       // too early and no listener will be informed since they're not added

--- a/framework/source/class/qx/ui/root/Page.js
+++ b/framework/source/class/qx/ui/root/Page.js
@@ -107,7 +107,7 @@ qx.Class.define("qx.ui.root.Page",
       });
 
       // Store reference to the widget in the DOM element.
-      root.connectWidget(this);
+      root.connectObject(this);
 
       // Mark the element of this root with a special attribute to prevent
       // that qx.event.handler.Focus is performing a focus action.

--- a/framework/source/class/qx/xml/Document.js
+++ b/framework/source/class/qx/xml/Document.js
@@ -80,7 +80,7 @@ qx.Bootstrap.define("qx.xml.Document",
       // ActiveX - This is the preferred way for IE9 as well since it has no XPath
       // support when using the native implementation.createDocument
       if (qx.core.Environment.get("plugin.activex")) {
-        var obj = new ActiveXObject(this.DOMDOC);
+        var obj = new window.ActiveXObject(this.DOMDOC);
         //The SelectionLanguage property is no longer needed in MSXML 6; trying
         // to set it causes an exception in IE9.
         if (this.DOMDOC == "MSXML2.DOMDocument.3.0") {
@@ -131,7 +131,7 @@ qx.Bootstrap.define("qx.xml.Document",
       }
 
       if (qx.core.Environment.get("xml.domparser")) {
-        var parser = new DOMParser();
+        var parser = new window.DOMParser();
         return parser.parseFromString(str, "text/xml");
       }
 
@@ -165,8 +165,8 @@ qx.Bootstrap.define("qx.xml.Document",
         {
           // Keep both objects in sync with the same version.
           // This is important as there were compatibility issues detected.
-          new ActiveXObject(domDoc[i]);
-          new ActiveXObject(httpReq[i]);
+          new window.ActiveXObject(domDoc[i]);
+          new window.ActiveXObject(httpReq[i]);
         }
         catch(ex) {
           continue;

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "type": "git",
     "url": "https://github.com/qooxdoo/qooxdoo"
   },
-  "main": "./lib/qx_server/qx_server.js",
+  "main": "./lib/qx_server/boot.js",
   "files": [
     "version.txt",
     "LICENSE",


### PR DESCRIPTION
This PR is about improving the Virtual DOM in `qx.html.*` and adding JSX support, primarily for use in server applications but also the browser.

The changes are:

- the `qx.html.Element` is split into `qx.html.Node` and `qx.html.Element`, and also the addition of `qx.html.Text`.  This change is entirely backwards compatible, and the addition of Text allows any arbitrary DOM structure to be represented (code in `qx.ui.*` does not have to use Text nodes because the UI classes always operate directly on the node to set/get text).
- Add JSX Factory implementation
- VDOM can be serialized into HTML text stream for delivery to the client browser
- An entire tree of the DOM on the browser (ie that which was built because the browser parsed the HTML text) can be reattached to a matching or sparse tree of `qx.html.Element` instances, based on the `qxObjectId`
- There are some additional properties and methods (eg `cssClass`, `addCssClass()`, `visible`, etc) which exist to simplify common tasks
- Document the new `qx.headless` property in the compiler which indicates that the code is compiled for the server
- There are a few warning fixes and other minor tweaks which have crept in
