### PR TITLE
Fixed icon reset for selected node of TreeVirtual

### DIFF
--- a/source/class/qx/ui/treevirtual/SimpleTreeDataCellRenderer.js
+++ b/source/class/qx/ui/treevirtual/SimpleTreeDataCellRenderer.js
@@ -408,7 +408,8 @@ qx.Class.define("qx.ui.treevirtual.SimpleTreeDataCellRenderer", {
       var node = cellInfo.value;
 
       // Add the node's icon
-      var imageUrl = node.bSelected ? node.iconSelected : node.icon;
+      var imageUrl =
+        bSelected && node.iconSelected ? node.iconSelected : node.icon;
 
       if (!imageUrl) {
         if (node.type == qx.ui.treevirtual.SimpleTreeDataModel.Type.LEAF) {

--- a/source/class/qx/ui/treevirtual/SimpleTreeDataCellRenderer.js
+++ b/source/class/qx/ui/treevirtual/SimpleTreeDataCellRenderer.js
@@ -409,7 +409,7 @@ qx.Class.define("qx.ui.treevirtual.SimpleTreeDataCellRenderer", {
 
       // Add the node's icon
       var imageUrl =
-        bSelected && node.iconSelected ? node.iconSelected : node.icon;
+        node.bSelected && node.iconSelected ? node.iconSelected : node.icon;
 
       if (!imageUrl) {
         if (node.type == qx.ui.treevirtual.SimpleTreeDataModel.Type.LEAF) {


### PR DESCRIPTION
Fixed #10607 

Please correct me. I think if the icon for a selected node is unset and usual icon is set then the selected node should have usual icon.