### PR TITLE
TreeVirtual - Keyboard expand/collapse not working (Ctrl+Left/Right)

### DIFF
--- a/framework/source/class/qx/ui/treevirtual/TreeVirtual.js
+++ b/framework/source/class/qx/ui/treevirtual/TreeVirtual.js
@@ -683,7 +683,7 @@ qx.Class.define("qx.ui.treevirtual.TreeVirtual",
      *   The event.
      *
      */
-    _onKeyPress : function(evt)
+    _onKeyDown : function(evt)
     {
       if (!this.getEnabled())
       {


### PR DESCRIPTION
In the Treevirtual, there is code to enable the keyboard to expand/contract nodes, but it was not working. It seems that the wrong event was being overridden. Changing this to override the _onKeyDown gets the functionality working again