### PR TITLE
Check contentElement exists before modification

### DIFF
--- a/source/class/qx/ui/menu/Menu.js
+++ b/source/class/qx/ui/menu/Menu.js
@@ -523,10 +523,12 @@ qx.Class.define("qx.ui.menu.Menu",
     _applyOpener : function(value, old)
     {
       // ARIA attrs
-      if (value) {
-        this.getContentElement().setAttribute("aria-labelledby", value);
-      } else {
-        this.getContentElement().removeAttribute("aria-labelledby");
+      if (this.getContentElement()) {
+        if (value) {
+          this.getContentElement().setAttribute("aria-labelledby", value);
+        } else {
+          this.getContentElement().removeAttribute("aria-labelledby");
+        }
       }
     },
 


### PR DESCRIPTION
Fixes a bug on destruction where opener is set to null and getContentElement returns null

Reference:
https://github.com/qooxdoo/qooxdoo/pull/10277#discussion_r775014305_