### PR TITLE
Treevirtual - reselect all selections, not just the last one

### DIFF
--- a/source/class/qx/ui/treevirtual/SimpleTreeDataModel.js
+++ b/source/class/qx/ui/treevirtual/SimpleTreeDataModel.js
@@ -831,9 +831,16 @@ qx.Class.define("qx.ui.treevirtual.SimpleTreeDataModel", {
       // Set selections in the selection model now
       var selectionModel = this.getTree().getSelectionModel();
       var selections = this._selections;
-      for (var nodeId in selections) {
-        var nRowIndex = this.getRowFromNodeId(nodeId);
-        selectionModel.setSelectionInterval(nRowIndex, nRowIndex);
+
+      selectionModel.setBatchMode(true);
+      try {
+        selectionModel.resetSelection();
+        for (var nodeId in selections) {
+          var nRowIndex = this.getRowFromNodeId(nodeId);
+          selectionModel.addSelectionInterval(nRowIndex, nRowIndex);
+        }
+      } finally {
+        selectionModel.setBatchMode(false);
       }
     },
 


### PR DESCRIPTION
I discovered a bug with the Treevirtual whereby it does not reselect all the previous selections when refreshed (in multi-selection mode). This is already apparent in the DemoBrowser where 2 selections are made in the set-up, but upon setting the datamodel, only one selection is actually displayed.

Demo Browser where it fails to select 2 nodes
http://qooxdoo.org/qxl.demobrowser/#treevirtual~TreeVirtual_Selections.html

The fix uses the `batchMode` of the selectionModel to add each of the selections before ultimately firing the `changeSelection` event once all selections are added. For single selection mode, the effect will be the same as before where the last of the selections would be selected.

This is a link to a Playground example of the above Demo Browser with my fix applied:
https://tinyurl.com/y2jdc8v7
