### PR TITLE
Refactor to allow more easily exending functionality of Boolean cell renderer

### DIFF
--- a/source/class/qx/ui/progressive/renderer/table/Row.js
+++ b/source/class/qx/ui/progressive/renderer/table/Row.js
@@ -284,7 +284,8 @@ qx.Class.define("qx.ui.progressive.renderer.table.Row", {
           element: element,
           dataIndex: i,
           cellData: data[i],
-          height: height
+          height: height,
+          rowRenderer: this     // useful, e.g., for getting default row height
         };
 
         // Render this cell

--- a/source/class/qx/ui/progressive/renderer/table/cell/Boolean.js
+++ b/source/class/qx/ui/progressive/renderer/table/cell/Boolean.js
@@ -28,13 +28,13 @@ qx.Class.define("qx.ui.progressive.renderer.table.cell.Boolean", {
   construct() {
     super();
 
-    this.__resolveImages();
+    this._resolveImages();
 
     // dynamic theme switch
     if (qx.core.Environment.get("qx.dyntheme")) {
       qx.theme.manager.Meta.getInstance().addListener(
         "changeTheme",
-        this.__resolveImages,
+        this._resolveImages,
         this
       );
     }
@@ -53,19 +53,13 @@ qx.Class.define("qx.ui.progressive.renderer.table.cell.Boolean", {
   },
 
   members: {
-    __iconUrlTrue: null,
-    __iconUrlFalse: null,
-    __numericAllowed: null,
-    __conditions: null,
-    __defaultTextAlign: null,
-    __defaultColor: null,
-    __defaultFontStyle: null,
-    __defaultFontWeight: null,
+    _iconUrlTrue: null,
+    _iconUrlFalse: null,
 
     /**
      * Resolve the boolean images using the alias and resource manager.
      */
-    __resolveImages() {
+    _resolveImages() {
       var aliasManager = qx.util.AliasManager.getInstance();
       var resourceManager = qx.util.ResourceManager.getInstance();
       var boolTrueImg = aliasManager.resolve(
@@ -76,25 +70,29 @@ qx.Class.define("qx.ui.progressive.renderer.table.cell.Boolean", {
         "decoration/table/boolean-false.png"
       );
 
-      this.__iconUrlTrue = resourceManager.toUri(boolTrueImg);
-      this.__iconUrlFalse = resourceManager.toUri(boolFalseImg);
+      this._iconUrlTrue = resourceManager.toUri(boolTrueImg);
+      this._iconUrlFalse = resourceManager.toUri(boolFalseImg);
+    },
+
+    _getDefaultImageData(cellInfo) {
+      return {
+        imageWidth: 11,
+        imageHeight: 11
+      };
     },
 
     // overridden
     _identifyImage(cellInfo) {
-      var imageData = {
-        imageWidth: 11,
-        imageHeight: 11
-      };
+      var imageData = this._getDefaultImageData(cellInfo);
 
       switch (cellInfo.cellData) {
         case true:
-          imageData.url = this.__iconUrlTrue;
+          imageData.url = this._iconUrlTrue;
           imageData.extras = "celldata='1' ";
           break;
 
         case false:
-          imageData.url = this.__iconUrlFalse;
+          imageData.url = this._iconUrlFalse;
           imageData.extras = "celldata='0' ";
           break;
 
@@ -115,7 +113,7 @@ qx.Class.define("qx.ui.progressive.renderer.table.cell.Boolean", {
 
         if (
           qx.core.Environment.get("css.alphaimageloaderneeded") &&
-          /\.png$/i.test(this.__iconUrlTrue)
+          /\.png$/i.test(this._iconUrlTrue)
         ) {
           imageData.extras +=
             "  this.src='" +
@@ -124,18 +122,18 @@ qx.Class.define("qx.ui.progressive.renderer.table.cell.Boolean", {
             "  var loader = 'DXImageTransform.Microsoft.AlphaImageLoader'; " +
             "  var filters = this.filters.item(loader); " +
             "  filters.src='" +
-            this.__iconUrlTrue +
+            this._iconUrlTrue +
             "'; " +
             "  filters.sizingMethod = 'scale'; ";
         } else {
-          imageData.extras += "  this.src='" + this.__iconUrlTrue + "'; ";
+          imageData.extras += "  this.src='" + this._iconUrlTrue + "'; ";
         }
 
         imageData.extras += "  node.nodeValue='1'; " + "} " + "else " + "{";
 
         if (
           qx.core.Environment.get("css.alphaimageloaderneeded") &&
-          /\.png$/i.test(this.__iconUrlFalse)
+          /\.png$/i.test(this._iconUrlFalse)
         ) {
           imageData.extras +=
             "  this.src='" +
@@ -144,11 +142,11 @@ qx.Class.define("qx.ui.progressive.renderer.table.cell.Boolean", {
             "  var loader = 'DXImageTransform.Microsoft.AlphaImageLoader'; " +
             "  var filters = this.filters.item(loader); " +
             "  filters.src='" +
-            this.__iconUrlFalse +
+            this._iconUrlFalse +
             "'; " +
             "  filters.sizingMethod = 'scale'; ";
         } else {
-          imageData.extras += "  this.src='" + this.__iconUrlFalse + "'; ";
+          imageData.extras += "  this.src='" + this._iconUrlFalse + "'; ";
         }
 
         imageData.extras += "  node.nodeValue='0'; " + "}";
@@ -176,13 +174,13 @@ qx.Class.define("qx.ui.progressive.renderer.table.cell.Boolean", {
   },
 
   destruct() {
-    this.__iconUrlTrue = this.__iconUrlFalse = null;
+    this._iconUrlTrue = this._iconUrlFalse = null;
 
     // remove dynamic theme listener
     if (qx.core.Environment.get("qx.dyntheme")) {
       qx.theme.manager.Meta.getInstance().removeListener(
         "changeTheme",
-        this.__resolveImages,
+        this._resolveImages,
         this
       );
     }

--- a/source/class/qx/ui/progressive/renderer/table/cell/Icon.js
+++ b/source/class/qx/ui/progressive/renderer/table/cell/Icon.js
@@ -21,6 +21,8 @@
 
 /**
  * Abstract Icon cell renderer.
+ *
+ * @asset(qx/static/blank.gif)
  */
 qx.Class.define("qx.ui.progressive.renderer.table.cell.Icon", {
   type: "abstract",
@@ -34,14 +36,14 @@ qx.Class.define("qx.ui.progressive.renderer.table.cell.Icon", {
     var resourceManager = qx.util.ResourceManager.getInstance();
     var blankImg = aliasManager.resolve("qx/static/blank.gif");
 
-    this.__imageBlank = resourceManager.toUri(blankImg);
+    this._imageBlank = resourceManager.toUri(blankImg);
   },
 
   members: {
     /**
      * A blank image for use as a spacer in place of another image
      */
-    __imageBlank: null,
+    _imageBlank: null,
 
     /**
      * Retrieve the URI for a blank image
@@ -50,7 +52,7 @@ qx.Class.define("qx.ui.progressive.renderer.table.cell.Icon", {
      *   The URI of the blank image.
      */
     getBlankImage() {
-      return this.__imageBlank;
+      return this._imageBlank;
     },
 
     /**
@@ -118,7 +120,7 @@ qx.Class.define("qx.ui.progressive.renderer.table.cell.Icon", {
     // overridden
     _getContentHtml(cellInfo) {
       var html = [];
-      var imageData = this.__getImageData(cellInfo);
+      var imageData = this._getImageData(cellInfo);
 
       // Start the image tag
       html.push("<img ");
@@ -130,7 +132,7 @@ qx.Class.define("qx.ui.progressive.renderer.table.cell.Icon", {
       ) {
         html.push(
           'src="',
-          this.__imageBlank,
+          this._imageBlank,
           '" style="filter:',
           "progid:DXImageTransform.Microsoft.AlphaImageLoader(src='",
           imageData.url,
@@ -192,7 +194,7 @@ qx.Class.define("qx.ui.progressive.renderer.table.cell.Icon", {
      * @return {Map}
      *   See {@link #_identifyImage}
      */
-    __getImageData(cellInfo) {
+    _getImageData(cellInfo) {
       // Query the subclass about image and tooltip
       var imageData = this._identifyImage(cellInfo);
 
@@ -206,7 +208,7 @@ qx.Class.define("qx.ui.progressive.renderer.table.cell.Icon", {
 
       // If subclass gave null as url, replace with url to empty image
       if (imageData.url == null) {
-        imageData.url = this.__imageBlank;
+        imageData.url = this._imageBlank;
       }
 
       return imageData;

--- a/source/class/qx/ui/progressive/renderer/table/cell/Image.js
+++ b/source/class/qx/ui/progressive/renderer/table/cell/Image.js
@@ -34,31 +34,34 @@ qx.Class.define("qx.ui.progressive.renderer.table.cell.Image", {
   construct(width, height) {
     super();
 
-    if (width === undefined) {
-      this.__imageWidth = width;
+    if (width !== undefined) {
+      this._imageWidth = width;
     } else {
-      this.__imageWidth = 16;
+      this._imageWidth = 16;
     }
 
-    if (height === undefined) {
-      this.__imageHeight = height;
+    if (height !== undefined) {
+      this._imageHeight = height;
     } else {
-      this.__imageHeight = 16;
+      this._imageHeight = 16;
     }
   },
 
   members: {
-    __imageWidth: null,
-    __imageHeight: null,
+    _imageWidth: null,
+    _imageHeight: null,
+
+    _getDefaultImageData(cellInfo) {
+      return {
+        imageWidth: this._imageWidth,
+        imageHeight: this._imageHeight
+      };
+    },
 
     // overridden
     _identifyImage(cellInfo) {
-      var imageData = {
-        imageWidth: this.__imageWidth,
-        imageHeight: this.__imageHeight
-      };
-
       var height;
+      var imageData = this._getDefaultImageData(cellInfo);
 
       // String data is the unresolved url for the image.
       // Object data is a map containing the url, tooltip, and a height


### PR DESCRIPTION
Due to both code organization and the fact that some members were private rather than protected, it was difficult to extend Progressive's Boolean cell render without writing an entire new renderer. This attempts to correct that problem.

This is a draft PR while I check with @gyflorand who first reported the issue, that it solves his problem.