### PR TITLE
Allow to replace the default contains function.

### DIFF
--- a/framework/source/class/qx/ui/popup/Manager.js
+++ b/framework/source/class/qx/ui/popup/Manager.js
@@ -62,6 +62,16 @@ qx.Class.define("qx.ui.popup.Manager",
   {
     __objects : null,
 
+    __containsFunction : qx.ui.core.Widget.contains,
+
+    /**
+     * Replace the default contains function.
+     * 
+     * @param func {Function|qx.ui.core.Widget.contains}
+     */
+    setContainsFunction: function(func){
+      this.__containsFunction = func;
+    },
 
     /**
      * Registers a visible popup.
@@ -167,7 +177,7 @@ qx.Class.define("qx.ui.popup.Manager",
       {
         var obj = reg[i];
 
-        if (!obj.getAutoHide() || target == obj || qx.ui.core.Widget.contains(obj, target)) {
+        if (!obj.getAutoHide() || target == obj || this.__containsFunction(obj, target)) {
           continue;
         }
 

--- a/framework/source/class/qx/ui/popup/Manager.js
+++ b/framework/source/class/qx/ui/popup/Manager.js
@@ -50,7 +50,17 @@ qx.Class.define("qx.ui.popup.Manager",
   },
 
 
-
+  properties :
+  {
+    /**
+     * Function that is used to determine if a widget is contained within another one.
+     **/
+    containsFunction :
+    {
+      check : "Function",
+      init : qx.ui.core.Widget.contains
+    }
+  },
 
   /*
   *****************************************************************************
@@ -61,17 +71,6 @@ qx.Class.define("qx.ui.popup.Manager",
   members :
   {
     __objects : null,
-
-    __containsFunction : qx.ui.core.Widget.contains,
-
-    /**
-     * Replace the default contains function.
-     * 
-     * @param func {Function|qx.ui.core.Widget.contains}
-     */
-    setContainsFunction: function(func){
-      this.__containsFunction = func;
-    },
 
     /**
      * Registers a visible popup.
@@ -177,7 +176,7 @@ qx.Class.define("qx.ui.popup.Manager",
       {
         var obj = reg[i];
 
-        if (!obj.getAutoHide() || target == obj || this.__containsFunction(obj, target)) {
+        if (!obj.getAutoHide() || target == obj || this.getContainsFunction()(obj, target)) {
           continue;
         }
 


### PR DESCRIPTION
This is just a tiny non-breaking addition to the API, but I consider it very useful.

With the freedom to supply my own contains function to the qx.ui.popup.Manager, I was finally able to fix some issues with too early closing of a parent popup when clicking inside a nested menu.

This allows e.g. to write a custom contains function that not only considers the layout parents, but also logical parents. 

- I needed it to display a table inside a popup withouth the popup closing when (de)-selecting columns from the table-column-menu.
- for my custom select boxes with search capabilities, closing using the _onBlur event of the selectBox was really hard to get right, since a click into the search filter would close the selectBox. I tried lots of workarounds, but with the notion of logical parents this got a whole lot easier.