### PR TITLE
Update AbstractImage.js

### DIFF
--- a/framework/source/class/qx/ui/table/cellrenderer/AbstractImage.js
+++ b/framework/source/class/qx/ui/table/cellrenderer/AbstractImage.js
@@ -242,7 +242,7 @@ qx.Class.define("qx.ui.table.cellrenderer.AbstractImage",
           width: this.__imageData.width + "px",
           height: this.__imageData.height + "px",
           display: qx.core.Environment.get("css.inlineblock"),
-          verticalAlign: "top",
+          verticalAlign: "middle",
           position: "static"
         }
         if (qx.util.ResourceManager.getInstance().getCombinedFormat(this.__imageData.url) === "") {


### PR DESCRIPTION
When changing table row height, images are aligned to top which  results on an ugly look, aligning it to middle fixes it.