### PR TITLE
fix `es6ify --arrowFunctions` and `lint --fix-jsdoc-params` commands

### DIFF
--- a/source/class/qx/tool/cli/commands/Lint.js
+++ b/source/class/qx/tool/cli/commands/Lint.js
@@ -95,7 +95,16 @@ qx.Class.define("qx.tool.cli.commands.Lint", {
 
   members: {
     async process() {
-      await this.__applyFixes();
+
+      let files = this.argv.files || [];
+      if (files.length === 0) {
+        files.push("source/class/**/*.js");
+      }
+      for (let i = 0; i < files.length; i++) {
+        files[i] = path.join(process.cwd(), files[i]);
+      }
+
+      await this.__applyFixes(files);
 
       let helperFilePath = require.main.path;
       while (true) {
@@ -134,13 +143,6 @@ qx.Class.define("qx.tool.cli.commands.Lint", {
         fix: this.argv.fix
       });
 
-      let files = this.argv.files || [];
-      if (files.length === 0) {
-        files.push("source/class/**/*.js");
-      }
-      for (let i = 0; i < files.length; i++) {
-        files[i] = path.join(process.cwd(), files[i]);
-      }
       if (this.argv.printConfig) {
         const fileConfig = await linter.calculateConfigForFile(files[0]);
         qx.tool.compiler.Console.info(JSON.stringify(fileConfig, null, "  "));
@@ -230,7 +232,7 @@ qx.Class.define("qx.tool.cli.commands.Lint", {
      * @return {Promise<void>}
      * @private
      */
-    async __applyFixes() {
+    async __applyFixes(files) {
       const fixParams = this.argv.fixJsdocParams;
       if (fixParams && fixParams !== "off") {
         const regex =
@@ -238,7 +240,7 @@ qx.Class.define("qx.tool.cli.commands.Lint", {
             ? /@param\s+([\w$]+)\s+({[\w|[\]{}<>?. ]+})/g
             : /@param\s+({[\w|[\]{}<>?. ]+})\s+([\w$]+)/g;
         let replaceInFiles = {
-          files: "source/class/**/*.js",
+          files: files,
           from: regex,
           to: "@param $2 $1"
         };

--- a/source/class/qx/tool/cli/commands/Lint.js
+++ b/source/class/qx/tool/cli/commands/Lint.js
@@ -233,16 +233,15 @@ qx.Class.define("qx.tool.cli.commands.Lint", {
     async __applyFixes() {
       const fixParams = this.argv.fixJsdocParams;
       if (fixParams && fixParams !== "off") {
-        let replaceInFiles = [];
         const regex =
           fixParams === "type-first"
             ? /@param\s+([\w$]+)\s+({[\w|[\]{}<>?. ]+})/g
             : /@param\s+({[\w|[\]{}<>?. ]+})\s+([\w$]+)/g;
-        replaceInFiles.push({
+        let replaceInFiles = {
           files: "source/class/**/*.js",
           from: regex,
           to: "@param $2 $1"
-        });
+        };
 
         await replaceInFile(replaceInFiles);
       }

--- a/source/class/qx/tool/compiler/Es6ify.js
+++ b/source/class/qx/tool/compiler/Es6ify.js
@@ -288,7 +288,7 @@ qx.Class.define("qx.tool.compiler.Es6ify", {
                 if (
                   path.node.arguments.length != 3 ||
                   path.node.arguments[0].type != "StringLiteral" ||
-                  path.node.arguments[1].type != "ArrowFunctionExpression" ||
+                  path.node.arguments[1].type != "FunctionExpression" ||
                   path.node.arguments[2].type != "ThisExpression"
                 ) {
                   return;
@@ -329,7 +329,6 @@ qx.Class.define("qx.tool.compiler.Es6ify", {
           CallExpression(path) {
             if (
               path.node.callee.type == "MemberExpression" &&
-              path.node.callee.object.type == "ThisExpression" &&
               path.node.callee.property.type == "Identifier" &&
               path.node.callee.property.name == "addListener" &&
               path.node.arguments.length == 3 &&

--- a/source/class/qx/tool/compiler/Es6ify.js
+++ b/source/class/qx/tool/compiler/Es6ify.js
@@ -106,6 +106,7 @@ qx.Class.define("qx.tool.compiler.Es6ify", {
   construct(filename) {
     super();
     this.__filename = filename;
+    this.__knownApiFunctions = ["addListener","addListenerOnce"];
   },
 
   properties: {
@@ -125,6 +126,7 @@ qx.Class.define("qx.tool.compiler.Es6ify", {
 
   members: {
     __filename: null,
+    __knownApiFunctions: null,
 
     async transform() {
       let src = await fs.promises.readFile(this.__filename, "utf8");
@@ -275,6 +277,7 @@ qx.Class.define("qx.tool.compiler.Es6ify", {
       let t = this;
       const isTest = this.__filename.indexOf("/test/") > -1;
       let arrowFunctions = this.getArrowFunctions();
+      let knownApiFunctions = this.__knownApiFunctions;
 
       return {
         visitor: {
@@ -282,7 +285,7 @@ qx.Class.define("qx.tool.compiler.Es6ify", {
             if (path.node.callee.type == "MemberExpression") {
               let callee = collapseMemberExpression(path.node.callee);
               if (arrowFunctions == "careful") {
-                if (!callee.endsWith(".addListener")) {
+                if (!knownApiFunctions.some(fName => callee.endsWith("."+fName))) {
                   return;
                 }
                 if (
@@ -324,13 +327,14 @@ qx.Class.define("qx.tool.compiler.Es6ify", {
      * @returns
      */
     __pluginRemoveUnnecessaryThis() {
+      let knownApiFunctions = this.__knownApiFunctions;
       return {
         visitor: {
           CallExpression(path) {
             if (
               path.node.callee.type == "MemberExpression" &&
               path.node.callee.property.type == "Identifier" &&
-              path.node.callee.property.name == "addListener" &&
+              knownApiFunctions.includes(path.node.callee.property.name) &&
               path.node.arguments.length == 3 &&
               path.node.arguments[0].type == "StringLiteral" &&
               path.node.arguments[1].type == "ArrowFunctionExpression" &&


### PR DESCRIPTION
- default run (--arrowFunctions=careful) did not change ANY functions to arrowFunctions due to a small typo in `__pluginArrowFunctions`
- `this` as last arg was only removed for this.addListener, not if .addListener was called on another object, due to extra condition in `__pluginRemoveUnnecessaryThis`