### PR TITLE
adds support for declaring environment checks

### DIFF
--- a/framework/Manifest.json
+++ b/framework/Manifest.json
@@ -128,7 +128,35 @@
           "qx/iconfont/MaterialIcons/materialiconstwotone-v17.otf"
         ]
       }
-    ]
+    ],
+    "environmentChecks": {
+      "browser.*": "qx.bom.client.Browser",
+      "css.*": "qx.bom.client.Css",
+      "css.animation": "qx.bom.client.CssAnimation",
+      "css.animation.requestframe": "qx.bom.client.CssAnimation",
+      "css.transform": "qx.bom.client.CssTransform",
+      "css.transform.3d": "qx.bom.client.CssTransform",
+      "css.transition": "qx.bom.client.CssTransition",
+      "device.*": "qx.bom.client.Device",
+      "ecmascript.*": "qx.bom.client.EcmaScript",
+      "engine.*": "qx.bom.client.Engine",
+      "event.*": "qx.bom.client.Event",
+      "html.stylesheet.*": "qx.bom.client.Stylesheet",
+      "html.*": "qx.bom.client.Html",
+      "io.*": "qx.bom.client.Transport",
+      "locale": "qx.bom.client.Locale",
+      "locale.*": "qx.bom.client.Locale",
+      "os.*": "qx.bom.client.OperatingSystem",
+      "os.scrollBarOverlayed": "qx.bom.client.Scroll",
+      "phonegap*": "qx.bom.client.PhoneGap",
+      "plugin.flash*": "qx.bom.client.Flash",
+      "plugin.*": "qx.bom.client.Plugin",
+      "qx.globalErrorHandling": "qx.event.GlobalError",
+      "qx.mobile.nativescroll": "qx.bom.client.Scroll",
+      "qx.promise.*": "qx.Promise",
+      "runtime.name": "qx.bom.client.Runtime",
+      "xml.*": "qx.bom.client.Xml"
+    }
   },
 
   "setup" :

--- a/framework/source/class/qx/core/Environment.js
+++ b/framework/source/class/qx/core/Environment.js
@@ -37,6 +37,12 @@
  * classes for each check. When using a check of a new category, make sure to
  * rebuild you application and let the compiler include the necessary files.
  *
+ * When you define a new environment check, the compiler needs to know which class
+ * implements the check; to do this, you can either prefix the name of your check 
+ * with your class name (eg `my.package.MyClass.someEnvCheck`) or you can create
+ * short names like the ones below and then add an entry to your library's
+ * Manifest.json (under `provides.environmentChecks`).
+ *
  * The following table shows the available checks. If you are
  * interested in more details, check the reference to the implementation of
  * each check. Please do not use those check implementations directly, as the


### PR DESCRIPTION
adds support for declaring environment checks, to allow the compiler to know which class implements the checks identified with short codes - eg calling `qx.core.Environment.get("browser.name")` means that the class `qx.bom.client.Browser` has to be first, so that the implementation is in place.

There is a corresponding PR https://github.com/qooxdoo/qooxdoo-compiler/pull/775 in the compiler which needs to go out at the same time