### PR TITLE
fix preventDefault not working with autoDestroy

### DIFF
--- a/source/class/qx/ui/window/Window.js
+++ b/source/class/qx/ui/window/Window.js
@@ -639,15 +639,16 @@ qx.Class.define("qx.ui.window.Window", {
         return;
       }
 
-      if (
-        this.fireNonBubblingEvent("beforeClose", qx.event.type.Event, [
-          false,
-          true
-        ])
-      ) {
-        this.hide();
-        this.fireEvent("close");
+      if (! this.fireNonBubblingEvent(
+              "beforeClose",
+              qx.event.type.Event,
+              [ false, true ])) {
+        // preventDefault() was called
+        return;
       }
+
+      this.hide();
+      this.fireEvent("close");
 
       // If automatically destroying the window upon close was requested, do
       // so now. (Note that we explicitly re-obtain the autoDestroy property


### PR DESCRIPTION
Calling `e.preventDefault()` from within the `beforeClose` handler did not work if the window's `autoDestroy` property was enabled. Now it works as it should.