### PR TITLE
Add provision for updating a single table row

### DIFF
--- a/framework/source/class/qx/ui/table/cellrenderer/Boolean.js
+++ b/framework/source/class/qx/ui/table/cellrenderer/Boolean.js
@@ -131,13 +131,18 @@ qx.Class.define("qx.ui.table.cellrenderer.Boolean",
 
       // Retrieve the ID
       rm = qx.util.ResourceManager.getInstance();
-      ids = rm.getIds(this.__iconUrlTrue);
 
-      // If ID was found, we'll use its first (likely only) element here.
-      if (ids)
-      {
-        id = ids[0];
+      if (rm.has(this.__iconUrlTrue)) {
+        id = this.__iconUrlTrue;
+      } else {
+        ids = rm.getIds(this.__iconUrlTrue);
+        // If ID was found, we'll use its first (likely only) element here.
+        if (ids) {
+          id = ids[0];
+        }
+      }
 
+      if (id) {
         // Get the natural size of the image
         w = rm.getImageWidth(id);
         h = rm.getImageHeight(id);

--- a/framework/source/class/qx/ui/table/model/Simple.js
+++ b/framework/source/class/qx/ui/table/model/Simple.js
@@ -608,6 +608,9 @@ qx.Class.define("qx.ui.table.model.Simple",
         startIndex = this._rowArr.length;
       }
 
+      // store the original length before we alter rowArr for use in splice.apply
+      var rowArrLength = rowArr.length;
+
       // Prepare the rowArr so it can be used for apply
       rowArr.splice(0, 0, startIndex, 0);
 
@@ -618,7 +621,7 @@ qx.Class.define("qx.ui.table.model.Simple",
       var data =
       {
         firstRow    : startIndex,
-        lastRow     : this._rowArr.length - 1,
+        lastRow     : startIndex + rowArrLength - 1,
         firstColumn : 0,
         lastColumn  : this.getColumnCount() - 1
       };
@@ -667,6 +670,9 @@ qx.Class.define("qx.ui.table.model.Simple",
         startIndex = 0;
       }
 
+      // store the original length before we alter rowArr for use in splice.apply
+      var rowArrLength = rowArr.length;
+
       // Prepare the rowArr so it can be used for apply
       rowArr.splice(0, 0, startIndex, rowArr.length);
 
@@ -677,7 +683,7 @@ qx.Class.define("qx.ui.table.model.Simple",
       var data =
       {
         firstRow    : startIndex,
-        lastRow     : this._rowArr.length - 1,
+        lastRow     : startIndex + rowArrLength - 1,
         firstColumn : 0,
         lastColumn  : this.getColumnCount() - 1
       };

--- a/framework/source/class/qx/ui/table/pane/Pane.js
+++ b/framework/source/class/qx/ui/table/pane/Pane.js
@@ -663,7 +663,7 @@ qx.Class.define("qx.ui.table.pane.Pane",
 
     _updateSingleRow: function(row) {
       var elem = this.getContentElement().getDomElement();
-      if (!elem) {
+      if (!elem || !elem.firstChild) {
         // pane has not yet been rendered, just exit
         return;
       }
@@ -679,9 +679,10 @@ qx.Class.define("qx.ui.table.pane.Pane",
 
       var tableBody = elem.firstChild;
       var tableChildNodes = tableBody.childNodes;
-      var rowElem = tableChildNodes[row];
+      var offset = row - firstRow;
+      var rowElem = tableChildNodes[offset];
 
-      if (row > modelRowCount || rowElem == null) {
+      if (row > modelRowCount || rowElem === undefined) {
         this._updateAllRows();
         return;
       }

--- a/framework/source/class/qx/ui/table/pane/Pane.js
+++ b/framework/source/class/qx/ui/table/pane/Pane.js
@@ -677,13 +677,14 @@ qx.Class.define("qx.ui.table.pane.Pane",
 
       var modelRowCount = this.getTable().getTableModel().getRowCount();
 
-      if (row > modelRowCount) {
-        this._updateAllRows();
-        return;
-      }
       var tableBody = elem.firstChild;
       var tableChildNodes = tableBody.childNodes;
       var rowElem = tableChildNodes[row];
+
+      if (row > modelRowCount || rowElem == null) {
+        this._updateAllRows();
+        return;
+      }
 
       // render new lines
       if (!this.__tableContainer) {

--- a/framework/source/class/qx/ui/table/pane/Pane.js
+++ b/framework/source/class/qx/ui/table/pane/Pane.js
@@ -283,7 +283,11 @@ qx.Class.define("qx.ui.table.pane.Pane",
       if (lastRow == -1 || lastRow >= paneFirstRow && firstRow < paneFirstRow + rowCount)
       {
         // The change intersects this pane
-        this.updateContent();
+        if (firstRow === lastRow) {
+          this.updateContent(false, null, firstRow, false);
+        } else {
+          this.updateContent();
+        }
       }
     },
 
@@ -379,6 +383,8 @@ qx.Class.define("qx.ui.table.pane.Pane",
         this._scrollContent(scrollOffset);
       } else if (onlySelectionOrFocusChanged && !this.getTable().getAlwaysUpdateCells()) {
         this._updateRowStyles(onlyRow);
+      } else if (onlyRow) {
+        this._updateSingleRow(onlyRow);
       } else {
         this._updateAllRows();
       }
@@ -655,6 +661,44 @@ qx.Class.define("qx.ui.table.pane.Pane",
       this.fireEvent("paneUpdated");
     },
 
+    _updateSingleRow: function(row) {
+      var elem = this.getContentElement().getDomElement();
+      if (!elem) {
+        // pane has not yet been rendered, just exit
+        return;
+      }
+      var visibleRowCount = this.getVisibleRowCount();
+      var firstRow = this.getFirstVisibleRow();
+
+      if (row < firstRow || row > firstRow+visibleRowCount) {
+        // No need to redraw it
+        return;
+      }
+
+      var modelRowCount = this.getTable().getTableModel().getRowCount();
+
+      if (row > modelRowCount) {
+        this._updateAllRows();
+        return;
+      }
+      var tableBody = elem.firstChild;
+      var tableChildNodes = tableBody.childNodes;
+      var rowElem = tableChildNodes[row];
+
+      // render new lines
+      if (!this.__tableContainer) {
+        this.__tableContainer = document.createElement("div");
+      }
+      this.__tableContainer.innerHTML = "<div>" + this._getRowsHtml(row, 1) + "</div>";
+      var newTableRows = this.__tableContainer.firstChild.childNodes;
+
+      tableBody.replaceChild(newTableRows[0], rowElem);
+
+      // update focus indicator
+      this._updateRowStyles(null);
+
+      this.fireEvent("paneUpdated");
+    },
 
     /**
      * Updates the content of the pane (implemented using array joins).

--- a/framework/source/class/qx/ui/table/pane/Pane.js
+++ b/framework/source/class/qx/ui/table/pane/Pane.js
@@ -282,8 +282,8 @@ qx.Class.define("qx.ui.table.pane.Pane",
 
       if (lastRow == -1 || lastRow >= paneFirstRow && firstRow < paneFirstRow + rowCount)
       {
-        // The change intersects this pane
-        if (firstRow === lastRow) {
+        // The change intersects this pane, check if a full or partial update is required
+        if (firstRow === lastRow && this.getTable().getTableModel().getRowCount() > 1) {
           this.updateContent(false, null, firstRow, false);
         } else {
           this.updateContent();
@@ -383,7 +383,7 @@ qx.Class.define("qx.ui.table.pane.Pane",
         this._scrollContent(scrollOffset);
       } else if (onlySelectionOrFocusChanged && !this.getTable().getAlwaysUpdateCells()) {
         this._updateRowStyles(onlyRow);
-      } else if (onlyRow) {
+      } else if (typeof onlyRow == "number" && onlyRow >= 0) {
         this._updateSingleRow(onlyRow);
       } else {
         this._updateAllRows();

--- a/framework/source/class/qx/util/ResourceManager.js
+++ b/framework/source/class/qx/util/ResourceManager.js
@@ -77,7 +77,7 @@ qx.Class.define("qx.util.ResourceManager",
       // Calculate the optimal ratio, based on the rem scale factor of the application and the device pixel ratio.
       if (!factor) {
         factor = parseFloat(qx.bom.client.Device.getDevicePixelRatio().toFixed(2));
-      }  
+      }
       if (factor <= 1) {
         return false;
       }
@@ -138,18 +138,9 @@ qx.Class.define("qx.util.ResourceManager",
       if(!registry) {
         return null;
       }
-
-      var ids = [];
-      for (var id in registry) {
-        if (registry.hasOwnProperty(id)) {
-          if(pathfragment && id.indexOf(pathfragment) == -1) {
-            continue;
-          }
-          ids.push(id);
-        }
-      }
-
-      return ids;
+      return Object.keys(registry).filter(function(key){
+        return !pathfragment || key.indexOf(pathfragment) != -1;
+      });
     },
 
     /**


### PR DESCRIPTION
Prompted by performance of refreshing a cell which was incrementing each second, allow to send an update for just the affected row. The method is constructed from parts taken from the full update, or an update due to scroll.

As part of this, I also spotted that the performance of getIds() in ResourceManager was not great. The change here halved the time taken in that method for me so hopefully that is also beneficial to everyone else.