### PR TITLE
cache and use-eslintrc are booleans

### DIFF
--- a/source/class/qx/tool/cli/commands/Lint.js
+++ b/source/class/qx/tool/cli/commands/Lint.js
@@ -39,10 +39,12 @@ qx.Class.define("qx.tool.cli.commands.Lint", {
           },
           "use-eslintrc": {
             describe: "Use the .eslintrc file for configuration, if it exists",
+            type: "boolean",
             default: true
           },
           "cache": {
             describe: "operate only on changed files",
+            type: "boolean",
             default: false
           },
           "warnAsError": {


### PR DESCRIPTION
The options `--cache` and `--use-eslintrc` are recognized as `string`
and they remain always true. This PR sets them as `boolean` so yargs
translates them properly