### PR TITLE
TreeVirtual NodeEdit - Fix for old/new node label is the same in dataEdited

### DIFF
--- a/framework/source/class/qx/ui/treevirtual/SimpleTreeDataModel.js
+++ b/framework/source/class/qx/ui/treevirtual/SimpleTreeDataModel.js
@@ -379,8 +379,10 @@ qx.Class.define("qx.ui.treevirtual.SimpleTreeDataModel",
         if (!this.__tree.getAllowNodeEdit() || value["label"] === undefined) {
           return;
         }
-        // only allow to set the node label via this method
-        node.label = value.label;
+        // only allow to set the node label via this method, clone the original node
+        var updatedNode = qx.lang.Object.clone(node);
+        updatedNode.label = value.label;
+        this._nodeArr[node.nodeId] = updatedNode;
       } else {
         if (node.columnData[columnIndex] == value) {
           return;


### PR DESCRIPTION
When the dataEdited event is fired, the old and new values refer to the same object, albeit with the label updated. If the node object is replaced with a clone with the updated label, the old and new values are as expected.