### PR TITLE
Fix IndigoDark tooltip

### DIFF
--- a/source/class/qx/theme/indigo/AppearanceDark.js
+++ b/source/class/qx/theme/indigo/AppearanceDark.js
@@ -34,14 +34,6 @@ qx.Theme.define("qx.theme.indigo.AppearanceDark", {
   extend: qx.theme.indigo.Appearance,
 
   appearances: {
-    "label": {
-      style(states) {
-        return {
-          textColor: states.disabled ? "text-disabled" : "text"
-        };
-      }
-    },
-
     "listitem": {
       alias: "atom",
 

--- a/source/class/qx/theme/indigo/AppearanceDark.js
+++ b/source/class/qx/theme/indigo/AppearanceDark.js
@@ -34,40 +34,6 @@ qx.Theme.define("qx.theme.indigo.AppearanceDark", {
   extend: qx.theme.indigo.Appearance,
 
   appearances: {
-    "listitem": {
-      alias: "atom",
-
-      style(states) {
-        var padding = [3, 5, 3, 5];
-        if (states.lead) {
-          padding = [2, 4, 2, 4];
-        }
-        if (states.dragover) {
-          padding[2] -= 2;
-        }
-
-        var backgroundColor;
-        if (states.selected) {
-          backgroundColor = "background-selected";
-          if (states.disabled) {
-            backgroundColor += "-disabled";
-          }
-        }
-        return {
-          gap: 4,
-          padding: padding,
-          backgroundColor: backgroundColor,
-          textColor: states.selected ? "text-selected" : undefined,
-          decorator: states.lead
-            ? "lead-item"
-            : states.dragover
-              ? "dragover"
-              : undefined,
-          opacity: states.drag ? 0.5 : undefined
-        };
-      }
-    },
-
     "progressbar": {
       style(states) {
         return {

--- a/source/class/qx/theme/indigo/ColorDark.js
+++ b/source/class/qx/theme/indigo/ColorDark.js
@@ -85,8 +85,8 @@ qx.Theme.define("qx.theme.indigo.ColorDark", {
     "text-placeholder": "#cbc8cd",
 
     // tooltip
-    "tooltip": "#dddddd",
-    "tooltip-text": "#000000",
+    "tooltip": "#666666",
+    "tooltip-text": "#dddddd",
 
     // table
     "table-header": "#f2f2f2",


### PR DESCRIPTION
Remove label appearance which was preventing the tooltip textcolor cascading through.
I can't see that this has upset any other label usage in the Widget Browser

Did look like this:
<img width="96" alt="image" src="https://user-images.githubusercontent.com/45275736/210763480-e30de0cf-fd9f-4846-8c71-2fe3e37adb4d.png">

Now looks like this:
<img width="68" alt="image" src="https://user-images.githubusercontent.com/45275736/210763585-3f064afe-1387-42b7-9bb8-773a0040901a.png">
