### PR TITLE
Fix sporading Layout flush null errors.

### DIFF
--- a/framework/source/class/qx/ui/core/queue/Layout.js
+++ b/framework/source/class/qx/ui/core/queue/Layout.js
@@ -106,7 +106,8 @@ qx.Class.define("qx.ui.core.queue.Layout",
           // This is an inner item of layout changes. Do a relayout of its
           // children without changing its position and size.
           var bounds = widget.getBounds();
-          widget.renderLayout(bounds.left, bounds.top, bounds.width, bounds.height);
+          if (bounds)
+            widget.renderLayout(bounds.left, bounds.top, bounds.width, bounds.height);
         }
       }
     },

--- a/framework/source/class/qx/ui/core/queue/Layout.js
+++ b/framework/source/class/qx/ui/core/queue/Layout.js
@@ -106,8 +106,9 @@ qx.Class.define("qx.ui.core.queue.Layout",
           // This is an inner item of layout changes. Do a relayout of its
           // children without changing its position and size.
           var bounds = widget.getBounds();
-          if (bounds)
+          if (bounds) {
             widget.renderLayout(bounds.left, bounds.top, bounds.width, bounds.height);
+          }
         }
       }
     },


### PR DESCRIPTION
It's rare but sometimes we get a null error when a widget flushes Layout queue.