### PR TITLE
Fix wait

### DIFF
--- a/source/class/qx/tool/cli/Watch.js
+++ b/source/class/qx/tool/cli/Watch.js
@@ -236,7 +236,6 @@ qx.Class.define("qx.tool.cli.Watch", {
 
         watcher.on("ready", () => {
           this.__watcherReady = true;
-          this.__make();
         });
         watcher.on("error", err => {
           qx.tool.compiler.Console.print(

--- a/source/class/qx/tool/cli/commands/Compile.js
+++ b/source/class/qx/tool/cli/commands/Compile.js
@@ -631,7 +631,7 @@ Framework: v${await this.getQxVersion()} in ${await this.getQxPath()}`);
               "source/index.html"
             );
           }
-
+          let res;
           // Simple one of make
           if (!this.argv.watch) {
             maker.addListener("making", () => {
@@ -646,9 +646,10 @@ Framework: v${await this.getQxVersion()} in ${await this.getQxPath()}`);
                 this.fireEvent("made");
               }
             });
+            res = maker.make();
           }
-          await maker.make();
           if (this.argv.watch) {
+            await maker.make();
             // Continuous make
             let watch = new qx.tool.cli.Watch(maker);
             config.applications.forEach(appConfig => {
@@ -685,8 +686,9 @@ Framework: v${await this.getQxVersion()} in ${await this.getQxPath()}`);
             ].filter(str => Boolean(str));
 
             watch.setConfigFilenames(arr);
-            return await watch.start();
+            res = watch.start();
           }
+          return res;
         })
       );
     },

--- a/source/class/qx/tool/cli/commands/Compile.js
+++ b/source/class/qx/tool/cli/commands/Compile.js
@@ -359,7 +359,7 @@ qx.Class.define("qx.tool.cli.commands.Compile", {
       }
 
       if (this.argv.verbose) {
-        console.log(`
+        qx.tool.compiler.Console.log(`
 Compiler:  v${this.getCompilerVersion()} in ${require.main.filename}
 Framework: v${await this.getQxVersion()} in ${await this.getQxPath()}`);
       }
@@ -682,6 +682,7 @@ Framework: v${await this.getQxVersion()} in ${await this.getQxPath()}`);
           );
 
           watch.setConfigFilenames(arr);
+          qx.tool.compiler.Console.log(`Start watching ...`);
           return watch.start();
         })
       );

--- a/source/class/qx/tool/cli/commands/Deploy.js
+++ b/source/class/qx/tool/cli/commands/Deploy.js
@@ -102,12 +102,8 @@ qx.Class.define("qx.tool.cli.commands.Deploy", {
     /*
      * @Override
      */
-    processArgs(argv) {
-      super.processArgs(argv);
-      if (!argv.clean) {
-        qx.tool.compiler.Console.print("qx.tool.cli.deploy.notClean");
-      }
-
+    async process() {
+      let argv = this.argv;
       let compileArgv = {
         writeLibraryInfo: false,
         download: false,
@@ -120,15 +116,10 @@ qx.Class.define("qx.tool.cli.commands.Deploy", {
       };
 
       qx.lang.Object.mergeWith(argv, compileArgv);
-    },
-
-    /*
-     * @Override
-     */
-    async process() {
+      if (!argv.clean) {
+        qx.tool.compiler.Console.print("qx.tool.cli.deploy.notClean");
+      }
       await super.process();
-
-      let argv = this.argv;
       let appNames = null;
       if (argv.appName) {
         appNames = {};


### PR DESCRIPTION
[fix problem that wait will always restart if you change files during compile.

Up to now wait starts before the first build was finished. So if you change files during build, e.g. generated version infos, build was restartet infinite.
Now the wait starts after the first build is finished
