### PR TITLE
Add row & cell attributes to cell markup

### DIFF
--- a/framework/source/class/qx/ui/table/cellrenderer/Abstract.js
+++ b/framework/source/class/qx/ui/table/cellrenderer/Abstract.js
@@ -223,6 +223,8 @@ qx.Class.define("qx.ui.table.cellrenderer.Abstract",
         'left:', cellInfo.styleLeft, 'px;',
         this._getCellSizeStyle(cellInfo.styleWidth, cellInfo.styleHeight, this._insetX, this._insetY),
         this._getCellStyle(cellInfo), '" ',
+        'data-qx-table-cell-row="', cellInfo.row, '" ',
+        'data-qx-table-cell-col="', cellInfo.col, '" ',
         this._getCellAttributes(cellInfo),
         '>' +
         this._getContentHtml(cellInfo),


### PR DESCRIPTION
As requested by @cboulanger, this adds initial row and column attributes to the markup to identify cells in the table. 