### PR TITLE
properly render icons in menubar

### DIFF
--- a/source/class/qx/theme/tangible/Appearance.js
+++ b/source/class/qx/theme/tangible/Appearance.js
@@ -1006,6 +1006,18 @@ qx.Theme.define("qx.theme.tangible.Appearance", {
         };
       }
     },
+    "menubar-button/icon": {
+      style(states) {
+        return {
+          textColor: states.disabled 
+            ? "text-disabled-on-surface" 
+            : ( states.pressed || states.hovered )
+            ? "text-on-primary" 
+            : "text-on-surface"
+        }
+      }
+    },
+    
 
     /*
     ---------------------------------------------------------------------------


### PR DESCRIPTION
when the button is not hovered, font icons should still show.