### PR TITLE
Fix - Prevent multiple redraws on cascading open/close node

### DIFF
--- a/source/class/qx/ui/treevirtual/MNode.js
+++ b/source/class/qx/ui/treevirtual/MNode.js
@@ -226,7 +226,7 @@ qx.Mixin.define("qx.ui.treevirtual.MNode", {
       }
       if (cascade) {
         node.children.forEach(child =>
-          this.nodeSetOpened(child, opened, cascade, true)
+          this._nodeSetOpenedInternal(child, opened, cascade, true)
         );
       }
       if (!cascade || !isRecursed) {


### PR DESCRIPTION
Fixes a problem from when I introduced this code some while back. The private method should have been called in the node loop to prevent redraws whilst cascading the open/close nodes. It had the correct parameters, but was erroneously calling the public method. 