### PR TITLE
Allow clearData to be called for a TreeVirtual without a re-render of the tree

### DIFF
--- a/source/class/qx/ui/treevirtual/SimpleTreeDataModel.js
+++ b/source/class/qx/ui/treevirtual/SimpleTreeDataModel.js
@@ -809,10 +809,13 @@ qx.Class.define("qx.ui.treevirtual.SimpleTreeDataModel", {
      *   has completed building or modifying a tree by issuing a series of
      *   calls to {@link #addBranch} and/or {@link #addLeaf}.
      *
+     * @param bRerender {Boolean?true}
+     *  Rerender the tree data after setting the data. If set false it becomes the caller's responsibility to
+     *    call setData() subsequently to cause a redraw.
      *
      * @throws {Error} If the parameter has the wrong type.
      */
-    setData(nodeArr) {
+    setData(nodeArr, bRerender = true) {
       this._checkEditing();
       if (nodeArr instanceof Array) {
         // Save the user-supplied data.
@@ -825,8 +828,10 @@ qx.Class.define("qx.ui.treevirtual.SimpleTreeDataModel", {
         );
       }
 
-      // Re-render the row array
-      this.__render();
+      // Re-render the row array, if so requested
+      if (bRerender) {
+        this.__render();
+      }
 
       // Set selections in the selection model now
       var selectionModel = this.getTree().getSelectionModel();
@@ -859,11 +864,14 @@ qx.Class.define("qx.ui.treevirtual.SimpleTreeDataModel", {
     /**
      * Clears the tree of all nodes
      *
+     * @param bRerender {Boolean?true}
+     *   Rerender the tree data after clearing. If set false it becomes the caller's responsibility to
+     *    call setData() subsequently to cause a redraw.
      */
-    clearData() {
+    clearData(bRerender = true) {
       this._checkEditing();
       this._clearSelections();
-      this.setData([qx.ui.treevirtual.MTreePrimitive._getEmptyTree()]);
+      this.setData([qx.ui.treevirtual.MTreePrimitive._getEmptyTree()], bRerender);
     },
 
     /**


### PR DESCRIPTION
When pruning all nodes from a TreeVirtual SimpleTreeDataModel `prune(0)`, the nodes are recursively "deleted" by replacing the node array entries with null and removing these from any selections. When the tree is re-filled, the amount of data in the node array is increased. If this happens for a large tree several times over then the performance of the tree starts to degrade which is something noticed in our application.

Pruning at zero (root node) is a special case because all the nodes except root node are removed. The node array can be reset to a single root node and still maintain a nodeId == index correspondence for all new nodes as noted just below the amended code within the `prune` method. This allows prune and re-population to take place without growing the node array.

There is a method `clearData` of the datamodel which also does this, but causes the tree to be re-rendered which was not desirable in our use-case and the reason we were pruning in the first instance. Arguably that method could also be amended to suppress the re-render and used instead.  I'm happy to take direction and amend as required.