### PR TITLE
Fix for UTC parsing not working correctly

### DIFF
--- a/source/class/qx/test/util/DateFormat.js
+++ b/source/class/qx/test/util/DateFormat.js
@@ -805,13 +805,31 @@ qx.Class.define("qx.test.util.DateFormat",
         this._testIsoMasks(date, 'isoDate', 'yyyy-MM-dd');
         this._testIsoMasks(date, 'isoTime', 'HH:mm:ss');
         this._testIsoMasks(date, 'isoDateTime', "yyyy-MM-dd'T'HH:mm:ss");
-
-//        var isodf = new qx.util.format.DateFormat('isoUtcDateTime');
-//        var df = new qx.util.format.DateFormat("yyyy-MM-dd'T'HH:mm:ss'Z'");
-//        var isoDateFormatted = isodf.format(date);
-//        var dateFormatted = df.format(date);
-//        this.assertEquals(isodf.parse(isoDateFormatted).getTime(),df.parse(dateFormatted).getTime());
+        this._testIsoMasks(date, 'isoDateTimeTz', "yyyy-MM-dd'T'HH:mm:ssZ");
+        //this._testIsoMasks(date, 'isoUtcDateTime', "yyyy-MM-dd'T'HH:mm:ss'Z'");
       }
+  },
+
+  testUtc : function () {
+    var isodf = new qx.util.format.DateFormat('isoUtcDateTime');
+    var parsedDate = isodf.parse("2013-01-01T00:00:00Z");
+    this.assertEquals(parsedDate.getUTCFullYear(), 2013);
+    this.assertEquals(parsedDate.getUTCMonth(), 0);
+    this.assertEquals(parsedDate.getUTCDate(), 1);
+    this.assertEquals(parsedDate.getUTCHours(), 0);
+    this.assertEquals(parsedDate.getUTCMinutes(), 0);
+    this.assertEquals(parsedDate.getUTCSeconds(), 0);
+    this.assertEquals(parsedDate.getUTCMilliseconds(), 0);
+
+    // checks that UTC hours are calculated correctly
+    parsedDate = isodf.parse("2004-04-04T04:04:04Z");
+    this.assertEquals(parsedDate.getUTCHours(), 4);
+
+    // checks that UTC format does not parse a date with a timezone
+    this.assertException(function() {
+      isodf.parse("2004-04-04T04:04:04+05:00");
+    }, Error);
+
   },
 
   testChangingLocales : function()

--- a/source/class/qx/test/util/DateFormat.js
+++ b/source/class/qx/test/util/DateFormat.js
@@ -810,6 +810,27 @@ qx.Class.define("qx.test.util.DateFormat",
       }
   },
 
