### PR TITLE
qx.ui.form.FileSelectorButton

### DIFF
--- a/source/class/qx/test/ui/form/FileSelectorButton.js
+++ b/source/class/qx/test/ui/form/FileSelectorButton.js
@@ -26,7 +26,6 @@ qx.Class.define("qx.test.ui.form.FileSelectorButon", {
       let uploadField = new qx.ui.form.FileSelectorButton("Select a File");
       this.getRoot().add(uploadField);
       this.flush();
-      this.assertEquals(uploadField.constructor.ID_CNTR,1);
       uploadField.destroy();
     }
   }

--- a/source/class/qx/test/ui/form/FileSelectorButton.js
+++ b/source/class/qx/test/ui/form/FileSelectorButton.js
@@ -1,0 +1,33 @@
+/* ************************************************************************
+
+   qooxdoo
+
+   http://qooxdoo.org
+
+   Copyright:
+     2021 OETIKER+PARTNER AG
+
+   License:
+     MIT: https://opensource.org/licenses/MIT
+     See the LICENSE file in the project's top-level directory for details.
+
+   Authors:
+     * Tobias Oetiker (oetiker)
+
+************************************************************************ */
+
+qx.Class.define("qx.test.ui.form.FileSelectorButon", {
+  extend: qx.test.ui.LayoutTestCase,
+
+  include: [qx.dev.unit.MRequirements, qx.dev.unit.MMock],
+
+  members: {
+    testInstantiation() {
+      let uploadField = new qx.ui.form.FileSelectorButton("Select a File");
+      this.getRoot().add(uploadField);
+      this.flush();
+      this.assertEquals(uploadField.constructor.ID_CNTR,1);
+      uploadField.destroy();
+    }
+  }
+});

