### PR TITLE
Implement liveUpdateOnRxMatch property

### DIFF
--- a/framework/source/class/qx/ui/form/AbstractField.js
+++ b/framework/source/class/qx/ui/form/AbstractField.js
@@ -213,7 +213,17 @@ qx.Class.define("qx.ui.form.AbstractField",
       check : "Boolean",
       init : false
     },
-
+    /**
+     * Fire a {@link #changeValue} event whenever the content of the
+     * field matches the given regular expression. Accepts both regular
+     * expression objects as well as strings for input.
+     */
+    liveUpdateOnRxMatch :
+    {
+      check : "RegExp",
+      transform : "_string2RegExp",
+      init : null
+    },
     /**
      * String value which will be shown as a hint if the field is all of:
      * unset, unfocused and enabled. Set to null to not show a placeholder
@@ -524,6 +534,13 @@ qx.Class.define("qx.ui.form.AbstractField",
       }
     },
 
+    // property transform
+    _string2RegExp: function(value, old) {
+        if (qx.lang.Type.isString(value)) {
+            value = RegExp(value);
+        }
+        return value;
+    },
 
     // overridden
     tabFocus : function() {
@@ -585,6 +602,11 @@ qx.Class.define("qx.ui.form.AbstractField",
         // check for the live change event
         if (this.getLiveUpdate()) {
           this.__fireChangeValueEvent(value);
+        }
+        // check for the fireChangeValueOnRxMatch change event
+        var fireRx = this.getLiveUpdateOnRxMatch();
+        if (fireRx && value.match(fireRx)) {
+            this.__fireChangeValueEvent(value);
         }
       }
     },

--- a/framework/source/class/qx/ui/form/AbstractField.js
+++ b/framework/source/class/qx/ui/form/AbstractField.js
@@ -537,7 +537,7 @@ qx.Class.define("qx.ui.form.AbstractField",
     // property transform
     _string2RegExp: function(value, old) {
         if (qx.lang.Type.isString(value)) {
-            value = RegExp(value);
+            value = new RegExp(value);
         }
         return value;
     },

--- a/framework/source/class/qx/ui/form/AbstractField.js
+++ b/framework/source/class/qx/ui/form/AbstractField.js
@@ -603,10 +603,12 @@ qx.Class.define("qx.ui.form.AbstractField",
         if (this.getLiveUpdate()) {
           this.__fireChangeValueEvent(value);
         }
-        // check for the fireChangeValueOnRxMatch change event
-        var fireRx = this.getLiveUpdateOnRxMatch();
-        if (fireRx && value.match(fireRx)) {
-            this.__fireChangeValueEvent(value);
+        // check for the liveUpdateOnRxMatch change event
+        else {
+            var fireRx = this.getLiveUpdateOnRxMatch();
+            if (fireRx && value.match(fireRx)) {
+                this.__fireChangeValueEvent(value);
+            }
         }
       }
     },


### PR DESCRIPTION
If `liveUpdate` is set on a textField then a changeValue event is fired every time a key is pressed.

This PR adds a sort of restricted version of `liveUpdate`. Set `liveUpdateOnRxMatch` to a regular expression *or* string (which will be transformed into a regular expression). This will cause the `changeValue` event to be fired only once the content of the field matches the regular expression. This allows combining validation with live update behavior without the field going 'red' while typing without a chance of the value being valid. For an email address the following might be handy: `'^\S+@\S+\.\S{2,}$'`