### PR TITLE
Fix TextArea's autoSize behaviour on android tablets.

### DIFF
--- a/source/class/qx/ui/form/TextArea.js
+++ b/source/class/qx/ui/form/TextArea.js
@@ -186,7 +186,7 @@ qx.Class.define("qx.ui.form.TextArea",
           // Remember original area height
           this.__originalAreaHeight = this.__originalAreaHeight || this._getAreaHeight();
 
-          var scrolledHeight = this._getScrolledAreaHeight();
+          var scrolledHeight = Math.round(this._getScrolledAreaHeight());
 
           // Show scroll-bar when above maxHeight, if defined
           if (this.getMaxHeight()) {


### PR DESCRIPTION
the scrollTop value used to calculate the TextArea's height might be fractional in some cases (e.g. on an
android tablet with opened virtual keyboard). That breaks assertions in dimension values some layout managers (they expect integers).
And in these cases the autoSize feature of the TextArea is broken.

Rounding fixes the problem.

Initial error reported here: https://github.com/CometVisu/CometVisu/pull/1057#issuecomment-819035567