### PR TITLE
Fix misleading documentation

### DIFF
--- a/framework/source/class/qx/ui/table/columnmodel/Basic.js
+++ b/framework/source/class/qx/ui/table/columnmodel/Basic.js
@@ -727,7 +727,7 @@ qx.Class.define("qx.ui.table.columnmodel.Basic",
      * @param newPositions {Integer[]} Array mapping the index of a column in table model to its wanted overall
      *                            position on screen (both zero based). If the table models holds
      *                            col0, col1, col2 and col3 and you give [1,3,2,0], the new column order
-     *                            will be col3, col0, col2, col1
+     *                            will be col1, col3, col2, col0
      */
     setColumnsOrder : function(newPositions)
     {


### PR DESCRIPTION
The documentation for setting the column orders was misleading. Perhaps is was correct at some point, but it's not how it currently works. This fixes the docu to hopefully save someone else some time.
Example:  https://tinyurl.com/y3e9v4rg