### PR TITLE
add a timeStamp macro to the compiler

### DIFF
--- a/docs/development/compiler/internals/CustomAppStartup.md
+++ b/docs/development/compiler/internals/CustomAppStartup.md
@@ -57,6 +57,7 @@ The template variables supported are:
 - `appPath` - a relative path to the application's output folder
 - `preBootJs` - a code snippet to be placed in index.html immediately before the
   boot.js script is loaded
+- `timeStamp` - seconds since epoch at compile/deploy time which could be used to prevent browser caching in URLs
 
 Note that previous version of the compiler would also add a `<script>` tag which
 links to `boot.js` but this is now also done by template replacements - you MUST

--- a/source/class/qx/tool/compiler/targets/Target.js
+++ b/source/class/qx/tool/compiler/targets/Target.js
@@ -776,14 +776,16 @@ qx.Class.define("qx.tool.compiler.targets.Target", {
       }
 
       var resDir = this.getApplicationRoot(application);
-
+      
+      let timeStamp = (new Date()).getTime();
       let pathToTarget = path.relative(path.join(t.getOutputDir(), t.getProjectDir(application)), t.getOutputDir()) + "/";
       let TEMPLATE_VARS = {
         "resourcePath": pathToTarget + "resource/",
         "targetPath": pathToTarget,
         "appPath": "",
         "preBootJs": "",
-        "appTitle": (application.getTitle()||"Qooxdoo Application")
+        "appTitle": (application.getTitle()||"Qooxdoo Application"),
+        "timeStamp": timeStamp
       };
 
       function replaceVars(code) {
@@ -853,7 +855,8 @@ qx.Class.define("qx.tool.compiler.targets.Target", {
           "targetPath": "",
           "appPath": t.getProjectDir(application) + "/",
           "preBootJs": "",
-          "appTitle": (application.getTitle()||"Qooxdoo Application")
+          "appTitle": (application.getTitle()||"Qooxdoo Application"),
+          "timeStamp": timeStamp
         };
         await fs.writeFileAsync(t.getOutputDir() + "index.html", replaceVars(indexHtml), { encoding: "utf8" });
       }


### PR DESCRIPTION
`${timeStamp}` macro which is replaced by the seconds since epoch at compile/deploy time which could be used to prevent browser caching in URLs