### PR TITLE
Fix Boolean Renderer position

### DIFF
--- a/framework/source/class/qx/ui/table/cellrenderer/AbstractImage.js
+++ b/framework/source/class/qx/ui/table/cellrenderer/AbstractImage.js
@@ -44,7 +44,6 @@ qx.Class.define("qx.ui.table.cellrenderer.AbstractImage",
       clazz.stylesheet = qx.bom.Stylesheet.createElement(
         ".qooxdoo-table-cell-icon {" +
         "  text-align:center;" +
-        "  padding-top:1px;" +
         "}"
       );
     }

--- a/framework/source/class/qx/ui/table/cellrenderer/Boolean.js
+++ b/framework/source/class/qx/ui/table/cellrenderer/Boolean.js
@@ -122,11 +122,6 @@ qx.Class.define("qx.ui.table.cellrenderer.Boolean",
     // overridden
     _insetY : 5,
 
-    // overridden
-    _getCellStyle : function(cellInfo) {
-      return this.base(arguments, cellInfo) + ";padding-top:4px;";
-    },
-
 
     // overridden
     _identifyImage : function(cellInfo)


### PR DESCRIPTION
With #9980, images are now vertically aligned to middle. The boolean renderer assumed alignment to top and thus added a padding of 4px which is now no longer required or the checkboxes look offset.