### PR TITLE
Fix mixin this base support

### DIFF
--- a/framework/source/class/qx/Class.js
+++ b/framework/source/class/qx/Class.js
@@ -1450,12 +1450,12 @@ qx.Bootstrap.define("qx.Class",
         // classes which are function like as well.
         if (base !== false && member instanceof Function && member.$$type == null)
         {
-          if (wrap == true)
+          if (!qx.core.Environment.get("qx.compiler") && wrap == true)
           {
             // wrap "patched" mixin member
             member = this.__mixinMemberWrapper(member, proto[key]);
           }
-          else
+          else if (wrap != true)
           {
             // Configure extend (named base here)
             // Hint: proto[key] is not yet overwritten here
@@ -1489,20 +1489,25 @@ qx.Bootstrap.define("qx.Class",
      */
     __mixinMemberWrapper : function(member, base)
     {
-      if (base)
-      {
-        return function()
+      if (qx.core.Environment.get("qx.compiler")) {
+        throw new Error("This function should not be used except with code compiled by the generator (ie python toolchain)");
+        
+      } else {
+        if (base)
         {
-          var oldBase = member.base;
-          member.base = base;
-          var retval = member.apply(this, arguments);
-          member.base = oldBase;
-          return retval;
-        };
-      }
-      else
-      {
-        return member;
+          return function()
+          {
+            var oldBase = member.base;
+            member.base = base;
+            var retval = member.apply(this, arguments);
+            member.base = oldBase;
+            return retval;
+          };
+        }
+        else
+        {
+          return member;
+        }
       }
     },
 

--- a/framework/source/class/qx/Mixin.js
+++ b/framework/source/class/qx/Mixin.js
@@ -300,6 +300,29 @@ qx.Bootstrap.define("qx.Mixin",
     },
     
     
+    /**
+     * This method is used to determine the base method to call at runtime, and is used
+     * by Mixins where the mixin method calls `this.base()`.  It is only required by the
+     * compiler, and not the generator.
+     *
+     * The problem is that while Mixin's cannot override the same methods in a single class,
+     * they can override methods that were implemented in a base base - but the compiler
+     * cannot emit compile-time code which knows the base class method because that depends
+     * on the class that the mixin is mixed-into.
+     *
+     * This method will search the hierarchy of the class at runtime, and figure out the 
+     * nearest superclass method to call; the result is cached, and it is acceptable for
+     * a mixin's method to override a method mixed into a superclass.
+     *
+     * Technically, this method should be private - it is internal and no notification will
+     * be given if the API changes.  However, because it needs to be called by generated code
+     * in any class, it has to appear as public.  Do not use it directly.
+     *
+     * @param clazz {Class} the class that is to be examined
+     * @param mixin {Mixin} the mixin that is calling `this.base`
+     * @param methodName {String} the name of the method in `mixin` that is calling `this.base`
+     * @return {Function} the base class function to call
+     */
     baseClassMethod : function(clazz, mixin, methodName) {
       if (!qx.core.Environment.get("qx.compiler")) {
         qx.log.Logger.error("qx.Mixin.baseClassMethod should not be used except with code compiled by the compiler (ie NOT the generator / python toolchain)");


### PR DESCRIPTION
Adds a method which allows the compiler to emit code that handles `this.base` when outputting methods which are in a mixin.

This should have no effect in apps written for the generator.

It depends on a new environment setting `qx.compiler` which will be true if the compiler created your application (this will not be output until the next release of the compiler).