### PR TITLE
Update AbstractField.js

### DIFF
--- a/source/class/qx/ui/form/AbstractField.js
+++ b/source/class/qx/ui/form/AbstractField.js
@@ -126,12 +126,13 @@ qx.Class.define("qx.ui.form.AbstractField", {
       this.setValue(value);
     }
     let el = this.getContentElement();
+    // change does not fire on ios webkit when just the keyboard is closed
+    // blur does fire though ... 
     // since ios allows no other html engines, checking for ios should do
-    // also the blur trick should work on other browsers too, but lets not rock the boat.
     if (qx.core.Environment.get("os.name") == "ios") {
-      el.addListener("blur", (e) => {
+      el.addListener("blur", () => {
         this._onChangeContent(new qx.event.type.Data(this.getValue()));
-      });
+      }, this);
     }
     else {
       el.addListener("change", this._onChangeContent, this);

--- a/source/class/qx/ui/form/AbstractField.js
+++ b/source/class/qx/ui/form/AbstractField.js
@@ -131,7 +131,9 @@ qx.Class.define("qx.ui.form.AbstractField", {
     // since ios allows no other html engines, checking for ios should do
     if (qx.core.Environment.get("os.name") == "ios") {
       el.addListener("blur", () => {
-        this._onChangeContent(new qx.event.type.Data(this.getValue()));
+        let ev = new qx.event.type.Data();
+        ev.init(el.getDomElement().value);
+        this._onChangeContent(ev);
       }, this);
     }
     else {

--- a/source/class/qx/ui/form/AbstractField.js
+++ b/source/class/qx/ui/form/AbstractField.js
@@ -125,9 +125,17 @@ qx.Class.define("qx.ui.form.AbstractField", {
     if (value != null) {
       this.setValue(value);
     }
-
-    this.getContentElement().addListener("change", this._onChangeContent, this);
-
+    let el = this.getContentElement();
+    // since ios allows no other html engines, checking for ios should do
+    // also the blur trick should work on other browsers too, but lets not rock the boat.
+    if (qx.core.Environment.get("os.name") == "ios") {
+      el.addListener("blur", (e) => {
+        this._onChangeContent(new qx.event.type.Data(this.getValue()));
+      });
+    }
+    else {
+      el.addListener("change", this._onChangeContent, this);
+    }
     // use qooxdoo placeholder if no native placeholder is supported
     if (this.__useQxPlaceholder) {
       // assign the placeholder text after the appearance has been applied


### PR DESCRIPTION
Make `changeValue` event working on ios. There is no `change` event when just closing the keyboard, only a `blur`. 

Fix for #10628