### PR TITLE
https://github.com/qooxdoo/qooxdoo/issues/10018 qx.ui.tree.VirtualTre…

### DIFF
--- a/framework/source/class/qx/ui/tree/VirtualTree.js
+++ b/framework/source/class/qx/ui/tree/VirtualTree.js
@@ -608,7 +608,7 @@ qx.Class.define("qx.ui.tree.VirtualTree",
     
     // Interface implementation
     isShowTopLevelOpenCloseIcons : function() {
-      return true;
+      return this.getShowTopLevelOpenCloseIcons();
     },
 
 

--- a/framework/source/class/qx/ui/tree/VirtualTree.js
+++ b/framework/source/class/qx/ui/tree/VirtualTree.js
@@ -605,12 +605,6 @@ qx.Class.define("qx.ui.tree.VirtualTree",
       return this.__lookupTable;
     },
     
-    
-    // Interface implementation
-    isShowTopLevelOpenCloseIcons : function() {
-      return this.getShowTopLevelOpenCloseIcons();
-    },
-
 
     /**
      * Performs a lookup from model index to row.


### PR DESCRIPTION
…e: method isShowTopLevelOpenCloseIcons always returns true and ignores property showTopLevelOpenCloseIcons

*Solution*

Method isShowTopLevelOpenCloseIcons of class qx.ui.tree.VirtualTree should return the same value as a method getShowTopLevelOpenCloseIcons