### PR TITLE
Raise error if table is editing when trying to modify the data in the model

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 ## Breaking changes
 
+- (>=v8.0.0) Setting model data for a `qx.ui.table.Table` when the table is still editing will
+now raise an error as this could have lead to an invalid edit. To prevent any errors, ensure
+that the table edits are completed or cancelled before refreshing table model data.
+
+# v7.0.0
+
+## Breaking changes
+
 - The `qx.library` config setting is no longer used by the
 compiler. If you want to override the path to the framework
 source, add the path to `compile.json`'s `libraries` array.
@@ -15,9 +23,6 @@ at the bottom. Before that, the 2 values were reversed
 - `qx.ui.command.Group` fixed a bug where new `qx.ui.command.Command` added was
 not set the `active` status of the group, thus staying active even if the group
 was inactive.
-
-  ```
-
 
 ## Deprecations:
 

--- a/source/class/qx/ui/table/model/Abstract.js
+++ b/source/class/qx/ui/table/model/Abstract.js
@@ -66,11 +66,22 @@ qx.Class.define("qx.ui.table.model.Abstract", {
     this.__columnIndexMap = {};
   },
 
+  statics: {
+    /**
+     * Member to control if a table should throw an error when you try to change the
+     * data model data whilst there is an incomplete edit. It could possibly break
+     * current implementations so only introduce the change from QX v8.
+     * Ref: https://github.com/qooxdoo/qooxdoo/pull/10377#discussion_r818697343
+     */
+    THROW_ON_MODEL_CHANGE_DURING_EDIT: parseInt(qx.core.Environment.get("qx.version"), 10) >= 8
+  },
+
   members: {
     __columnIdArr: null,
     __columnNameArr: null,
     __columnIndexMap: null,
     __internalChange: null,
+    __table: null,
 
     /**
      * Initialize the table model <--> table interaction. The table model is
@@ -84,7 +95,17 @@ qx.Class.define("qx.ui.table.model.Abstract", {
      *   The table to which this model is attached
      */
     init(table) {
-      // default implementation has nothing to do
+      // store a reference back to the table
+      this.__table = table;
+    },
+
+    /**
+     *
+     *
+     * @returns table {qx.ui.table.Table}
+     */
+    getTable() {
+      return this.__table;
     },
 
     /**
@@ -292,6 +313,15 @@ qx.Class.define("qx.ui.table.model.Abstract", {
       }
 
       this.setColumnNamesByIndex(columnNameArr);
+    },
+
+    _checkEditing() {
+      if (!qx.ui.table.model.Abstract.THROW_ON_MODEL_CHANGE_DURING_EDIT) {
+        return;
+      }
+      if (this.getTable() && this.getTable().isEditing()) {
+        throw new Error("A cell is currently being edited. Commit or cancel the edit before setting the table data");
+      }
     }
   },
 

--- a/source/class/qx/ui/table/model/Remote.js
+++ b/source/class/qx/ui/table/model/Remote.js
@@ -548,6 +548,7 @@ qx.Class.define("qx.ui.table.model.Remote", {
      * @param rowIndex {Integer} the index of the row to remove.
      */
     removeRow(rowIndex) {
+      this._checkEditing();
       if (this.getClearCacheOnRemove()) {
         this.clearCache();
 

--- a/source/class/qx/ui/table/model/Simple.js
+++ b/source/class/qx/ui/table/model/Simple.js
@@ -531,6 +531,7 @@ qx.Class.define("qx.ui.table.model.Simple", {
      * @param clearSorting {Boolean ? true} Whether to clear the sort state.
      */
     setData(rowArr, clearSorting) {
+      this._checkEditing();
       this._rowArr = rowArr;
 
       // Inform the listeners
@@ -650,6 +651,7 @@ qx.Class.define("qx.ui.table.model.Simple", {
      * @param clearSorting {Boolean ? true} Whether to clear the sort state.
      */
     setRows(rowArr, startIndex, clearSorting) {
+      this._checkEditing();
       if (startIndex == null) {
         startIndex = 0;
       }
@@ -708,6 +710,7 @@ qx.Class.define("qx.ui.table.model.Simple", {
      * @param clearSorting {Boolean ? true} Whether to clear the sort state.
      */
     removeRows(startIndex, howMany, clearSorting) {
+      this._checkEditing();
       // In the case of `removeRows`, specifically, we must create the
       // listeners' event data before actually removing the rows from
       // the row data, so that the `lastRow` calculation is correct.

--- a/source/class/qx/ui/treevirtual/SimpleTreeDataModel.js
+++ b/source/class/qx/ui/treevirtual/SimpleTreeDataModel.js
@@ -813,6 +813,7 @@ qx.Class.define("qx.ui.treevirtual.SimpleTreeDataModel", {
      * @throws {Error} If the parameter has the wrong type.
      */
     setData(nodeArr) {
+      this._checkEditing();
       if (nodeArr instanceof Array) {
         // Save the user-supplied data.
         this._nodeArr = nodeArr;
@@ -853,6 +854,7 @@ qx.Class.define("qx.ui.treevirtual.SimpleTreeDataModel", {
      *
      */
     clearData() {
+      this._checkEditing();
       this._clearSelections();
       this.setData([qx.ui.treevirtual.MTreePrimitive._getEmptyTree()]);
     },


### PR DESCRIPTION
As discussed briefly with @derrell in Gitter, this PR adds the throwing of an error if trying to set the data for the table model when the table is still being edited. The model *could* change to a dataset that no longer includes the row being edited at which point an error is raised when the user attempts to navigate from the cell being edited.

This would represent a change in behaviour. Currently, if the table is being edited and the table model is updated, the displayed table will update and there would be an error in the console (unlikely to be seen by the user) when navigating from the edited cell. With this change, the table will not be updated.