### PR TITLE
Some refactoring and correction to FileSelectorButton widget

### DIFF
--- a/source/class/qx/ui/form/FileSelectorButton.js
+++ b/source/class/qx/ui/form/FileSelectorButton.js
@@ -147,7 +147,7 @@ qx.Class.define("qx.ui.form.FileSelectorButton", {
         null,
         { id: id }
       ));
-      input.hide();
+      input.exclude();
       let label = new qx.html.Element("label", {}, { for: id });
       label.addListenerOnce(
         "appear",

--- a/source/class/qx/ui/form/FileSelectorButton.js
+++ b/source/class/qx/ui/form/FileSelectorButton.js
@@ -64,12 +64,12 @@ qx.Class.define("qx.ui.form.FileSelectorButton", {
   extend: qx.ui.form.Button,
 
   statics: {
-    _FileInputElementIdCounter: 0,
-    _FileInputElementIdPrefix: "qxFileSelector_",
+    _fileInputElementIdCounter: 0,
+    _fileInputElementIdPrefix: "qxFileSelector_",
 
     _generateElementId: function(){
-      ++this._FileInputElementIdCounter;
-      return this._FileInputElementIdPrefix + this._FileInputElementIdCounter;
+      ++this._fileInputElementIdCounter;
+      return this._fileInputElementIdPrefix + this._fileInputElementIdCounter;
     }
   },
 

--- a/source/class/qx/ui/form/FileSelectorButton.js
+++ b/source/class/qx/ui/form/FileSelectorButton.js
@@ -21,11 +21,11 @@
  * files from the local filesystem. A FileList is returned which allows access
  * to the content of the selected files from javascript. The file(s) can now be
  *  processed in javascript, or it/they can be uploaded to a server.
- * 
+ *
  * *Example*
  *
  * Post the content of the file to the server.
- * 
+ *
  * ```javascript
  * let button = new qx.ui.form.FileSelectorButton("Select File");
  * button.addListener('changeFileSelection',function(e){
@@ -40,9 +40,9 @@
  *   });
  * });
  * ```
- * 
+ *
  * Process the file directly in javascript using the FileReader API.
- * 
+ *
  * ```javascript
  * let button = new qx.ui.form.FileSelectorButton("Select File");
  * button.addListener('changeFileSelection',function(e){
@@ -134,9 +134,10 @@ qx.Class.define("qx.ui.form.FileSelectorButton", {
       let id = "qxFileSelector_" + InputElementIdCounter++;
       let input = (this.__inputObject = new qx.html.Input(
         "file",
-        { display: "none" },
+        null,
         { id: id }
       ));
+      input.hide();
       let label = new qx.html.Element("label", {}, { for: id });
       label.addListenerOnce(
         "appear",

--- a/source/class/qx/ui/form/FileSelectorButton.js
+++ b/source/class/qx/ui/form/FileSelectorButton.js
@@ -157,10 +157,10 @@ qx.Class.define("qx.ui.form.FileSelectorButton", {
       );
       input.addListenerOnce("appear", e => {
         let inputEl = input.getDomElement();
-       // since qx.html.Node does not even create the
-       // domNode if it is not set to visible initially
-       // we have to quickly hide it after creation.
-       input.setVisible(false);
+        // since qx.html.Node does not even create the
+        // domNode if it is not set to visible initially
+        // we have to quickly hide it after creation.
+        input.setVisible(false);
         inputEl.addEventListener("change", e => {
           this.fireDataEvent("changeFileSelection", inputEl.files);
           inputEl.value = "";

--- a/source/class/qx/ui/form/FileSelectorButton.js
+++ b/source/class/qx/ui/form/FileSelectorButton.js
@@ -55,8 +55,8 @@
  *   const file = fileList[0];
  *   reader.readAsText(file.slice(0,4));
  * });
-
-*
+ * ```
+ *
  * [MDN Documentation](https://developer.mozilla.org/en-US/docs/Web/API/File_API/Using_files_from_web_applications)
  */
 

--- a/source/class/qx/ui/form/FileSelectorButton.js
+++ b/source/class/qx/ui/form/FileSelectorButton.js
@@ -60,9 +60,19 @@
  * [MDN Documentation](https://developer.mozilla.org/en-US/docs/Web/API/File_API/Using_files_from_web_applications)
  */
 
-let InputElementIdCounter = 0;
 qx.Class.define("qx.ui.form.FileSelectorButton", {
   extend: qx.ui.form.Button,
+
+  statics: {
+    _FileInputElementIdCounter: 0,
+    _FileInputElementIdPrefix: "qxFileSelector_",
+
+    _generateElementId: function(){
+      ++this._FileInputElementIdCounter;
+      return this._FileInputElementIdPrefix + this._FileInputElementIdCounter;
+    }
+  },
+
   events: {
     /**
      * The event is fired when the file selection changes.
@@ -122,7 +132,7 @@ qx.Class.define("qx.ui.form.FileSelectorButton", {
     _applyAttribute: function (value, old, attr) {
       if (attr === "directoriesOnly") {
         // while the name of the attribute indicates that this only
-        // works for webkit borwsers, this is not the case. These
+        // works for webkit browsers, this is not the case. These
         // days the attribute is supported by
         // [everyone](https://caniuse.com/?search=webkitdirectory).
         attr = "webkitdirectory";
@@ -131,7 +141,7 @@ qx.Class.define("qx.ui.form.FileSelectorButton", {
     },
 
     _createContentElement: function () {
-      let id = "qxFileSelector_" + InputElementIdCounter++;
+      let id = qx.ui.form.FileSelectorButton._generateElementId();
       let input = (this.__inputObject = new qx.html.Input(
         "file",
         null,

--- a/source/class/qx/ui/form/FileSelectorButton.js
+++ b/source/class/qx/ui/form/FileSelectorButton.js
@@ -157,7 +157,10 @@ qx.Class.define("qx.ui.form.FileSelectorButton", {
       );
       input.addListenerOnce("appear", e => {
         let inputEl = input.getDomElement();
-        input.setStyle('display', 'none');
+       // since qx.html.Node does not even create the
+       // domNode if it is not set to visible initially
+       // we have to quickly hide it after creation.
+       input.setVisible(false);
         inputEl.addEventListener("change", e => {
           this.fireDataEvent("changeFileSelection", inputEl.files);
           inputEl.value = "";

--- a/source/class/qx/ui/form/FileSelectorButton.js
+++ b/source/class/qx/ui/form/FileSelectorButton.js
@@ -147,7 +147,7 @@ qx.Class.define("qx.ui.form.FileSelectorButton", {
         null,
         { id: id }
       ));
-      input.exclude();
+
       let label = new qx.html.Element("label", {}, { for: id });
       label.addListenerOnce(
         "appear",
@@ -157,6 +157,7 @@ qx.Class.define("qx.ui.form.FileSelectorButton", {
       );
       input.addListenerOnce("appear", e => {
         let inputEl = input.getDomElement();
+        input.hide();
         inputEl.addEventListener("change", e => {
           this.fireDataEvent("changeFileSelection", inputEl.files);
           inputEl.value = "";

--- a/source/class/qx/ui/form/FileSelectorButton.js
+++ b/source/class/qx/ui/form/FileSelectorButton.js
@@ -157,7 +157,7 @@ qx.Class.define("qx.ui.form.FileSelectorButton", {
       );
       input.addListenerOnce("appear", e => {
         let inputEl = input.getDomElement();
-        input.hide();
+        input.setStyle('display', 'none');
         inputEl.addEventListener("change", e => {
           this.fireDataEvent("changeFileSelection", inputEl.files);
           inputEl.value = "";

--- a/source/class/qx/ui/form/FileSelectorButton.js
+++ b/source/class/qx/ui/form/FileSelectorButton.js
@@ -64,13 +64,7 @@ qx.Class.define("qx.ui.form.FileSelectorButton", {
   extend: qx.ui.form.Button,
 
   statics: {
-    _fileInputElementIdCounter: 0,
-    _fileInputElementIdPrefix: "qxFileSelector_",
-
-    _generateElementId: function(){
-      ++this._fileInputElementIdCounter;
-      return this._fileInputElementIdPrefix + this._fileInputElementIdCounter;
-    }
+    _fileInputElementIdCounter: 0
   },
 
   events: {
@@ -141,7 +135,7 @@ qx.Class.define("qx.ui.form.FileSelectorButton", {
     },
 
     _createContentElement: function () {
-      let id = qx.ui.form.FileSelectorButton._generateElementId();
+      let id = "qxFileSelector_" + (++qx.ui.form.FileSelectorButton._fileInputElementIdCounter);
       let input = (this.__inputObject = new qx.html.Input(
         "file",
         null,

--- a/source/class/qx/ui/form/FileSelectorButton.js
+++ b/source/class/qx/ui/form/FileSelectorButton.js
@@ -64,13 +64,7 @@ qx.Class.define("qx.ui.form.FileSelectorButton", {
   extend: qx.ui.form.Button,
 
   statics: {
-    _fileInputElementIdCounter: 0,
-    _fileInputElementIdPrefix: "qxFileSelector_",
-
-    _generateElementId: function(){
-      ++this._fileInputElementIdCounter;
-      return this._fileInputElementIdPrefix + this._fileInputElementIdCounter;
-    }
+    _fileInputElementIdCounter: 0
   },
 
   events: {
@@ -141,7 +135,7 @@ qx.Class.define("qx.ui.form.FileSelectorButton", {
     },
 
     _createContentElement: function () {
-      let id = qx.ui.form.FileSelectorButton._generateElementId();
+      let id = "qxFileSelector_" + qx.ui.form.FileSelectorButton._fileInputElementIdCounter;
       let input = (this.__inputObject = new qx.html.Input(
         "file",
         null,


### PR DESCRIPTION
- The internal file input element doesn't start hidden in Chrome 102.0.5005.61 64bits linux
- Refactored the element ID counter from a global variable to a static member, created an internal id generator