### PR TITLE
add member declarations for previously undeclared members

### DIFF
--- a/source/class/qx/event/dispatch/Direct.js
+++ b/source/class/qx/event/dispatch/Direct.js
@@ -56,6 +56,8 @@ qx.Class.define("qx.event.dispatch.Direct", {
   */
 
   members: {
+    _manager : undefined,
+
     /*
     ---------------------------------------------------------------------------
       EVENT DISPATCHER INTERFACE

--- a/source/class/qx/event/type/Event.js
+++ b/source/class/qx/event/type/Event.js
@@ -58,6 +58,18 @@ qx.Class.define("qx.event.type.Event", {
   */
 
   members: {
+    _type : undefined,
+    _target : undefined,
+    _currentTarget : undefined,
+    _relatedTarget : undefined,
+    _originalTarget : undefined,
+    _stopPropagation : undefined,
+    _preventDefault : undefined,
+    _bubbles : undefined,
+    _cancelable : undefined,
+    _timeStamp : undefined,
+    _eventPhase : undefined,
+
     /** {qx.Promise[]} promises returned by event handlers */
     _promises: null,
 

--- a/source/class/qx/tool/compiler/ClassFile.js
+++ b/source/class/qx/tool/compiler/ClassFile.js
@@ -253,6 +253,9 @@ qx.Class.define("qx.tool.compiler.ClassFile", {
   },
 
   members: {
+    __privateMangling : undefined,
+    __usesJsx : undefined,
+
     __analyser: null,
     __className: null,
     __numClassesDefined: 0,

--- a/source/class/qx/tool/compiler/resources/Manager.js
+++ b/source/class/qx/tool/compiler/resources/Manager.js
@@ -54,6 +54,8 @@ qx.Class.define("qx.tool.compiler.resources.Manager", {
   },
 
   members: {
+    __assets : undefined,
+
     /** {String} filename of database */
     __dbFilename: null,
 

--- a/source/class/qx/tool/compiler/targets/meta/ApplicationMeta.js
+++ b/source/class/qx/tool/compiler/targets/meta/ApplicationMeta.js
@@ -82,6 +82,8 @@ qx.Class.define("qx.tool.compiler.targets.meta.ApplicationMeta", {
   },
 
   members: {
+    __partsLookup : undefined,
+
     /** {qx.tool.compiler.targets.Target} the target */
     __target: null,
 

--- a/source/class/qx/tool/compiler/targets/meta/BootJs.js
+++ b/source/class/qx/tool/compiler/targets/meta/BootJs.js
@@ -43,6 +43,8 @@ qx.Class.define("qx.tool.compiler.targets.meta.BootJs", {
   },
 
   members: {
+    __embeddedJsLookup : undefined,
+
     __embeddedJs: null,
     __sourceMapOffsets: null,
 

--- a/source/class/qx/tool/compiler/targets/meta/PackageJavascript.js
+++ b/source/class/qx/tool/compiler/targets/meta/PackageJavascript.js
@@ -50,6 +50,8 @@ qx.Class.define("qx.tool.compiler.targets.meta.PackageJavascript", {
   },
 
   members: {
+    __pkg : undefined,
+    
     __sourceMapOffsets: null,
 
     /*

--- a/source/class/qx/tool/utils/LogManager.js
+++ b/source/class/qx/tool/utils/LogManager.js
@@ -134,6 +134,13 @@ qx.Class.define("qx.tool.utils.LogManager", {
   },
 
   members: {
+    _loggers : undefined,
+    _levels : undefined,
+    _sinks : undefined,
+    _config : undefined,
+    _defaultSink : undefined,
+    _defautLevel :  undefined,
+
     async loadConfig(config) {
       if (typeof config == "string") {
         config = await qx.tool.utils.Json.loadJsonAsync(config);

--- a/source/class/qx/tool/utils/json/Tokenizer.js
+++ b/source/class/qx/tool/utils/json/Tokenizer.js
@@ -59,6 +59,11 @@ qx.Class.define("qx.tool.utils.json.Tokenizer", {
   },
 
   members: {
+    input : undefined,
+    settings : undefined,
+    tokens : undefined,
+    tokenIndex : undefined,
+
     token() {
       if (this.tokens === null) {
         throw new Error("No tokens to return (have you called tokenize?)");


### PR DESCRIPTION
These ought to be documented and have more appropriate initializers than `undefined`. The new class system detects and warns of undeclared member variables. We'd be good to have these all declared soon/now so that when we later add JSDoc type definitions to the member declaration, they'll all already be there.

This is not an all-inclusive list of changes. It includes only those I've yet detected, i.e., classes I've yet run through the new class system.