### PR TITLE
Fixes a crash in node

### DIFF
--- a/source/resource/qx/tool/cli/templates/loader/loader-node.tmpl.js
+++ b/source/resource/qx/tool/cli/templates/loader/loader-node.tmpl.js
@@ -5,6 +5,7 @@
   if (typeof window === "undefined")
     window = this;
   window.addEventListener = function() {};
+  window.removeEventListener = function() {};
   window.dispatchEvent = function() {};
 
   if (!window.navigator) window.navigator = {};


### PR DESCRIPTION
adds another method to the node `window` emulation - it is required by the framework and exceptions are raised without it