### PR TITLE
Create the popup only when necessary

### DIFF
--- a/source/class/qx/ui/form/AbstractSelectBox.js
+++ b/source/class/qx/ui/form/AbstractSelectBox.js
@@ -210,7 +210,10 @@ qx.Class.define("qx.ui.form.AbstractSelectBox", {
      * Hides the list popup.
      */
     close() {
-      this.getChildControl("popup").hide();
+      var popup = this.getChildControl("popup", true);
+      if (popup && popup.isVisible()) {
+        popup.hide();
+      }
     },
 
     /**


### PR DESCRIPTION
A blur or a tap causes the ComboBox to create the popup.