### PR TITLE
Fix a problem on format with named parameters when there is no spaces…

### DIFF
--- a/framework/source/class/qx/lang/String.js
+++ b/framework/source/class/qx/lang/String.js
@@ -299,7 +299,7 @@ qx.Bootstrap.define("qx.lang.String",
     format : function(pattern, args)
     {
       var str = pattern;
-      var regexp = /%(\d+)|%{(\S*)}/g;
+      var regexp = /%(\d+)|%{(\S[^{]*)}/g;
       if (!Array.isArray(args)) {
         args = [args];
       }

--- a/framework/source/class/qx/lang/String.js
+++ b/framework/source/class/qx/lang/String.js
@@ -299,7 +299,7 @@ qx.Bootstrap.define("qx.lang.String",
     format : function(pattern, args)
     {
       var str = pattern;
-      var regexp = /%(\d+)|%{(\S[^{]*)}/g;
+      var regexp = /%(\d+)|%{(\S[^}]*)}/g;
       if (!Array.isArray(args)) {
         args = [args];
       }

--- a/framework/source/class/qx/lang/String.js
+++ b/framework/source/class/qx/lang/String.js
@@ -299,7 +299,7 @@ qx.Bootstrap.define("qx.lang.String",
     format : function(pattern, args)
     {
       var str = pattern;
-      var regexp = /%(\d+)|%{(\S[^}]*)}/g;
+      var regexp = /%(\d+)|%{(\S[^}\s]*)}/g;
       if (!Array.isArray(args)) {
         args = [args];
       }


### PR DESCRIPTION
This commit fixes a bug when you had no spaces between two parameters in string format function (used by exemple in translation)

Exemple: 
`It's %{currentNumber}/%{totalNumber} done.`
The current code will detect only one argument named `currentNumber}/%{totalNumber`, where it should find `currentNumber` and `totalNumber`. It was because we were looking in arguments for non whitespace characters including `}` , i now excluded the `}` from the valid parameters characters.