### PR TITLE
Escape strings using codePointAt(), rather than charCodeAt()

### DIFF
--- a/framework/source/class/qx/test/lang/String.js
+++ b/framework/source/class/qx/test/lang/String.js
@@ -122,6 +122,8 @@ qx.Class.define("qx.test.lang.String",
 
       this.assertEquals("&lt;div id='1'&gt;&amp;nbsp; &euro;&lt;/div&gt;", qx.bom.String.escape("<div id='1'>&nbsp; €</div>"));
 
+      this.assertEquals("&#127774; 1", qx.bom.String.escape("🌞 1"));
+
       // textToHtml
       this.assertEquals("&lt;div id='1'&gt;<br> &nbsp;&amp;nbsp; &euro;&lt;/div&gt;", qx.bom.String.fromText("<div id='1'>\n  &nbsp; €</div>"));
 
@@ -134,6 +136,8 @@ qx.Class.define("qx.test.lang.String",
       this.assertEquals("juhu <>", qx.bom.String.unescape("juhu &lt;&gt;"));
 
       this.assertEquals("<div id='1'>&nbsp; €</div>", qx.bom.String.unescape("&lt;div id='1'&gt;&amp;nbsp; &euro;&lt;/div&gt;"));
+
+      this.assertEquals("🌞 1", qx.bom.String.unescape("&#127774; 1"));
 
       this.assertEquals(">&zzzz;x", qx.bom.String.unescape("&gt;&zzzz;x"));
 
@@ -251,14 +255,14 @@ qx.Class.define("qx.test.lang.String",
       var str = "This is a <script>foobar</script>test";
 
       this.assertIdentical(qx.lang.String.stripScripts(str), "This is a test");
-      
+
       var spy = this.spy(qx.lang.Function, "globalEval");
 
       str = "This is a test with<script>console.log('foobar');</script> script";
 
       this.assertIdentical(qx.lang.String.stripScripts(str, true), "This is a test with script");
       this.assertCalledOnce(spy);
-      
+
       spy.restore();
     }
   }

--- a/framework/source/class/qx/util/StringEscape.js
+++ b/framework/source/class/qx/util/StringEscape.js
@@ -40,7 +40,9 @@ qx.Bootstrap.define("qx.util.StringEscape",
       for (var i=0, l=str.length; i<l; i++)
       {
         var chr = str.charAt(i);
-        var code = chr.charCodeAt(0);
+        var code = str.codePointAt(i);
+
+        i += String.fromCodePoint(code).length-1;
 
         if (charCodeToEntities[code]) {
           entity = "&" + charCodeToEntities[code] + ";";
@@ -89,7 +91,7 @@ qx.Bootstrap.define("qx.util.StringEscape",
 
               // match hex number
               if (code.match(/^[0-9A-Fa-f]+$/gi)) {
-                chr = String.fromCharCode(parseInt(code, 16));
+                chr = String.fromCodePoint(parseInt(code, 16));
               }
             }
             else
@@ -98,7 +100,7 @@ qx.Bootstrap.define("qx.util.StringEscape",
 
               // match integer
               if (code.match(/^\d+$/gi)) {
-                chr = String.fromCharCode(parseInt(code, 10));
+                chr = String.fromCodePoint(parseInt(code, 10));
               }
             }
           }


### PR DESCRIPTION
To fix an issue where emojis were not showing correctly in a table because the cell renderer was escaping the string value.
Quick demo here of the issue here https://tinyurl.com/yy5k255z