### PR TITLE
fix compile.json schema validation; enable it during `qx compile`

### DIFF
--- a/source/class/qx/tool/cli/commands/Compile.js
+++ b/source/class/qx/tool/cli/commands/Compile.js
@@ -359,7 +359,10 @@ qx.Class.define("qx.tool.cli.commands.Compile", {
         this.argv["feedback"] = configDb.db("qx.default.feedback", true);
       }
 
-      if (this.argv.verbose) {
+     // Validate compile.json against the schema
+     await qx.tool.config.Compile.getInstance().load();
+
+     if (this.argv.verbose) {
         console.log(`
 Compiler:  v${this.getCompilerVersion()} in ${require.main.filename}
 Framework: v${await this.getQxVersion()} in ${await this.getQxPath()}`);

--- a/source/class/qx/tool/utils/Json.js
+++ b/source/class/qx/tool/utils/Json.js
@@ -23,7 +23,7 @@
  * *********************************************************************** */
 
 const Ajv = require("ajv");
-const betterAjvErrors = require("better-ajv-errors");
+const betterAjvErrors = require("better-ajv-errors").default;
 const fs = qx.tool.utils.Promisify.fs;
 
 qx.Class.define("qx.tool.utils.Json", {

--- a/source/resource/qx/tool/schema/compile-1-0-0.json
+++ b/source/resource/qx/tool/schema/compile-1-0-0.json
@@ -53,11 +53,11 @@
       "minItems": 1,
       "items": {
         "type": "object",
-        "additionalItems": false,
         "required": [
           "class",
           "name"
         ],
+        "additionalProperties": false,
         "properties": {
           "class" : {
             "description": "The class name of the main application class (it typically inherits from `qx.application.Standalone` for web applications)",


### PR DESCRIPTION
There were multiple issue:

- the correct property banning extra keys was missing, and an obsolete
one was in its place.

- with the correct property there, it tries to use better-ajv-errors
but it was not properly required, so crashed when trying to generate
the error.

- schema validation was not implemented for `qx compile`