--- a/source/class/qx/ui/form/FileSelectorButton.js
+++ b/source/class/qx/ui/form/FileSelectorButton.js
@@ -142,8 +142,7 @@ qx.Class.define("qx.ui.form.FileSelectorButton", {
         "appear",
         e => {
           label.add(input);
-        },
-        this
+        }
       );
       input.addListenerOnce("appear", e => {
         let inputEl = input.getDomElement();

--- a/source/class/qx/ui/form/FileSelectorButton.js
+++ b/source/class/qx/ui/form/FileSelectorButton.js
@@ -123,7 +123,7 @@ qx.Class.define("qx.ui.form.FileSelectorButton", {
       if (attr === "directoriesOnly") {
         // while the name of the attribute indicates that this only
         // works for webkit borwsers, this is not the case. These
-        // days the attribute is supported by 
+        // days the attribute is supported by
         // [everyone](https://caniuse.com/?search=webkitdirectory).
         attr = "webkitdirectory";
       }
@@ -140,7 +140,7 @@ qx.Class.define("qx.ui.form.FileSelectorButton", {
       let label = new qx.html.Element("label", {}, { for: id });
       label.addListenerOnce(
         "appear",
-        function (e) {
+        e => {
           label.add(input);
         },
         this

--- a/source/class/qx/ui/form/FileSelectorButton.js
+++ b/source/class/qx/ui/form/FileSelectorButton.js
@@ -30,14 +30,14 @@
  * let button = new qx.ui.form.FileSelectorButton("Select File");
  * button.addListener('changeFileSelection',function(e){
  * let fileList = e.getData();
- *     let form = new FormData();
- *     form.append('file',fileList[0]);
- *     let req = new qx.io.request.Xhr("upload",'POST').set({
- *         requestData: form
- *     });
- *     req.addListener('success',(e) => {
- *         let response = req.getResponse();
- *     });
+ *   let form = new FormData();
+ *   form.append('file',fileList[0]);
+ *   let req = new qx.io.request.Xhr("upload",'POST').set({
+ *     requestData: form
+ *   });
+ *   req.addListener('success',(e) => {
+ *     let response = req.getResponse();
+ *   });
  * });
  * ```
  * 
@@ -60,13 +60,10 @@
  * [MDN Documentation](https://developer.mozilla.org/en-US/docs/Web/API/File_API/Using_files_from_web_applications)
  */
 
+let InputElementIdCounter = 0;
 qx.Class.define("qx.ui.form.FileSelectorButton", {
-  extend : qx.ui.form.Button,
-  statics: {
-    ID_CNTR: 0
-  },
+  extend: qx.ui.form.Button,
   events: {
-
     /**
      * The event is fired when the file selection changes.
      *
@@ -77,65 +74,77 @@ qx.Class.define("qx.ui.form.FileSelectorButton", {
   },
   properties: {
     /**
-     * What type of files should be offered in the fileselection dialog. 
+     * What type of files should be offered in the fileselection dialog.
      * Use a comma separated list of [Unique file type specifiers](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input/file#unique_file_type_specifiers). If you dont set anything, all files
      * are allowed.
-     * 
+     *
      * *Example*
-     * 
+     *
      * `.doc,.docx,application/msword`
      */
     accept: {
       nullable: true,
-      apply : "_applyAttribute"
+      check: "String",
+      apply: "_applyAttribute"
     },
     /**
      * Specify that the camera should be used for getting the "file". The
-     * value defines which camera should be used for capturing images. 
-     * `user` is indicates the user-facing camera. 
+     * value defines which camera should be used for capturing images.
+     * `user` indicates the user-facing camera.
      * `environment` indicates the camera facing away from the user.
      */
     capture: {
       nullable: true,
-      apply : "_applyAttribute"
+      check: ["user", "environment"],
+      apply: "_applyAttribute"
     },
     /**
      * Set to "true" if you want to allow the selection of multiple files.
      */
     multiple: {
       nullable: true,
-      apply : "_applyAttribute"
+      check: "Boolean",
+      apply: "_applyAttribute"
     },
     /**
      * If present, indicates that only directories should be available for
-     * selection. Despite the name, this attribute is supported by [all
-     * major browsers](https://caniuse.com/?search=webkitdirectory) 
-     * these days (not IE!).
+     * selection.
      */
-    webkitdirectory: {
+    directoriesOnly: {
       nullable: true,
-      apply : "_applyAttribute"
+      check: "Boolean",
+      apply: "_applyAttribute"
     }
   },
   members: {
     __inputObject: null,
 
-    _applyAttribute: function(value,old,attr){
-      this.__inputObject.setAttribute(attr,value);
+    _applyAttribute: function (value, old, attr) {
+      if (attr === "directoriesOnly") {
+        attr = "webkitdirectory";
+      }
+      this.__inputObject.setAttribute(attr, value);
     },
-    
-    _createContentElement: function() {
-      let id = 'qxFileSelector_'+(this.constructor.ID_CNTR++);
-      let input = this.__inputObject 
-        = new qx.html.Input("file",{display: 'none'},{id: id});
-      let label = new qx.html.Element("label",{},{'for': id});
-      label.addListenerOnce('appear',function(e){
-        label.add(input);
-      },this);
-      input.addListenerOnce('appear', (e) => {
+
+    _createContentElement: function () {
+      let id = "qxFileSelector_" + InputElementIdCounter++;
+      let input = (this.__inputObject = new qx.html.Input(
+        "file",
+        { display: "none" },
+        { id: id }
+      ));
+      let label = new qx.html.Element("label", {}, { for: id });
+      label.addListenerOnce(
+        "appear",
+        function (e) {
+          label.add(input);
+        },
+        this
+      );
+      input.addListenerOnce("appear", e => {
         let inputEl = input.getDomElement();
-        inputEl.addEventListener('change',(e) => {
-          this.fireDataEvent('changeFileSelection',inputEl.files);
+        inputEl.addEventListener("change", e => {
+          this.fireDataEvent("changeFileSelection", inputEl.files);
           inputEl.value = "";
         });
       });

--- a/source/class/qx/ui/form/FileSelectorButton.js
+++ b/source/class/qx/ui/form/FileSelectorButton.js
@@ -1,0 +1,128 @@
+/* ************************************************************************
+
+   qooxdoo
+
+   https://qooxdoo.org
+
+   Copyright:
+     2022 OETIKER+PARTNER AG
+
+   License:
+     MIT: https://opensource.org/licenses/MIT
+     See the LICENSE file in the project's top-level directory for details.
+
+   Authors:
+     * Tobias Oetiker (oetiker)
+
+************************************************************************ */
+
+/**
+ * The FileSelectionButton opens a window and lets the user pick one or several
+ * files from the local filesystem. A handle is returned which allows access
+ * to the content of the file from javascript. The file can now be processed
+ * in javascript, or it can also be uploaded to a server.
+ * 
+ * *Example*
+ *
+ * Post the content of the file to the server.
+ * 
+ * ```javascript
+ * let button = new qx.ui.form.FileSelectorButton("Select File");
+ * button.addListener('changeFileSelection',function(e){
+ * let fileList = e.getData();
+ *     let form = new FormData();
+ *     form.append('file',fileList[0]);
+ *     let req = new qx.io.request.Xhr("upload",'POST').set({
+ *         requestData: form
+ *     });
+ *     req.addListener('success',(e) => {
+ *         let response = req.getResponse();
+ *     });
+ * });
+ *
+ * [MDN Documentation](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input/file)
+ */
+
+qx.Class.define("qx.ui.form.FileSelectorButton", {
+  extend : qx.ui.form.Button,
+  statics: {
+    ID_CNTR: 0
+  },
+  events: {
+
+    /**
+     * The event is fired when the file selection changes.
+     *
+     * The method {@link qx.event.type.Data#getData} returns the
+     * current [fileList](https://developer.mozilla.org/en-US/docs/Web/API/FileList)
+     */
+    changeFileSelection: "qx.event.type.Data"
+  },
+  properties: {
+    /**
+     * What type of files should be offered in the fileselection dialog. 
+     * Use a comma separated list of [Unique file type specifiers](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input/file#unique_file_type_specifiers). If you dont set anything, all files
+     * are allowed.
+     * 
+     * *Example*
+     * 
+     * `.doc,.docx,application/msword`
+     */
+    accept: {
+      nullable: true,
+      apply : "_applyAttribute"
+    },
+    /**
+     * Specify that the camera should be used for getting the "file". The
+     * value defines which camera should be used for capturing images. 
+     * `user` is indicates the user-facing camera. 
+     * `environment` indicates the camera facing away from the user.
+     */
+    capture: {
+      nullable: true,
+      apply : "_applyAttribute"
+    },
+    /**
+     * Set to "true" if you want to allow the selection of multiple files.
+     */
+    multiple: {
+      nullable: true,
+      apply : "_applyAttribute"
+    },
+    /**
+     * If present, indicates that only directories should be available for
+     * selection. Despite the name, this attribute is supported by [all
+     * major browsers](https://caniuse.com/?search=webkitdirectory) 
+     * these days (not IE!).
+     */
+    webkitdirectory: {
+      nullable: true,
+      apply : "_applyAttribute"
+    }
+  },
+  members: {
+    __inputObject: null,
+
+    _applyAttribute: function(value,old,attr){
+      this.__inputObject.setAttribute(attr,value);
+    },
+    
+    _createContentElement: function() {
+      let id = 'qxFileSelector_'+(this.constructor.ID_CNTR++);
+      let input = this.__inputObject 
+        = new qx.html.Input("file",{display: 'none'},{id: id});
+      let label = new qx.html.Element("label",{},{'for': id});
+      label.addListenerOnce('appear',function(e){
+        label.add(input);
+      },this);
+      input.addListenerOnce('appear', (e) => {
+        let inputEl = input.getDomElement();
+        inputEl.addEventListener('change',(e) => {
+          this.fireDataEvent('changeFileSelection',inputEl.files);
+          inputEl.value = "";
+        });
+      });
+      return label;
+    }
+  }
+});

--- a/source/class/qx/ui/form/FileSelectorButton.js
+++ b/source/class/qx/ui/form/FileSelectorButton.js
@@ -121,6 +121,10 @@ qx.Class.define("qx.ui.form.FileSelectorButton", {
 
     _applyAttribute: function (value, old, attr) {
       if (attr === "directoriesOnly") {
+        // while the name of the attribute indicates that this only
+        // works for webkit borwsers, this is not the case. These
+        // days the attribute is supported by 
+        // [everyone](https://caniuse.com/?search=webkitdirectory).
         attr = "webkitdirectory";
       }
       this.__inputObject.setAttribute(attr, value);

--- a/source/class/qx/ui/form/FileSelectorButton.js
+++ b/source/class/qx/ui/form/FileSelectorButton.js
@@ -17,10 +17,10 @@
 ************************************************************************ */
 
 /**
- * The FileSelectionButton opens a window and lets the user pick one or several
- * files from the local filesystem. A handle is returned which allows access
- * to the content of the file from javascript. The file can now be processed
- * in javascript, or it can also be uploaded to a server.
+ * The FileSelectorButton opens a window and lets the user pick one or several
+ * files from the local filesystem. A FileList is returned which allows access
+ * to the content of the selected files from javascript. The file(s) can now be
+ *  processed in javascript, or it/they can be uploaded to a server.
  * 
  * *Example*
  *
@@ -39,8 +39,25 @@
  *         let response = req.getResponse();
  *     });
  * });
- *
- * [MDN Documentation](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input/file)
+ * ```
+ * 
+ * Process the file directly in javascript using the FileReader API.
+ * 
+ * ```javascript
+ * let button = new qx.ui.form.FileSelectorButton("Select File");
+ * button.addListener('changeFileSelection',function(e){
+ *   let fileList = e.getData();
+ *   const reader = new FileReader();
+ *   reader.addEventListener('load', () => {
+ *     let response = reader.result;
+ *     console.log("The first 4 chrs are: " + response);
+ *   });
+ *   const file = fileList[0];
+ *   reader.readAsText(file.slice(0,4));
+ * });
+
+*
+ * [MDN Documentation](https://developer.mozilla.org/en-US/docs/Web/API/File_API/Using_files_from_web_applications)
  */
 
 qx.Class.define("qx.ui.form.FileSelectorButton", {

--- a/source/class/qx/ui/toolbar/FileSelectorButton.js
+++ b/source/class/qx/ui/toolbar/FileSelectorButton.js
@@ -20,33 +20,32 @@
  * A toolbar-aware version of the {@link qx.ui.form.FileSelectionButton}.
  */
 
-qx.Class.define("qx.ui.toolbar.FileSelectorButton",
-{
-  extend : qx.ui.form.FileSelectorButton,
-  construct: function(label, icon, command) {
-    this.base(arguments,label, icon, command);
+qx.Class.define("qx.ui.toolbar.FileSelectorButton", {
+  extend: qx.ui.form.FileSelectorButton,
+  construct: function (label, icon, command) {
+    this.base(arguments, label, icon, command);
     // Toolbar buttons should not support the keyboard events
     this.removeListener("keydown", this._onKeyDown);
     this.removeListener("keyup", this._onKeyUp);
   },
   properties: {
-    appearance : {
-      refine : true,
-      init : "toolbar-button"
+    appearance: {
+      refine: true,
+      init: "toolbar-button"
     },
-    show : {
-      refine : true,
-      init : "inherit"
+    show: {
+      refine: true,
+      init: "inherit"
     },
-    focusable : {
-      refine : true,
-      init : false
+    focusable: {
+      refine: true,
+      init: false
     }
-  }, 
-  
-  members : {
+  },
+
+  members: {
     // overridden
-    _applyVisibility : function(value, old) {
+    _applyVisibility: function (value, old) {
       this.base(arguments, value, old);
       // trigger a appearance recalculation of the parent
       let parent = this.getLayoutParent();

--- a/source/class/qx/ui/toolbar/FileSelectorButton.js
+++ b/source/class/qx/ui/toolbar/FileSelectorButton.js
@@ -1,0 +1,58 @@
+/* ************************************************************************
+
+   qooxdoo
+
+   https://qooxdoo.org
+
+   Copyright:
+     2022 OETIKER+PARTNER AG
+
+   License:
+     MIT: https://opensource.org/licenses/MIT
+     See the LICENSE file in the project's top-level directory for details.
+
+   Authors:
+     * Tobias Oetiker (oetiker)
+
+************************************************************************ */
+
+/**
+ * A toolbar-aware version of the {@link qx.ui.form.FileSelectionButton}.
+ */
+
+qx.Class.define("qx.ui.toolbar.FileSelectorButton",
+{
+  extend : qx.ui.form.FileSelectorButton,
+  construct: function(label, icon, command) {
+    this.base(arguments,label, icon, command);
+    // Toolbar buttons should not support the keyboard events
+    this.removeListener("keydown", this._onKeyDown);
+    this.removeListener("keyup", this._onKeyUp);
+  },
+  properties: {
+    appearance : {
+      refine : true,
+      init : "toolbar-button"
+    },
+    show : {
+      refine : true,
+      init : "inherit"
+    },
+    focusable : {
+      refine : true,
+      init : false
+    }
+  }, 
+  
+  members : {
+    // overridden
+    _applyVisibility : function(value, old) {
+      this.base(arguments, value, old);
+      // trigger a appearance recalculation of the parent
+      let parent = this.getLayoutParent();
+      if (parent && parent instanceof qx.ui.toolbar.PartContainer) {
+        qx.ui.core.queue.Appearance.add(parent);
+      }
+    }
+  }
+});

--- a/source/class/qx/ui/toolbar/FileSelectorButton.js
+++ b/source/class/qx/ui/toolbar/FileSelectorButton.js
@@ -17,7 +17,7 @@
 ************************************************************************ */
 
 /**
- * A toolbar-aware version of the {@link qx.ui.form.FileSelectionButton}.
+ * A toolbar-aware version of the {@link qx.ui.form.FileSelectorButton}.
  */
 
 qx.Class.define("qx.ui.toolbar.FileSelectorButton", {


### PR DESCRIPTION
This PR adds two new widgets. The `qx.ui.form.FileSelectorButton` and the `qx.ui.toolbar.FileSelectorButton`. 

There is also a very very simple test 

For a an actual e2e test, the button would have to be 'pushed' externally using playwrigh. Not sure how todo this with our testing infrastructure.