### PR TITLE
Prevent dbl-click open/close button starting node edit

### DIFF
--- a/framework/source/class/qx/ui/treevirtual/SelectionManager.js
+++ b/framework/source/class/qx/ui/treevirtual/SelectionManager.js
@@ -118,27 +118,12 @@ qx.Class.define("qx.ui.treevirtual.SelectionManager",
         // Was this a mouse event?
         if (evt instanceof qx.event.type.Mouse)
         {
-          // Yup.  Get the order of the columns
-          var tcm = tree.getTableColumnModel();
-          var columnPositions = tcm._getColToXPosMap();
-
-          // Calculate the position of the beginning of the tree column
-          var left = qx.bom.element.Location.getLeft(
-            tree.getContentElement().getDomElement());
-
-          for (var i=0; i<columnPositions[treeCol].visX; i++) {
-            left += tcm.getColumnWidth(columnPositions[i].visX);
-          }
-
-          // Was the click on the open/close button?  That button begins at
-          // (node.level - 1) * (rowHeight + 3) + 2 (the latter for padding),
-          // and has width (rowHeight + 3). We add a bit of latitude to that.
+          // Was the click on the open/close button? We get the position and add a bit of
+          // latitude to that
           var x = evt.getViewportLeft();
           var latitude = 2;
-          var rowHeight = _this.__table.getRowHeight();
-          var buttonPos = left + (node.level - 1) * (rowHeight + 3) + 2;
-
-          if (x >= buttonPos - latitude && x <= buttonPos + rowHeight + 3 + latitude)
+          var buttonPos = tree.getOpenCloseButtonPosition(node);
+          if (x >= buttonPos.left - latitude && x <= buttonPos.left + buttonPos.width + latitude)
           {
             // Yup.  Toggle the opened state for this node if open/close is allowed
             if (!node.bHideOpenClose && node.type !== qx.ui.treevirtual.SimpleTreeDataModel.Type.LEAF) {
@@ -148,6 +133,15 @@ qx.Class.define("qx.ui.treevirtual.SelectionManager",
           }
           else
           {
+            // Yup.  Get the order of the columns
+            var tcm = tree.getTableColumnModel();
+            var columnPositions = tcm._getColToXPosMap();
+
+            // Calculate the position of the beginning of the tree column
+            var left = qx.bom.element.Location.getLeft(tree.getContentElement().getDomElement());
+            for (var i=0; i<columnPositions[treeCol].visX; i++) {
+              left += tcm.getColumnWidth(columnPositions[i].visX);
+            }
             return _this._handleExtendedClick(tree, evt, node, left);
           }
         }

--- a/framework/source/class/qx/ui/treevirtual/SimpleTreeDataCellRenderer.js
+++ b/framework/source/class/qx/ui/treevirtual/SimpleTreeDataCellRenderer.js
@@ -734,6 +734,29 @@ qx.Class.define("qx.ui.treevirtual.SimpleTreeDataCellRenderer",
       }
 
       return { icon : this.BLANK };
+    },
+
+    /**
+     * Determine the position in the cell of the open/close button image
+     *
+     * @param table {Table}
+     *   The column of indentation being requested, zero-relative
+     *
+     * @param node {Node}
+     *   The node being displayed in the row.  The properties of a node are
+     *   described in {@link qx.ui.treevirtual.SimpleTreeDataModel}
+     *
+     * @return {Object} Position of the Open/Close Button
+     */
+    getOpenCloseButtonPosition: function(table, node) {
+      var padding = 2;
+      var width = table.getRowHeight() + 3;
+      return {
+        top: 0,
+        left: (node.level - 1) * width + padding,
+        width: width,
+        height: table.getRowHeight()
+      };
     }
   },
 

--- a/framework/source/class/qx/ui/treevirtual/TreeVirtual.js
+++ b/framework/source/class/qx/ui/treevirtual/TreeVirtual.js
@@ -95,6 +95,17 @@ qx.Class.define("qx.ui.treevirtual.TreeVirtual",
    *           return new qx.ui.table.columnmodel.Resize(obj);
    *         }
    *       </pre></dd>
+   *     <dt>tablePaneScroller</dt>
+   *       <dd>
+   *         Instance of {@link qx.ui.treevirtual.pane.Scroller}.
+   *         Custom table pane scroller for the tree
+   *         <pre class='javascript'>
+   *         function(obj)
+   *         {
+   *           return new qx.ui.table.columnmodel.Resize(obj);
+   *         }
+   *       </pre>
+   *       </dd>
    *   </dl>
    */
   construct : function(headings, custom)
@@ -153,6 +164,12 @@ qx.Class.define("qx.ui.treevirtual.TreeVirtual",
         {
           return new qx.ui.table.columnmodel.Resize(obj);
         };
+    }
+
+    if (!custom.tablePaneScroller) {
+      custom.tablePaneScroller = function(obj) {
+        return new qx.ui.treevirtual.pane.Scroller(obj);
+      };
     }
 
     // Specify the column headings.  We accept a single string (one single
@@ -516,6 +533,31 @@ qx.Class.define("qx.ui.treevirtual.TreeVirtual",
       var treeCol = this.getDataModel().getTreeColumn();
       var dcr = this.getTableColumnModel().getDataCellRenderer(treeCol);
       return dcr.getAlwaysShowOpenCloseSymbol();
+    },
+
+
+    /**
+     * Returns the position of the open/close button for a node
+     *
+     * @return {Object} The position of the open/close button within the tree row
+     */
+    getOpenCloseButtonPosition : function(node)
+    {
+      var treeCol = this.getDataModel().getTreeColumn();
+      var dcr = this.getTableColumnModel().getDataCellRenderer(treeCol);
+      var rowPos = dcr.getOpenCloseButtonPosition(this, node);
+
+      // Get the order of the columns
+      var tcm = this.getTableColumnModel();
+      var columnPositions = tcm._getColToXPosMap();
+
+      // Calculate the position of the beginning of the tree column
+      var left = qx.bom.element.Location.getLeft(this.getContentElement().getDomElement());
+      for (var i=0; i<columnPositions[treeCol].visX; i++) {
+        left += tcm.getColumnWidth(columnPositions[i].visX);
+      }
+      rowPos.left += left;
+      return rowPos;
     },
 
 

--- a/framework/source/class/qx/ui/treevirtual/pane/Scroller.js
+++ b/framework/source/class/qx/ui/treevirtual/pane/Scroller.js
@@ -1,0 +1,73 @@
+/* ************************************************************************
+
+   qooxdoo - the new era of web development
+
+   http://qooxdoo.org
+
+   Copyright:
+     2020 Tartan Solutions, Inc, http://www.tartansolutions.com
+
+   License:
+     MIT: https://opensource.org/licenses/MIT
+     See the LICENSE file in the project's top-level directory for details.
+
+   Authors:
+     * Patrick Buxton
+
+************************************************************************ */
+
+/**
+ * An overridden pane Scroller for the treevirtual to allow capture of
+ * the mouse dblclick event in the tree column. To prevent starting an
+ * edit when the tree node editing is turned on and the open/close button
+ * is tapped quickly
+ */
+qx.Class.define("qx.ui.treevirtual.pane.Scroller",
+{
+  extend : qx.ui.table.pane.Scroller,
+  include : [qx.ui.core.scroll.MScrollBarFactory],
+
+  /*
+  *****************************************************************************
+     MEMBERS
+  *****************************************************************************
+  */
+
+  members :
+  {
+    /**
+     * Event handler. Called when the user double tapped a pointer button over the pane.
+     *
+     * @param e {Map} the event.
+     */
+    _onDbltapPane : function(e)
+    {
+      var pageX = e.getDocumentLeft();
+      var pageY = e.getDocumentTop();
+      var col = this._getColumnForPageX(pageX);
+      var row = this._getRowForPagePos(pageX, pageY);
+
+      if (col !== null && row !== null) {
+        // check if the user is tapping on the open/close button of the tree
+        var tree = this.getTable();
+        var tableModel = tree.getTableModel();
+
+        if (tableModel instanceof qx.ui.treevirtual.SimpleTreeDataModel && col === tableModel.getTreeColumn()) {
+          // Was the click on the open/close button? We get the position and add a bit of
+          // latitude to that
+          var x = e.getViewportLeft();
+          var latitude = 2;
+
+          // Get the node to which this event applies
+          var node = tree.getDataModel().getNode(row);
+
+          var buttonPos = tree.getOpenCloseButtonPosition(node);
+          if (x >= buttonPos.left - latitude && x <= buttonPos.left + buttonPos.width + latitude) {
+            return;
+          }
+        }
+      }
+      this.base(arguments, e);
+    }
+  }
+});


### PR DESCRIPTION
With the tree node editing available, it was possible to click on the open/close button twice and invoke the edit, which is not desirable after this has happened a few times. 
The purpose of the PR is to capture the dblclick if it occurs on the open/close button and prevent the edit. There was some code for identifying the position of the open/close button in the Selection Manger. The calculation of this has been pushed to the tree renderer that was responsible for placing the button - seemed like sense. The position is then accessible via a method call on the main tree.