### PR TITLE
Adds ARIA role to window and aria helper functions to widget

### DIFF
--- a/docs/release-notes.md
+++ b/docs/release-notes.md
@@ -130,6 +130,7 @@ Accessibility is an important topic in nowadays webdevelopment in order to allow
 - Tabview
 - ToggleButton
 - Toolbar
+- Window
 
 Other components will follow.
 

--- a/source/class/qx/ui/core/Widget.js
+++ b/source/class/qx/ui/core/Widget.js
@@ -3827,7 +3827,74 @@ qx.Class.define("qx.ui.core.Widget",
 
 
 
+    /*
+    ---------------------------------------------------------------------------
+      ARIA attrs support
+    ---------------------------------------------------------------------------
+    */
+    
+    /**
+     * Sets the string which labels this widget. This will be read out by screenreaders. Needed if there is no
+     * readable text/label in this widget which would automatically act as aria-label.
+     * @param {String} label Labelling Text
+     */
+    setAriaLabel: function(label) {
+      this.getContentElement().setAttribute("aria-label", label);
+    },
 
+    /**
+     * Marks that this widget gets labelled by another widget. This will be read out by screenreaders as first
+     * information.
+     * Similiar to aria-label, difference being that the labelling widget is an different widget and multiple
+     * widgets can be added.
+     * @param {Array} labelWidgets Indefinite Number of labelling Widgets
+     */
+    addAriaLabelledBy: function(...labelWidgets) {
+      this.__addAriaXBy(labelWidgets, "aria-labelledby");
+    },
+
+    /**
+     * Marks that this widget gets described by another widget. This will be read out by screenreaders as last
+     * information. Multiple Widgets possible.
+     * @param {Array} describingWidgets Indefinite Number of describing Widgets
+     */
+    addAriaDescribedBy: function(...describingWidgets) {
+      this.__addAriaXBy(describingWidgets, "aria-describedby");
+    },
+
+    /**
+     * Sets either aria-labelledby or aria-describedby
+     * @param {Array} widgets Indefinite Number of widgets
+     * @param {String} ariaAttr aria-labelledby | aria-describedby
+     */
+    __addAriaXBy: function(widgets, ariaAttr) {
+      if (!["aria-labelledby", "aria-describedby"].includes(ariaAttr)) {
+        throw new Error("Only aria-labelledby or aria-describedby allowed!");
+      }
+      let idArr = [];
+      for (const widget of widgets) {
+        const contentEl = widget.getContentElement();
+        let widgetId = contentEl.getAttribute("id");
+        if (!widgetId) {
+          widgetId = `label-${widget.toHashCode()}`;
+          contentEl.setAttribute("id", widgetId);
+        }
+        if (!idArr.includes(widgetId)) {
+          idArr.push(widgetId);
+        }
+      }
+      if (idArr.length === 0) {
+        return;
+      }
+      const idStr = idArr.join(" ");
+      const contentEl = this.getContentElement();
+      let res = contentEl.getAttribute(ariaAttr);
+      res = res ? `${res} ${idStr}` : idStr;
+      contentEl.setAttribute(ariaAttr, res);
+    },
+
+
+    
     /*
     ---------------------------------------------------------------------------
       ENHANCED DISPOSE SUPPORT

--- a/source/class/qx/ui/core/Widget.js
+++ b/source/class/qx/ui/core/Widget.js
@@ -3836,7 +3836,7 @@ qx.Class.define("qx.ui.core.Widget",
     /**
      * Sets the string which labels this widget. This will be read out by screenreaders. Needed if there is no
      * readable text/label in this widget which would automatically act as aria-label.
-     * @param {String} label Labelling Text
+     * @param label {String} Labelling Text
      */
     setAriaLabel: function(label) {
       this.getContentElement().setAttribute("aria-label", label);
@@ -3847,7 +3847,7 @@ qx.Class.define("qx.ui.core.Widget",
      * information.
      * Similiar to aria-label, difference being that the labelling widget is an different widget and multiple
      * widgets can be added.
-     * @param {Array} labelWidgets Indefinite Number of labelling Widgets
+     * @param labelWidgets {qx.ui.core.Widget[]} Indefinite Number of labelling Widgets
      */
     addAriaLabelledBy: function(...labelWidgets) {
       this.__addAriaXBy(labelWidgets, "aria-labelledby");
@@ -3856,7 +3856,7 @@ qx.Class.define("qx.ui.core.Widget",
     /**
      * Marks that this widget gets described by another widget. This will be read out by screenreaders as last
      * information. Multiple Widgets possible.
-     * @param {Array} describingWidgets Indefinite Number of describing Widgets
+     * @param describingWidgets {qx.ui.core.Widget[]} Indefinite Number of describing Widgets
      */
     addAriaDescribedBy: function(...describingWidgets) {
       this.__addAriaXBy(describingWidgets, "aria-describedby");
@@ -3864,8 +3864,8 @@ qx.Class.define("qx.ui.core.Widget",
 
     /**
      * Sets either aria-labelledby or aria-describedby
-     * @param {Array} widgets Indefinite Number of widgets
-     * @param {String} ariaAttr aria-labelledby | aria-describedby
+     * @param widgets {qx.ui.core.Widget[]} Indefinite Number of widgets
+     * @param ariaAttr {String} aria-labelledby | aria-describedby
      */
     __addAriaXBy: function(widgets, ariaAttr) {
       if (!["aria-labelledby", "aria-describedby"].includes(ariaAttr)) {
@@ -3873,6 +3873,9 @@ qx.Class.define("qx.ui.core.Widget",
       }
       let idArr = [];
       for (const widget of widgets) {
+        if (!(widget instanceof qx.ui.core.Widget)) {
+          throw new Error("Given widget " + widget + " is not an instance of qx.ui.core.Widget!");
+        }
         const contentEl = widget.getContentElement();
         let widgetId = contentEl.getAttribute("id");
         if (!widgetId) {
@@ -3894,7 +3897,7 @@ qx.Class.define("qx.ui.core.Widget",
     },
 
 
-    
+
     /*
     ---------------------------------------------------------------------------
       ENHANCED DISPOSE SUPPORT

--- a/source/class/qx/ui/form/DateField.js
+++ b/source/class/qx/ui/form/DateField.js
@@ -616,7 +616,7 @@ qx.Class.define("qx.ui.form.DateField",
 
     // overridden
     addAriaDescribedBy: function(...describingWidgets) {
-      this.getChildControl("textfield").addAriaLabelledBy(describingWidgets);
+      this.getChildControl("textfield").addAriaDescribedBy(...describingWidgets);
     },
   },
 

--- a/source/class/qx/ui/form/DateField.js
+++ b/source/class/qx/ui/form/DateField.js
@@ -602,7 +602,22 @@ qx.Class.define("qx.ui.form.DateField",
 
       field.getFocusElement().focus();
       field.selectAllText();
-    }
+    },
+
+    // overridden
+    setAriaLabel: function(label) {
+      this.getChildControl("textfield").setAriaLabel(label);
+    },
+
+    // overridden
+    addAriaLabelledBy: function(...labelWidgets) {
+      this.getChildControl("textfield").addAriaLabelledBy(...labelWidgets);
+    },
+
+    // overridden
+    addAriaDescribedBy: function(...labelWidgets) {
+      this.getChildControl("textfield").addAriaLabelledBy(labelWidgets);
+    },
   },
 
 

--- a/source/class/qx/ui/form/DateField.js
+++ b/source/class/qx/ui/form/DateField.js
@@ -615,8 +615,8 @@ qx.Class.define("qx.ui.form.DateField",
     },
 
     // overridden
-    addAriaDescribedBy: function(...labelWidgets) {
-      this.getChildControl("textfield").addAriaLabelledBy(labelWidgets);
+    addAriaDescribedBy: function(...describingWidgets) {
+      this.getChildControl("textfield").addAriaLabelledBy(describingWidgets);
     },
   },
 

--- a/source/class/qx/ui/window/Window.js
+++ b/source/class/qx/ui/window/Window.js
@@ -102,6 +102,10 @@ qx.Class.define("qx.ui.window.Window",
 
     // Change the resize frames appearance
     this._getResizeFrame().setAppearance("window-resize-frame");
+    
+    // ARIA attrs
+    this.getContentElement().setAttribute("role", "dialog");
+    this.addAriaLabelledBy(this.getChildControl("title"));
   },
 
 
@@ -961,6 +965,9 @@ qx.Class.define("qx.ui.window.Window",
       } else {
         this.addState("modal");
       }
+      
+      // ARIA attrs
+      this.getContentElement().setAttribute("aria-modal", value);
     },
 
 

--- a/source/class/qx/ui/window/Window.js
+++ b/source/class/qx/ui/window/Window.js
@@ -106,6 +106,7 @@ qx.Class.define("qx.ui.window.Window",
     // ARIA attrs
     this.getContentElement().setAttribute("role", "dialog");
     this.addAriaLabelledBy(this.getChildControl("title"));
+    this.addAriaDescribedBy(this.getChildControl("statusbar-text"));
   },
 
 


### PR DESCRIPTION
I recognized that aria-label, aria-labelledby and aria-describedby are often needed when updating the code for screenreaders. The added functions in qx.ui.core.Widget help to achieve this.
This should be backportable. My only concern is the use of rest parameters (to achieve variadic functions). I checked https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Functions/rest_parameters and the supported Node Version is 6+. So this shouldn't be a problem, right?