### PR TITLE
Backport for bug in classes

### DIFF
--- a/framework/source/class/qx/Interface.js
+++ b/framework/source/class/qx/Interface.js
@@ -538,6 +538,12 @@ qx.Bootstrap.define("qx.Interface",
         }
 
         origFunction.wrapper = wrappedFunction;
+        if (origFunction.base !== undefined) {
+          if (wrappedFunction.base !== undefined) {
+            throw new Error("base is already defined for the wrapped function");
+          }
+          wrappedFunction.base = origFunction.base;
+        }
         return wrappedFunction;
       },
 


### PR DESCRIPTION
This fixes a critical bug where interface definitions can corrupt the inheritance data for methods when methods are wrapped;
Backport of https://github.com/qooxdoo/qooxdoo/pull/10267