### PR TITLE
make es6ify idempotent

### DIFF
--- a/source/class/qx/tool/cli/commands/Es6ify.js
+++ b/source/class/qx/tool/cli/commands/Es6ify.js
@@ -80,7 +80,7 @@ qx.Class.define("qx.tool.cli.commands.Es6ify", {
         if (ig.ignores(filename)) {
           return;
         }
-        console.log(`Processing ${filename}...`);
+        qx.tool.compiler.Console.info(`Processing ${filename}...`);
         let ify = new qx.tool.compiler.Es6ify(filename);
         ify.set({
           arrowFunctions: this.argv.arrowFunctions,

--- a/source/class/qx/tool/compiler/ClassFile.js
+++ b/source/class/qx/tool/compiler/ClassFile.js
@@ -389,6 +389,9 @@ qx.Class.define("qx.tool.compiler.ClassFile", {
                   qx.tool.compiler.ClassFile.JSX_OPTIONS
                 ]
               ],
+              generatorOpts: {
+                compact: false
+              },
 
               parserOpts: {
                 allowSuperOutsideMethod: true,

--- a/source/class/qx/tool/compiler/Es6ify.js
+++ b/source/class/qx/tool/compiler/Es6ify.js
@@ -162,14 +162,21 @@ qx.Class.define("qx.tool.compiler.Es6ify", {
         },
 
         generatorOpts: {
-          retainLines: true
+          retainLines: true,
+          compact: false
         },
 
         passPerPreset: true
       };
 
       let result;
+      let cycleCount = 0;
       while (true) {
+        cycleCount++;
+        if (cycleCount > 10) {
+          qx.tool.compiler.Console.warn(`Can not find a stable format for ${this.__filename}`);
+          break;
+        }
         result = babelCore.transform(src, config);
         if (result.code === src) {
           break;

--- a/source/class/qx/tool/compiler/Es6ify.js
+++ b/source/class/qx/tool/compiler/Es6ify.js
@@ -168,7 +168,14 @@ qx.Class.define("qx.tool.compiler.Es6ify", {
         passPerPreset: true
       };
 
-      let result = babelCore.transform(src, config);
+      let result;
+      while (true) {
+        result = babelCore.transform(src, config);
+        if (result.code === src) {
+          break;
+        }
+        src = result.code;
+      }
 
       let prettierConfig =
         (await prettier.resolveConfig(this.__filename, {


### PR DESCRIPTION
The problem is the call of babelCore.transform. This will change output during repeated calls.
Implement an modfied idea from @derrel. 

while (true) {
        result = babelCore.transform(src, config);
        if (result.code === src) {
          break;
        }
        src = result.code;
      }


