### PR TITLE
Using widget.setUserBounds() may break the layout.

### DIFF
--- a/source/class/qx/ui/core/LayoutItem.js
+++ b/source/class/qx/ui/core/LayoutItem.js
@@ -792,6 +792,14 @@ qx.Class.define("qx.ui.core.LayoutItem",
      */
     setUserBounds : function(left, top, width, height)
     {
+      
+      if (!this.__userBounds) {
+        var parent = this.$$parent;
+        if (parent) {
+          parent.updateLayoutProperties();
+        }
+      }
+      
       this.__userBounds = {
         left: left,
         top: top,
@@ -810,8 +818,16 @@ qx.Class.define("qx.ui.core.LayoutItem",
      */
     resetUserBounds : function()
     {
-      delete this.__userBounds;
-      qx.ui.core.queue.Layout.add(this);
+      if (this.__userBounds) {
+        delete this.__userBounds;
+
+        var parent = this.$$parent;
+        if (parent) {
+            parent.updateLayoutProperties();
+        }
+
+        qx.ui.core.queue.Layout.add(this);
+      }
     },
 
 


### PR DESCRIPTION
When a child widget is already added to a container using the Dock or Table layout managers that cache the layout children and you call setUserBounds() or resetUserBounds() the parent's layout manager is not updated and will ignore the user bounds breaking the layout.