### PR TITLE
Increase performance of Boolean cellrenderer

### DIFF
--- a/framework/source/class/qx/ui/table/cellrenderer/Boolean.js
+++ b/framework/source/class/qx/ui/table/cellrenderer/Boolean.js
@@ -131,13 +131,18 @@ qx.Class.define("qx.ui.table.cellrenderer.Boolean",
 
       // Retrieve the ID
       rm = qx.util.ResourceManager.getInstance();
-      ids = rm.getIds(this.__iconUrlTrue);
 
-      // If ID was found, we'll use its first (likely only) element here.
-      if (ids)
-      {
-        id = ids[0];
+      if (rm.has(this.__iconUrlTrue)) {
+        id = this.__iconUrlTrue;
+      } else {
+        ids = rm.getIds(this.__iconUrlTrue);
+        // If ID was found, we'll use its first (likely only) element here.
+        if (ids) {
+          id = ids[0];
+        }
+      }
 
+      if (id) {
         // Get the natural size of the image
         w = rm.getImageWidth(id);
         h = rm.getImageHeight(id);

--- a/framework/source/class/qx/util/ResourceManager.js
+++ b/framework/source/class/qx/util/ResourceManager.js
@@ -77,7 +77,7 @@ qx.Class.define("qx.util.ResourceManager",
       // Calculate the optimal ratio, based on the rem scale factor of the application and the device pixel ratio.
       if (!factor) {
         factor = parseFloat(qx.bom.client.Device.getDevicePixelRatio().toFixed(2));
-      }  
+      }
       if (factor <= 1) {
         return false;
       }
@@ -138,18 +138,9 @@ qx.Class.define("qx.util.ResourceManager",
       if(!registry) {
         return null;
       }
-
-      var ids = [];
-      for (var id in registry) {
-        if (registry.hasOwnProperty(id)) {
-          if(pathfragment && id.indexOf(pathfragment) == -1) {
-            continue;
-          }
-          ids.push(id);
-        }
-      }
-
-      return ids;
+      return Object.keys(registry).filter(function(key){
+        return !pathfragment || key.indexOf(pathfragment) != -1;
+      });
     },
 
     /**


### PR DESCRIPTION
We noticed performance issues with the Boolean renderer within a table. When analysed, it seemed that the method `getIds()` in `ResourceManager` was not optimal, changing to filter the keys seems to be a reasonable improvement there for the volume of resources we have.  Further analysis showed that only the Boolean renderer was using the `getIds()` method, and even then it would  take the first id given. So, changing the cell renderer to lookup the ID directly in the resource map improves things dramatically. I have left the original code there as a fallback in case there is not an exact match which seemed like it's purpose.