### PR TITLE
Treevirtual FontIcon support

### DIFF
--- a/source/class/qx/io/ImageLoader.js
+++ b/source/class/qx/io/ImageLoader.js
@@ -216,6 +216,16 @@ qx.Bootstrap.define("qx.io.ImageLoader",
           entry.callbacks.push(callback, context);
         }
 
+        var ResourceManager = qx.util.ResourceManager.getInstance();
+        if(ResourceManager.isFontUri(source))
+        {
+          var el = document.createElement('div');
+          var charCode = ResourceManager.fromFontUriToCharCode(source);
+          el.value = String.fromCharCode(charCode);
+          entry.element = el;
+          return;
+        }
+
         // Create image element
         var el = document.createElement('img');
 

--- a/source/class/qx/theme/tangible/Appearance.js
+++ b/source/class/qx/theme/tangible/Appearance.js
@@ -723,10 +723,10 @@ qx.Theme.define("qx.theme.tangible.Appearance", {
         }
       },
 
-    "treevirtual-line":
+    "treevirtual-blank":
       {
         style: function(states) {
-          return {icon: qx.theme.tangible.Image.URLS["treevirtual-line"]};
+          return {icon: qx.theme.tangible.Image.URLS["blank"]};
         }
       },
 
@@ -752,21 +752,9 @@ qx.Theme.define("qx.theme.tangible.Appearance", {
     "treevirtual-end-expand" : "treevirtual-expand",
     "treevirtual-cross-contract" : "treevirtual-contract",
     "treevirtual-cross-expand" : "treevirtual-expand",
-
-    "treevirtual-end":
-      {
-        style: function(states) {
-          return {icon: qx.theme.tangible.Image.URLS["treevirtual-end"]};
-        }
-      },
-
-    "treevirtual-cross":
-      {
-        style: function(states) {
-          return {icon: qx.theme.tangible.Image.URLS["treevirtual-cross"]};
-        }
-      },
-
+    "treevirtual-line" : "treevirtual-blank",
+    "treevirtual-end" : "treevirtual-blank",
+    "treevirtual-cross" : "treevirtual-blank",
 
     /*
     ---------------------------------------------------------------------------

--- a/source/class/qx/theme/tangible/Appearance.js
+++ b/source/class/qx/theme/tangible/Appearance.js
@@ -703,8 +703,8 @@ qx.Theme.define("qx.theme.tangible.Appearance", {
         style: function(states) {
           return {
             icon: (states.opened ?
-              // the old treevirtual code can not use fonticons
-              "icon/16/places/folder-open.png" : "icon/16/places/folder.png"),
+              qx.theme.tangible.Image.URLS["folder-open"] :
+              qx.theme.tangible.Image.URLS["folder"]),
             opacity: states.drag ? 0.5 : undefined
           };
         }
@@ -717,7 +717,7 @@ qx.Theme.define("qx.theme.tangible.Appearance", {
 
         style: function(states) {
           return {
-            icon: "icon/16/mimetypes/text-plain.png",
+            icon: qx.theme.tangible.Image.URLS["file"],
             opacity: states.drag ? 0.5 : undefined
           };
         }

--- a/source/class/qx/theme/tangible/Appearance.js
+++ b/source/class/qx/theme/tangible/Appearance.js
@@ -744,62 +744,14 @@ qx.Theme.define("qx.theme.tangible.Appearance", {
         }
       },
 
-    "treevirtual-only-contract":
-      {
-        style: function(states) {
-          return {icon: qx.theme.tangible.Image.URLS["treevirtual-minus-only"]};
-        }
-      },
-
-    "treevirtual-only-expand":
-      {
-        style: function(states) {
-          return {icon: qx.theme.tangible.Image.URLS["treevirtual-plus-only"]};
-        }
-      },
-
-    "treevirtual-start-contract":
-      {
-        style: function(states) {
-          return {icon: qx.theme.tangible.Image.URLS["treevirtual-minus-start"]};
-        }
-      },
-
-    "treevirtual-start-expand":
-      {
-        style: function(states) {
-          return {icon: qx.theme.tangible.Image.URLS["treevirtual-plus-start"]};
-        }
-      },
-
-    "treevirtual-end-contract":
-      {
-        style: function(states) {
-          return {icon: qx.theme.tangible.Image.URLS["treevirtual-minus-end"]};
-        }
-      },
-
-    "treevirtual-end-expand":
-      {
-        style: function(states) {
-          return {icon: qx.theme.tangible.Image.URLS["treevirtual-plus-end"]};
-        }
-      },
-
-    "treevirtual-cross-contract":
-      {
-        style: function(states) {
-          return {icon: qx.theme.tangible.Image.URLS["treevirtual-minus-cross"]};
-        }
-      },
-
-    "treevirtual-cross-expand":
-      {
-        style: function(states) {
-          return {icon: qx.theme.tangible.Image.URLS["treevirtual-plus-cross"]};
-        }
-      },
-
+    "treevirtual-only-contract" : "treevirtual-contract",
+    "treevirtual-only-expand" : "treevirtual-expand",
+    "treevirtual-start-contract" : "treevirtual-contract",
+    "treevirtual-start-expand" : "treevirtual-expand",
+    "treevirtual-end-contract" : "treevirtual-contract",
+    "treevirtual-end-expand" : "treevirtual-expand",
+    "treevirtual-cross-contract" : "treevirtual-contract",
+    "treevirtual-cross-expand" : "treevirtual-expand",
 
     "treevirtual-end":
       {

--- a/source/class/qx/theme/tangible/Image.js
+++ b/source/class/qx/theme/tangible/Image.js
@@ -82,7 +82,7 @@ qx.Class.define("qx.theme.tangible.Image",
       "knob-horizontal" : "@MaterialIcons/drag_indicator/12",
       "knob-vertical" : "@MaterialIcons/drag_handle/12",
 
-      // tree (someone is using this without fonticon support)
+      // tree
       "tree-minus" : "@MaterialIcons/arrow_drop_down/16",
       "tree-plus" : "@MaterialIcons/arrow_right/16",
 
@@ -93,14 +93,6 @@ qx.Class.define("qx.theme.tangible.Image",
 
       // tree virtual
       "treevirtual-line" : "decoration/treevirtual/line.gif",
-      "treevirtual-minus-only" : "decoration/treevirtual/only_minus.gif",
-      "treevirtual-plus-only" : "decoration/treevirtual/only_plus.gif",
-      "treevirtual-minus-start" : "decoration/treevirtual/start_minus.gif",
-      "treevirtual-plus-start" : "decoration/treevirtual/start_plus.gif",
-      "treevirtual-minus-end" : "decoration/treevirtual/end_minus.gif",
-      "treevirtual-plus-end" : "decoration/treevirtual/end_plus.gif",
-      "treevirtual-minus-cross" : "decoration/treevirtual/cross_minus.gif",
-      "treevirtual-plus-cross" : "decoration/treevirtual/cross_plus.gif",
       "treevirtual-end" : "decoration/treevirtual/end.gif",
       "treevirtual-cross" : "decoration/treevirtual/cross.gif",
       "folder-open": "@MaterialIcons/folder_open/15",

--- a/source/class/qx/theme/tangible/Image.js
+++ b/source/class/qx/theme/tangible/Image.js
@@ -92,9 +92,6 @@ qx.Class.define("qx.theme.tangible.Image",
       "table-descending" : "@MaterialIcons/keyboard_arrow_down/14",
 
       // tree virtual
-      "treevirtual-line" : "decoration/treevirtual/line.gif",
-      "treevirtual-end" : "decoration/treevirtual/end.gif",
-      "treevirtual-cross" : "decoration/treevirtual/cross.gif",
       "folder-open": "@MaterialIcons/folder_open/15",
       "folder": "@MaterialIcons/folder/15",
       "file": "@MaterialIcons/insert_drive_file/15",

--- a/source/class/qx/ui/basic/Image.js
+++ b/source/class/qx/ui/basic/Image.js
@@ -823,6 +823,18 @@ qx.Class.define("qx.ui.basic.Image",
       }
     },
 
+    __setFontSize : function(el, width, height)
+    {
+      if (this.getScale()) {
+        el.setStyle("fontSize", (width > height ? height : width) + "px");
+      } else {
+        var source = this.getSource();
+        var sparts = source.split("/");
+        var size = parseInt(sparts[2] || qx.theme.manager.Font.getInstance().resolve(source.match(/@([^/]+)/)[1]).getSize());
+        el.setStyle("fontSize", size + "px");
+      }
+    },
+
     _applyDimension : function()
     {
       this.base(arguments);
@@ -831,16 +843,10 @@ qx.Class.define("qx.ui.basic.Image",
       if (isFont) {
         var el = this.getContentElement();
         if (el) {
-          if (this.getScale()) {
-            var hint = this.getSizeHint();
-            var width = this.getWidth() || hint.width || 40;
-            var height = this.getHeight() || hint.height || 40;
-            el.setStyle("fontSize", (width > height ? height : width) + "px");
-          }
-          else {
-            var font = qx.theme.manager.Font.getInstance().resolve(this.getSource().match(/@([^/]+)/)[1]);
-            el.setStyle("fontSize", font.getSize() + "px");
-          }
+          var hint = this.getSizeHint();
+          var width = this.getWidth() || hint.width || 40;
+          var height = this.getHeight() || hint.height || 40;
+          this.__setFontSize(el,width,height);
         }
       } else {
         this.__updateContentHint();
@@ -935,8 +941,6 @@ qx.Class.define("qx.ui.basic.Image",
       var isFont = source && qx.lang.String.startsWith(source, "@");
 
       if (isFont) {
-        var sparts = source.split("/");
-
         var ResourceManager = qx.util.ResourceManager.getInstance();
         var font = qx.theme.manager.Font.getInstance().resolve(source.match(/@([^/]+)/)[1]);
         var fontStyles = qx.lang.Object.clone(font.getStyles());
@@ -947,13 +951,7 @@ qx.Class.define("qx.ui.basic.Image",
         el.setStyle("verticalAlign", "middle");
         el.setStyle("textAlign", "center");
 
-        if (this.getScale()) {
-          el.setStyle("fontSize", (this.__width > this.__height ? this.__height : this.__width) + "px");
-        }
-        else {
-          var size = parseInt(sparts[2] || qx.theme.manager.Font.getInstance().resolve(source.match(/@([^/]+)/)[1]).getSize());
-          el.setStyle("fontSize", size + "px");
-        }
+        this.__setFontSize(el, this.__width, this.__height);
 
         var charCode = ResourceManager.fromFontUriToCharCode(source);
         el.setValue(String.fromCharCode(charCode));

--- a/source/class/qx/ui/treevirtual/SimpleTreeDataCellRenderer.js
+++ b/source/class/qx/ui/treevirtual/SimpleTreeDataCellRenderer.js
@@ -317,6 +317,10 @@ qx.Class.define("qx.ui.treevirtual.SimpleTreeDataCellRenderer",
         html.push('">');
       }
 
+      if(qx.lang.String.startsWith(source, "@")){
+        var content = qx.bom.element.Decoration.create(source, "no-repeat", {});
+        html.push(content);
+      }else{
       // Don't use an image tag.  They render differently in Firefox and IE7
       // even if both are enclosed in a div specified as content box.  Instead,
       // add the image as the background image of a div.
@@ -343,6 +347,7 @@ qx.Class.define("qx.ui.treevirtual.SimpleTreeDataCellRenderer",
       }
 
       html.push('">&nbsp;</div>');
+      }
 
       if (imageInfo.position)
       {

--- a/source/class/qx/ui/treevirtual/SimpleTreeDataCellRenderer.js
+++ b/source/class/qx/ui/treevirtual/SimpleTreeDataCellRenderer.js
@@ -317,36 +317,39 @@ qx.Class.define("qx.ui.treevirtual.SimpleTreeDataCellRenderer",
         html.push('">');
       }
 
-      if(qx.lang.String.startsWith(source, "@")){
+      if (qx.lang.String.startsWith(source, "@"))
+      {
         var content = qx.bom.element.Decoration.create(source, "no-repeat", {});
         html.push(content);
-      }else{
-      // Don't use an image tag.  They render differently in Firefox and IE7
-      // even if both are enclosed in a div specified as content box.  Instead,
-      // add the image as the background image of a div.
-      html.push('<div style="');
-      html.push('background-image:url(' + source + ');');
-      html.push('background-repeat:no-repeat;');
-
-      if (imageInfo.imageWidth && imageInfo.imageHeight)
-      {
-        html.push(
-          ';width:' +
-          imageInfo.imageWidth +
-          'px' +
-          ';height:' +
-          imageInfo.imageHeight +
-          'px');
       }
-
-      var tooltip = imageInfo.tooltip;
-
-      if (tooltip != null)
+      else
       {
-        html.push('" title="' + tooltip);
-      }
+        // Don't use an image tag.  They render differently in Firefox and IE7
+        // even if both are enclosed in a div specified as content box.  Instead,
+        // add the image as the background image of a div.
+        html.push('<div style="');
+        html.push('background-image:url(' + source + ');');
+        html.push('background-repeat:no-repeat;');
 
-      html.push('">&nbsp;</div>');
+        if (imageInfo.imageWidth && imageInfo.imageHeight)
+        {
+          html.push(
+            ';width:' +
+            imageInfo.imageWidth +
+            'px' +
+            ';height:' +
+            imageInfo.imageHeight +
+            'px');
+        }
+
+        var tooltip = imageInfo.tooltip;
+
+        if (tooltip != null)
+        {
+          html.push('" title="' + tooltip);
+        }
+
+        html.push('">&nbsp;</div>');
       }
 
       if (imageInfo.position)


### PR DESCRIPTION
This adds fonticon support to the table-based treevirtual, to allow proper styling in the new Tangible theme. 
See also [DemoBrowser](https://qooxdoo.org/qxl.demobrowser/#treevirtual~TreeVirtual.html), then select Tangible Dark theme.

Before: 
![TreeVirtual_Old](https://user-images.githubusercontent.com/6432001/119547296-3a404780-bd95-11eb-8a7d-849806f1793b.png)

After:
![TreeVirtual_new](https://user-images.githubusercontent.com/6432001/119547279-344a6680-bd95-11eb-9649-0bfcbd7f42ae.png)
