### PR TITLE
TreeVirtual - Prevent call to setData upon setValue()

### DIFF
--- a/framework/source/class/qx/ui/treevirtual/SimpleTreeDataModel.js
+++ b/framework/source/class/qx/ui/treevirtual/SimpleTreeDataModel.js
@@ -389,8 +389,8 @@ qx.Class.define("qx.ui.treevirtual.SimpleTreeDataModel",
           return;
         }
         node.columnData[columnIndex] = value;
+        this._rowArr[rowIndex][columnIndex] = value;
       }
-      this.setData();
       // Inform the listeners
       if (this.hasListener("dataChanged"))
       {


### PR DESCRIPTION
 * Populate the private _rowArr

As mentioned in https://github.com/qooxdoo/qooxdoo/issues/10064, a call to set a value in the model currently causes a full rebuild of the tree which seems a bit heavy handed. This PR attempts to remove that full refresh and just populate  the required internals.