### PR TITLE
Command activenes matches that of the group

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,7 @@ at the bottom. Before that, the 2 values were reversed
 
 - `qx.ui.command.Group` fixed a bug where new `qx.ui.command.Command` added
   was not set the `active` status of the group, thus staying active even if the 
-  group was inactive.
+  group was inactive. This may affect code that relied in such behavior.
 
 ## Deprecations:
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,9 +12,9 @@ at the bottom. Before that, the 2 values were reversed
 
 - all flash supporting classes are removed - flash is dead since January 2020.
 
-- `qx.ui.command.Group` fixed a bug where new `qx.ui.command.Command` added
-  was not set the `active` status of the group, thus staying active even if the 
-  group was inactive.
+- `qx.ui.command.Group` fixed a bug where new `qx.ui.command.Command` added was
+not set the `active` status of the group, thus staying active even if the group
+was inactive.
 
 ## Deprecations:
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,7 @@ at the bottom. Before that, the 2 values were reversed
 
 - `qx.ui.command.Group` fixed a bug where new `qx.ui.command.Command` added
   was not set the `active` status of the group, thus staying active even if the 
-  group was inactive. This may affect code that relied in such behavior.
+  group was inactive.
 
 ## Deprecations:
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,10 @@ at the bottom. Before that, the 2 values were reversed
 
 - all flash supporting classes are removed - flash is dead since January 2020.
 
+- `qx.ui.command.Group` fixed a bug where new `qx.ui.command.Command` added
+  was not set the `active` status of the group, thus staying active even if the 
+  group was inactive.
+
 ## Deprecations:
 
 - `qx package migrate` has been deprecated in favor of `qx migrate` 

--- a/source/class/qx/test/ui/command/Group.js
+++ b/source/class/qx/test/ui/command/Group.js
@@ -41,6 +41,24 @@ qx.Class.define("qx.test.ui.command.Group",
       this.assertCallCount(handler, 1);
     },
 
+    testDeactivatingAndAdding : function()
+    {
+      var handler = this.spy();
+      var group = new qx.ui.command.Group();
+      group.setActive(false);
+
+      var cmd = new qx.ui.command.Command("Meta+T");
+
+      cmd.addListener("execute", handler);
+      this.assertTrue(group.add("test", cmd));
+
+      cmd.execute();
+      this.assertCallCount(handler, 0);
+
+      group.setActive(true);
+      cmd.execute();
+      this.assertCallCount(handler, 1);
+    },
 
     testHasCommand : function()
     {

--- a/source/class/qx/ui/command/Group.js
+++ b/source/class/qx/ui/command/Group.js
@@ -85,7 +85,8 @@ qx.Class.define("qx.ui.command.Group",
         }
         return false;
       }
-
+      
+      command.setActive(this.getActive());
       this._cmds[key] = command;
 
       return true;


### PR DESCRIPTION
When CommandGroup is set inactive and then commands are added to it, the new commands don't follow the active status of the group until that status changes. One would expect that since the group is inactive, all the commands should be inactive. Here is an example

```javascript
      const commandGroup = new qx.ui.command.Group();
      commandGroup.setActive(false);

      const command = new qx.ui.command.Command("Enter");
      command.addListener("execute", function () {
        alert("Executed");
        }, this
      );

      commandGroup.add("enter", command);
```
Working playground example https://tinyurl.com/y6vfad54

This PR fixes that by aplying CommandGroup's active status to the command, before adding it to it's list.