### PR TITLE
Remove spaces in OR of JSDoc

### DIFF
--- a/docs/_media/docsify.js
+++ b/docs/_media/docsify.js
@@ -1366,7 +1366,7 @@
   		 *
   		 * This does __not__ work for line script element.
   		 *
-  		 * @returns {HTMLScriptElement | null}
+  		 * @returns {HTMLScriptElement|null}
   		 */
   		currentScript: function () {
   			if (typeof document === 'undefined') {

--- a/source/class/qx/Class.js
+++ b/source/class/qx/Class.js
@@ -491,7 +491,7 @@ qx.Bootstrap.define("qx.Class", {
      *
      * @param clazz {Class} class to look for the property
      * @param name {String} name of the property
-     * @return {Class | null} The class which includes the property
+     * @return {Class|null} The class which includes the property
      */
     getByProperty(clazz, name) {
       while (clazz) {
@@ -554,7 +554,7 @@ qx.Bootstrap.define("qx.Class", {
      *
      * @param clazz {Class} class to look for the mixin
      * @param mixin {Mixin} mixin to look for
-     * @return {Class | null} The class which directly includes the given mixin
+     * @return {Class|null} The class which directly includes the given mixin
      */
     getByMixin(clazz, mixin) {
       var list, i, l;
@@ -619,7 +619,7 @@ qx.Bootstrap.define("qx.Class", {
      * @signature function(clazz, iface)
      * @param clazz {Class} class to look for the interface
      * @param iface {Interface} interface to look for
-     * @return {Class | null} the class which directly implements the given interface
+     * @return {Class|null} the class which directly implements the given interface
      */
     getByInterface: qx.util.OOUtil.getByInterface,
 

--- a/source/class/qx/bom/Cookie.js
+++ b/source/class/qx/bom/Cookie.js
@@ -45,7 +45,7 @@ qx.Bootstrap.define("qx.bom.Cookie", {
      * Returns the string value of a cookie.
      *
      * @param key {String} The key for the saved string value.
-     * @return {null | String} Returns the saved string value, if the cookie
+     * @return {null|String} Returns the saved string value, if the cookie
      *    contains a value for the key, <code>null</code> otherwise.
      */
     get(key) {

--- a/source/class/qx/data/Array.js
+++ b/source/class/qx/data/Array.js
@@ -922,7 +922,7 @@ qx.Class.define("qx.data.Array", {
      * Returns the highest value in the given array.
      * Supports numeric values only.
      *
-     * @return {Number | null} The highest of all values or undefined if the
+     * @return {Number|null} The highest of all values or undefined if the
      *   array is empty.
      */
     max() {
@@ -941,7 +941,7 @@ qx.Class.define("qx.data.Array", {
      * Returns the lowest value in the array. Supports
      * numeric values only.
      *
-     * @return {Number | null} The lowest of all values or undefined
+     * @return {Number|null} The lowest of all values or undefined
      *   if the array is empty.
      */
     min() {
@@ -1017,7 +1017,7 @@ qx.Class.define("qx.data.Array", {
      *   <li><code>index</code>: the index of the current item</li>
      *   <li><code>array</code>: The native array instance, NOT the data array instance.</li>
      * @param self {var?undefined} The context of the callback.
-     * @return {var | undefined} The found item.
+     * @return {var|undefined} The found item.
      */
     find(callback, self) {
       return this.__array.find(callback, self);

--- a/source/class/qx/data/SingleValueBinding.js
+++ b/source/class/qx/data/SingleValueBinding.js
@@ -927,7 +927,7 @@ qx.Class.define("qx.data.SingleValueBinding", {
      * @param targetProperties {String[]} Array containing the names of the properties
      * @param index {Number?} The array index of the last property to be considered.
      * Default: The last item's index
-     * @return {qx.core.Object | null} The object on which the last property
+     * @return {qx.core.Object|null} The object on which the last property
      *   should be set.
      */
     __getTargetFromChain(targetObject, targetProperties, index) {

--- a/source/class/qx/dom/Hierarchy.js
+++ b/source/class/qx/dom/Hierarchy.js
@@ -103,7 +103,7 @@ qx.Bootstrap.define("qx.dom.Hierarchy", {
      * "nextSibling" is not good enough as it might return a text or comment element
      *
      * @param element {Element} Starting element node
-     * @return {Element | null} Next element node
+     * @return {Element|null} Next element node
      */
     getNextElementSibling(element) {
       while (
@@ -123,7 +123,7 @@ qx.Bootstrap.define("qx.dom.Hierarchy", {
      * "previousSibling" is not good enough as it might return a text or comment element
      *
      * @param element {Element} Starting element node
-     * @return {Element | null} Previous element node
+     * @return {Element|null} Previous element node
      */
     getPreviousElementSibling(element) {
       while (

--- a/source/class/qx/event/Manager.js
+++ b/source/class/qx/event/Manager.js
@@ -260,7 +260,7 @@ qx.Class.define("qx.event.Manager", {
      * @param type {String} Event type
      * @param capture {Boolean ? false} Whether the listener is for the
      *       capturing phase of the bubbling phase.
-     * @return {Array | null} Array of registered event handlers. May return
+     * @return {Array|null} Array of registered event handlers. May return
      *       null when no listener were found.
      */
     getListeners(target, type, capture) {

--- a/source/class/qx/event/handler/TouchCore.js
+++ b/source/class/qx/event/handler/TouchCore.js
@@ -423,7 +423,7 @@ qx.Bootstrap.define("qx.event.handler.TouchCore", {
      * Checks which elements are placed to position x/y and traverses the array
      * till one element has no "pointer-events:none" inside its style attribute.
      * @param domEvent {Event} DOM event
-     * @return {Element | null} Event target
+     * @return {Element|null} Event target
      */
     __evaluateTarget(domEvent) {
       var clientX = null;

--- a/source/class/qx/html/Jsx.js
+++ b/source/class/qx/html/Jsx.js
@@ -37,7 +37,7 @@ qx.Class.define("qx.html.Jsx", {
      * @param tagname {String} the name of the tag
      * @param attributes {Map?} map of attribute values
      * @param children {qx.html.Node[]} array of children
-     * @return {qx.html.Element | qx.data.Array}
+     * @return {qx.html.Element|qx.data.Array}
      */
     createElement(tagname, attributes) {
       var children = qx.lang.Array.fromArguments(arguments, 2);

--- a/source/class/qx/lang/Array.js
+++ b/source/class/qx/lang/Array.js
@@ -420,7 +420,7 @@ qx.Bootstrap.define("qx.lang.Array", {
      * numeric values only.
      *
      * @param arr {Number[]} Array to process
-     * @return {Number | null} The highest of all values or undefined if array is empty.
+     * @return {Number|null} The highest of all values or undefined if array is empty.
      */
     max(arr) {
       if (qx.core.Environment.get("qx.debug")) {
@@ -446,7 +446,7 @@ qx.Bootstrap.define("qx.lang.Array", {
      * numeric values only.
      *
      * @param arr {Number[]} Array to process
-     * @return {Number | null} The lowest of all values or undefined if array is empty.
+     * @return {Number|null} The lowest of all values or undefined if array is empty.
      */
     min(arr) {
       if (qx.core.Environment.get("qx.debug")) {

--- a/source/class/qx/locale/MTranslation.js
+++ b/source/class/qx/locale/MTranslation.js
@@ -32,7 +32,7 @@ qx.Mixin.define("qx.locale.MTranslation", {
      *
      * @param messageId {String} message id (may contain format strings)
      * @param varargs {Object?} variable number of arguments applied to the format string
-     * @return {String | LocalizedString} The translated message or localized string
+     * @return {String|LocalizedString} The translated message or localized string
      */
     tr(messageId, varargs) {
       var nlsManager = qx.locale.Manager;
@@ -55,7 +55,7 @@ qx.Mixin.define("qx.locale.MTranslation", {
      * @param pluralMessageId {String} message id of the plural form (may contain format strings)
      * @param count {Integer} if greater than 1 the plural form otherwise the singular form is returned.
      * @param varargs {Object?} variable number of arguments applied to the format string
-     * @return {String | LocalizedString} The translated message or localized string
+     * @return {String|LocalizedString} The translated message or localized string
      */
     trn(singularMessageId, pluralMessageId, count, varargs) {
       var nlsManager = qx.locale.Manager;
@@ -75,7 +75,7 @@ qx.Mixin.define("qx.locale.MTranslation", {
      * @param hint {String} hint for the translator of the message. Will be included in the .po file.
      * @param messageId {String} message id (may contain format strings)
      * @param varargs {Object?} variable number of arguments applied to the format string
-     * @return {String | LocalizedString} The translated message or localized string
+     * @return {String|LocalizedString} The translated message or localized string
      */
     trc(hint, messageId, varargs) {
       var nlsManager = qx.locale.Manager;
@@ -99,7 +99,7 @@ qx.Mixin.define("qx.locale.MTranslation", {
      * @param pluralMessageId {String} message id of the plural form (may contain format strings)
      * @param count {Integer} if greater than 1 the plural form otherwise the singular form is returned.
      * @param varargs {Object?} variable number of arguments applied to the format string
-     * @return {String | LocalizedString} The translated message or localized string
+     * @return {String|LocalizedString} The translated message or localized string
      */
     trnc(hint, singularMessageId, pluralMessageId, count, varargs) {
       var nlsManager = qx.locale.Manager;

--- a/source/class/qx/locale/Manager.js
+++ b/source/class/qx/locale/Manager.js
@@ -64,7 +64,7 @@ qx.Class.define("qx.locale.Manager", {
      *
      * @param messageId {String} message id (may contain format strings)
      * @param varargs {Object} variable number of arguments applied to the format string
-     * @return {String | LocalizedString} The translated message or localized string
+     * @return {String|LocalizedString} The translated message or localized string
      * @see qx.lang.String.format
      */
     tr(messageId, varargs) {
@@ -82,7 +82,7 @@ qx.Class.define("qx.locale.Manager", {
      * @param pluralMessageId {String} message id of the plural form (may contain format strings)
      * @param count {Integer} singular form if equals 1, otherwise plural
      * @param varargs {Object} variable number of arguments applied to the format string
-     * @return {String | LocalizedString} The translated message or localized string
+     * @return {String|LocalizedString} The translated message or localized string
      * @see qx.lang.String.format
      */
     trn(singularMessageId, pluralMessageId, count, varargs) {
@@ -108,7 +108,7 @@ qx.Class.define("qx.locale.Manager", {
      * @param hint {String} hint for the translator of the message. Will be included in the .po file.
      * @param messageId {String} message id (may contain format strings)
      * @param varargs {Object} variable number of arguments applied to the format string
-     * @return {String | LocalizedString} The translated message or localized string
+     * @return {String|LocalizedString} The translated message or localized string
      * @see qx.lang.String.format
      */
     trc(hint, messageId, varargs) {
@@ -128,7 +128,7 @@ qx.Class.define("qx.locale.Manager", {
      * @param pluralMessageId {String} message id of the plural form (may contain format strings)
      * @param count {Integer} singular form if equals 1, otherwise plural
      * @param varargs {Object} variable number of arguments applied to the format string
-     * @return {String | LocalizedString} The translated message or localized string
+     * @return {String|LocalizedString} The translated message or localized string
      * @see qx.lang.String.format
      */
     trnc(hint, singularMessageId, pluralMessageId, count, varargs) {
@@ -335,7 +335,7 @@ qx.Class.define("qx.locale.Manager", {
      * @param messageId {String} message id (may contain format strings)
      * @param args {Object[]} array of objects, which are inserted into the format string
      * @param locale {String ? #locale} locale to be used; if not given, defaults to the value of {@link #locale}
-     * @return {String | LocalizedString} translated message or localized string
+     * @return {String|LocalizedString} translated message or localized string
      */
     translate(messageId, args, locale) {
       var catalog = this.__translations;
@@ -353,7 +353,7 @@ qx.Class.define("qx.locale.Manager", {
      * @param messageId {String} message id (may contain format strings)
      * @param args {Object[]} array of objects, which are inserted into the format string
      * @param locale {String ? #locale} locale to be used; if not given, defaults to the value of {@link #locale}
-     * @return {String | LocalizedString} translated message or localized string
+     * @return {String|LocalizedString} translated message or localized string
      */
     localize(messageId, args, locale) {
       var catalog = this.__locales;
@@ -372,7 +372,7 @@ qx.Class.define("qx.locale.Manager", {
      * @param messageId {String} message id (may contain format strings)
      * @param args {Object[]} array of objects, which are inserted into the format string
      * @param locale {String ? #locale} locale to be used; if not given, defaults to the value of {@link #locale}
-     * @return {String | LocalizedString} translated message or localized string
+     * @return {String|LocalizedString} translated message or localized string
      */
     __lookupAndExpand(catalog, messageId, args, locale) {
       if (qx.core.Environment.get("qx.debug")) {

--- a/source/class/qx/module/util/Array.js
+++ b/source/class/qx/module/util/Array.js
@@ -111,7 +111,7 @@ qx.Bootstrap.define("qx.module.util.Array", {
      * @attachStatic {qxWeb, array.max}
      *
      * @param arr {Array} Array to process.
-     * @return {Number | undefined} The highest of all values or undefined if array is empty.
+     * @return {Number|undefined} The highest of all values or undefined if array is empty.
      */
     max: qx.lang.Array.max,
 
@@ -123,7 +123,7 @@ qx.Bootstrap.define("qx.module.util.Array", {
      * @attachStatic {qxWeb, array.min}
      *
      * @param arr {Array} Array to process.
-     * @return {Number | undefined} The lowest of all values or undefined if array is empty.
+     * @return {Number|undefined} The lowest of all values or undefined if array is empty.
      */
     min: qx.lang.Array.min,
 

--- a/source/class/qx/ui/command/Group.js
+++ b/source/class/qx/ui/command/Group.js
@@ -90,7 +90,7 @@ qx.Class.define("qx.ui.command.Group", {
      *
      * @param key {String} Key which addresses the command
      *
-     * @return {qx.ui.command.Command | null} Corresponding command instance or null
+     * @return {qx.ui.command.Command|null} Corresponding command instance or null
      */
     get(key) {
       if (qx.core.Environment.get("qx.debug")) {
@@ -134,7 +134,7 @@ qx.Class.define("qx.ui.command.Group", {
      *
      * @param key {String} Key which addresses the command
      *
-     * @return {qx.ui.command.Command | null} Corresponding command instance or null
+     * @return {qx.ui.command.Command|null} Corresponding command instance or null
      */
     remove(key) {
       if (qx.core.Environment.get("qx.debug")) {

--- a/source/class/qx/ui/command/GroupManager.js
+++ b/source/class/qx/ui/command/GroupManager.js
@@ -81,7 +81,7 @@ qx.Class.define("qx.ui.command.GroupManager", {
      *
      * @param group {qx.ui.command.Group} Command group
      *
-     * @return {qx.ui.command.Group | null} Command group or null if group was not added before
+     * @return {qx.ui.command.Group|null} Command group or null if group was not added before
      */
     remove(group) {
       if (qx.core.Environment.get("qx.debug")) {
@@ -155,7 +155,7 @@ qx.Class.define("qx.ui.command.GroupManager", {
     /**
      * Returns active command group.
      *
-     * @return {qx.ui.command.Group | null} Active command group
+     * @return {qx.ui.command.Group|null} Active command group
      */
     getActive() {
       return this.__activeGroup;
@@ -184,7 +184,7 @@ qx.Class.define("qx.ui.command.GroupManager", {
      *
      * @param group {qx.ui.command.Group} Command group
      *
-     * @return {qx.ui.command.Group | null} Command group or null
+     * @return {qx.ui.command.Group|null} Command group or null
      */
     _getGroup(group) {
       var index = this.__groups.indexOf(group);

--- a/source/class/qx/ui/control/ColorSelector.js
+++ b/source/class/qx/ui/control/ColorSelector.js
@@ -557,7 +557,7 @@ qx.Class.define("qx.ui.control.ColorSelector", {
     /**
      * Returns the currently selected color.
      *
-     * @return {String | null} The HEX value of the color of if not color
+     * @return {String|null} The HEX value of the color of if not color
      *   is set, null.
      */
     getValue() {

--- a/source/class/qx/ui/core/MMultiSelectionHandling.js
+++ b/source/class/qx/ui/core/MMultiSelectionHandling.js
@@ -327,7 +327,7 @@ qx.Mixin.define("qx.ui.core.MMultiSelectionHandling", {
     /**
      * Returns the last selection context.
      *
-     * @return {String | null} One of <code>tap</code>, <code>quick</code>,
+     * @return {String|null} One of <code>tap</code>, <code>quick</code>,
      *    <code>drag</code> or <code>key</code> or <code>null</code>.
      */
     getSelectionContext() {

--- a/source/class/qx/ui/core/SingleSelectionManager.js
+++ b/source/class/qx/ui/core/SingleSelectionManager.js
@@ -105,7 +105,7 @@ qx.Class.define("qx.ui.core.SingleSelectionManager", {
     /**
      * Returns the current selected element.
      *
-     * @return {qx.ui.core.Widget | null} The current selected widget or
+     * @return {qx.ui.core.Widget|null} The current selected widget or
      *    <code>null</code> if the selection is empty.
      */
     getSelected() {

--- a/source/class/qx/ui/form/Form.js
+++ b/source/class/qx/ui/form/Form.js
@@ -346,7 +346,7 @@ qx.Class.define("qx.ui.form.Form", {
      * Validates the form using the
      * {@link qx.ui.form.validation.Manager#validate} method.
      *
-     * @return {Boolean | null} The validation result.
+     * @return {Boolean|null} The validation result.
      */
     validate() {
       return this._validationManager.validate();

--- a/source/class/qx/ui/list/List.js
+++ b/source/class/qx/ui/list/List.js
@@ -449,7 +449,7 @@ qx.Class.define("qx.ui.list.List", {
     /**
      * Returns the selectable model items.
      *
-     * @return {qx.data.Array | null} The selectable items.
+     * @return {qx.data.Array|null} The selectable items.
      */
     _getSelectables() {
       return this.getModel();

--- a/source/class/qx/ui/mobile/form/Form.js
+++ b/source/class/qx/ui/mobile/form/Form.js
@@ -72,7 +72,7 @@ qx.Class.define("qx.ui.mobile.form.Form", {
      * {@link qx.ui.form.validation.Manager#validate} method.
      * @lint ignoreDeprecated(alert)
      *
-     * @return {Boolean | null} The validation result.
+     * @return {Boolean|null} The validation result.
      */
     validate() {
       var validateResult = super.validate();
@@ -135,7 +135,7 @@ qx.Class.define("qx.ui.mobile.form.Form", {
      * Gets the item with the given group and rowIndex.
      * @param groupIndex {Integer} the index of the group to which the row belongs to
      * @param rowIndex {Integer} the index of the row inside the target group
-     * @return {qx.ui.form.IForm | null} The validation result.
+     * @return {qx.ui.form.IForm|null} The validation result.
      */
     _getItemByIndex(groupIndex, rowIndex) {
       var groups = this.getGroups();

--- a/source/class/qx/util/OOUtil.js
+++ b/source/class/qx/util/OOUtil.js
@@ -103,7 +103,7 @@ qx.Bootstrap.define("qx.util.OOUtil", {
      *
      * @param clazz {Class} class to look for the interface
      * @param iface {Interface} interface to look for
-     * @return {Class | null} the class which directly implements the given interface
+     * @return {Class|null} the class which directly implements the given interface
      */
     getByInterface(clazz, iface) {
       var list, i, l;


### PR DESCRIPTION
Mentioned in https://github.com/qooxdoo/qxl.apiviewer/issues/48 , https://github.com/qooxdoo/qooxdoo/pull/10353 .
In JSDoc there are no spaces between "I" (OR) and two types: https://jsdoc.app/tags-type.html#overview (multiple types row).
In latest API viewer type before "|" (OR) is not showed.
The one disadvantage of my fix is type doesn't work as reference. It could be implemented in API viewer I guess. 
My opinion type is visible better than nothing.
In some cases return types are showed up as `null | qx.random.Class | null` or `| qx.random.Class2` for example which is incorrect.