### PR TITLE
Remove overridden offsets for images now v-aligned middle

### DIFF
--- a/framework/source/class/qx/ui/table/cellrenderer/AbstractImage.js
+++ b/framework/source/class/qx/ui/table/cellrenderer/AbstractImage.js
@@ -103,8 +103,6 @@ qx.Class.define("qx.ui.table.cellrenderer.AbstractImage",
     __defaultHeight : 16,
     __imageData : null,
 
-    // overridden
-    _insetY : 2,
 
     /**
      * Identifies the Image to show. This is a template method, which must be

--- a/framework/source/class/qx/ui/table/cellrenderer/Boolean.js
+++ b/framework/source/class/qx/ui/table/cellrenderer/Boolean.js
@@ -120,10 +120,6 @@ qx.Class.define("qx.ui.table.cellrenderer.Boolean",
 
 
     // overridden
-    _insetY : 5,
-
-
-    // overridden
     _identifyImage : function(cellInfo)
     {
       var w;


### PR DESCRIPTION
With https://github.com/qooxdoo/qooxdoo/pull/9980, cell images are v-aligned to middle. A fix in https://github.com/qooxdoo/qooxdoo/pull/10000 was not quite enough, the Boolean checkbox was getting clipped under Chrome on Windows. Removing the vertical inset seems to have cured the issue such that the containing div is the same size as the table row. 