### PR TITLE
Fix styling of qx.ui.form.SelectBox which have a coloured button

### DIFF
--- a/source/class/qx/ui/form/SelectBox.js
+++ b/source/class/qx/ui/form/SelectBox.js
@@ -81,7 +81,7 @@ qx.Class.define("qx.ui.form.SelectBox", {
   */
 
   properties: {
-    // overridden
+    /**@override*/
     appearance: {
       refine: true,
       init: "selectbox"
@@ -114,7 +114,7 @@ qx.Class.define("qx.ui.form.SelectBox", {
       this.getChildControl("atom").setRich(value);
     },
 
-    // overridden
+    /**@override*/
     _defaultFormat(item) {
       if (item) {
         if (typeof item.isRich == "function" && item.isRich()) {
@@ -125,7 +125,7 @@ qx.Class.define("qx.ui.form.SelectBox", {
       return null;
     },
 
-    // overridden
+    /**@override*/
     _createChildControlImpl(id, hash) {
       var control;
 
@@ -147,14 +147,29 @@ qx.Class.define("qx.ui.form.SelectBox", {
           control = new qx.ui.basic.Image();
           control.setAnonymous(true);
 
-          this._add(control);
+          this.getQxObject("arrowButton")._add(control);
+          this._add(this.getQxObject("arrowButton"));
           break;
       }
 
       return control || super._createChildControlImpl(id);
     },
 
-    // overridden
+    /**@overload */
+    _createQxObjectImpl(id) {
+      switch (id) {
+        case "arrowButton":
+          const layout = new qx.ui.layout.HBox().set({ alignY: "middle" });
+          return new qx.ui.container.Composite(layout).set({
+            allowGrowY: true,
+            appearance: "selectbox-arrow-button"
+          });
+      }
+
+      return super._createQxObjectImpl(id);
+    },
+
+    /**@override*/
     /**
      * @lint ignoreReferenceField(_forwardStates)
      */
@@ -306,7 +321,7 @@ qx.Class.define("qx.ui.form.SelectBox", {
       this.toggle();
     },
 
-    // overridden
+    /**@override*/
     _onKeyPress(e) {
       var iden = e.getKeyIdentifier();
       if ((iden == "Down" || iden == "Up") && e.isAltPressed()) {
@@ -341,7 +356,7 @@ qx.Class.define("qx.ui.form.SelectBox", {
       this.getChildControl("list").dispatchEvent(clone);
     },
 
-    // overridden
+    /**@override*/
     _onListPointerDown(e) {
       // Apply pre-selected item (translate quick selection to real selection)
       if (this.__preSelectedItem) {
@@ -350,7 +365,7 @@ qx.Class.define("qx.ui.form.SelectBox", {
       }
     },
 
-    // overridden
+    /**@override*/
     _onListChangeSelection(e) {
       var current = e.getData();
       var old = e.getOldData();
@@ -399,7 +414,7 @@ qx.Class.define("qx.ui.form.SelectBox", {
       }
     },
 
-    // overridden
+    /**@override*/
     _onPopupChangeVisibility(e) {
       super._onPopupChangeVisibility(e);
 

--- a/source/class/qx/ui/form/SelectBox.js
+++ b/source/class/qx/ui/form/SelectBox.js
@@ -159,7 +159,7 @@ qx.Class.define("qx.ui.form.SelectBox", {
     _createQxObjectImpl(id) {
       switch (id) {
         case "arrowButton":
-          const layout = new qx.ui.layout.HBox().set({ alignY: "middle" });
+          var layout = new qx.ui.layout.HBox().set({ alignY: "middle" });
           return new qx.ui.container.Composite(layout).set({
             allowGrowY: true,
             appearance: "selectbox-arrow-button"


### PR DESCRIPTION
This PR fixes the issue that occurs when an instance of qx.ui.form.SelectBox is made taller (thicker) than its default height, causing its button to not stretch to the SelectBox's full height. It happens for example when a SelectBox is placed inside a toolbar. This causes visual issues in themes where the button is a different colour to the rest of the select box, like in zx.ui.theme.avocado:

<img width="264" alt="image" src="https://github.com/qooxdoo/qooxdoo/assets/29703546/6d4e575b-c295-4b90-baa0-f92a416fb8ab">

However, SelectBoxes with their default heights look fine:
<img width="264" alt="image" src="https://github.com/qooxdoo/qooxdoo/assets/29703546/2e3617e1-caf3-48ca-a90b-0a64616d9f2c">

This PR solves the problem by wrapping the SelectBox's "arrow" child control in a qx.ui.container.Composite (qxObject id: "arrowButton"). The `arrowButton` is made to stretch to the full height of the SelectBox, but the `arrow` stays in the centre of `arrowButton`.

NB: while the Composite is named like a button, it is not an actual Qooxdoo button, but it still behaves like a button.

This is a very minimally-breaking change, which at least does not break Qooxdoo's build in themes (Tangible, Classic, Modern, etc). This will only really affect themes which give a backgroundColor to `selectbox/arrow` that is different to the SelectBox's backgroundColor, and this can be fixed by adding the following to the theme's Appearance.js:

```
"selectbox-arrow-button": {
      include: "widget",
      style(states) {
        return {
          backgroundColor: "selectbox-button-color"
        }
      }
    }
```

Also, as a bonus, I have changed the overrides to be standard JSDoc.