### PR TITLE
Fixes for locale bugs 

### DIFF
--- a/source/class/qx/tool/compiler/app/Cldr.js
+++ b/source/class/qx/tool/compiler/app/Cldr.js
@@ -29,6 +29,7 @@ var xml2js = require("xml2js");
 const CLDR = require("cldr");
 const { promisify } = require("util");
 const readFile = promisify(fs.readFile);
+const readDir = promisify(fs.readdir);
 
 var log = qx.tool.utils.LogManager.createLog("cldr");
 
@@ -59,9 +60,24 @@ qx.Class.define("qx.tool.compiler.app.Cldr", {
       }
       log.debug("Loading CLDR " + cldrPath);
 
-      return readFile(path.join(cldrPath, data_path, locale + ".xml"), {
-        encoding: "utf-8"
+      const fullDir = path.join(cldrPath, data_path);
+
+      return readDir(fullDir).then(names => {
+        return new Promise((resolve, reject) => {
+          const searchedName = locale.toLowerCase() + ".xml";
+          const realName = names.find(name => name.toLowerCase() === searchedName);
+          if (realName){
+            resolve(realName);
+          } else {
+            reject(new Error("Cannot find XML file for locale \"" + locale + "\" in CLDR folder"));
+          }
+        });
       })
+        .then(fileName =>
+          readFile(path.join(fullDir, fileName), {
+            encoding: "utf-8"
+          })
+        )
         .then(data =>
           qx.tool.utils.Utils.promisifyThis(parser.parseString, parser, data)
         )
@@ -564,29 +580,28 @@ qx.Class.define("qx.tool.compiler.app.Cldr", {
             });
 
             var monthContext = get("months[0].monthContext", cal);
-            find(monthContext, "type", "format", function (row) {
-              find(row.monthWidth, "type", "abbreviated", function (row) {
-                for (var i = 0; i < row.month.length; i++) {
-                  var m = row.month[i];
-                  cldr["cldr_month_format_abbreviated_" + m["$"].type] =
-                    getText(m);
-                }
-              });
-            });
-            find(monthContext, "type", "format", function (row) {
-              find(row.monthWidth, "type", "wide", function (row) {
-                for (var i = 0; i < row.month.length; i++) {
-                  var m = row.month[i];
-                  cldr["cldr_month_format_wide_" + m["$"].type] = getText(m);
-                }
-              });
-            });
-            find(monthContext, "type", "stand-alone", function (row) {
-              for (var i = 0; i < row.monthWidth[0].month.length; i++) {
-                var m = row.monthWidth[0].month[i];
-                cldr["cldr_month_stand-alone_narrow_" + m["$"].type] =
-                  getText(m);
+
+            const parseMonth = (months, where) => {
+              if (!months){
+                return;
               }
+              months.forEach(month => {
+                cldr[where + "_" + month["$"].type] = getText(month);
+              });
+            }
+
+            const parseMonthContext = (what, where) => {
+              find(monthContext, "type", "format", function (row) {
+                find(row.monthWidth, "type", what, function (row) {
+                  parseMonth(row.month, where);
+                });
+              });
+            }
+
+            parseMonthContext("abbreviated","cldr_month_format_abbreviated");
+            parseMonthContext("wide","cldr_month_format_wide");
+            find(monthContext, "type", "stand-alone", function (row) {
+              parseMonth(row.monthWidth[0].month, "cldr_month_stand-alone_narrow");
             });
 
             function getTimeFormatPattern(row) {


### PR DESCRIPTION
Fixed #10522 

1. Compiling such locales as en_GB and sr_Latn now works on Linux (case-sensitive OS)
2. sr_Latn has root.xml (parent locale dependency) which doesn't have some content like month abbreviations.

If there is rejection for readdir promise in case when file for searched locale is not found I do nothing (except trace there will be error after compilation). I don't know how properly handle it. Any suggestion.