### PR TITLE
Static method with reference value

### DIFF
--- a/source/class/qx/tool/compiler/ClassFile.js
+++ b/source/class/qx/tool/compiler/ClassFile.js
@@ -854,7 +854,8 @@ qx.Class.define("qx.tool.compiler.ClassFile", {
         if (sectionName === "members" || sectionName === "statics") {
           if (
             node.type == "ObjectMethod" ||
-            node.value.type === "FunctionExpression"
+            node.value.type === "FunctionExpression" ||
+            node.value.type === "MemberExpression"
           ) {
             meta.type = "function";
           } else {


### PR DESCRIPTION
Static methods value of which is other qooxdoo class method full name are displayed as constants in API Viewer. Investigating the problem I found out that detection of static method requires another check. This issue is related to [this](https://github.com/qooxdoo/qxl.apiviewer/issues/46).