### PR TITLE
Desktop dispose fix

### DIFF
--- a/source/class/qx/ui/window/Manager.js
+++ b/source/class/qx/ui/window/Manager.js
@@ -81,7 +81,7 @@ qx.Class.define("qx.ui.window.Manager", {
      * {@link qx.ui.core.queue.Widget widget queue}.
      */
     syncWidget() {
-      if (!this.__desktop){
+      if (this.isDisposed()){
         return;
       }
       this.__desktop.forceUnblock();

--- a/source/class/qx/ui/window/Manager.js
+++ b/source/class/qx/ui/window/Manager.js
@@ -81,6 +81,9 @@ qx.Class.define("qx.ui.window.Manager", {
      * {@link qx.ui.core.queue.Widget widget queue}.
      */
     syncWidget() {
+      if (!this.__desktop){
+        return;
+      }
       this.__desktop.forceUnblock();
 
       var windows = this.__desktop.getWindows();


### PR DESCRIPTION
There are tightly coupled classes: `qx.ui.window.Desktop` and `qx.ui.window.Manager`. In destructor of Desktop there is disposing of Manager and vice versa. There is a case when desktop could be disposed firstly BUT `syncWidget` of Manager uses desktop member and leads to an error.

It is a fast and straightforward solution If you know better one just let me know. Thanks.