### PR TITLE
a bunch of compiler fixes

### DIFF
--- a/docs/development/compiler/configuration/compile.md
+++ b/docs/development/compiler/configuration/compile.md
@@ -76,6 +76,10 @@ The `applications` key is an array of objects, and each object can contain:
 - `name` - this is an arbitrary, but unique, short name for your application and
   should be filename and URL friendly - IE no spaces or special characters
 
+- `group` - this is either a string or an array of strings, and is used to group
+  applications together; by using the `--app-group` command line arg when compiling,
+  you can choose to only compile those application which have a given group name
+
 - `title` - (**optional**) this is the human readable, customer facing
   description used to set the `<title>` tag of the application web page, i.e. in
   the application's index.html

--- a/source/class/qx/tool/cli/Cli.js
+++ b/source/class/qx/tool/cli/Cli.js
@@ -418,7 +418,12 @@ Version: v${await qx.tool.config.Utils.getQxVersion()}
       let needLibraries = qx.lang.Type.isArray(this.argv._) && this.argv._[0] !== "clean";
       // check if libraries are loaded
       if (config.libraries && needLibraries) {
-        if (!config.libraries.every(libData => fs.existsSync(libData + "/Manifest.json"))) {
+        let neededLibraries = config.libraries.filter(libData => !fs.existsSync(libData + "/Manifest.json"));
+        if (neededLibraries.length) {
+          if (!fs.existsSync(qx.tool.config.Manifest.config.fileName)) { 
+            qx.tool.compiler.Console.error("Libraries are missing and there is no Manifest.json in the current directory so we cannot attempt to install them; the missing libraries are: \n     " + neededLibraries.join("\n     "));  
+            process.exit(1);
+          }
           qx.tool.compiler.Console.info("One or more libraries not found - trying to install them from library repository...");
           const installer = new qx.tool.cli.commands.package.Install({
             quiet: true,

--- a/source/class/qx/tool/cli/api/AbstractApi.js
+++ b/source/class/qx/tool/cli/api/AbstractApi.js
@@ -91,7 +91,7 @@ qx.Class.define("qx.tool.cli.api.AbstractApi", {
         stdio: "inherit"
       });
     }
-	
+  
 
   }
 });

--- a/source/class/qx/tool/cli/api/CompilerApi.js
+++ b/source/class/qx/tool/cli/api/CompilerApi.js
@@ -131,4 +131,3 @@ qx.Class.define("qx.tool.cli.api.CompilerApi", {
     }
   }
 });
-

--- a/source/class/qx/tool/cli/api/LibraryApi.js
+++ b/source/class/qx/tool/cli/api/LibraryApi.js
@@ -53,4 +53,3 @@ qx.Class.define("qx.tool.cli.api.LibraryApi", {
     
   }
 });
-

--- a/source/class/qx/tool/cli/commands/Clean.js
+++ b/source/class/qx/tool/cli/commands/Clean.js
@@ -57,6 +57,9 @@ qx.Class.define("qx.tool.cli.commands.Clean", {
         }
       }
       await this.__removePath(path.join(process.cwd(), qx.tool.cli.commands.Package.cache_dir));
+      
+      // check if we have to migrate files
+      await this.checkMigrations();
     },
 
     __removePath: async function(pathToRemove) {

--- a/source/class/qx/tool/cli/commands/Command.js
+++ b/source/class/qx/tool/cli/commands/Command.js
@@ -61,8 +61,6 @@ qx.Class.define("qx.tool.cli.commands.Command", {
           }
         });
       }
