### PR TITLE
fix mangled private method names

### DIFF
--- a/framework/source/class/qx/Bootstrap.js
+++ b/framework/source/class/qx/Bootstrap.js
@@ -74,7 +74,7 @@ qx.Bootstrap = {
     {
       var value = functionMap[name];
       if (value instanceof Function) {
-        value.displayName = classname + "." + name + "()";
+        value.displayName = classname + "." + (value.name || name) + "()";
       }
     }
   },


### PR DESCRIPTION
change the display names of functions so that if one is already provided, we use it rather than the key name - this is so that private mangling works, but does not show the mangled name.

(mangled private symbols are coming to the compiler)