### PR TITLE
fix problem that wait will always restart if you change files during compile

### DIFF
--- a/source/class/qx/tool/cli/Watch.js
+++ b/source/class/qx/tool/cli/Watch.js
@@ -13,6 +13,7 @@
 
    Authors:
      * John Spackman (john.spackman@zenesis.com, @johnspackman)
+     * Henner Kollmann (Henner.Kollmann@gmx.de, @hkollmann)
 
 ************************************************************************ */
 
@@ -221,30 +222,31 @@ qx.Class.define("qx.tool.cli.Watch", {
             `DEBUG: confirmed=${JSON.stringify(confirmed, 2)}`
           );
         }
-
-        var watcher = (this._watcher = chokidar.watch(confirmed, {
-          //ignored: /(^|[\/\\])\../
-        }));
-        watcher.on("change", filename =>
-          this.__onFileChange("change", filename)
-        );
-
-        watcher.on("add", filename => this.__onFileChange("add", filename));
-        watcher.on("unlink", filename =>
-          this.__onFileChange("unlink", filename)
-        );
-
-        watcher.on("ready", () => {
-          this.__watcherReady = true;
-          this.__make();
-        });
-        watcher.on("error", err => {
-          qx.tool.compiler.Console.print(
-            err.code == "ENOSPC"
-              ? "qx.tool.cli.watch.enospcError"
-              : "qx.tool.cli.watch.watchError",
-            err
+        this.__make().then(() => {
+          var watcher = (this._watcher = chokidar.watch(confirmed, {
+            //ignored: /(^|[\/\\])\../
+          }));
+          watcher.on("change", filename =>
+            this.__onFileChange("change", filename)
           );
+
+          watcher.on("add", filename => this.__onFileChange("add", filename));
+          watcher.on("unlink", filename =>
+            this.__onFileChange("unlink", filename)
+          );
+
+          watcher.on("ready", () => {
+            qx.tool.compiler.Console.log(`Start watching ...`);
+            this.__watcherReady = true;
+          });
+          watcher.on("error", err => {
+            qx.tool.compiler.Console.print(
+              err.code == "ENOSPC"
+                ? "qx.tool.cli.watch.enospcError"
+                : "qx.tool.cli.watch.watchError",
+              err
+            );
+          });
         });
       });
     },


### PR DESCRIPTION

Up to now wait starts before the first build was finished. So if you change files during build, e.g. generated version infos, build was restartet infinite. Now the wait starts after the first build is finished