### PR TITLE
fix a couple of bugs in compiler

### DIFF
--- a/source/class/qx/tool/compiler/Analyser.js
+++ b/source/class/qx/tool/compiler/Analyser.js
@@ -1105,12 +1105,9 @@ qx.Class.define("qx.tool.compiler.Analyser", {
             var dbMtime = null;
             try {
               dbMtime = dbClassInfo.mtime && new Date(dbClassInfo.mtime);
-            } catch (e) {
-              // Nothing
-            }
-            // Check for exact matches on the mtime, because the file could have been moved in from somewhere else
+            } catch (e) {}
             if (dbMtime && dbMtime.getTime() == sourceStat.mtime.getTime()) {
-              if (outputStat.mtime.getTime() == sourceStat.mtime.getTime()) {
+              if (outputStat.mtime.getTime() >= sourceStat.mtime.getTime()) {
                 await t.fireDataEventAsync("alreadyCompiledClass", {
                   className: className,
                   dbClassInfo: dbClassInfo

--- a/source/class/qx/tool/compiler/Analyser.js
+++ b/source/class/qx/tool/compiler/Analyser.js
@@ -1105,9 +1105,12 @@ qx.Class.define("qx.tool.compiler.Analyser", {
             var dbMtime = null;
             try {
               dbMtime = dbClassInfo.mtime && new Date(dbClassInfo.mtime);
-            } catch (e) {}
+            } catch (e) {
+              // Nothing
+            }
+            // Check for exact matches on the mtime, because the file could have been moved in from somewhere else
             if (dbMtime && dbMtime.getTime() == sourceStat.mtime.getTime()) {
-              if (outputStat.mtime.getTime() >= sourceStat.mtime.getTime()) {
+              if (outputStat.mtime.getTime() == sourceStat.mtime.getTime()) {
                 await t.fireDataEventAsync("alreadyCompiledClass", {
                   className: className,
                   dbClassInfo: dbClassInfo

--- a/source/class/qx/tool/compiler/targets/meta/Browserify.js
+++ b/source/class/qx/tool/compiler/targets/meta/Browserify.js
@@ -56,9 +56,7 @@ qx.Class.define("qx.tool.compiler.targets.meta.Browserify", {
         "browser"
       ) {
         // Get a Set of unique `require`d CommonJS module names from classes needed by the application
-        let classnames = this.__appMeta__P_44_0
-          .getApplication()
-          .getDependencies();
+        let classnames = this.__appMeta.getApplication().getDependencies();
         for (let className of classnames) {
           let classInfo = db.classInfo[className];
           if (classInfo.commonjsModules) {


### PR DESCRIPTION
fix bug where classes which are no longer dependencies still have their `require` classes included in browserify output;
fix for better checking mtime when determining whether to recompile classes