### PR TITLE
Mousedown instead of tap event for abstract select box

### DIFF
--- a/source/class/qx/ui/form/AbstractSelectBox.js
+++ b/source/class/qx/ui/form/AbstractSelectBox.js
@@ -144,7 +144,9 @@ qx.Class.define("qx.ui.form.AbstractSelectBox", {
           );
 
           control.addListener("pointerdown", this._onListPointerDown, this);
-          control.getChildControl("pane").addListener("tap", this.close, this);
+          control
+            .getChildControl("pane")
+            .addListener("mousedown", this.close, this);
           break;
         }
         case "popup":


### PR DESCRIPTION
Fixed #9023.
I tested and noticed it doesn't depends on what browser is used but depends on what device is used. You could check this behaviour in Firefox dev tools changing device. After selecting some item SelectBox is focused. Maybe it shouldn't? If yes there is a simpler solution than changing event. I did check my changes for emulated devices but not for real so far.