### PR TITLE
Add option to deselect on tap below rows in Table

### DIFF
--- a/framework/source/class/qx/ui/table/Table.js
+++ b/framework/source/class/qx/ui/table/Table.js
@@ -556,6 +556,18 @@ qx.Class.define("qx.ui.table.Table",
     },
 
 
+    /**
+     * Whether to reset the selection when the unpopulated table area is tapped.
+     * The default is false which keeps the behaviour as before
+     */
+    resetSelectionOnTapBelowRows :
+    {
+      check : "Boolean",
+      init : false,
+      apply : "_applyResetSelectionOnTapBelowRows"
+    },
+
+
     /** The renderer to use for styling the rows. */
     dataRowRenderer :
     {
@@ -1177,6 +1189,17 @@ qx.Class.define("qx.ui.table.Table",
 
       for (var i=0; i<scrollerArr.length; i++) {
         scrollerArr[i].setResetSelectionOnHeaderTap(value);
+      }
+    },
+
+
+    // property modifier
+    _applyResetSelectionOnTapBelowRows : function(value, old)
+    {
+      var scrollerArr = this._getPaneScrollerArr();
+
+      for (var i=0; i<scrollerArr.length; i++) {
+        scrollerArr[i].setResetSelectionOnTapBelowRows(value);
       }
     },
 
@@ -2045,7 +2068,7 @@ qx.Class.define("qx.ui.table.Table",
       var verNeeded = false;
       var excludeScrollerScrollbarsIfNotNeeded;
 
-      
+
       // Determine whether we need to render horizontal scrollbars for meta
       // columns that don't themselves actually require it
       excludeScrollerScrollbarsIfNotNeeded =

--- a/framework/source/class/qx/ui/table/pane/Scroller.js
+++ b/framework/source/class/qx/ui/table/pane/Scroller.js
@@ -322,6 +322,16 @@ qx.Class.define("qx.ui.table.pane.Scroller",
       init : true
     },
 
+    /**
+     * Whether to reset the selection when the unpopulated table area is tapped.
+     * The default is false which keeps the behaviour as before
+     */
+    resetSelectionOnTapBelowRows :
+    {
+      check : "Boolean",
+      init : false
+    },
+
 
     /**
      * Interval time (in milliseconds) for the table update timer.
@@ -687,7 +697,7 @@ qx.Class.define("qx.ui.table.pane.Scroller",
         if (this.getFocusedRow() === null && rowCount > 0 && colCount > 0)
         {
           this.setFocusedCell(this.getFocusedColumn()||0, 0);
-        } 
+        }
         else if (this.getFocusedRow() >= rowCount)
         {
           if (rowCount == 0) {
@@ -1530,6 +1540,10 @@ qx.Class.define("qx.ui.table.pane.Scroller",
                          [this, e, row, col],
                          true);
           this.__firedTapEvent = true;
+        }
+      } else {
+        if (row == null && this.getResetSelectionOnTapBelowRows()) {
+          table.getSelectionModel().resetSelection();
         }
       }
     },


### PR DESCRIPTION
A requirement for our particular implementation so I thought I'd make it an option for the table. If you click in the control, but below the table rows, the current selection is removed.