-      // check if we have to migrate files
-      await this.checkMigrations();
     },
 
     /**

--- a/source/class/qx/tool/cli/commands/Lint.js
+++ b/source/class/qx/tool/cli/commands/Lint.js
@@ -179,4 +179,3 @@ qx.Class.define("qx.tool.cli.commands.Lint", {
     }
   }
 });
-

--- a/source/class/qx/tool/cli/commands/Run.js
+++ b/source/class/qx/tool/cli/commands/Run.js
@@ -189,4 +189,3 @@ qx.Class.define("qx.tool.cli.commands.Run", {
     }, "error");
   }
 });
-

--- a/source/class/qx/tool/cli/commands/Serve.js
+++ b/source/class/qx/tool/cli/commands/Serve.js
@@ -220,4 +220,3 @@ qx.Class.define("qx.tool.cli.commands.Serve", {
     });
   }
 });
-

--- a/source/class/qx/tool/cli/commands/Test.js
+++ b/source/class/qx/tool/cli/commands/Test.js
@@ -207,4 +207,3 @@ qx.Class.define("qx.tool.cli.commands.Test", {
     }
   }
 });
-

--- a/source/class/qx/tool/compiler/Analyser.js
+++ b/source/class/qx/tool/compiler/Analyser.js
@@ -71,6 +71,12 @@ qx.Class.define("qx.tool.compiler.Analyser", {
       check: "String"
     },
 
+    /** Supported application types */
+    applicationTypes: {
+      init: [ "node", "browser" ],
+      check: "Array"
+    },
+
     /** Whether to preserve line numbers */
     trackLineNumbers: {
       check: "Boolean",
@@ -1368,4 +1374,3 @@ qx.Class.define("qx.tool.compiler.Analyser", {
     }
   }
 });
-

