### PR TITLE
Templates from es5 to es6 syntax

### DIFF
--- a/source/resource/qx/tool/cli/templates/skeleton/desktop/source/class/custom/Application.tmpl.js
+++ b/source/resource/qx/tool/cli/templates/skeleton/desktop/source/class/custom/Application.tmpl.js
@@ -28,15 +28,15 @@ qx.Class.define("${namespace}.Application",
   members :
   {
     /**
-     * This method contains the initial application code and gets called 
+     * This method contains the initial application code and gets called
      * during startup of the application
-     * 
+     *
      * @lint ignoreDeprecated(alert)
      */
-    main : function()
+    main()
     {
       // Call super class
-      this.base(arguments);
+      super.main();
 
       // Enable logging in debug variant
       if (qx.core.Environment.get("qx.debug"))
@@ -54,10 +54,10 @@ qx.Class.define("${namespace}.Application",
       */
 
       // Create a button
-      var button1 = new qx.ui.form.Button("Click me", "${namespace_as_path}/test.png");
+      const button1 = new qx.ui.form.Button("Click me", "${namespace_as_path}/test.png");
 
       // Document is the application root
-      var doc = this.getRoot();
+      const doc = this.getRoot();
 
       // Add button to document at fixed coordinates
       doc.add(button1, {left: 100, top: 50});

--- a/source/resource/qx/tool/cli/templates/skeleton/desktop/source/class/custom/test/DemoTest.tmpl.js
+++ b/source/resource/qx/tool/cli/templates/skeleton/desktop/source/class/custom/test/DemoTest.tmpl.js
@@ -11,13 +11,13 @@
 /**
  * This class demonstrates how to define unit tests for your application.
  *
- * Execute <code>qx test</code> to generate a testrunner application 
+ * Execute <code>qx test</code> to generate a testrunner application
  * and open it from <tt>test/index.html</tt>
  *
- * The methods that contain the tests are instance methods with a 
- * <code>test</code> prefix. You can create an arbitrary number of test 
- * classes like this one. They can be organized in a regular class hierarchy, 
- * i.e. using deeper namespaces and a corresponding file structure within the 
+ * The methods that contain the tests are instance methods with a
+ * <code>test</code> prefix. You can create an arbitrary number of test
+ * classes like this one. They can be organized in a regular class hierarchy,
+ * i.e. using deeper namespaces and a corresponding file structure within the
  * <tt>test</tt> folder.
  */
 qx.Class.define("${namespace}.test.DemoTest",
@@ -31,11 +31,11 @@ qx.Class.define("${namespace}.test.DemoTest",
       TESTS
     ---------------------------------------------------------------------------
     */
-  
+
     /**
      * Here are some simple tests
      */
-    testSimple : function()
+    testSimple()
     {
       this.assertEquals(4, 3+1, "This should never fail!");
       this.assertFalse(false, "Can false be true?!");
@@ -44,10 +44,10 @@ qx.Class.define("${namespace}.test.DemoTest",
     /**
      * Here are some more advanced tests
      */
-    testAdvanced: function () 
+    testAdvanced()
     {
-      var a = 3;
-      var b = a;
+      let a = 3;
+      let b = a;
       this.assertIdentical(a, b, "A rose by any other name is still a rose");
       this.assertInRange(3, 1, 10, "You must be kidding, 3 can never be outside [1,10]!");
     }

--- a/source/resource/qx/tool/cli/templates/skeleton/mobile/source/class/custom/Application.tmpl.js
+++ b/source/resource/qx/tool/cli/templates/skeleton/mobile/source/class/custom/Application.tmpl.js
@@ -25,10 +25,10 @@ qx.Class.define("${namespace}.Application",
      * This method contains the initial application code and gets called
      * during startup of the application
      */
-    main : function()
+    main()
     {
       // Call super class
-      this.base(arguments);
+      super.main();
 
       // Enable logging in debug variant
       if (qx.core.Environment.get("qx.debug"))
@@ -47,11 +47,11 @@ qx.Class.define("${namespace}.Application",
       -------------------------------------------------------------------------
       */
 
-      var login = new ${namespace}.page.Login();
-      var overview = new ${namespace}.page.Overview();
+      const login = new ${namespace}.page.Login();
+      const overview = new ${namespace}.page.Overview();
 
       // Add the pages to the page manager.
-      var manager = new qx.ui.mobile.page.Manager(false);
+      const manager = new qx.ui.mobile.page.Manager(false);
       manager.addDetail([
         login,
         overview
@@ -69,7 +69,7 @@ qx.Class.define("${namespace}.Application",
      * Default behaviour when a route matches. Displays the corresponding page on screen.
      * @param data {Map} the animation properties
      */
-    _show : function(data) {
+    _show(data) {
       this.show(data.customData);
     }
   }

--- a/source/resource/qx/tool/cli/templates/skeleton/mobile/source/class/custom/page/Login.tmpl.js
+++ b/source/resource/qx/tool/cli/templates/skeleton/mobile/source/class/custom/page/Login.tmpl.js
@@ -15,9 +15,9 @@ qx.Class.define("${namespace}.page.Login",
 {
   extend : qx.ui.mobile.page.NavigationPage,
 
-  construct : function()
+  construct()
   {
-    this.base(arguments);
+    super();
     this.setTitle("Login");
   },
 
@@ -28,22 +28,22 @@ qx.Class.define("${namespace}.page.Login",
 
 
     // overridden
-    _initialize: function() {
-      this.base(arguments);
+    _initialize() {
+      super._initialize();
 
       // Username
-      var user = new qx.ui.mobile.form.TextField();
+      const user = new qx.ui.mobile.form.TextField();
       user.setRequired(true);
 
       // Password
-      var pwd = new qx.ui.mobile.form.PasswordField();
+      const pwd = new qx.ui.mobile.form.PasswordField();
       pwd.setRequired(true);
 
       // Login Button
-      var loginButton = new qx.ui.mobile.form.Button("Login");
+      const loginButton = new qx.ui.mobile.form.Button("Login");
       loginButton.addListener("tap", this._onButtonTap, this);
 
-      var loginForm = this.__form = new qx.ui.mobile.form.Form();
+      const loginForm = this.__form = new qx.ui.mobile.form.Form();
       loginForm.add(user, "Username");
       loginForm.add(pwd, "Password");
 
@@ -56,7 +56,7 @@ qx.Class.define("${namespace}.page.Login",
     /**
      * Event handler for <code>tap</code> on the login button.
      */
-    _onButtonTap: function() {
+    _onButtonTap() {
       // use form validation
       if (this.__form.validate()) {
         qx.core.Init.getApplication().getRouting().executeGet("/overview");

--- a/source/resource/qx/tool/cli/templates/skeleton/mobile/source/class/custom/page/Overview.tmpl.js
+++ b/source/resource/qx/tool/cli/templates/skeleton/mobile/source/class/custom/page/Overview.tmpl.js
@@ -15,9 +15,9 @@ qx.Class.define("${namespace}.page.Overview",
 {
   extend : qx.ui.mobile.page.NavigationPage,
 
-  construct : function()
+  construct()
   {
-    this.base(arguments);
+    super();
     this.setTitle("Overview");
     this.setShowBackButton(true);
     this.setBackButtonText("Back");
@@ -27,16 +27,16 @@ qx.Class.define("${namespace}.page.Overview",
   members :
   {
     // overridden
-    _initialize : function()
+    _initialize()
     {
-      this.base(arguments);
+      super._initialize(arguments);
 
       this.getContent().add(new qx.ui.mobile.basic.Label("Your first app."));
     },
 
 
     // overridden
-    _back : function(triggeredByKeyEvent)
+    _back(triggeredByKeyEvent)
     {
       qx.core.Init.getApplication().getRouting().back();
     }

--- a/source/resource/qx/tool/cli/templates/skeleton/package/source/class/custom/demo/Application.tmpl.js
+++ b/source/resource/qx/tool/cli/templates/skeleton/package/source/class/custom/demo/Application.tmpl.js
@@ -24,15 +24,15 @@ qx.Class.define("${namespace}.demo.Application",
   members :
   {
     /**
-     * This method contains the initial application code and gets called 
+     * This method contains the initial application code and gets called
      * during startup of the application
-     * 
+     *
      * @lint ignoreDeprecated(alert)
      */
-    main : function()
+    main()
     {
       // Call super class
-      this.base(arguments);
+      super.main();
 
       // Enable logging in debug variant
       if (qx.core.Environment.get("qx.debug"))
@@ -50,10 +50,10 @@ qx.Class.define("${namespace}.demo.Application",
       */
 
       // Create a button
-      var button1 = new ${namespace}.Button("Very special button", "${namespace_as_path}/test.png");
+      const button1 = new ${namespace}.Button("Very special button", "${namespace_as_path}/test.png");
 
       // Document is the application root
-      var doc = this.getRoot();
+      const doc = this.getRoot();
 
       // Add button to document at fixed coordinates
       doc.add(button1, {left: 100, top: 50});

--- a/source/resource/qx/tool/cli/templates/skeleton/package/source/class/custom/test/DemoTest.tmpl.js
+++ b/source/resource/qx/tool/cli/templates/skeleton/package/source/class/custom/test/DemoTest.tmpl.js
@@ -11,13 +11,13 @@
 /**
  * This class demonstrates how to define unit tests for your application.
  *
- * Execute <code>qx test</code> to generate a testrunner application 
+ * Execute <code>qx test</code> to generate a testrunner application
  * and open it from <tt>test/index.html</tt>
  *
- * The methods that contain the tests are instance methods with a 
- * <code>test</code> prefix. You can create an arbitrary number of test 
- * classes like this one. They can be organized in a regular class hierarchy, 
- * i.e. using deeper namespaces and a corresponding file structure within the 
+ * The methods that contain the tests are instance methods with a
+ * <code>test</code> prefix. You can create an arbitrary number of test
+ * classes like this one. They can be organized in a regular class hierarchy,
+ * i.e. using deeper namespaces and a corresponding file structure within the
  * <tt>test</tt> folder.
  */
 qx.Class.define("${namespace}.test.DemoTest",
@@ -31,11 +31,11 @@ qx.Class.define("${namespace}.test.DemoTest",
       TESTS
     ---------------------------------------------------------------------------
     */
-  
+
     /**
      * Here are some simple tests
      */
-    testSimple : function()
+    testSimple()
     {
       this.assertEquals(4, 3+1, "This should never fail!");
       this.assertFalse(false, "Can false be true?!");
@@ -44,10 +44,10 @@ qx.Class.define("${namespace}.test.DemoTest",
     /**
      * Here are some more advanced tests
      */
-    testAdvanced: function () 
+    testAdvanced()
     {
-      var a = 3;
-      var b = a;
+      let a = 3;
+      let b = a;
       this.assertIdentical(a, b, "A rose by any other name is still a rose");
       this.assertInRange(3, 1, 10, "You must be kidding, 3 can never be outside [1,10]!");
     }

--- a/source/resource/qx/tool/cli/templates/skeleton/server/source/class/custom/Application.tmpl.js
+++ b/source/resource/qx/tool/cli/templates/skeleton/server/source/class/custom/Application.tmpl.js
@@ -34,7 +34,7 @@ qx.Class.define("${namespace}.Application",
      * This method contains the initial application code and gets called
      * during startup of the application
      */
-    main : function()
+    main()
     {
       if (qx.core.Environment.get("runtime.name") == "rhino") {
         qx.log.Logger.register(qx.log.appender.RhinoConsole);
@@ -59,10 +59,10 @@ qx.Class.define("${namespace}.Application",
      *
      * @param args {String[]} Rhino arguments object
      */
-    _argumentsToSettings : function(args)
+    _argumentsToSettings(args)
     {
-      var opts;
-      for (var i=0, l=args.length; i<l; i++) {
+      let opts;
+      for (let i=0, l=args.length; i<l; i++) {
         if (args[i].indexOf("settings=") == 0) {
           opts = args[i].substr(9);
           break;
@@ -75,8 +75,8 @@ qx.Class.define("${namespace}.Application",
       if (opts) {
         opts = opts.replace(/\\\{/g, "{").replace(/\\\}/g, "}");
         opts = qx.lang.Json.parse(opts);
-        for (var prop in opts) {
-          var value = opts[prop];
+        for (let prop in opts) {
+          let value = opts[prop];
           if (typeof value == "string") {
             value = value.replace(/\$$/g, " ");
           }

--- a/source/resource/qx/tool/cli/templates/skeleton/server/source/class/custom/test/DemoTest.tmpl.js
+++ b/source/resource/qx/tool/cli/templates/skeleton/server/source/class/custom/test/DemoTest.tmpl.js
@@ -11,13 +11,13 @@
 /**
  * This class demonstrates how to define unit tests for your application.
  *
- * Execute <code>qx test</code> to generate a testrunner application 
+ * Execute <code>qx test</code> to generate a testrunner application
  * and open it from <tt>test/index.html</tt>
  *
- * The methods that contain the tests are instance methods with a 
- * <code>test</code> prefix. You can create an arbitrary number of test 
- * classes like this one. They can be organized in a regular class hierarchy, 
- * i.e. using deeper namespaces and a corresponding file structure within the 
+ * The methods that contain the tests are instance methods with a
+ * <code>test</code> prefix. You can create an arbitrary number of test
+ * classes like this one. They can be organized in a regular class hierarchy,
+ * i.e. using deeper namespaces and a corresponding file structure within the
  * <tt>test</tt> folder.
  */
 qx.Class.define("${namespace}.test.DemoTest",
@@ -33,11 +33,11 @@ qx.Class.define("${namespace}.test.DemoTest",
       TESTS
     ---------------------------------------------------------------------------
     */
-  
+
     /**
      * Here are some simple tests
      */
-    testSimple : function()
+    testSimple()
     {
       this.assertEquals(4, 3+1, "This should never fail!");
       this.assertFalse(false, "Can false be true?!");
@@ -46,20 +46,20 @@ qx.Class.define("${namespace}.test.DemoTest",
     /**
      * Here are some more advanced tests
      */
-    testAdvanced: function () 
+    testAdvanced()
     {
-      var a = 3;
-      var b = a;
+      let a = 3;
+      let b = a;
       this.assertIdentical(a, b, "A rose by any other name is still a rose");
       this.assertInRange(3, 1, 10, "You must be kidding, 3 can never be outside [1,10]!");
     },
 
-    hasNodeJs : function()
+    hasNodeJs()
     {
       return qx.core.Environment.get("runtime.name") == "node.js";
     },
 
-    testNodeJs : function()
+    testNodeJs()
     {
       this.require(["nodeJs"]);
       // test node stuff


### PR DESCRIPTION
Moving to ES6 syntax:

- `var` -> `const` or `let`
- using `super` instead `this.base`
- using `super` for calling parent method
- removing `function` from method syntax