### PR TITLE
fix npm deployment

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,6 +35,8 @@ tmp/
 /deploy
 /build
 /qx_packages
+/qooxdoo-compiler
+/source
 
 # CSS compiler
 /framework/source/resource/qx/mobile/scss/.sass-cache/

--- a/.travis/deploy_npm
+++ b/.travis/deploy_npm
@@ -40,7 +40,7 @@ echo ">>> Installing dependencies..."
 exe npm install
 
 echo ">>> Installing github.com/qooxdoo/qooxdoo-compiler"
-exe [ -d ./qooxdoo-compiler ] && exe rm -rf ./qooxdoo-compiler
+exe rm -rf ./qooxdoo-compiler
 exe git clone https://github.com/qooxdoo/qooxdoo-compiler.git --depth=1 --single-branch ./qooxdoo-compiler
 exe cd ./qooxdoo-compiler
 exe npm install
@@ -53,6 +53,11 @@ exe $QX compile --config-file=compile-server.json --target=build
 exe mkdir -p ./lib
 exe rm -rf ./lib/*
 exe cp -R compiled/build/qx_server ./lib
+
+echo ">>> Running Compiler Tests"
+exe cd ./qooxdoo-compiler
+exe test/test.linux.sh
+exe cd ..
 
 echo ">>> Compiling & deploying server library with compiler master using the newly built qx_server library..."
 exe rm -rf ./qooxdoo-compiler/node_modules/@qooxdoo/framework/lib
@@ -81,5 +86,6 @@ echo "//registry.npmjs.org/:_authToken=${NPM_TOKEN:-}" > ~/.npmrc
 exe npm publish --access public
 
 
-
+echo ">>> Cleaning up"
+rm -rf qooxdoo-compiler source
 

--- a/.travis/deploy_npm
+++ b/.travis/deploy_npm
@@ -30,7 +30,7 @@ echo "-------------------------------------------------------------------------"
 cd $BASE_DIR
 if [ "{TRAVIS_TAG:-}" != "$FRAMEWORK_VERSION" ]; then
     echo "Bump version ..."
-    #exe tool/admin/bin/bumpqxversion.py $TAG_VERSION
+    exe tool/admin/bin/bumpqxversion.py $TAG_VERSION
 fi
 
 exe node -v
@@ -44,12 +44,12 @@ exe [ -d ./qooxdoo-compiler ] && exe rm -rf ./qooxdoo-compiler
 exe git clone https://github.com/qooxdoo/qooxdoo-compiler.git --depth=1 --single-branch ./qooxdoo-compiler
 exe cd ./qooxdoo-compiler
 exe npm install
-exe npm link
+QX=`pwd`/qx
 exe cd ..
-exe qx --version
+exe $QX --version
 
 echo ">>> Compiling & deploying server library with the compiler master using current qx_server library from NPM..."
-exe qx compile --config-file=compile-server.json --target=build
+exe $QX compile --config-file=compile-server.json --target=build
 exe mkdir -p ./lib
 exe rm -rf ./lib/*
 exe cp -R compiled/build/qx_server ./lib
@@ -58,24 +58,28 @@ echo ">>> Compiling & deploying server library with compiler master using the ne
 exe rm -rf ./qooxdoo-compiler/node_modules/@qooxdoo/framework/lib
 exe cp -fR lib ./qooxdoo-compiler/node_modules/@qooxdoo/framework
 exe cp -f package.json Manifest.json ./qooxdoo-compiler/node_modules/@qooxdoo/framework
-exe qx compile --config-file=compile-server.json --target=build
-exe qx deploy
+exe rm -rf compiled
+exe $QX compile --config-file=compile-server.json --target=build
+exe $QX deploy --config-file=compile-server.json
 
 echo ">>> Compiling & deploying API Viewer..."
-exe qx compile --config-file=compile.json --target=build
-exe qx deploy
+exe $QX compile --config-file=compile.json --target=build
+exe $QX deploy --config-file=compile.json
 
 echo ">>> Deploying Qooxdoo source"
 exe mkdir -p source
 exe rm -rf ./source/*
 exe cp -rf ./framework/source/* ./source
 
-# we're not deplyoing anything, just testing
-exit 0;
+# we're not deploying anything, just testing
+# exit 0;
 
 
 echo ">>> Publishing to NPM"
 # fill .npmrc with access token
 echo "//registry.npmjs.org/:_authToken=${NPM_TOKEN:-}" > ~/.npmrc
 exe npm publish --access public
+
+
+
 

--- a/.travis/deploy_npm
+++ b/.travis/deploy_npm
@@ -54,15 +54,17 @@ exe mkdir -p ./lib
 exe rm -rf ./lib/*
 exe cp -R compiled/build/qx_server ./lib
 
+echo ">>> Installing the newly built qx_server library..."
+exe rm -rf ./qooxdoo-compiler/node_modules/@qooxdoo/framework/lib
+exe cp -fR lib ./qooxdoo-compiler/node_modules/@qooxdoo/framework
+exe cp -f package.json Manifest.json ./qooxdoo-compiler/node_modules/@qooxdoo/framework
+
 echo ">>> Running Compiler Tests"
 exe cd ./qooxdoo-compiler
 exe test/test.linux.sh
 exe cd ..
 
-echo ">>> Compiling & deploying server library with compiler master using the newly built qx_server library..."
-exe rm -rf ./qooxdoo-compiler/node_modules/@qooxdoo/framework/lib
-exe cp -fR lib ./qooxdoo-compiler/node_modules/@qooxdoo/framework
-exe cp -f package.json Manifest.json ./qooxdoo-compiler/node_modules/@qooxdoo/framework
+echo ">>> Recompiling & deploying server library..."
 exe rm -rf compiled
 exe $QX compile --config-file=compile-server.json --target=build
 exe $QX deploy --config-file=compile-server.json

--- a/.travis/deploy_npm
+++ b/.travis/deploy_npm
@@ -30,28 +30,52 @@ echo "-------------------------------------------------------------------------"
 cd $BASE_DIR
 if [ "{TRAVIS_TAG:-}" != "$FRAMEWORK_VERSION" ]; then
     echo "Bump version ..."
-    exe tool/admin/bin/bumpqxversion.py $TAG_VERSION
+    #exe tool/admin/bin/bumpqxversion.py $TAG_VERSION
 fi
 
 exe node -v
 exe npm  -v
 
+echo ">>> Installing dependencies..."
 exe npm install
-exe npm install --no-save @qooxdoo/compiler
 
-exe npx qx --version
-exe npx qx pkg install -v 
-#compile everything
-exe npx qx compile --config-file=compileServer.json --target=build 
-#exe npx qx compile --config-file=compile.json       --target=build 
-#remove unnecessary stuff
-#exe find ./apps/transpiled -type f -name '*.map' -delete
-#exe find ./apps/transpiled -type f -name '*.js'  -delete
-#copy source
+echo ">>> Installing github.com/qooxdoo/qooxdoo-compiler"
+exe [ -d ./qooxdoo-compiler ] && exe rm -rf ./qooxdoo-compiler
+exe git clone https://github.com/qooxdoo/qooxdoo-compiler.git --depth=1 --single-branch ./qooxdoo-compiler
+exe cd ./qooxdoo-compiler
+exe npm install
+exe npm link
+exe cd ..
+exe qx --version
+
+echo ">>> Compiling & deploying server library with the compiler master using current qx_server library from NPM..."
+exe qx compile --config-file=compile-server.json --target=build
+exe mkdir -p ./lib
+exe rm -rf ./lib/*
+exe cp -R compiled/build/qx_server ./lib
+
+echo ">>> Compiling & deploying server library with compiler master using the newly built qx_server library..."
+exe rm -rf ./qooxdoo-compiler/node_modules/@qooxdoo/framework/lib
+exe cp -fR lib ./qooxdoo-compiler/node_modules/@qooxdoo/framework
+exe cp -f package.json Manifest.json ./qooxdoo-compiler/node_modules/@qooxdoo/framework
+exe qx compile --config-file=compile-server.json --target=build
+exe qx deploy
+
+echo ">>> Compiling & deploying API Viewer..."
+exe qx compile --config-file=compile.json --target=build
+exe qx deploy
+
+echo ">>> Deploying Qooxdoo source"
 exe mkdir -p source
+exe rm -rf ./source/*
 exe cp -rf ./framework/source/* ./source
+
+# we're not deplyoing anything, just testing
+exit 0;
+
+
+echo ">>> Publishing to NPM"
 # fill .npmrc with access token
 echo "//registry.npmjs.org/:_authToken=${NPM_TOKEN:-}" > ~/.npmrc
-# publish to npm
-exe npm publish --access public 
+exe npm publish --access public
 

--- a/compile-all-apps.json
+++ b/compile-all-apps.json
@@ -138,5 +138,5 @@
   "sass": {
     "compiler": "legacy"
   },
-  "$schema": "https://raw.githubusercontent.com/qooxdoo/qooxdoo-compiler/master/source/resource/qx/tool/schema/compile-1-0-0.json"
+  "$schema": "https://qooxdoo.org/schema/compile-1-0-0.json"
 }

--- a/compile-all-apps.json
+++ b/compile-all-apps.json
@@ -1,0 +1,142 @@
+{
+  "environment": {
+    "qx.serve.appspath": "/apps/",
+    "qx.serve.docspath": "/"
+  },
+  "targets": [
+    {
+      "type": "source",
+      "outputPath": "compiled/source",
+      "bundle": {
+        "include": [
+          "qx.*",
+          "qxWeb",
+          "qxl.*"
+        ]
+      },
+      "babelOptions": {
+        "targets": "edge >=18, chrome >= 73, firefox >= 66"
+      }
+    },
+    {
+      "type": "build",
+      "outputPath": "compiled/build",
+      "deployPath": "apps"
+    }
+  ],
+  "defaultTarget": "source",
+  "locales": [
+    "en"
+  ],
+  "libraries": [
+    "./framework"
+  ],
+  "applications": [
+    {
+      "class": "qxl.apiviewer.Application",
+      "theme": "qxl.apiviewer.Theme",
+      "name": "apiviewer",
+      "title": "API Viewer",
+      "environment": {
+        "qx.icontheme": "Tango",
+        "excludeFromAPIViewer": [
+          "qxl.*"
+        ]
+      },
+      "include": [
+        "qx.*"
+      ],
+      "exclude": [
+        "qx.test.*",
+        "qx.module.Blocker",
+        "qx.module.Placement"
+      ]
+    },
+    {
+      "class": "qxl.playground.Application",
+      "theme": "qxl.playground.theme.Theme",
+      "name": "playground",
+      "title": "Playground",
+      "bootPath": "source/boot",
+      "include": [
+        "qx.*"
+      ],
+      "exclude": [
+        "qx.test.*",
+        "qx.module.Blocker",
+        "qx.module.Placement"
+      ]
+    },
+    {
+      "class": "qxl.demobrowser.Application",
+      "theme": "qxl.demobrowser.Theme",
+      "name": "demobrowser",
+      "title": "Demobrowser",
+      "include": [
+        "qx.*",
+        "qxl.demobrowser.*",
+        "qx.theme.Modern",
+        "qx.theme.Simple",
+        "qx.theme.Classic"
+      ],
+      "environment": {
+        "qx.allowUrlVariants": true,
+        "qx.allowUrlSettings": true,
+        "qx.contrib": false,
+        "qx.icontheme": [
+          "Tango",
+          "Oxygen"
+        ]
+      }
+    },
+    {
+      "class": "qxl.widgetbrowser.Application",
+      "theme": "qx.theme.Indigo",
+      "name": "widgetbrowser",
+      "title": "Widgetbrowser",
+      "include": [
+        "qx.theme.Modern",
+        "qx.theme.Simple",
+        "qx.theme.Classic",
+        "qxl.widgetbrowser.pages.Tree",
+        "qxl.widgetbrowser.pages.List",
+        "qxl.widgetbrowser.pages.Table",
+        "qxl.widgetbrowser.pages.Form",
+        "qxl.widgetbrowser.pages.ToolBar",
+        "qxl.widgetbrowser.pages.Window",
+        "qxl.widgetbrowser.pages.Tab",
+        "qxl.widgetbrowser.pages.Control",
+        "qxl.widgetbrowser.pages.Embed",
+        "qxl.widgetbrowser.pages.EmbedFrame",
+        "qxl.widgetbrowser.pages.Basic",
+        "qxl.widgetbrowser.pages.Misc"
+      ]
+    },
+    {
+      "class": "qxl.mobileshowcase.Application",
+      "title": "MobileShowcase",
+      "name": "mobileshowcase",
+      "bootPath": "source/boot",
+      "theme": ""
+    },
+    {
+      "class": "qxl.testtapper.Application",
+      "name": "testtapper",
+      "theme": "qx.theme.Simple",
+      "title": "Qooxdoo TestTAPper",
+      "environment": {
+        "qx.icontheme": "Tango",
+        "testtapper.testNameSpace": "qx.test"
+      },
+      "include": [
+        "qx.test.*"
+      ],
+      "exclude": [
+      ]
+    }
+  ],
+  "sass": {
+    "compiler": "legacy"
+  },
+  "$schema": "https://raw.githubusercontent.com/qooxdoo/qooxdoo-compiler/master/source/resource/qx/tool/schema/compile-1-0-0.json"
+}

--- a/compile-server.json
+++ b/compile-server.json
@@ -2,17 +2,18 @@
   "targets": [
     {
       "type": "build",
-      "outputPath": "lib",
+      "outputPath": "compiled/build",
       "minify": "off",
       "babelOptions": {
         "targets": "node >= 10"
-      }
+      },
+      "deployPath": "lib"
     }
   ],
   "defaultTarget": "build",
   "locales": [
     "en"
-  ],  
+  ],
   "libraries": [
     "./framework"
   ],
@@ -66,5 +67,6 @@
         "qx.event.handler.PointerCore"
       ]
     }
-  ]
+  ],
+  "$schema": "https://raw.githubusercontent.com/qooxdoo/qooxdoo-compiler/master/source/resource/qx/tool/schema/compile-1-0-0.json"
 }

--- a/compile-server.json
+++ b/compile-server.json
@@ -68,5 +68,5 @@
       ]
     }
   ],
-  "$schema": "https://raw.githubusercontent.com/qooxdoo/qooxdoo-compiler/master/source/resource/qx/tool/schema/compile-1-0-0.json"
+  "$schema": "https://qooxdoo.org/schema/compile-1-0-0.json"
 }

--- a/compile-test.json
+++ b/compile-test.json
@@ -53,5 +53,5 @@
   "sass": {
     "compiler": "legacy"
   },
-  "$schema": "https://raw.githubusercontent.com/qooxdoo/qooxdoo-compiler/master/source/resource/qx/tool/schema/compile-1-0-0.json"
+  "$schema": "https://qooxdoo.org/schema/compile-1-0-0.json"
 }

--- a/compile.json
+++ b/compile.json
@@ -56,5 +56,5 @@
   "sass": {
     "compiler": "legacy"
   },
-  "$schema": "https://raw.githubusercontent.com/qooxdoo/qooxdoo-compiler/master/source/resource/qx/tool/schema/compile-1-0-0.json"
+  "$schema": "https://qooxdoo.org/schema/compile-1-0-0.json"
 }

--- a/compile.json
+++ b/compile.json
@@ -6,7 +6,7 @@
   "targets": [
     {
       "type": "source",
-      "outputPath": "apps",
+      "outputPath": "compiled/source",
       "bundle": {
         "include": [
           "qx.*",
@@ -20,7 +20,8 @@
     },
     {
       "type": "build",
-      "outputPath": "apps"
+      "outputPath": "compiled/build",
+      "deployPath": "apps"
     }
   ],
   "defaultTarget": "source",
@@ -49,88 +50,6 @@
         "qx.test.*",
         "qx.module.Blocker",
         "qx.module.Placement"
-      ]
-    },
-    {
-      "class": "qxl.playground.Application",
-      "theme": "qxl.playground.theme.Theme",
-      "name": "playground",
-      "title": "Playground",
-      "bootPath": "source/boot",
-      "include": [
-        "qx.*"
-      ],
-      "exclude": [
-        "qx.test.*",
-        "qx.module.Blocker",
-        "qx.module.Placement"
-      ]
-    },
-    {
-      "class": "qxl.demobrowser.Application",
-      "theme": "qxl.demobrowser.Theme",
-      "name": "demobrowser",
-      "title": "Demobrowser",
-      "include": [
-        "qx.*",
-        "qxl.demobrowser.*",
-        "qx.theme.Modern",
-        "qx.theme.Simple",
-        "qx.theme.Classic"
-      ],
-      "environment": {
-        "qx.allowUrlVariants": true,
-        "qx.allowUrlSettings": true,
-        "qx.contrib": false,
-        "qx.icontheme": [
-          "Tango",
-          "Oxygen"
-        ]
-      }
-    },
-    {
-      "class": "qxl.widgetbrowser.Application",
-      "theme": "qx.theme.Indigo",
-      "name": "widgetbrowser",
-      "title": "Widgetbrowser",
-      "include": [
-        "qx.theme.Modern",
-        "qx.theme.Simple",
-        "qx.theme.Classic",
-        "qxl.widgetbrowser.pages.Tree",
-        "qxl.widgetbrowser.pages.List",
-        "qxl.widgetbrowser.pages.Table",
-        "qxl.widgetbrowser.pages.Form",
-        "qxl.widgetbrowser.pages.ToolBar",
-        "qxl.widgetbrowser.pages.Window",
-        "qxl.widgetbrowser.pages.Tab",
-        "qxl.widgetbrowser.pages.Control",
-        "qxl.widgetbrowser.pages.Embed",
-        "qxl.widgetbrowser.pages.EmbedFrame",
-        "qxl.widgetbrowser.pages.Basic",
-        "qxl.widgetbrowser.pages.Misc"
-      ]
-    },
-    {
-      "class": "qxl.mobileshowcase.Application",
-      "title": "MobileShowcase",
-      "name": "mobileshowcase",
-      "bootPath": "source/boot",
-      "theme": ""
-    },
-    {
-      "class": "qxl.testtapper.Application",
-      "name": "testtapper",
-      "theme": "qx.theme.Simple",
-      "title": "Qooxdoo TestTAPper",
-      "environment": {
-        "qx.icontheme": "Tango",
-        "testtapper.testNameSpace": "qx.test"
-      },
-      "include": [
-        "qx.test.*"
-      ],
-      "exclude": [
       ]
     }
   ],


### PR DESCRIPTION
Minor amendments to @cboulanger 's update to add sanity-check to deployment - this builds the framework, then uses that to replace the compiler's version of the framework, and then rebuilds it.

This should ensure we don't have an issue where the cyclic dependencies between compiler and framework break the builds post deployment.