### PR TITLE
Sometimes Icon Fonts have no Range Records

### DIFF
--- a/source/class/qx/tool/compiler/app/WebFont.js
+++ b/source/class/qx/tool/compiler/app/WebFont.js
@@ -255,12 +255,14 @@ qx.Class.define("qx.tool.compiler.app.WebFont", {
           lookupListIndexes.forEach(index => {
             let subTable = lookupList[index].subTables[0];
             let leadingCharacters = [];
-            subTable.coverage.rangeRecords.forEach(coverage => {
-              for (let i = coverage.start; i <= coverage.end; i++) {
-                let character = font.stringsForGlyph(i)[0];
-                leadingCharacters.push(character);
-              }
-            });
+            if (subTable.coverage.rangeRecords) {
+              subTable.coverage.rangeRecords.forEach(coverage => {
+                for (let i = coverage.start; i <= coverage.end; i++) {
+                  let character = font.stringsForGlyph(i)[0];
+                  leadingCharacters.push(character);
+                }
+              });
+            }
             let ligatureSets = subTable.ligatureSets.toArray();
             ligatureSets.forEach((ligatureSet, ligatureSetIndex) => {
               let leadingCharacter = leadingCharacters[ligatureSetIndex];


### PR DESCRIPTION
While adding support for https://tabler-icons.io/ I found that their IconFont https://github.com/tabler/tabler-icons/tree/master/iconfont/fonts breaks the compiler ... with this patch in place it works.