### PR TITLE
Sometimes getWindow is absent what leads call of this method to an error

### DIFF
--- a/source/class/qx/event/handler/GestureCore.js
+++ b/source/class/qx/event/handler/GestureCore.js
@@ -472,7 +472,7 @@ qx.Bootstrap.define("qx.event.handler.GestureCore", {
       if (
         (Math.abs(deltaY) < 1 && Math.abs(deltaX) < 1) ||
         this.__stopMomentum[oldTimeoutId] ||
-        !this.getWindow()
+        (this.getWindow && !this.getWindow())
       ) {
         delete this.__stopMomentum[oldTimeoutId];
         delete this.__momentum[domEvent.pointerId];


### PR DESCRIPTION
The error is detected in API viewer and described in https://github.com/qooxdoo/qxl.apiviewer/issues/54 .