### PR TITLE
Provision for updating a single table row

### DIFF
--- a/framework/source/class/qx/ui/table/model/Simple.js
+++ b/framework/source/class/qx/ui/table/model/Simple.js
@@ -667,6 +667,9 @@ qx.Class.define("qx.ui.table.model.Simple",
         startIndex = 0;
       }
 
+      // store the original length before we alter rowArr for use in splice.apply
+      var rowArrLength = rowArr.length;
+
       // Prepare the rowArr so it can be used for apply
       rowArr.splice(0, 0, startIndex, rowArr.length);
 
@@ -677,7 +680,7 @@ qx.Class.define("qx.ui.table.model.Simple",
       var data =
       {
         firstRow    : startIndex,
-        lastRow     : this._rowArr.length - 1,
+        lastRow     : startIndex + rowArrLength - 1,
         firstColumn : 0,
         lastColumn  : this.getColumnCount() - 1
       };

--- a/framework/source/class/qx/ui/table/pane/Pane.js
+++ b/framework/source/class/qx/ui/table/pane/Pane.js
@@ -282,8 +282,12 @@ qx.Class.define("qx.ui.table.pane.Pane",
 
       if (lastRow == -1 || lastRow >= paneFirstRow && firstRow < paneFirstRow + rowCount)
       {
-        // The change intersects this pane
-        this.updateContent();
+        // The change intersects this pane, check if a full or partial update is required
+        if (firstRow === lastRow && this.getTable().getTableModel().getRowCount() > 1) {
+          this.updateContent(false, null, firstRow, false);
+        } else {
+          this.updateContent();
+        }
       }
     },
 
@@ -379,6 +383,8 @@ qx.Class.define("qx.ui.table.pane.Pane",
         this._scrollContent(scrollOffset);
       } else if (onlySelectionOrFocusChanged && !this.getTable().getAlwaysUpdateCells()) {
         this._updateRowStyles(onlyRow);
+      } else if (typeof onlyRow == "number" && onlyRow >= 0) {
+        this._updateSingleRow(onlyRow);
       } else {
         this._updateAllRows();
       }
@@ -655,6 +661,46 @@ qx.Class.define("qx.ui.table.pane.Pane",
       this.fireEvent("paneUpdated");
     },
 
+    _updateSingleRow: function(row) {
+      var elem = this.getContentElement().getDomElement();
+      if (!elem || !elem.firstChild) {
+        // pane has not yet been rendered, just exit
+        return;
+      }
+      var visibleRowCount = this.getVisibleRowCount();
+      var firstRow = this.getFirstVisibleRow();
+
+      if (row < firstRow || row > firstRow+visibleRowCount) {
+        // No need to redraw it
+        return;
+      }
+
+      var modelRowCount = this.getTable().getTableModel().getRowCount();
+
+      var tableBody = elem.firstChild;
+      var tableChildNodes = tableBody.childNodes;
+      var offset = row - firstRow;
+      var rowElem = tableChildNodes[offset];
+
+      if (row > modelRowCount || rowElem === undefined) {
+        this._updateAllRows();
+        return;
+      }
+
+      // render new lines
+      if (!this.__tableContainer) {
+        this.__tableContainer = document.createElement("div");
+      }
+      this.__tableContainer.innerHTML = "<div>" + this._getRowsHtml(row, 1) + "</div>";
+      var newTableRows = this.__tableContainer.firstChild.childNodes;
+
+      tableBody.replaceChild(newTableRows[0], rowElem);
+
+      // update focus indicator
+      this._updateRowStyles(null);
+
+      this.fireEvent("paneUpdated");
+    },
 
     /**
      * Updates the content of the pane (implemented using array joins).

--- a/framework/source/class/qx/ui/table/pane/Pane.js
+++ b/framework/source/class/qx/ui/table/pane/Pane.js
@@ -682,7 +682,7 @@ qx.Class.define("qx.ui.table.pane.Pane",
       var offset = row - firstRow;
       var rowElem = tableChildNodes[offset];
 
-      if (row > modelRowCount || rowElem === undefined) {
+      if (row > modelRowCount || typeof rowElem == "undefined") {
         this._updateAllRows();
         return;
       }


### PR DESCRIPTION
Prompted by performance of refreshing a cell which was incrementing each second, allow to send an update for just the affected row set by using the setRows() method of the Simple table model. The method is constructed from parts taken from the full update, or an update due to scroll.