### PR TITLE
Remove all listeners in qx.core.Object's destructor

### DIFF
--- a/source/class/qx/core/Object.js
+++ b/source/class/qx/core/Object.js
@@ -345,6 +345,13 @@ qx.Class.define("qx.core.Object",
         }
       }
 
+      // Remove all listeners.
+      //
+      // This must be done early, since it calls
+      // qx.core.ObjectRegistry.toHashCode(target) which would add a
+      // hash code back in after code here has cleaned it up.
+      qx.event.Registration.removeAllListeners(this);
+
       // Deconstructor support for classes
       var clazz = this.constructor;
       var mixins;
@@ -372,8 +379,6 @@ qx.Class.define("qx.core.Object",
         // Jump up to next super class
         clazz = clazz.superclass;
       }
-
-      qx.event.Registration.removeAllListeners(this);
 
       this.$$disposing = false;
       

--- a/source/class/qx/core/Object.js
+++ b/source/class/qx/core/Object.js
@@ -373,6 +373,8 @@ qx.Class.define("qx.core.Object",
         clazz = clazz.superclass;
       }
 
+      qx.event.Registration.removeAllListeners(this);
+
       this.$$disposing = false;
       
       // Additional checks


### PR DESCRIPTION
This was inspired by #10159 which added a bunch of listener removal to Table. It seemed that the proper, and more general fix, would be to do that in the superclass of all qooxdoo objects, `qx.core.Object`. This should negate the need for #10159, I believe.

The tests which fail with this change are the same ones that fail without it; this causes no new failures in the test suite. That said, it's still a dangerous change, as it affects all objects, so thorough reviews are welcome!
