### PR TITLE
Update example of calling static members from subclass

### DIFF
--- a/docs/core/oo_feature_summary.md
+++ b/docs/core/oo_feature_summary.md
@@ -122,11 +122,13 @@ qx.Class.define('B'), {
   extend: A,
   members: {
      e: function() {
-        this.superclass.self(arguments).f();
+        this.constructor.superclass.f();
      }
   }
 });
 ```
+
+Generally, it's easier (and more obvious to readers), to simply use the fully-qualified name: `A.f()` (instead of `this.constructor.superclass.f();`).
 
 Static functions can access other static functions directly through the `this`
 keyword.


### PR DESCRIPTION
The suggested way to call a static member from a subclass was wrong. The proposed change corrects the mistake.

See discussion in Gitter at https://gitter.im/qooxdoo/qooxdoo?at=60e275beb60c3137c3aaf2ad .