### PR TITLE
TreeVirtual - Add options for expandAll, collapseAll that suppress redraws

### DIFF
--- a/source/class/qx/ui/treevirtual/MNode.js
+++ b/source/class/qx/ui/treevirtual/MNode.js
@@ -165,7 +165,33 @@ qx.Mixin.define("qx.ui.treevirtual.MNode", {
     },
 
     /**
-     * Set the opened state for a node.  (Note that this method has no effect
+     * Opens all nodes in the tree with minimal redraw
+     */
+    nodeOpenAll() {
+      var model = this.getTableModel();
+      model.getData().forEach(node => {
+        if (node) {
+          model.setState(node.nodeId, {bOpened: true}, true);
+        }
+      });
+      model.setData();
+    },
+
+    /**
+     * Closes all nodes in the tree with minimal redraw
+     */
+    nodeCloseAll() {
+      var model = this.getTableModel();
+      model.getData().forEach(node => {
+        if (node) {
+          model.setState(node.nodeId, {bOpened: false}, true);
+        }
+      });
+      model.setData();
+    },
+
+    /**
+     * Internal call to set the opened state for a node. (Note that this method has no effect
      * if the requested state is the same as the current state.)
      *
      * @param nodeReference {Object | Integer}
@@ -173,11 +199,16 @@ qx.Mixin.define("qx.ui.treevirtual.MNode", {
      *   represented either by the node object, or the node id (as would have
      *   been returned by addBranch(), addLeaf(), etc.)
      *
-     * @param b {Boolean}
+     * @param opened {Boolean}
      *   The new opened state for the specified node.
      *
+     * @param cascade {Boolean}
+     *   Whether to descend the tree changing opened state of all children
+     *
+     * @param isRecursed {Boolean?}
+     *   For internal use when cascading to determine outer level and call setData
      */
-    nodeSetOpened(nodeReference, b) {
+    _nodeSetOpenedInternal(nodeReference, opened, cascade, isRecursed) {
       var node;
 
       if (typeof nodeReference == "object") {
@@ -190,9 +221,33 @@ qx.Mixin.define("qx.ui.treevirtual.MNode", {
 
       // Only set new state if not already in the requested state, since
       // setting new state involves dispatching events.
-      if (b != node.bOpened) {
-        this.nodeToggleOpened(node);
+      if (opened != node.bOpened) {
+        this.getTableModel().setState(node.nodeId, { bOpened: opened }, true);
       }
+      if (cascade) {
+        node.children.forEach(child => this.nodeSetOpened(child, opened, cascade, true));
+      }
+      if (!cascade || !isRecursed) {
+        this.getTableModel().setData();
+      }
+    },
+    /**
+     * Set the opened state for a node.  (Note that this method has no effect
+     * if the requested state is the same as the current state.)
+     *
+     * @param nodeReference {Object | Integer}
+     *   The node for which the opened state is being set.  The node can be
+     *   represented either by the node object, or the node id (as would have
+     *   been returned by addBranch(), addLeaf(), etc.)
+     *
+     * @param opened {Boolean}
+     *   The new opened state for the specified node.
+     *
+     * @param cascade {Boolean}
+     *   Whether to descend the tree changing opened state of all children
+     */
+    nodeSetOpened(nodeReference, opened, cascade) {
+      this._nodeSetOpenedInternal(nodeReference, opened, cascade, false);
     },
 
     /**

--- a/source/class/qx/ui/treevirtual/SimpleTreeDataModel.js
+++ b/source/class/qx/ui/treevirtual/SimpleTreeDataModel.js
@@ -795,7 +795,7 @@ qx.Class.define("qx.ui.treevirtual.SimpleTreeDataModel", {
      * Sets the whole data en bulk, or notifies the data model that node
      * modifications are complete.
      *
-     * @param nodeArr {Array | null}
+     * @param nodeArr {Array?null}
      *   Pass either an Array of node objects, or null.
      *
      *   If non-null, nodeArr is an array of node objects containing the
@@ -907,9 +907,13 @@ qx.Class.define("qx.ui.treevirtual.SimpleTreeDataModel", {
      *   {@link SimpleTreeDataModel}.  Each property value will be assigned
      *   to the corresponding property of the node specified by nodeId.
      *
+     * @param suppressRedraw {Boolean}
+     *    If true then prevents redraw; it becomes the caller's responsibility to
+     *    call setData() subsequently, to cause a redraw.
+     *
      * @throws {Error} If the node object or id is not valid.
      */
-    setState(nodeReference, attributes) {
+    setState(nodeReference, attributes, suppressRedraw) {
       var node;
       var nodeId;
 
@@ -1003,7 +1007,9 @@ qx.Class.define("qx.ui.treevirtual.SimpleTreeDataModel", {
 
             // Re-render the row data since formerly visible rows may now be
             // invisible, or vice versa.
-            this.setData();
+            if (!suppressRedraw) {
+              this.setData();
+            }
             break;
 
           default:


### PR DESCRIPTION
Also adds expandBeneath, collapseBeneath for expand/collapse tree below a node.

This has a considerable performance benefit when expanding a large tree and maintains backwards compatibility if new parameter `suppressRedraw` is not passed. 