### PR TITLE
Obtain rendered row height to calculate row positions

### DIFF
--- a/source/class/qx/ui/table/pane/FocusIndicator.js
+++ b/source/class/qx/ui/table/pane/FocusIndicator.js
@@ -124,9 +124,9 @@ qx.Class.define("qx.ui.table.pane.FocusIndicator", {
               wl = deco.getWidthLeft();
             }
           }
-          var userHeight = rowHeight + (wl + wr - 2);
+          var userHeight = rowHeight + (wt + wb - 2);
           var renderedRowHeight = this.__scroller.getTablePane().getRenderedRowHeight();
-          var userTop = Math.floor((row - firstRow) * renderedRowHeight) - (wr - 1);
+          var userTop = Math.floor((row - firstRow) * renderedRowHeight) - (wt - 1);
           if (
             editing &&
             this.__scroller.getMinCellEditHeight() &&
@@ -140,9 +140,9 @@ qx.Class.define("qx.ui.table.pane.FocusIndicator", {
           }
 
           this.setUserBounds(
-            paneModel.getColumnLeft(col) - (wt - 1),
+            paneModel.getColumnLeft(col) - (wl - 1),
             userTop,
-            columnModel.getColumnWidth(col) + (wt + wb - 3),
+            columnModel.getColumnWidth(col) + (wl + wr - 3),
             userHeight
           );
 

--- a/source/class/qx/ui/table/pane/FocusIndicator.js
+++ b/source/class/qx/ui/table/pane/FocusIndicator.js
@@ -125,7 +125,8 @@ qx.Class.define("qx.ui.table.pane.FocusIndicator", {
             }
           }
           var userHeight = rowHeight + (wl + wr - 2);
-          var userTop = (row - firstRow) * rowHeight - (wr - 1);
+          var renderedRowHeight = this.__scroller.getTablePane().getRenderedRowHeight();
+          var userTop = Math.floor((row - firstRow) * renderedRowHeight) - (wr - 1);
           if (
             editing &&
             this.__scroller.getMinCellEditHeight() &&

--- a/source/class/qx/ui/table/pane/Pane.js
+++ b/source/class/qx/ui/table/pane/Pane.js
@@ -710,6 +710,20 @@ qx.Class.define("qx.ui.table.pane.Pane", {
       this.__lastColCount = colCount;
       this.__lastRowCount = rowCount;
       this.fireEvent("paneUpdated");
+    },
+
+    getRenderedRowHeight() {
+      var rowHeight = this.getTable().getRowHeight();
+
+      var elem = this.getContentElement().getDomElement();
+      if (elem && elem.firstChild) {
+        // pane has been rendered
+        var tableBody = elem.firstChild;
+        if (tableBody.childNodes && tableBody.childNodes.length > 0) {
+          rowHeight = tableBody.childNodes[0].getBoundingClientRect().height;
+        }
+      }
+      return rowHeight;
     }
   },
 

--- a/source/class/qx/ui/table/pane/Scroller.js
+++ b/source/class/qx/ui/table/pane/Scroller.js
@@ -2037,7 +2037,7 @@ qx.Class.define("qx.ui.table.pane.Scroller", {
 
       if (pageY >= panePos.top && pageY <= panePos.bottom) {
         // This event is in the pane -> Get the row
-        var rowHeight = this.getTable().getRowHeight();
+        var rowHeight = this.__tablePane.getRenderedRowHeight()
 
         var scrollY = this.__verScrollBar.getPosition();
 

--- a/source/class/qx/ui/table/pane/Scroller.js
+++ b/source/class/qx/ui/table/pane/Scroller.js
@@ -833,7 +833,7 @@ qx.Class.define("qx.ui.table.pane.Scroller", {
       }
       var scrollbar = this.__verScrollBar;
       this.__inOnScrollY = true;
-      // calculate delta so that one row is scrolled at an minimum
+      // calculate delta so that one row is scrolled at a minimum
       var rowHeight = this.getTable().getRowHeight();
       var delta = e.getData() - e.getOldData();
       if (Math.abs(delta) > 1 && Math.abs(delta) < rowHeight) {
@@ -2042,7 +2042,7 @@ qx.Class.define("qx.ui.table.pane.Scroller", {
         var scrollY = this.__verScrollBar.getPosition();
 
         if (this.getTable().getKeepFirstVisibleRowComplete()) {
-          scrollY = Math.floor(scrollY / rowHeight) * rowHeight;
+          scrollY = Math.floor(scrollY / this.getTable().getRowHeight()) * rowHeight;
         }
 
         var tableY = scrollY + pageY - panePos.top;


### PR DESCRIPTION
An attempt to fix https://github.com/qooxdoo/qooxdoo/issues/10505 as this has been driving me nuts on a 4k monitor with Windows 11 and scaling set to 150%
This seems to fix the issue, but I don't know if there's a better way of doing this but I'm happy to fix it up now I know it can be fixed.
Also, for the FocusIndicator.js, is it correct that the `userHeight` and `userTop` values are calculated using some left and right decoration widths?