+  testIsoTz : function() {
+    var isodf = new qx.util.format.DateFormat('isoDateTimeTz');
+    var parsedDate = isodf.parse("2013-01-01T00:00:00+0000");
+    this.assertEquals(parsedDate.getUTCFullYear(), 2013);
+    this.assertEquals(parsedDate.getUTCMonth(), 0);
+    this.assertEquals(parsedDate.getUTCDate(), 1);
+    this.assertEquals(parsedDate.getUTCHours(), 0);
+    this.assertEquals(parsedDate.getUTCMinutes(), 0);
+    this.assertEquals(parsedDate.getUTCSeconds(), 0);
+    this.assertEquals(parsedDate.getUTCMilliseconds(), 0);
+
+    parsedDate = isodf.parse("2004-04-04T04:04:04-0500")
+    this.assertEquals(parsedDate.getUTCFullYear(), 2004);
+    this.assertEquals(parsedDate.getUTCMonth(), 3);
+    this.assertEquals(parsedDate.getUTCDate(), 3);
+    this.assertEquals(parsedDate.getUTCHours(), 23);
+    this.assertEquals(parsedDate.getUTCMinutes(), 4);
+    this.assertEquals(parsedDate.getUTCSeconds(), 4);
+    this.assertEquals(parsedDate.getUTCMilliseconds(), 0);
+  },
+
   testUtc : function () {
     var isodf = new qx.util.format.DateFormat('isoUtcDateTime');
     var parsedDate = isodf.parse("2013-01-01T00:00:00Z");

--- a/source/class/qx/util/format/DateFormat.js
+++ b/source/class/qx/util/format/DateFormat.js
@@ -763,7 +763,7 @@ qx.Class.define("qx.util.format.DateFormat",
         min         : 0,
         sec         : 0,
         ms          : 0,
-        tzOffsetMins: 0
+        tzOffsetMins: null
       };
 
       var currGroup = 1;
@@ -828,7 +828,7 @@ qx.Class.define("qx.util.format.DateFormat",
       }
 
       var date;
-      if (this.__UTC || dateValues.tzOffsetMins !== 0) {
+      if (this.__UTC || dateValues.tzOffsetMins !== null) {
         var utcMs = Date.UTC(dateValues.year, dateValues.month, dateValues.day, (dateValues.ispm) ? (dateValues.hour + 12) : dateValues.hour, dateValues.min, dateValues.sec, dateValues.ms);
         if (dateValues.tzOffsetMins !== 0) {
           utcMs += (dateValues.tzOffsetMins * 60000);

--- a/source/class/qx/util/format/DateFormat.js
+++ b/source/class/qx/util/format/DateFormat.js
@@ -64,7 +64,7 @@
  * single-quoted.
  *
  * The same format patterns will be used for both parsing and output formatting.
- * 
+ *
  * NOTE: Instances of this class must be disposed of after use
  *
  */
@@ -181,6 +181,7 @@ qx.Class.define("qx.util.format.DateFormat",
       isoDate :        "yyyy-MM-dd",
       isoTime :        "HH:mm:ss",
       isoDateTime :    "yyyy-MM-dd'T'HH:mm:ss",
+      isoDateTimeTz :  "yyyy-MM-dd'T'HH:mm:ssZ",
       isoUtcDateTime : "yyyy-MM-dd'T'HH:mm:ss'Z'"
     },
 
@@ -406,14 +407,14 @@ qx.Class.define("qx.util.format.DateFormat",
       }
       this.__locale = value === null ? this.__initialLocale : value;
     },
-    
+
     /**
      * Resets the Locale
      */
     resetLocale : function() {
       this.setLocale(null);
     },
-    
+
     /**
      * Returns the locale
      */
@@ -427,7 +428,7 @@ qx.Class.define("qx.util.format.DateFormat",
 
     /**
      * Returns the original format string
-     * 
+     *
      * @return {String}
      */
     getFormatString() {
@@ -761,7 +762,8 @@ qx.Class.define("qx.util.format.DateFormat",
         weekOfYear  : 1,
         min         : 0,
         sec         : 0,
-        ms          : 0
+        ms          : 0,
+        tzOffsetMins: 0
       };
 
       var currGroup = 1;
@@ -825,14 +827,21 @@ qx.Class.define("qx.util.format.DateFormat",
         dateValues.year = dateValues.year * dateValues.era;
       }
 
-      var date = new Date(dateValues.year, dateValues.month, dateValues.day, (dateValues.ispm) ? (dateValues.hour + 12) : dateValues.hour, dateValues.min, dateValues.sec, dateValues.ms);
-
-      if(this.__UTC) {
-        date = new Date(date.getUTCFullYear(),date.getUTCMonth(),date.getUTCDate(),date.getUTCHours(),date.getUTCMinutes(),date.getUTCSeconds(),date.getUTCMilliseconds());
-      }
-
-      if (dateValues.month != date.getMonth() || dateValues.year != date.getFullYear()) {
-        throw new Error("Error parsing date '" + dateStr + "': the value for day or month is too large");
+      var date;
+      if (this.__UTC || dateValues.tzOffsetMins !== 0) {
+        var utcMs = Date.UTC(dateValues.year, dateValues.month, dateValues.day, (dateValues.ispm) ? (dateValues.hour + 12) : dateValues.hour, dateValues.min, dateValues.sec, dateValues.ms);
+        if (dateValues.tzOffsetMins !== 0) {
+          utcMs += (dateValues.tzOffsetMins * 60000);
+        }
+        date = new Date(utcMs);
+        if (this.__UTC && (dateValues.month !== date.getUTCMonth() || dateValues.year !== date.getUTCFullYear())) {
+          throw new Error("Error parsing date '" + dateStr + "': the value for day or month is too large");
+        }
+      } else {
+        date = new Date(dateValues.year, dateValues.month, dateValues.day, (dateValues.ispm) ? (dateValues.hour + 12) : dateValues.hour, dateValues.min, dateValues.sec, dateValues.ms);
+        if (dateValues.month !== date.getMonth() || dateValues.year !== date.getFullYear()) {
+          throw new Error("Error parsing date '" + dateStr + "': the value for day or month is too large");
+        }
       }
 
       return date;
@@ -1207,9 +1216,27 @@ qx.Class.define("qx.util.format.DateFormat",
         dateValues.hour = parseInt(value, 10) % 12;
       };
 
-      var ignoreManipulator = function(dateValues, value) {
-        return;
+      var timezoneManipulator = function(dateValues, value) {
+        var regEx = new RegExp("([+-]*)(\\d\\d)[:]*(\\d\\d)*$");
+        var tzResults = regEx.exec(value);
+        var offsetHours = parseInt(tzResults[2], 10);
+        var offsetMins = parseInt(tzResults[3], 10);
+        // basic check, hours range is -12 to +14 https://en.wikipedia.org/wiki/Category:UTC_offsets
+        if (offsetHours > 14) {
+          throw new Error("Invalid hours in time zone offset.");
+        }
+        if (offsetMins > 59) {
+          throw new Error("Invalid minutes in time zone offset.");
+        }
+        dateValues.tzOffsetMins = (offsetHours * 60) + offsetMins;
+        if (tzResults[1] === "-") {
+          dateValues.tzOffsetMins = -dateValues.tzOffsetMins;
+        }
       };
+
+      // var ignoreManipulator = function(dateValues, value) {
+      //   return;
+      // };
 
       var narrowEraNames = ['A', 'B'];
       var narrowEraNameManipulator = function(dateValues, value) {
@@ -1755,14 +1782,14 @@ qx.Class.define("qx.util.format.DateFormat",
       {
         pattern     : "Z",
         regex       : "([\\+\\-]\\d\\d\\d\\d)",
-        manipulator : ignoreManipulator
+        manipulator : timezoneManipulator
       });
 
       rules.push(
       {
         pattern     : "z",
         regex       : "(GMT[\\+\\-]\\d\\d:\\d\\d)",
-        manipulator : ignoreManipulator
+        manipulator : timezoneManipulator
       });
     }
   }

--- a/source/class/qx/util/format/DateFormat.js
+++ b/source/class/qx/util/format/DateFormat.js
@@ -1217,7 +1217,7 @@ qx.Class.define("qx.util.format.DateFormat",
       };
 
       var timezoneManipulator = function(dateValues, value) {
-        var regEx = new RegExp("([+-]*)(\\d\\d)[:]*(\\d\\d)*$");
+        var regEx = new RegExp("([+-]?)(\\d\\d)(?::?(\\d\\d))?$");
         var tzResults = regEx.exec(value);
         var offsetHours = parseInt(tzResults[2], 10);
         var offsetMins = parseInt(tzResults[3], 10);


### PR DESCRIPTION
Per old bug https://github.com/qooxdoo/qooxdoo/issues/7946, UTC parsing was not working correctly. Also the timezone format identifiers 'Z' & 'z' were not being processed if non-literal in the format string.

 * Use date.UTC() to correctly determine the UTC date.
 * Adds isoDateTimeTz as a format to parse timezone details in the date string, i.e. offset from UTC