### PR TITLE
long running compile processes do  not exit

### DIFF
--- a/source/class/qx/tool/cli/Application.js
+++ b/source/class/qx/tool/cli/Application.js
@@ -34,9 +34,9 @@ qx.Class.define("qx.tool.cli.Application", {
         await new qx.tool.cli.Cli().run();
       } catch (e) {
         qx.tool.compiler.Console.error("Error: " + (e.stack || e.message));
-        process.exitCode = -1;
+        process.exitCode = 1;
       } finally {
-        process.exit(process.exitCode);
+        process.exit();
       }
     }
   },

--- a/source/class/qx/tool/cli/Application.js
+++ b/source/class/qx/tool/cli/Application.js
@@ -28,13 +28,16 @@ qx.Class.define("qx.tool.cli.Application", {
      * This method contains the initial application code and gets called
      * during startup of the application
      */
-    async main() {
-      try {
-        await new qx.tool.cli.Cli().run();
-      } catch (e) {
-        qx.tool.compiler.Console.error("Error: " + (e.stack || e.message));
-        process.exit(1);
-      }
+    main() {
+      new qx.tool.cli.Cli()
+        .run()
+        .then(() => {
+          process.exit(0);
+        })
+        .catch(e => {
+          qx.tool.compiler.Console.error("Error: " + (e.stack || e.message));
+          process.exit(1);
+        });
     }
   },
 

--- a/source/class/qx/tool/cli/Application.js
+++ b/source/class/qx/tool/cli/Application.js
@@ -28,16 +28,16 @@ qx.Class.define("qx.tool.cli.Application", {
      * This method contains the initial application code and gets called
      * during startup of the application
      */
-    main() {
-      new qx.tool.cli.Cli()
-        .run()
-        .then(() => {
-          process.exit(0);
-        })
-        .catch(e => {
-          qx.tool.compiler.Console.error("Error: " + (e.stack || e.message));
-          process.exit(1);
-        });
+    async main() {
+      process.exitCode = 0;
+      try {
+        await new qx.tool.cli.Cli().run();
+      } catch (e) {
+        qx.tool.compiler.Console.error("Error: " + (e.stack || e.message));
+        process.exitCode = -1;
+      } finally {
+        process.exit(process.exitCode);
+      }
     }
   },
 

--- a/source/class/qx/tool/cli/Cli.js
+++ b/source/class/qx/tool/cli/Cli.js
@@ -58,7 +58,7 @@ qx.Class.define("qx.tool.cli.Cli", {
     _compileJsonFilename: null,
 
     /** @type {Object} Parsed arguments */
-    _parsedArgs: null,
+    __parsedArgs: null,
 
     /** @type {Boolean} Whether libraries have had their `.load()` method called yet */
     __librariesNotified: false,
@@ -567,8 +567,8 @@ Version: v${await qx.tool.config.Utils.getQxVersion()}
           config.serve.listenPort || this.argv.listenPort;
       }
 
-      this._parsedArgs = await compilerApi.getConfiguration();
-      return this._parsedArgs;
+      this.__parsedArgs = await compilerApi.getConfiguration();
+      return this.__parsedArgs;
     },
 
     /**

--- a/source/class/qx/tool/cli/Cli.js
+++ b/source/class/qx/tool/cli/Cli.js
@@ -355,7 +355,8 @@ Version: v${await qx.tool.config.Utils.getQxVersion()}
             (await qx.tool.utils.Json.loadJsonAsync(name)) || lockfileContent;
         } catch (ex) {
           // Nothing
-        } // check semver-type compatibility (i.e. compatible as long as major version stays the same)
+        } 
+        // check semver-type compatibility (i.e. compatible as long as major version stays the same)
         let schemaVersion = semver.coerce(
           qx.tool.config.Lockfile.getInstance().getVersion(),
           true

--- a/source/class/qx/tool/cli/Cli.js
+++ b/source/class/qx/tool/cli/Cli.js
@@ -249,15 +249,9 @@ Version: v${await qx.tool.config.Utils.getQxVersion()}
     async processCommand(command) {
       qx.tool.compiler.Console.getInstance().setVerbose(this.argv.verbose);
       await this.__notifyLibraries();
-      try {
-        const res = await command.process();
-        await this._compilerApi.afterProcessFinished(command, res);
-        return res;
-      } catch (e) {
-        qx.tool.compiler.Console.error("Error: " + (e.stack || e.message));
-        process.exit(1);
-        return null;
-      }
+      const res = await command.process();
+      await this._compilerApi.afterProcessFinished(command, res);
+      return res;
     },
 
     /**

--- a/source/class/qx/tool/cli/Watch.js
+++ b/source/class/qx/tool/cli/Watch.js
@@ -103,11 +103,9 @@ qx.Class.define("qx.tool.cli.Watch", {
         }
         config._process = null;
       }
-
       console.log(
         "Starting application: " + config._cmd + " " + config._args.join(" ")
       );
-
       config._processPromise = new qx.Promise((resolve, reject) => {
         let child = (config._process = require("child_process").spawn(
           config._cmd,
@@ -229,12 +227,10 @@ qx.Class.define("qx.tool.cli.Watch", {
           watcher.on("change", filename =>
             this.__onFileChange("change", filename)
           );
-
           watcher.on("add", filename => this.__onFileChange("add", filename));
           watcher.on("unlink", filename =>
             this.__onFileChange("unlink", filename)
           );
-
           watcher.on("ready", () => {
             qx.tool.compiler.Console.log(`Start watching ...`);
             this.__watcherReady = true;
@@ -249,6 +245,9 @@ qx.Class.define("qx.tool.cli.Watch", {
           });
         });
       });
+      process.on("beforeExit", this.__onStop.bind(this));
+      process.on("exit", this.__onStop.bind(this));
+      return this.__runningPromise;
     },
 
     async stop() {
@@ -352,8 +351,8 @@ qx.Class.define("qx.tool.cli.Watch", {
           }
           return null;
         });
-
-      return (this.__making = runIt());
+      this.__making = runIt();
+      return this.__making;
     },
 
     __scheduleMake() {

--- a/source/class/qx/tool/cli/commands/Compile.js
+++ b/source/class/qx/tool/cli/commands/Compile.js
@@ -685,7 +685,7 @@ Framework: v${await this.getQxVersion()} in ${await this.getQxPath()}`);
           );
 
           watch.setConfigFilenames(arr);
-          return await watch.start();
+          return watch.start();
         })
       );
     },
@@ -1230,6 +1230,7 @@ Framework: v${await this.getQxVersion()} in ${await this.getQxPath()}`);
             data.localModules || {},
             false
           );
+
           if (!qx.lang.Object.isEmpty(appConfig.localModules)) {
             app.setLocalModules(appConfig.localModules);
           }

--- a/source/class/qx/tool/cli/commands/Lint.js
+++ b/source/class/qx/tool/cli/commands/Lint.js
@@ -113,7 +113,7 @@ qx.Class.define("qx.tool.cli.commands.Lint", {
         helperFilePath = path.dirname(helperFilePath);
       }
 
-      let config = await qx.tool.cli.Cli.getInstance().getParsedArgs();
+      let config = qx.tool.cli.Cli.getInstance().getParsedArgs();
       let lintOptions = config.eslintConfig || {};
       lintOptions.extends = lintOptions.extends || ["@qooxdoo/qx/browser"];
       lintOptions.globals = Object.assign(

--- a/source/class/qx/tool/cli/commands/Run.js
+++ b/source/class/qx/tool/cli/commands/Run.js
@@ -68,12 +68,12 @@ qx.Class.define("qx.tool.cli.commands.Run", {
       let config = this.getCompilerApi().getConfiguration();
       if (!config.run) {
         qx.tool.compiler.Console.print("qx.tool.cli.run.noRunConfig");
-        process.exit(-1);
+        process.exit(1);
       }
 
       if (!config.run.application) {
         qx.tool.compiler.Console.print("qx.tool.cli.run.noAppName");
-        process.exit(-1);
+        process.exit(1);
       }
 
       let maker = null;
@@ -85,14 +85,14 @@ qx.Class.define("qx.tool.cli.commands.Run", {
         if (apps.length) {
           if (maker) {
             qx.tool.compiler.Console.print("qx.tool.cli.run.tooManyMakers");
-            process.exit(-1);
+            process.exit(1);
           }
           if (apps.length != 1) {
             qx.tool.compiler.Console.print(
               "qx.tool.cli.run.tooManyApplications"
             );
 
-            process.exit(-1);
+            process.exit(1);
           }
           maker = tmp;
           app = apps[0];
@@ -100,11 +100,11 @@ qx.Class.define("qx.tool.cli.commands.Run", {
       });
       if (!app) {
         qx.tool.compiler.Console.print("qx.tool.cli.run.noAppName");
-        process.exit(-1);
+        process.exit(1);
       }
       if (app.getType() != "node") {
         qx.tool.compiler.Console.print("qx.tool.cli.run.mustBeNode");
-        process.exit(-1);
+        process.exit(1);
       }
 
       let target = maker.getTarget();
@@ -150,7 +150,6 @@ qx.Class.define("qx.tool.cli.commands.Run", {
         child.stdout.on("data", function (data) {
           console.log(data);
         });
-
         child.stderr.setEncoding("utf8");
         child.stderr.on("data", function (data) {
           console.error(data);

--- a/source/class/qx/tool/cli/commands/Serve.js
+++ b/source/class/qx/tool/cli/commands/Serve.js
@@ -221,7 +221,7 @@ qx.Class.define("qx.tool.cli.commands.Serve", {
             config.serve.listenPort
           );
 
-          process.exit(-1);
+          process.exit(1);
         } else {
           qx.tool.compiler.Console.log("Error when starting web server: " + e);
         }

--- a/source/class/qx/tool/cli/commands/Serve.js
+++ b/source/class/qx/tool/cli/commands/Serve.js
@@ -90,9 +90,6 @@ qx.Class.define("qx.tool.cli.commands.Serve", {
   },
 
   members: {
-    /** @type {qx.tool.utils.Website} the Website instance */
-    _website: null,
-
     /*
      * @Override
      */
@@ -100,18 +97,19 @@ qx.Class.define("qx.tool.cli.commands.Serve", {
       this.argv.watch = true;
       this.argv["machine-readable"] = false;
       this.argv["feedback"] = false;
-      await super.process();
 
       // build website if it hasn't been built yet.
-      const website = (this._website = new qx.tool.utils.Website());
+      const website = new qx.tool.utils.Website();
       if (!(await fs.existsAsync(website.getTargetDir()))) {
         qx.tool.compiler.Console.info(">>> Building startpage...");
-        await this._website.rebuildAll();
+        await website.rebuildAll();
       } else if (this.argv.rebuildStartpage) {
-        this._website.startWatcher();
+        website.startWatcher();
       }
-
-      await this.runWebServer();
+      this.addListenerOnce("made", () => {
+        this.runWebServer();
+      });
+      return super.process();
     },
 
     /**
@@ -210,36 +208,31 @@ qx.Class.define("qx.tool.cli.commands.Serve", {
           res.send(JSON.stringify(appsData, null, 2));
         });
       }
-      this.addListenerOnce("made", e => {
-        let server = http.createServer(app);
-        this.fireDataEvent("beforeStart", {
-          server: server,
-          application: app,
-          outputdir: defaultMaker.getTarget().getOutputDir()
-        });
-
-        server.on("error", e => {
-          if (e.code === "EADDRINUSE") {
-            qx.tool.compiler.Console.print(
-              "qx.tool.cli.serve.webAddrInUse",
-              config.serve.listenPort
-            );
-
-            process.exit(-1);
-          } else {
-            qx.tool.compiler.Console.log(
-              "Error when starting web server: " + e
-            );
-          }
-        });
-        server.listen(config.serve.listenPort, () => {
+      let server = http.createServer(app);
+      this.fireDataEvent("beforeStart", {
+        server: server,
+        application: app,
+        outputdir: defaultMaker.getTarget().getOutputDir()
+      });
+      server.on("error", e => {
+        if (e.code === "EADDRINUSE") {
           qx.tool.compiler.Console.print(
-            "qx.tool.cli.serve.webStarted",
-            "http://localhost:" + config.serve.listenPort
+            "qx.tool.cli.serve.webAddrInUse",
+            config.serve.listenPort
           );
 
-          this.fireEvent("afterStart");
-        });
+          process.exit(-1);
+        } else {
+          qx.tool.compiler.Console.log("Error when starting web server: " + e);
+        }
+      });
+      server.listen(config.serve.listenPort, () => {
+        qx.tool.compiler.Console.print(
+          "qx.tool.cli.serve.webStarted",
+          "http://localhost:" + config.serve.listenPort
+        );
+
+        this.fireEvent("afterStart");
       });
     },
 

--- a/source/class/qx/tool/cli/commands/Test.js
+++ b/source/class/qx/tool/cli/commands/Test.js
@@ -188,7 +188,7 @@ qx.Class.define("qx.tool.cli.commands.Test", {
              See documentation at https://qooxdoo.org/docs/#/development/testing/`
           );
 
-          process.exit(-1);
+          process.exit(1);
         }
       });
 

--- a/source/class/qx/tool/cli/commands/Test.js
+++ b/source/class/qx/tool/cli/commands/Test.js
@@ -206,7 +206,8 @@ qx.Class.define("qx.tool.cli.commands.Test", {
           await test.execute();
         }
         // for bash exitcode is not allowed to be more then 255!
-        process.exitCode = Math.min(255, this.getExitCode());
+        // We must exit the process here because serve runs infinite!
+        process.exit(Math.min(255, this.getExitCode()));
       });
 
       if (this.__needsServer()) {

--- a/source/class/qx/tool/cli/commands/Test.js
+++ b/source/class/qx/tool/cli/commands/Test.js
@@ -206,7 +206,7 @@ qx.Class.define("qx.tool.cli.commands.Test", {
           await test.execute();
         }
         // for bash exitcode is not allowed to be more then 255!
-        process.exit(Math.min(255, this.getExitCode()));
+        process.exitCode = Math.min(255, this.getExitCode());
       });
 
       if (this.__needsServer()) {
@@ -216,7 +216,7 @@ qx.Class.define("qx.tool.cli.commands.Test", {
         // compile only
         await qx.tool.cli.commands.Compile.prototype.process.call(this);
         // since the server is not started, manually fire the event necessary for firing the "runTests" event
-        this.fireEvent("afterStart");
+        await this.fireDataEventAsync("afterStart");
       }
     },
 

--- a/source/class/qx/tool/cli/commands/add/Script.js
+++ b/source/class/qx/tool/cli/commands/add/Script.js
@@ -140,7 +140,9 @@ qx.Class.define("qx.tool.cli.commands.add.Script", {
       }
       // save
       this.debug(script_list);
-      manifestModel.setValue("externalResources.script", script_list).save();
+      await manifestModel
+        .setValue("externalResources.script", script_list)
+        .save();
     }
   }
 });


### PR DESCRIPTION
This is problem with newer version of yargs which calls the process handler to early. 
This fix stores the needed command and do the processing after initialisation. 
Furthermore process.exit is added to end the process after finishing the promise.