### PR TITLE
Prevent creating the popup when not necessary

### DIFF
--- a/source/class/qx/ui/form/DateField.js
+++ b/source/class/qx/ui/form/DateField.js
@@ -314,7 +314,7 @@ qx.Class.define("qx.ui.form.DateField", {
     close() {
       var popup = this.getChildControl("popup", true);
       if (popup && popup.isVisible()) {
-        this.getChildControl("popup").hide();
+        popup.hide();
       }
     },
 

--- a/source/class/qx/ui/form/DateField.js
+++ b/source/class/qx/ui/form/DateField.js
@@ -312,7 +312,10 @@ qx.Class.define("qx.ui.form.DateField", {
      * Hides the date chooser popup.
      */
     close() {
-      this.getChildControl("popup").hide();
+      var popup = this.getChildControl("popup", true);
+      if (popup && popup.isVisible()) {
+        this.getChildControl("popup").hide();
+      }
     },
 
     /**


### PR DESCRIPTION
A tap or a blur on the DateField creates the popup when it's not necessary.