### PR TITLE
Don't switch lint output format

### DIFF
--- a/source/class/qx/tool/cli/commands/Lint.js
+++ b/source/class/qx/tool/cli/commands/Lint.js
@@ -157,13 +157,23 @@ qx.Class.define("qx.tool.cli.commands.Lint", {
         }
         if (report.errorCount > 0 || report.warningCount > 0) {
           let outputFormat = this.argv.format || "codeframe";
-
-          // If there are too many errors, the pretty formatter is appallingly slow
-          if (report.errorCount + report.warningCount > 150) {
-            outputFormat = "compact";
-          }
           const formatter = await linter.loadFormatter(outputFormat);
           const s = formatter.format(report);
+          // If there are too many errors, the pretty formatter is appallingly slow so if the
+          // user has not specified a format, change to compact mode
+          const maxDefaultFormatErrorCount = 150;
+          if (report.errorCount + report.warningCount > maxDefaultFormatErrorCount) {
+            if (!this.argv.format) {
+              qx.tool.compiler.Console.info(
+                `Total errors and warnings exceed ${maxDefaultFormatErrorCount}, switching to "compact" style report`
+              );
+              outputFormat = "compact";
+            } else {
+              qx.tool.compiler.Console.info(
+                `Total errors and warnings exceed ${maxDefaultFormatErrorCount}, the report may take some time to generate.`
+              );
+            }
+          }
           if (this.argv.outputFile) {
             if (this.argv.verbose) {
               qx.tool.compiler.Console.info(


### PR DESCRIPTION
This looks to have been added to improve performance of linting the qx source when there were 51,000 errors. That same operation currently only reports 1234 issues and takes about 25 seconds for me regardless of output format. Switching the format based on the number of errors is causing issues for our CI build which expects "checkstyle" XML format.

To address https://github.com/qooxdoo/qooxdoo/issues/10371