### PR TITLE
TreeVirtual - fixes bug where selection would not extend with shift+Up/Down

### DIFF
--- a/framework/source/class/qx/ui/treevirtual/SimpleTreeDataRowRenderer.js
+++ b/framework/source/class/qx/ui/treevirtual/SimpleTreeDataRowRenderer.js
@@ -64,7 +64,10 @@ qx.Class.define("qx.ui.treevirtual.SimpleTreeDataRowRenderer",
       {
         // Ensure that the selection model knows it's selected
         var row = rowInfo.row;
-        tree.getSelectionModel()._addSelectionInterval(row, row);
+        var selModel = tree.getSelectionModel();
+        if (!selModel.isSelectedIndex(row)) {
+          selModel._addSelectionInterval(row, row);
+        }
       }
 
       // Now call our superclass


### PR DESCRIPTION
Bug can be seen in old 5.02 Demo Browser
https://archive.qooxdoo.org/current/demobrowser/#treevirtual~TreeVirtual_Selections.html

Holding down shift and trying to selection multiple rows with Up/Down keys would only result in at most two rows selected. The selection could be obtained using the mouse but this appears to fix the issue which was that the anchorSelectionIndex of the selection model was modified by calling the private method `_addSelectionInterval()` .  The private method appears to be called to prevent the changeSelection event.