### PR TITLE
fixes to use qooxdo as package

### DIFF
--- a/Manifest.json
+++ b/Manifest.json
@@ -177,7 +177,6 @@
     }
   },
   "requires": {
-    "@qooxdoo/compiler": "^1.0.3",
-    "@qooxdoo/framework": "^6.0.2"
+    "@qooxdoo/framework": "^7.0.0-beta.0"
   }
 }

--- a/compile.js
+++ b/compile.js
@@ -1,4 +1,4 @@
-const path = require("upath");
+const path = require("path");
 
 qx.Class.define("qx.compiler.CompilerApi", {
   extend: qx.tool.cli.api.CompilerApi,

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@qooxdoo/framework",
-  "version": "7.0.0-beta.0",
+  "version": "7.0.0-beta.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -5275,9 +5275,9 @@
       "integrity": "sha1-BF+XgtARrppoA93TgrJDkrPYkPc="
     },
     "set-value": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/set-value/-/set-value-4.0.1.tgz",
-      "integrity": "sha512-ayATicCYPVnlNpFmjq2/VmVwhoCQA9+13j8qWp044fmFE3IFphosPtRM+0CJ5xoIx5Uy52fCcwg3XeH2pHbbPQ==",
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/set-value/-/set-value-3.0.2.tgz",
+      "integrity": "sha512-npjkVoz+ank0zjlV9F47Fdbjfj/PfXyVhZvGALWsyIYU/qrMzpi6avjKW3/7KeSU2Df3I46BrN1xOI1+6vW0hA==",
       "requires": {
         "is-plain-object": "^2.0.4"
       },

--- a/package.json
+++ b/package.json
@@ -90,7 +90,7 @@
     "rimraf": "^3.0.2",
     "sass": "^1.34.1",
     "semver": "^7.3.4",
-    "set-value": "^4.0.1",
+    "set-value": "^3.0.2",
     "showdown": "^1.9.1",
     "source-map": "^0.5.7",
     "tap-colorize": "^1.2.0",

--- a/source/class/qx/tool/compiler/Version.js
+++ b/source/class/qx/tool/compiler/Version.js
@@ -15,6 +15,6 @@
 qx.Class.define("qx.tool.compiler.Version", {
   extend: qx.core.Object,
   statics: {
-    VERSION: "7.0.0-beta"
+    VERSION: "7.0.0-beta.1"
   }
 });

--- a/test/tool/integrationtest/test-qx-package.js
+++ b/test/tool/integrationtest/test-qx-package.js
@@ -1,7 +1,6 @@
 const test = require("tape");
 const fs = require("fs");
 const testUtils = require("../../../bin/tools/utils");
-const fsPromises = testUtils.fsPromises;
 const path = require("path");
 const testDir = path.join(__dirname, "test-qx-package");
 const appDir = path.join(testDir, "myapp");
@@ -34,7 +33,7 @@ test("Create app", async assert => {
 test("Install qxl.test1, latest version", async assert => {
   try {
     let result;
-    result = await testUtils.runCommand(appDir, qxCmdPath, "package", "install", "qooxdoo/qxl.test1");
+    result = await testUtils.runCommand(appDir, qxCmdPath, "package", "install", "qooxdoo/qxl.test1@latest");
     assert.ok(result.exitCode === 0);
     result = await testUtils.runCommand(appDir, qxCmdPath, "package", "list", "--short", "--noheaders", "--installed", "--all");
     assert.ok(result.exitCode === 0);
@@ -52,7 +51,7 @@ test("Install qxl.test1, latest version", async assert => {
 test("Install qxl.test2/qxl.test2A, latest version", async assert => {
   try {
     let result;
-    result = await testUtils.runCommand(appDir, qxCmdPath, "package", "install", "qooxdoo/qxl.test2/qxl.test2A");
+    result = await testUtils.runCommand(appDir, qxCmdPath, "package", "install", "qooxdoo/qxl.test2/qxl.test2A@2.0.2");
     assert.ok(result.exitCode === 0);
     result = await testUtils.runCommand(appDir, qxCmdPath, "package", "list", "--short", "--noheaders", "--installed", "--all");
     assert.ok(result.exitCode === 0);


### PR DESCRIPTION
Manifest.json: remove @qooxdoo/compiler, it's not laodable as package
compile.js: s/upath/path, upath is not node standard,