### PR TITLE
Compiler warnings fixes

### DIFF
--- a/source/class/qx/test/core/Validation.js
+++ b/source/class/qx/test/core/Validation.js
@@ -33,7 +33,7 @@ qx.Class.define("qx.test.core.Validation", {
         custom: {
           init: "Some String",
           check: "String",
-          validate: "__validateCustom"
+          validate: "_validateCustom"
         },
 
         number: {
@@ -78,7 +78,7 @@ qx.Class.define("qx.test.core.Validation", {
       },
 
       members: {
-        __validateCustom(value) {
+        _validateCustom(value) {
           // if the length is lower than 4
           if (value.length < 4) {
             throw new qx.core.ValidationError(

--- a/source/class/qx/theme/iconfont/LoadMaterialIconsOutlined.js
+++ b/source/class/qx/theme/iconfont/LoadMaterialIconsOutlined.js
@@ -20,7 +20,7 @@
  * A dummy class to trigger the compiler to copy the MaterialIconsOutlined font files
  */
 /**
- * @usefont(MaterialIconsOutlines)
+ * @usefont(MaterialIconsOutlined)
  * @deprecated use the `@usefont` directive directly in your code
  */
 qx.Class.define("qx.theme.iconfont.LoadMaterialIconsOutlined", {});

--- a/source/class/qx/tool/cli/Watch.js
+++ b/source/class/qx/tool/cli/Watch.js
@@ -21,6 +21,9 @@ const fs = require("fs");
 const path = require("upath");
 const chokidar = require("chokidar");
 
+/**
+ * @ignore(setImmediate)
+ */
 qx.Class.define("qx.tool.cli.Watch", {
   extend: qx.core.Object,
 

--- a/source/class/qx/tool/cli/commands/Compile.js
+++ b/source/class/qx/tool/cli/commands/Compile.js
@@ -27,6 +27,7 @@ require("app-module-path").addPath(process.cwd() + "/node_modules");
 
 /**
  * Handles compilation of the project
+ * @ignore(setImmediate)
  */
 qx.Class.define("qx.tool.cli.commands.Compile", {
   extend: qx.tool.cli.commands.Command,
@@ -536,6 +537,10 @@ Framework: v${await this.getQxVersion()} in ${await this.getQxPath()}`);
      * @return {Boolean} true if all makers succeeded
      */
     async _loadConfigAndStartMaking() {
+      if (!this.getCompilerApi().compileJsonExists()) {
+        qx.tool.compiler.Console.error("Cannot find compile.json");
+        process.exit(1);
+      }
       var config = this.getCompilerApi().getConfiguration();
       var makers = (this.__makers = await this.createMakersFromConfig(config));
       if (!makers || !makers.length) {

--- a/source/class/qx/tool/cli/commands/Compile.js
+++ b/source/class/qx/tool/cli/commands/Compile.js
@@ -537,10 +537,6 @@ Framework: v${await this.getQxVersion()} in ${await this.getQxPath()}`);
      * @return {Boolean} true if all makers succeeded
      */
     async _loadConfigAndStartMaking() {
-      if (!this.getCompilerApi().compileJsonExists()) {
-        qx.tool.compiler.Console.error("Cannot find compile.json");
-        process.exit(1);
-      }
       var config = this.getCompilerApi().getConfiguration();
       var makers = (this.__makers = await this.createMakersFromConfig(config));
       if (!makers || !makers.length) {

--- a/source/class/qx/tool/cli/commands/package/Update.js
+++ b/source/class/qx/tool/cli/commands/package/Update.js
@@ -325,10 +325,10 @@ qx.Class.define("qx.tool.cli.commands.package.Update", {
           }
 
           // create a list of libraries via their manifests
-          for (let [index, { path: manifest_path }] of manifests.entries()) {
+          for (let [index, manifest] of manifests.entries()) {
             let manifest_data;
-            manifest_path = path.join(
-              manifest_path,
+            const manifest_path = path.join(
+              manifest.path,
               qx.tool.config.Manifest.config.fileName
             );
 


### PR DESCRIPTION
During the compile process some projects I get warnings/errors. There they are:
```
qx.test.core.Environment: [159,6 to 161,8] warning: Environment check 'affe' may be indeterminable, add to Manifest/provides/environment or use class name prefix
qx.test.core.Environment: [171,6] warning: Environment check 'affe' may be indeterminable, add to Manifest/provides/environment or use class name prefix
qx.test.core.Validation: warning: The mangling of private variable '__validateCustom' has been blocked because it is referenced as a string before it is declared
qx.test.dev.unit.Requirements: [60,6 to 62,8] warning: Environment check 'qx.test.requirement.syncTrue' may be indeterminable, add to Manifest/provides/environment or use class name prefix
qx.test.dev.unit.Requirements: [74,6 to 76,8] warning: Environment check 'qx.test.requirement.syncFalse' may be indeterminable, add to Manifest/provides/environment or use class name prefix
qx.tool.cli.Watch: [287,16] warning: Unresolved use of symbol setImmediate
qx.tool.cli.commands.Compile: [681,12] warning: Unresolved use of symbol setImmediate
qx.tool.cli.commands.package.Update: [330,12] warning: Unresolved use of symbol manifest_path
```

Couldn't only find a way so far how to handle "Environment check may be indeterminable" warnings so far. Any suggestion?