### PR TITLE
fixes a bug where it was impossible to use a splitpane without a `flex:1`

### DIFF
--- a/source/class/qx/ui/splitpane/HLayout.js
+++ b/source/class/qx/ui/splitpane/HLayout.js
@@ -94,11 +94,11 @@ qx.Class.define("qx.ui.splitpane.HLayout",
         var beginFlex = begin.getLayoutProperties().flex;
         var endFlex = end.getLayoutProperties().flex;
 
-        if (beginFlex == null) {
+        if (beginFlex === undefined || beginFlex === null) {
           beginFlex = 1;
         }
 
-        if (endFlex == null) {
+        if (endFlex === undefined || endFlex === null) {
           endFlex = 1;
         }
 

--- a/source/class/qx/ui/splitpane/Pane.js
+++ b/source/class/qx/ui/splitpane/Pane.js
@@ -347,7 +347,7 @@ qx.Class.define("qx.ui.splitpane.Pane",
      */
     add : function(widget, flex)
     {
-      if (flex == null) {
+      if (flex === undefined) {
         this._add(widget);
       } else {
         this._add(widget, {flex : flex});

--- a/source/class/qx/ui/splitpane/VLayout.js
+++ b/source/class/qx/ui/splitpane/VLayout.js
@@ -94,11 +94,11 @@ qx.Class.define("qx.ui.splitpane.VLayout",
         var beginFlex = begin.getLayoutProperties().flex;
         var endFlex = end.getLayoutProperties().flex;
 
-        if (beginFlex == null) {
+        if (beginFlex === undefined || beginFlex === null) {
           beginFlex = 1;
         }
 
-        if (endFlex == null) {
+        if (endFlex === undefined || endFlex === null) {
           endFlex = 1;
         }
 


### PR DESCRIPTION
the layouts were written to support a flex of zero, but because `==` was used instead of `===` this was effectively disabled.

In order to keep BC, the default option is to assume a flex of `1`, but with this PR you can now explicitly choose a flex of `0`.