### PR TITLE
revert PR 10491 because it breaks drag and drop

### DIFF
--- a/source/class/qx/ui/core/scroll/MRoll.js
+++ b/source/class/qx/ui/core/scroll/MRoll.js
@@ -58,6 +58,11 @@ qx.Mixin.define("qx.ui.core.scroll.MRoll", {
      * @param e {qx.event.type.Roll} Roll event
      */
     _onRoll(e) {
+      // only wheel and touch
+      if (e.getPointerType() == "mouse") {
+        return;
+      }
+
       if (this._cancelRoll && e.getMomentum()) {
         e.stopMomentum();
         this._cancelRoll = null;


### PR DESCRIPTION
The PR in https://github.com/qooxdoo/qooxdoo/pull/10491 enabled the mouse to scroll the container, but this breaks the drag and drop behaviour if the item being dragged is inside a list which is on a scrollable container.

What happens is that as the user tries to drag an item (eg to reorder the contents of a list), then as they move the mouse the entire container scrolls, and this makes it impossible to position the drop target - because as you move closer to where you want to drag it, the entire container scrolls and moves the list.

Sometimes this causes the screen to jitter as the repositioning causes the drag target as the mouse moves due to automatic scrolling.

I have not investigated a fix which could allow auto-scroll and drag and drop to not conflict, but as this is a relatively recent change it seems that a first response would be to stop the problem from occurring