### PR TITLE
Allow to set a MinCellEditHeight on table

### DIFF
--- a/framework/source/class/qx/ui/table/Table.js
+++ b/framework/source/class/qx/ui/table/Table.js
@@ -567,6 +567,16 @@ qx.Class.define("qx.ui.table.Table",
       apply : "_applyResetSelectionOnTapBelowRows"
     },
 
+    /**
+     * If set then defines the minimum height of the focus indicator when editing
+     */
+    minCellEditHeight: {
+      check: "Integer",
+      nullable: true,
+      init: null,
+      apply: "_applyMinCellEditHeight"
+    },
+
 
     /** The renderer to use for styling the rows. */
     dataRowRenderer :
@@ -844,6 +854,16 @@ qx.Class.define("qx.ui.table.Table",
 
       for (var i=0; i<scrollerArr.length; i++) {
         scrollerArr[i].getHeader().setHeight(value);
+      }
+    },
+
+
+    // property modifier
+    _applyMinCellEditHeight: function(value) {
+      var scrollerArr = this._getPaneScrollerArr();
+
+      for (var i=0; i<scrollerArr.length; i++) {
+        scrollerArr[i].setMinCellEditHeight(value);
       }
     },
 

--- a/framework/source/class/qx/ui/table/pane/FocusIndicator.js
+++ b/framework/source/class/qx/ui/table/pane/FocusIndicator.js
@@ -83,8 +83,9 @@ qx.Class.define("qx.ui.table.pane.FocusIndicator",
      *
      * @param col {Integer?null} The table column
      * @param row {Integer?null} The table row
+     * @param editing {Boolean?null} Whether or not the cell is being edited
      */
-    moveToCell : function(col, row)
+    moveToCell : function(col, row, editing)
     {
       // check if the focus indicator is shown and if the new column is
       // editable. if not, just exclude the indicator because the pointer events
@@ -109,7 +110,7 @@ qx.Class.define("qx.ui.table.pane.FocusIndicator",
       {
         var xPos = this.__scroller.getTablePaneModel().getX(col);
 
-        if (xPos == -1)
+        if (xPos === -1)
         {
           this.hide();
           this.setRow(null);
@@ -137,11 +138,18 @@ qx.Class.define("qx.ui.table.pane.FocusIndicator",
               wl = deco.getWidthLeft();
             }
           }
+          var userHeight = rowHeight + (wl+wr-2);
+          var userTop = (row - firstRow) * rowHeight - (wr - 1);
+          if (editing && this.__scroller.getMinCellEditHeight() && this.__scroller.getMinCellEditHeight() > userHeight) {
+            userTop -= Math.floor((this.__scroller.getMinCellEditHeight() - userHeight) / 2);
+            userHeight = this.__scroller.getMinCellEditHeight();
+          }
+
           this.setUserBounds(
-              paneModel.getColumnLeft(col) - (wt - 1) ,
-              (row - firstRow) * rowHeight - (wr - 1),
-              columnModel.getColumnWidth(col) + (wt+wb-3),
-              rowHeight + (wl+wr-2)
+            paneModel.getColumnLeft(col) - (wt - 1),
+            userTop,
+            columnModel.getColumnWidth(col) + (wt+wb-3),
+            userHeight
           );
           this.show();
           this.setRow(row);

--- a/framework/source/class/qx/ui/table/pane/Scroller.js
+++ b/framework/source/class/qx/ui/table/pane/Scroller.js
@@ -176,7 +176,7 @@ qx.Class.define("qx.ui.table.pane.Scroller",
 
   /*
   *****************************************************************************
-     PROPERTIES
+     EVENTS
   *****************************************************************************
   */
 
@@ -349,6 +349,15 @@ qx.Class.define("qx.ui.table.pane.Scroller",
     {
       refine : true,
       init : "table-scroller"
+    },
+
+    /**
+     * If set then defines the minimum height of the focus indicator when editing
+     */
+    minCellEditHeight: {
+      check: "Integer",
+      init: null,
+      nullable: true
     }
   },
 
@@ -1957,6 +1966,7 @@ qx.Class.define("qx.ui.table.pane.Scroller",
             e.stopPropagation();
           }, this);
 
+          this._updateFocusIndicator(true);
           this.__focusIndicator.add(this._cellEditor);
           this.__focusIndicator.addState("editing");
           this.__focusIndicator.setKeepActive(false);
@@ -1993,8 +2003,8 @@ qx.Class.define("qx.ui.table.pane.Scroller",
 
     /**
      * Writes the editor's value to the model
-     * 
-     * @param cancel {Boolean ? false} Whether to also cancel 
+     *
+     * @param cancel {Boolean ? false} Whether to also cancel
      *      editing before firing the 'dateEdited' event.
      */
     flushEditor : function(cancel)
@@ -2039,6 +2049,7 @@ qx.Class.define("qx.ui.table.pane.Scroller",
 						this.__focusIndicator.removeListenerById(this.__focusIndicatorPointerDownListener);
 						this.__focusIndicatorPointerDownListener = null;
 					}
+					this._updateFocusIndicator();
         }
         this._cellEditor.destroy();
         this._cellEditor = null;
@@ -2441,8 +2452,9 @@ qx.Class.define("qx.ui.table.pane.Scroller",
     /**
      * Updates the location and the visibility of the focus indicator.
      *
+     * @param editing {Boolean ? false} True if editing the cell
      */
-    _updateFocusIndicator : function()
+    _updateFocusIndicator : function(editing)
     {
       var table = this.getTable();
 
@@ -2450,7 +2462,7 @@ qx.Class.define("qx.ui.table.pane.Scroller",
         return;
       }
 
-      this.__focusIndicator.moveToCell(this.__focusedCol, this.__focusedRow);
+      this.__focusIndicator.moveToCell(this.__focusedCol, this.__focusedRow, editing);
     }
   },
 


### PR DESCRIPTION
When using a table with very tightly packed rows, using the in-line editor does not allow to see the full text within the editor. This PR allows a user to set a `minCellEditHeight` against a Table which adjusts the size of the FocusIndicator that hosts the cell editor itself, for the period of the edit.  This seems to work well as far as I can tell and only makes the adjustments if the property has been set so should have no effect on current usages.