--- a/source/class/qx/tool/compiler/ClassFile.js
+++ b/source/class/qx/tool/compiler/ClassFile.js
@@ -1365,7 +1365,8 @@ qx.Class.define("qx.tool.compiler.ClassFile", {
             ForOfStatement: 1,
             TaggedTemplateExpression: 1,
             ClassExpression: 1,
-            OptionalCallExpression: 1
+            OptionalCallExpression: 1,
+            JSXExpressionContainer: 1
           };
           let root = path;
           while (root) {

--- a/source/class/qx/tool/compiler/ClassFile.js
+++ b/source/class/qx/tool/compiler/ClassFile.js
@@ -402,7 +402,10 @@ qx.Class.define("qx.tool.compiler.ClassFile", {
             callback(err);
             return;
           }
-          fs.writeFile(outputPath, result.code + "\n\n//# sourceMappingURL=" + name + ".js.map?dt=" + (new Date().getTime()), {encoding: "utf-8"}, function(err) {
+          let mappingUrl = name + ".js.map";
+          if (qx.lang.Array.contains(t.__analyser.getApplicationTypes(), "browser"))
+            mappingUrl += "?dt=" + (new Date().getTime());
+          fs.writeFile(outputPath, result.code + "\n\n//# sourceMappingURL=" + mappingUrl, {encoding: "utf-8"}, function(err) {
             if (err) {
               callback(err);
               return;
@@ -2664,4 +2667,3 @@ qx.Class.define("qx.tool.compiler.ClassFile", {
   }
 
 });
-

--- a/source/class/qx/tool/compiler/Console.js
+++ b/source/class/qx/tool/compiler/Console.js
@@ -212,6 +212,7 @@ qx.Class.define("qx.tool.compiler.Console", {
       "qx.tool.compiler.environment.unreachable": "Environment check '%1' may be indeterminable, add to Manifest/provides/environment or use class name prefix",
 
       "qx.tool.compiler.target.missingAppLibrary": "Cannot find the application library for %1",
+      "qx.tool.compiler.webfonts.noResources": "Assets required for webfont %1 are not available in application %2, consider using @asset to include %3",
       "qx.tool.compiler.target.missingBootJs": "There is no reference to index.js script in the index.html copied from %1 (see https://git.io/fh7NI)",
       /* eslint-disable no-template-curly-in-string */
       "qx.tool.compiler.target.missingPreBootJs": "There is no reference to ${preBootJs} in the index.html copied from %1 (see https://git.io/fh7NI)",

--- a/source/class/qx/tool/compiler/jsdoc/Parser.js
+++ b/source/class/qx/tool/compiler/jsdoc/Parser.js
@@ -145,4 +145,3 @@ qx.Class.define("qx.tool.compiler.jsdoc.Parser", {
     }
   }
 });
-

--- a/source/class/qx/tool/compiler/resources/AbstractMatcher.js
+++ b/source/class/qx/tool/compiler/resources/AbstractMatcher.js
@@ -61,8 +61,11 @@ qx.Class.define("qx.tool.compiler.resources.AbstractMatcher", {
     /**
      * Called to determine whether this handler is appropriate for the given filename;
      * default implementation is to check the RegEx passed to the constructor
+     * 
+     * @param filename {String} the name of the resource
+     * @param library {qx.tool.compiler.app.Library} the library its in
      */
-    matches: function(filename) {
+    matches: function(filename, library) {
       return this.__match !== null && this.__match(filename);
     }
   }

--- a/source/class/qx/tool/compiler/resources/ImageLoader.js
+++ b/source/class/qx/tool/compiler/resources/ImageLoader.js
@@ -32,6 +32,9 @@ qx.Class.define("qx.tool.compiler.resources.ImageLoader", {
   },
 
   members: {
+    /**
+     * @Override
+     */
     needsLoad(filename, fileInfo, stat) {
       if (!fileInfo || fileInfo.width === undefined || fileInfo.height === undefined) {
         return true;
@@ -39,6 +42,23 @@ qx.Class.define("qx.tool.compiler.resources.ImageLoader", {
       return this.base(arguments, filename, fileInfo, stat);
     },
 
+    /**
+     * @Override
+     */
+    matches: function(filename, library) {
+      if (filename.endsWith("svg")) {
+        let isWebFont = library.getWebFonts().find(webFont => webFont.getResources().find(resource => resource == filename));
+        if (isWebFont)
+          return false;
+      }
+
+      return this.base(arguments, filename, library);
+    },
+
+
+    /**
+     * @Override
+     */
     async load(asset) {
       let filename = asset.getSourceFilename();
       let fileInfo = asset.getFileInfo();

--- a/source/class/qx/tool/compiler/resources/ImageLoader.js
+++ b/source/class/qx/tool/compiler/resources/ImageLoader.js
@@ -47,7 +47,7 @@ qx.Class.define("qx.tool.compiler.resources.ImageLoader", {
      */
     matches: function(filename, library) {
       if (filename.endsWith("svg")) {
-        let isWebFont = library.getWebFonts().find(webFont => webFont.getResources().find(resource => resource == filename));
+        let isWebFont = library.getWebFonts() && library.getWebFonts().find(webFont => webFont.getResources().find(resource => resource == filename));
         if (isWebFont)
           return false;
       }

--- a/source/class/qx/tool/compiler/resources/Manager.js
+++ b/source/class/qx/tool/compiler/resources/Manager.js
@@ -338,8 +338,8 @@ qx.Class.define("qx.tool.compiler.resources.Manager", {
         }
       });
 
-      asset.setLoaders(this.__loaders.filter(loader => loader.matches(filename)));
-      asset.setConverters(this.__converters.filter(converter => converter.matches(filename)));
+      asset.setLoaders(this.__loaders.filter(loader => loader.matches(filename, library)));
+      asset.setConverters(this.__converters.filter(converter => converter.matches(filename, library)));
     },
 
     /**

--- a/source/class/qx/tool/compiler/targets/Target.js
+++ b/source/class/qx/tool/compiler/targets/Target.js
@@ -454,13 +454,13 @@ qx.Class.define("qx.tool.compiler.targets.Target", {
       ];      
       
       var fontCntr = 0;
-      if (analyser.getApplicationTypes().indexOf("browser") > -1) {
-        var assets = {};
-        rm.getAssetsForPaths(assetUris).forEach(asset => {
-          bootPackage.addAsset(asset);
-          assets[asset.getFilename()] = asset.toString();
-        });
+      var assets = {};
+      rm.getAssetsForPaths(assetUris).forEach(asset => {
+        bootPackage.addAsset(asset);
+        assets[asset.getFilename()] = asset.toString();
+      });
 
+      if (analyser.getApplicationTypes().indexOf("browser") > -1) {
         requiredLibs.forEach(libnamespace => {
           var library = analyser.findLibrary(libnamespace);
           var fonts = library.getWebFonts();

--- a/source/class/qx/tool/compiler/targets/meta/Part.js
+++ b/source/class/qx/tool/compiler/targets/meta/Part.js
@@ -50,4 +50,3 @@ qx.Class.define("qx.tool.compiler.targets.meta.Part", {
     }
   }
 });
-

--- a/source/class/qx/tool/config/Utils.js
+++ b/source/class/qx/tool/config/Utils.js
@@ -29,6 +29,8 @@ const semver = require("semver");
 qx.Class.define("qx.tool.config.Utils", {
   type: "static",
   statics: {
+    /** @type{Promise<String} promise for cache of getQxPath() */
+    __qxPathPromise: null,
 
     /**
      * Returns data on the project in the currect working directory.
@@ -137,47 +139,61 @@ qx.Class.define("qx.tool.config.Utils", {
      * @param {String?} dir The base directory. If not given, the current working dir is used
      * @return {Promise<*string>}
      */
-
-     async __getQxPath(dir) {
-       let root = path.parse(dir).root;
-       while (dir !== root) {
-         // 1. Manifest.json files
-         if (await this.isQxLibrary(dir)) {
-           return dir;
-         }
-         // 2. node_modules folders
-         let npmdir = path.join(dir, "node_modules", "@qooxdoo", "framework")
-         if (await this.isQxLibrary(npmdir)) {
-           return npmdir;
-         }
-         // walk up the directory tree
-         dir = path.resolve(path.join(dir, ".."));
-       }
-       return null;
-     },
-
-     async getQxPath(dir=null) {
-      // 1. current dir
-      let res = await this.__getQxPath(path.resolve(dir || process.cwd()));
-      if (res) {
-        return res;
+    async getQxPath() {
+      if (this.__qxPathPromise) {
+        return await this.__qxPathPromise;
       }
 
-      // 2. try script dir
-      /* eslint-disable-next-line @qooxdoo/qx/no-illegal-private-usage */
-      res = await this.__getQxPath(__dirname);
-      if (res) {
-        return res;
-      }
+      const scanAncestors = async dir => {
+        let root = path.parse(dir).root;
+        while (dir !== root) {
+          // 1. Manifest.json files
+          if (await this.isQxLibrary(dir)) {
+            return dir;
+          }
+          // 2. node_modules folders
+          let npmdir = path.join(dir, "node_modules", "@qooxdoo", "framework")
+          if (await this.isQxLibrary(npmdir)) {
+            return npmdir;
+          }
+          // walk up the directory tree
+          dir = path.resolve(path.join(dir, ".."));
+        }
+        return null;
+      };
 
-      // 3. global npm package
-      let npmdir = (await qx.tool.utils.Utils.exec("npm root -g")).trim();
-      res = path.join(npmdir, "@qooxdoo", "framework");
-      if (await this.isQxLibrary(res)) {
-        return res;
-      }
+      const getQxPathImpl = async () => {
+        // 1. Look for the parent directory of the currently running command (eg `qx`)
+        let res = await scanAncestors(path.parse(require.main.filename).dir);
+        if (res) {
+          return res;
+        }
 
-      throw new qx.tool.utils.Utils.UserError(`Path to the qx library cannot be determined.`);
+        // 2. current dir
+        res = await scanAncestors(path.resolve(process.cwd()));
+        if (res) {
+          return res;
+        }
+
+        // 3. try script dir
+        /* eslint-disable-next-line @qooxdoo/qx/no-illegal-private-usage */
+        res = await scanAncestors(__dirname);
+        if (res) {
+          return res;
+        }
+
+        // 4. global npm package
+        let npmdir = (await qx.tool.utils.Utils.exec("npm root -g")).trim();
+        res = path.join(npmdir, "@qooxdoo", "framework");
+        if (await this.isQxLibrary(res)) {
+          return res;
+        }
+
+        throw new qx.tool.utils.Utils.UserError(`Path to the qx library cannot be determined.`);
+      };
+  
+      this.__qxPathPromise = getQxPathImpl();
+      return await this.__qxPathPromise;
     },
 
     /**
@@ -192,45 +208,12 @@ qx.Class.define("qx.tool.config.Utils", {
     },
 
     /**
-     * Returns the absolute path to the qooxdoo framework used by the current
-     * project, If the application does not specify a path, it is taken from the
-     * environment. Throws if no path can be determined.
-     *
-     * @param {String?} dir The base directory. If not given, the current working dir is used
-     * @return {Promise<String>} Promise that resolves with the path {String}
-     */
-    async getAppQxPath(dir=null) {
-      dir = dir || process.cwd();
-      // if there is no compile.json file, throw
-      if (!await this.applicationExists(dir)) {
-        throw new qx.tool.utils.Utils.UserError(`No compilable application exists in ${dir}.`);
-      }
-      // 1. check `libraries` key of compile.json which overrides anything else
-      let compileJsonModel = await qx.tool.config.Compile.getInstance().set({baseDir: dir}).load();
-      let appPath = await this.getApplicationPath();
-      let libraries = compileJsonModel.getValue("libraries");
-      if (libraries) {
-        for (let somepath of libraries) {
-          let libraryPath = somepath;
-          if (!path.isAbsolute(somepath)) {
-            libraryPath = path.join(appPath, libraryPath);
-          }
-          if (await this.isQxLibrary(libraryPath)) {
-            return libraryPath;
-          }
-        }
-      }
-      // 2. node_modules etc.
-      return this.getQxPath(dir);
-    },
-
-    /**
      * Returns the qooxdoo version from the current environment (not the application)
      * @param {String?} dir The base directory. If not given, the current working dir is used
      * @return {Promise<String>}
      */
-    async getQxVersion(dir=null) {
-      let qxpath = await this.getQxPath(dir);
+    async getQxVersion() {
+      let qxpath = await this.getQxPath();
       return qx.tool.config.Utils.getLibraryVersion(qxpath);
     },
 

--- a/source/class/qx/tool/migration/M7_0_0.js
+++ b/source/class/qx/tool/migration/M7_0_0.js
@@ -61,4 +61,3 @@ qx.Class.define("qx.tool.migration.M7_0_0", {
     }
   }
 });
-

--- a/source/class/qx/tool/utils/LogManager.js
+++ b/source/class/qx/tool/utils/LogManager.js
@@ -184,5 +184,3 @@ qx.Class.define("qx.tool.utils.LogManager", {
     }
   }
 });
-
-

--- a/source/class/qx/tool/utils/Logger.js
+++ b/source/class/qx/tool/utils/Logger.js
@@ -81,4 +81,3 @@ qx.Class.define("qx.tool.utils.Logger", {
 
   }
 });
-

--- a/source/class/qx/tool/utils/files/FindFiles.js
+++ b/source/class/qx/tool/utils/files/FindFiles.js
@@ -91,4 +91,3 @@ qx.Class.define("qx.tool.utils.files.FindFiles", {
   }
 
 });
-

--- a/source/class/qx/tool/utils/files/Utils.js
+++ b/source/class/qx/tool/utils/files/Utils.js
@@ -326,4 +326,3 @@ qx.Class.define("qx.tool.utils.files.Utils", {
     }
   }
 });
-

--- a/source/class/qx/tool/utils/json/Tokenizer.js
+++ b/source/class/qx/tool/utils/json/Tokenizer.js
@@ -596,4 +596,3 @@ qx.Class.define("qx.tool.utils.json.Tokenizer", {
 
   }
 });
-

--- a/source/resource/qx/tool/schema/compile-1-0-0.json
+++ b/source/resource/qx/tool/schema/compile-1-0-0.json
@@ -73,6 +73,22 @@
             "description": "An arbitrary, but unique, short name for the application. Should be filename and URL friendly - IE no spaces or special characters",
             "type": "string"
           },
+          "group": {
+            "description": "An arbitrary, but unique, short name for grouping applications. Should be filename and URL friendly - IE no spaces or special characters",
+            "anyOf": [
+              {
+                "type": "string",
+                "pattern": "^[-_a-zA-Z0-9]+$"
+              }, 
+              {
+                "type": "array",
+                "items": {
+                  "type": "string",
+                  "pattern": "^[-_a-zA-Z0-9]+$"
+                }
+              }
+            ]
+          },
           "title": {
             "description": "The human readable, customer facing name used to set the <title> tag of the application web page, i.e. in the application's index.html",
             "type": "string"


### PR DESCRIPTION
fixes a bug where a missing Manifest.json in compile.json directory breaks the compile;
stops running migrations for every compile;
adds application groups to the compile (so that a set of applications can be chosen for compilation from the command line)
fixes a bug where the sourcemapping URL is broken in some IDEs (eg VS code)
fixes a bug in resolving the Qooxdoo path, it now favours the qooxdoo that the `qx` command is in