### PR TITLE
Fixes for toggling opened state

### DIFF
--- a/framework/source/class/qx/ui/treevirtual/SelectionManager.js
+++ b/framework/source/class/qx/ui/treevirtual/SelectionManager.js
@@ -140,8 +140,10 @@ qx.Class.define("qx.ui.treevirtual.SelectionManager",
 
           if (x >= buttonPos - latitude && x <= buttonPos + rowHeight + 3 + latitude)
           {
-            // Yup.  Toggle the opened state for this node.
-            dataModel.setState(node, { bOpened : ! node.bOpened });
+            // Yup.  Toggle the opened state for this node if open/close is allowed
+            if (!node.bHideOpenClose && node.type !== qx.ui.treevirtual.SimpleTreeDataModel.Type.LEAF) {
+              dataModel.setState(node, {bOpened: !node.bOpened});
+            }
             return tree.getOpenCloseClickSelectsRow() ? false : true;
           }
           else

--- a/framework/source/class/qx/ui/treevirtual/SimpleTreeDataModel.js
+++ b/framework/source/class/qx/ui/treevirtual/SimpleTreeDataModel.js
@@ -1053,6 +1053,11 @@ qx.Class.define("qx.ui.treevirtual.SimpleTreeDataModel",
           break;
 
         case "bOpened":
+          // Don't do anything if this is a leaf, leaf has no opened/closed
+          if (node.type === qx.ui.treevirtual.MTreePrimitive.Type.LEAF) {
+            break;
+          }
+
           // Don't do anything if the requested state is the same as the
           // current state.
           if (attributes[attribute] == node.bOpened)


### PR DESCRIPTION
Open/Close events were being fired for leaf nodes that cannot be opened/closed. Also it was possible to toggle the opened state by clicking where the open/close button should be on a leaf or on a branch with a hidden button. This should not have been the case and was already protected against in the SelectionManager for the "Enter" key (line 165).