### PR TITLE
Add warning about result of this.tr("")

### DIFF
--- a/docs/development/howto/internationalization.md
+++ b/docs/development/howto/internationalization.md
@@ -219,7 +219,7 @@ of the application may be specified in `compile.json`, in the
 
 This would add a German and a French translation to
 the project. For a more exhaustive list of available
-locales see [here](http://unicode.org/cldr/apps/survey).
+locales see [here](http:/cldr.unicode.org/index/survey-tool).
 
 A run of `npx qx compile --update-po-files` or its shorthand `npx qx
 compile -u` will generate a `.po` file for each configured locale,

--- a/docs/development/howto/internationalization.md
+++ b/docs/development/howto/internationalization.md
@@ -219,7 +219,7 @@ of the application may be specified in `compile.json`, in the
 
 This would add a German and a French translation to
 the project. For a more exhaustive list of available
-locales see [here](http:/cldr.unicode.org/index/survey-tool).
+locales see [here](http://cldr.unicode.org/index/survey-tool).
 
 A run of `npx qx compile --update-po-files` or its shorthand `npx qx
 compile -u` will generate a `.po` file for each configured locale,

--- a/docs/development/howto/internationalization.md
+++ b/docs/development/howto/internationalization.md
@@ -119,6 +119,10 @@ that setting if you plan to support locale switching during run time.
 If the string given to `tr` does not have a translation
 under the current locale, the string itself will be returned.
 
+If the string given to `tr` is the empty string, the header of the
+.po file is returned (which can be a bit confusing if done
+accidentally, but is correct according to the [PO specs](https://www.gnu.org/software/gettext/manual/html_node/PO-Files.html#PO-Files PO specs).
+
 There is one exception to the simple rule that all strings can just be
 replaced by wrapping them in an appropriate `this.tr()` function call:
 If init values of dynamic properties (core/understanding_properties)

--- a/framework/source/class/qx/locale/Manager.js
+++ b/framework/source/class/qx/locale/Manager.js
@@ -25,6 +25,9 @@
  * @require(qx.event.dispatch.Direct)
  * @require(qx.locale.LocalizedString)
  *
+ * Note: "translating" the empty string, e.g. tr("") will return the header
+ * of the respective .po file. See also https://www.gnu.org/software/gettext/manual/html_node/PO-Files.html#PO-Files
+ *
  * @cldr()
  */
 


### PR DESCRIPTION
`this.("")` returns the header of the .po file (see specs in https://www.gnu.org/software/gettext/manual/html_node/PO-Files.html#PO-Files).

This can be rather confusing to a developer who is not aware of this specification if she uses something like `this["tr"](textVar)` with textVar being the empty string.