### PR TITLE
Ensure column menu in table shows columns in the order of visibility

### DIFF
--- a/source/class/qx/ui/table/Table.js
+++ b/source/class/qx/ui/table/Table.js
@@ -2212,8 +2212,9 @@ qx.Class.define("qx.ui.table.Table",
       this.fireDataEvent("columnVisibilityMenuCreateStart", data);
 
       this.__columnMenuButtons = {};
-      for (var col=0, l=tableModel.getColumnCount(); col<l; col++)
+      for (var iCol=0, l=tableModel.getColumnCount(); iCol<l; iCol++)
       {
+        var col = columnModel.getOverallColumnAtX(iCol);
         var menuButton =
           columnButton.factory("menu-button",
                                {


### PR DESCRIPTION
This PR is fixing the order of the list of columns provided in the column menu. If the user has re-ordered many of the columns then the order became confusing. This fixes the list order to be the same as the column order displayed to the user.