### PR TITLE
Allow dispose of __scrollerParent to dispose of panescrollers

### DIFF
--- a/source/class/qx/ui/table/Table.js
+++ b/source/class/qx/ui/table/Table.js
@@ -2193,7 +2193,6 @@ qx.Class.define("qx.ui.table.Table", {
       );
     }
 
-    this._cleanUpMetaColumns(0);
     this.getTableColumnModel().dispose();
     this._disposeObjects(
       "__selectionManager",


### PR DESCRIPTION
Remove `_cleanUpMetaColumns` in favour of disposing the `__scrollerParent` which disposes it's children immediately. `_cleanUpMetaColumns` calls `destroy()` which is delayed and the mouse events do still fire, specifically the pointermove which calls `getTableColumnModel()` which attempts to recreate a columnModel if its already disposed, leading to the call stack below.
Luckily I had a very reproducible example in our application despite being unable to build a simple replica.
```
Uncaught TypeError: Cannot read properties of null (reading 'getChildren')
    at wrapper._getPaneScrollerArr (Table.js:1118:36)
    at wrapper._onColVisibilityChanged (Table.js:1490:30)
    at Direct.js:133:37
    at Function._true [as then] (Utils.js:149:22)
    at Direct.js:132:26
    at Array.forEach (<anonymous>)
    at wrapper.dispatchEvent (Direct.js:107:19)
    at wrapper.wrappedFunction [as dispatchEvent] (Interface.js:531:31)
    at wrapper.dispatchEvent (Manager.js:958:22)
    at Registration.js:361:40
    at Function._true [as then] (Utils.js:149:22)
    at Object.fireEvent (Registration.js:360:22)
    at wrapper.fireDataEvent (MEvent.js:292:36)
    at wrapper.init (Basic.js:204:14)
    at wrapper.getTableColumnModel (Table.js:860:21)
    at wrapper._getResizeColumnForPageX (Scroller.js:2006:43)
_getPaneScrollerArr	@	Table.js:1118
_onColVisibilityChanged	@	Table.js:1490
(anonymous)	@	Direct.js:133
_true	@	Utils.js:149
(anonymous)	@	Direct.js:132
dispatchEvent	@	Direct.js:107
wrappedFunction	@	Interface.js:531
dispatchEvent	@	Manager.js:958
(anonymous)	@	Registration.js:361
_true	@	Utils.js:149
fireEvent	@	Registration.js:360
fireDataEvent	@	MEvent.js:292
init	@	Basic.js:204
getTableColumnModel	@	Table.js:860
_getResizeColumnForPageX	@	Scroller.js:2006
_onPointermovePane	@	Scroller.js:1076
(anonymous)	@	EventHandler.js:298
```

