### PR TITLE
Make source-map compatibe with node v18

### DIFF
--- a/package.json
+++ b/package.json
@@ -109,7 +109,7 @@
     "semver": "^7.3.4",
     "set-value": "^4.1.0",
     "showdown": "^1.9.1",
-    "source-map": "^0.5.7",
+    "source-map": "^0.7.4",
     "tap-colorize": "^1.2.0",
     "terser": "^5.10.0",
     "tmp": "0.2.1",


### PR DESCRIPTION
It seems only source-map 0.7.4 works with node v18: mozilla/source-map#454