### PR TITLE
Fixes a bug where `Array` polyfills are loaded unnecessarily

### DIFF
--- a/framework/source/class/qx/lang/normalize/Array.js
+++ b/framework/source/class/qx/lang/normalize/Array.js
@@ -24,7 +24,7 @@
  * MDN documentation &copy; Mozilla Contributors.
  *
  * @group (Polyfill)
- * @use(qx.bom.client.EcmaScript)
+ * @require(qx.bom.client.EcmaScript)
  */
 qx.Bootstrap.define("qx.lang.normalize.Array", {
 


### PR DESCRIPTION
The compiler hint needs to be `@use` so that the `qx.bom.client.EcmaScript` class is loaded before this class; without this, the `qx.core.Environment` checks will fail and wrongly decide that the polyfill is necessary.

Normally this would be automatically detected by the compiler, but that does not work for this class because the implementation of `defer` uses dynamic strings