### PR TITLE
Allow parallel script loading in Firefox once more.

### DIFF
--- a/source/resource/qx/tool/cli/templates/loader/loader-browser.tmpl.js
+++ b/source/resource/qx/tool/cli/templates/loader/loader-browser.tmpl.js
@@ -91,7 +91,6 @@ qx.$$createdAt = function(obj, filename, lineNumber, column) {
 };
 
 var isWebkit = /AppleWebKit\/([^ ]+)/.test(navigator.userAgent);
-var isFirefox = navigator.userAgent.toLowerCase().indexOf('firefox') > -1;
 var isIE11 = !!window.MSInputMethodContext && !!document.documentMode;
 
 qx.$$loader = {
@@ -103,7 +102,7 @@ qx.$$loader = {
   closureParts : %{ClosureParts},
   bootIsInline : %{BootIsInline},
   addNoCacheParam : %{NoCacheParam},
-  isLoadParallel: !isFirefox && !isIE11 && 'async' in document.createElement('script'),
+  isLoadParallel: !isIE11 && 'async' in document.createElement('script'),
   delayDefer: false,
   splashscreen: window.QOOXDOO_SPLASH_SCREEN || null,
   isLoadChunked: false,


### PR DESCRIPTION
As reported in Gitter, loading source compiled apps in Firefox is incredibly slow. It's because the parallel script load was disabled many years ago due to a bug in Firefox debugger. https://github.com/qooxdoo/qooxdoo/issues/8946

Given that the bug was fixed in 2015, it's probably safe to now remove the restriction.