### PR TITLE
Fix two images in scaled basic.Image

### DIFF
--- a/source/class/qx/ui/basic/Image.js
+++ b/source/class/qx/ui/basic/Image.js
@@ -634,7 +634,7 @@ qx.Class.define("qx.ui.basic.Image", {
           }
 
           // Don't transfer background image when switching from image to icon font
-          if (this.__getMode() === "font") {
+          if (this.__getMode() === "font" || this.__getMode() === "scaled") {
             delete styles.backgroundImage;
           }
 
@@ -785,7 +785,9 @@ qx.Class.define("qx.ui.basic.Image", {
       if (this.getScale()) {
         el.setStyle("fontSize", (width > height ? height : width) + "px");
       } else {
-        var source = qx.util.AliasManager.getInstance().resolve(this.getSource());
+        var source = qx.util.AliasManager.getInstance().resolve(
+          this.getSource()
+        );
         var sparts = source.split("/");
         var font = this.__getFont(source);
         var size = parseInt(sparts[2] || font.getSize());

--- a/source/class/qx/ui/basic/Image.js
+++ b/source/class/qx/ui/basic/Image.js
@@ -634,7 +634,8 @@ qx.Class.define("qx.ui.basic.Image", {
           }
 
           // Don't transfer background image when switching from image to icon font
-          if (this.__getMode() === "font" || this.__getMode() === "scaled") {
+          var mode = this.__getMode();
+          if (mode === "font" || mode === "scaled") {
             delete styles.backgroundImage;
           }
 
@@ -788,6 +789,7 @@ qx.Class.define("qx.ui.basic.Image", {
         var source = qx.util.AliasManager.getInstance().resolve(
           this.getSource()
         );
+
         var sparts = source.split("/");
         var font = this.__getFont(source);
         var size = parseInt(sparts[2] || font.getSize());


### PR DESCRIPTION
Fixed #10529 .
The problem: the second and next basic.Images transform `div` into `img` internally but save a background-image css property which leads to two images. There are three types transformation: into scaled image, into font image and into non-scaled (forth is alfphaScaled, it is custom and don't know what it is). When "into font image" transformation backgroundImage properties are removed. I did the same with "into scaled".
Not sure it's safe. Please check carefully.

![Снимок экрана от 2023-02-15 19-13-16](https://user-images.githubusercontent.com/22189134/219085955-20162fbc-fdca-44ac-87c6-7f477f248fe5.png)