### PR TITLE
refactor: fromFontUriToCharCode

### DIFF
--- a/source/class/qx/bom/element/Decoration.js
+++ b/source/class/qx/bom/element/Decoration.js
@@ -151,15 +151,7 @@ qx.Class.define("qx.bom.element.Decoration",
           }
         }
 
-        var resource = ResourceManager.getData(source);
-        var charCode;
-        if (resource) {
-          charCode = resource[2];
-        }
-        else {
-          charCode = parseInt(qx.theme.manager.Font.getInstance().resolve(source.match(/@([^/]+)\/(.*)$/)[2]), 16);
-          qx.core.Assert.assertNumber(charCode, "Font source needs either a glyph name or the unicode number in hex");
-        }
+        var charCode = ResourceManager.fromFontUriToCharCode(source);
         
         return '<div style="' + css + '">' + String.fromCharCode(charCode) + '</div>';
       }

--- a/source/class/qx/ui/basic/Image.js
+++ b/source/class/qx/ui/basic/Image.js
@@ -936,11 +936,6 @@ qx.Class.define("qx.ui.basic.Image",
 
       if (isFont) {
         var sparts = source.split("/");
-        var fontSource = source;
-        if (sparts.length > 2) {
-          fontSource = sparts[0] + "/" + sparts[1];
-        }
-
 
         var ResourceManager = qx.util.ResourceManager.getInstance();
         var font = qx.theme.manager.Font.getInstance().resolve(source.match(/@([^/]+)/)[1]);
@@ -960,17 +955,8 @@ qx.Class.define("qx.ui.basic.Image",
           el.setStyle("fontSize", size + "px");
         }
 
-        var resource = ResourceManager.getData(fontSource);
-        if (resource) {
-          el.setValue(String.fromCharCode(resource[2]));
-        }
-        else {
-          var charCode = parseInt(qx.theme.manager.Font.getInstance().resolve(source.match(/@([^/]+)\/(.*)$/)[2]), 16);
-          if (qx.core.Environment.get("qx.debug")) {
-            this.assertNumber(charCode, "Font source needs either a glyph name or the unicode number in hex");
-          }
-          el.setValue(String.fromCharCode(charCode));
-        }
+        var charCode = ResourceManager.fromFontUriToCharCode(source);
+        el.setValue(String.fromCharCode(charCode));
 
         return;
       }

--- a/source/class/qx/util/ResourceManager.js
+++ b/source/class/qx/util/ResourceManager.js
@@ -331,6 +331,33 @@ qx.Class.define("qx.util.ResourceManager",
     isFontUri : function (resid)
     {
       return resid ? resid.startsWith("@") : false;
+    },
+
+    /**
+     * Returns the correct char code, ignoring scale postfix.
+     * 
+     * @param source {String} resource id of the image, e.g. @FontAwesome/heart or @MaterialIcons/home/16
+     * @returns charCode of the glyph
+     */
+    fromFontUriToCharCode : function (source)
+    {
+      var sparts = source.split("/");
+      var fontSource = source;
+      if (sparts.length > 2) {
+        fontSource = sparts[0] + "/" + sparts[1];
+      }
+      var resource = this.getData(fontSource);
+      var charCode;
+      if (resource) {
+        charCode = resource[2];
+      }
+      else {
+        charCode = parseInt(qx.theme.manager.Font.getInstance().resolve(source.match(/@([^/]+)\/(.*)$/)[2]), 16);
+        if (qx.core.Environment.get("qx.debug")) {
+          qx.core.Assert.assertNumber(charCode, "Font source: " + source +" needs either a glyph name or the unicode number in hex");
+        }
+      }
+      return charCode;
     }
   },
 


### PR DESCRIPTION
working code from Image.js for Icon font paths containing the size, e.g. `@MaterialIcons/home/16` now also called from Decoration.js, e.g. used in cellrenderer.Image.