### PR TITLE
Trailing rows could be left hanging in rendered tables

### DIFF
--- a/source/class/qx/ui/table/model/Simple.js
+++ b/source/class/qx/ui/table/model/Simple.js
@@ -708,9 +708,13 @@ qx.Class.define("qx.ui.table.model.Simple", {
      * @param clearSorting {Boolean ? true} Whether to clear the sort state.
      */
     removeRows(startIndex, howMany, clearSorting) {
-      this._rowArr.splice(startIndex, howMany);
-
-      // Inform the listeners
+      // In the case of `removeRows`, specifically, we must create the
+      // listeners' event data before actually removing the rows from
+      // the row data, so that the `lastRow` calculation is correct.
+      // If we do the delete operation first, as is done in other
+      // methods, the final rows of the table can escape being
+      // updated, thus leaving hanging old data on the rendered table.
+      // This reordering (deleting after creating event data) fixes #10365.
       var data = {
         firstRow: startIndex,
         lastRow: this._rowArr.length - 1,
@@ -720,7 +724,11 @@ qx.Class.define("qx.ui.table.model.Simple", {
         removeCount: howMany
       };
 
+      this._rowArr.splice(startIndex, howMany);
+
+      // Inform the listeners
       this.fireDataEvent("dataChanged", data);
+
       if (clearSorting !== false) {
         this.clearSorting();
       }

--- a/source/class/qx/ui/table/pane/Pane.js
+++ b/source/class/qx/ui/table/pane/Pane.js
@@ -632,7 +632,9 @@ qx.Class.define("qx.ui.table.pane.Pane", {
       var offset = row - firstRow;
       var rowElem = tableChildNodes[offset];
 
-      if (row > modelRowCount || typeof rowElem == "undefined") {
+      // `row` can be too big if rows were deleted. In that case, we
+      // can't update the current single row
+      if (row >= modelRowCount || typeof rowElem == "undefined") {
         this._updateAllRows();
         return;
       }


### PR DESCRIPTION
If rows immediately prior to the last row were removed with the table
model's `removeRows` method, the final row(s) would not get updated,
leaving stale and non-interactive rows at the end of the rendered
table. This Fixes #10365.

The above change broke removing the last row(s) of a table as a result
of a long-time bug, also fixed herein.