### PR TITLE
Since iPadOS 13 the device is detected as "Desktop"

### DIFF
--- a/source/class/qx/bom/client/Device.js
+++ b/source/class/qx/bom/client/Device.js
@@ -99,7 +99,7 @@ qx.Bootstrap.define("qx.bom.client.Device",
      * @param userAgentString {String} userAgent parameter, needed for decision.
      * @return {Boolean} Flag which indicates whether it is a mobile device.
      */
-    detectMobileDevice : function(userAgentString){
+    detectMobileDevice : function(userAgentString) {
       return /android.+mobile|ip(hone|od)|bada\/|blackberry|BB10|maemo|opera m(ob|in)i|fennec|NetFront|phone|psp|symbian|IEMobile|windows (ce|phone)|xda/i.test(userAgentString);
     },
 
@@ -109,11 +109,12 @@ qx.Bootstrap.define("qx.bom.client.Device",
      * @param userAgentString {String} userAgent parameter, needed for decision.
      * @return {Boolean} Flag which indicates whether it is a tablet device.
      */
-    detectTabletDevice : function(userAgentString){
+    detectTabletDevice : function(userAgentString) {
+      var iPadOS13Up = navigator.platform === 'MacIntel' && navigator.maxTouchPoints > 1;
       var isIE10Tablet = (/MSIE 10/i.test(userAgentString)) && (/ARM/i.test(userAgentString)) && !(/windows phone/i.test(userAgentString));
       var isCommonTablet = (!(/android.+mobile|Tablet PC/i.test(userAgentString)) && (/Android|ipad|tablet|playbook|silk|kindle|psp/i.test(userAgentString)));
 
-      return  isIE10Tablet || isCommonTablet;
+      return  isIE10Tablet || isCommonTablet || iPadOS13Up;
     },
 
 

--- a/source/class/qx/bom/client/Device.js
+++ b/source/class/qx/bom/client/Device.js
@@ -110,7 +110,7 @@ qx.Bootstrap.define("qx.bom.client.Device",
      * @return {Boolean} Flag which indicates whether it is a tablet device.
      */
     detectTabletDevice : function(userAgentString) {
-      var iPadOS13Up = navigator.platform === 'MacIntel' && navigator.maxTouchPoints > 1;
+      var iPadOS13Up = navigator.platform === "MacIntel" && navigator.maxTouchPoints > 1;
       var isIE10Tablet = (/MSIE 10/i.test(userAgentString)) && (/ARM/i.test(userAgentString)) && !(/windows phone/i.test(userAgentString));
       var isCommonTablet = (!(/android.+mobile|Tablet PC/i.test(userAgentString)) && (/Android|ipad|tablet|playbook|silk|kindle|psp/i.test(userAgentString)));
 


### PR DESCRIPTION
Apparently Apple decided to make the user agent in the iPad identical to the user agent in the mac. The consensus seems to be that this is needed to detect the new iPad:

navigator.platform === 'MacIntel' && navigator.maxTouchPoints > 1