### PR TITLE
`qx.ui.tabview.TabButton` does not conform to the API of superclass `qx.ui.basic.Atom`

### DIFF
--- a/source/class/qx/test/ui/basic/Atom.js
+++ b/source/class/qx/test/ui/basic/Atom.js
@@ -78,6 +78,39 @@ qx.Class.define("qx.test.ui.basic.Atom", {
       );
 
       a.destroy();
+    },
+
+    testLayoutOptionalProperties() {
+      let atomLayout;
+      const hasAtomLayout = new (qx.Class.define(null, {
+        extend: qx.ui.basic.Atom,
+        construct() {
+          super("test");
+          atomLayout = this._getLayout();
+        }
+      }))();
+
+      hasAtomLayout.setGap(10);
+      hasAtomLayout.setIconPosition("right");
+      hasAtomLayout.setCenter(true);
+
+      this.assertEquals(10, atomLayout.getGap());
+      this.assertEquals("right", atomLayout.getIconPosition());
+      this.assertEquals(true, atomLayout.getCenter());
+
+      const hasGridLayout = new (qx.Class.define(null, {
+        extend: qx.ui.basic.Atom,
+        construct() {
+          super("test");
+          this._getLayout().dispose();
+          this._setLayout(new qx.ui.layout.Grid());
+        }
+      }))();
+
+      // expect these to not throw an error (should log in debug env)
+      hasGridLayout.setGap(10);
+      hasGridLayout.setIconPosition("right");
+      hasGridLayout.setCenter(true);
     }
   }
 });

--- a/source/class/qx/test/ui/basic/Atom.js
+++ b/source/class/qx/test/ui/basic/Atom.js
@@ -111,6 +111,10 @@ qx.Class.define("qx.test.ui.basic.Atom", {
       hasGridLayout.setGap(10);
       hasGridLayout.setIconPosition("right");
       hasGridLayout.setCenter(true);
+      // the values will be set to the Atom, they will not be set (or attempt to be set) on the layout of the Atom
+      this.assertEquals(10, hasGridLayout.getGap());
+      this.assertEquals("right", hasGridLayout.getIconPosition());
+      this.assertEquals(true, hasGridLayout.getCenter());
     }
   }
 });

--- a/source/class/qx/ui/basic/Atom.js
+++ b/source/class/qx/ui/basic/Atom.js
@@ -283,9 +283,6 @@ qx.Class.define("qx.ui.basic.Atom", {
     },
 
     __safeSetPropertyOnLayout(value, propertyName) {
-      if (value === undefined) {
-        return;
-      }
       const layout = this._getLayout();
       const propertySetter = `set${qx.lang.String.firstUp(propertyName)}`;
       if (layout[propertySetter]) {

--- a/source/class/qx/ui/basic/Atom.js
+++ b/source/class/qx/ui/basic/Atom.js
@@ -277,8 +277,19 @@ qx.Class.define("qx.ui.basic.Atom", {
     },
 
     // property apply
-    _applyGap(value, old) {
-      this._getLayout().setGap(value);
+    _applyGap(value) {
+      if (value === undefined) return;
+      const layout = this._getLayout();
+      if (layout.setGap) layout.setGap(value);
+      else if (qx.core.Environment.get("qx.debug")) {
+        this.warn(
+          `The \`gap\` property of a ${
+            this.classname
+          } was set, but the layout ${
+            this._getLayout().classname
+          } does not support a \`gap\` property.`
+        );
+      }
     },
 
     // property apply
@@ -288,13 +299,36 @@ qx.Class.define("qx.ui.basic.Atom", {
     },
 
     // property apply
-    _applyIconPosition(value, old) {
-      this._getLayout().setIconPosition(value);
+    _applyIconPosition(value) {
+      if (value === undefined) return;
+      const layout = this._getLayout();
+      if (layout.setIconPosition) layout.setIconPosition(value);
+      else if (qx.core.Environment.get("qx.debug")) {
+        this.warn(
+          `The \`iconPosition\` property of a ${
+            this.classname
+          } was set, but the layout ${
+            this._getLayout().classname
+          } does not support a \`iconPosition\` property.`
+        );
+      }
     },
 
     // property apply
-    _applyCenter(value, old) {
+    _applyCenter(value) {
+      if (value === undefined) return;
       this._getLayout().setCenter(value);
+      const layout = this._getLayout();
+      if (layout.setCenter) layout.setCenter(value);
+      else if (qx.core.Environment.get("qx.debug")) {
+        this.warn(
+          `The \`center\` property of a ${
+            this.classname
+          } was set, but the layout ${
+            this._getLayout().classname
+          } does not support a \`center\` property.`
+        );
+      }
     },
 
     // overridden

--- a/source/class/qx/ui/basic/Atom.js
+++ b/source/class/qx/ui/basic/Atom.js
@@ -278,10 +278,13 @@ qx.Class.define("qx.ui.basic.Atom", {
 
     // property apply
     _applyGap(value) {
-      if (value === undefined) return;
+      if (value === undefined) {
+        return;
+      }
       const layout = this._getLayout();
-      if (layout.setGap) layout.setGap(value);
-      else if (qx.core.Environment.get("qx.debug")) {
+      if (layout.setGap) {
+        layout.setGap(value);
+      } else if (qx.core.Environment.get("qx.debug")) {
         this.warn(
           `The \`gap\` property of a ${
             this.classname
@@ -300,10 +303,13 @@ qx.Class.define("qx.ui.basic.Atom", {
 
     // property apply
     _applyIconPosition(value) {
-      if (value === undefined) return;
+      if (value === undefined) {
+        return;
+      }
       const layout = this._getLayout();
-      if (layout.setIconPosition) layout.setIconPosition(value);
-      else if (qx.core.Environment.get("qx.debug")) {
+      if (layout.setIconPosition) {
+        layout.setIconPosition(value);
+      } else if (qx.core.Environment.get("qx.debug")) {
         this.warn(
           `The \`iconPosition\` property of a ${
             this.classname
@@ -316,10 +322,13 @@ qx.Class.define("qx.ui.basic.Atom", {
 
     // property apply
     _applyCenter(value) {
-      if (value === undefined) return;
+      if (value === undefined) {
+        return;
+      }
       const layout = this._getLayout();
-      if (layout.setCenter) layout.setCenter(value);
-      else if (qx.core.Environment.get("qx.debug")) {
+      if (layout.setCenter) {
+        layout.setCenter(value);
+      } else if (qx.core.Environment.get("qx.debug")) {
         this.warn(
           `The \`center\` property of a ${
             this.classname

--- a/source/class/qx/ui/basic/Atom.js
+++ b/source/class/qx/ui/basic/Atom.js
@@ -287,9 +287,9 @@ qx.Class.define("qx.ui.basic.Atom", {
         return;
       }
       const layout = this._getLayout();
-      const propertyGetter = `get${qx.lang.String.firstUp(propertyName)}`;
-      if (layout[propertyGetter]) {
-        layout[propertyGetter](value);
+      const propertySetter = `set${qx.lang.String.firstUp(propertyName)}`;
+      if (layout[propertySetter]) {
+        layout[propertySetter](value);
       } else if (qx.core.Environment.get("qx.debug")) {
         this.warn(
           `The \`${propertyName}\` property of a ${

--- a/source/class/qx/ui/basic/Atom.js
+++ b/source/class/qx/ui/basic/Atom.js
@@ -317,7 +317,6 @@ qx.Class.define("qx.ui.basic.Atom", {
     // property apply
     _applyCenter(value) {
       if (value === undefined) return;
-      this._getLayout().setCenter(value);
       const layout = this._getLayout();
       if (layout.setCenter) layout.setCenter(value);
       else if (qx.core.Environment.get("qx.debug")) {

--- a/source/class/qx/ui/basic/Atom.js
+++ b/source/class/qx/ui/basic/Atom.js
@@ -277,66 +277,43 @@ qx.Class.define("qx.ui.basic.Atom", {
     },
 
     // property apply
-    _applyGap(value) {
-      if (value === undefined) {
-        return;
-      }
-      const layout = this._getLayout();
-      if (layout.setGap) {
-        layout.setGap(value);
-      } else if (qx.core.Environment.get("qx.debug")) {
-        this.warn(
-          `The \`gap\` property of a ${
-            this.classname
-          } was set, but the layout ${
-            this._getLayout().classname
-          } does not support a \`gap\` property.`
-        );
-      }
-    },
-
-    // property apply
     _applyShow(value, old) {
       this._handleLabel();
       this._handleIcon();
     },
 
-    // property apply
-    _applyIconPosition(value) {
+    __safeSetPropertyOnLayout(value, propertyName) {
       if (value === undefined) {
         return;
       }
       const layout = this._getLayout();
-      if (layout.setIconPosition) {
-        layout.setIconPosition(value);
+      const propertyGetter = `get${qx.lang.String.firstUp(propertyName)}`;
+      if (layout[propertyGetter]) {
+        layout[propertyGetter](value);
       } else if (qx.core.Environment.get("qx.debug")) {
         this.warn(
-          `The \`iconPosition\` property of a ${
+          `The \`${propertyName}\` property of a ${
             this.classname
           } was set, but the layout ${
             this._getLayout().classname
-          } does not support a \`iconPosition\` property.`
+          } does not support a \`${propertyName}\` property.`
         );
       }
     },
 
     // property apply
+    _applyGap(value) {
+      this.__safeSetPropertyOnLayout(value, "gap");
+    },
+
+    // property apply
+    _applyIconPosition(value) {
+      this.__safeSetPropertyOnLayout(value, "iconPosition");
+    },
+
+    // property apply
     _applyCenter(value) {
-      if (value === undefined) {
-        return;
-      }
-      const layout = this._getLayout();
-      if (layout.setCenter) {
-        layout.setCenter(value);
-      } else if (qx.core.Environment.get("qx.debug")) {
-        this.warn(
-          `The \`center\` property of a ${
-            this.classname
-          } was set, but the layout ${
-            this._getLayout().classname
-          } does not support a \`center\` property.`
-        );
-      }
+      this.__safeSetPropertyOnLayout(value, "center");
     },
 
     // overridden


### PR DESCRIPTION
Due to the following code in TabButton;

https://github.com/qooxdoo/qooxdoo/blob/b3553384ed4a5194e67d4addd41b1795ea73704f/source/class/qx/ui/tabview/TabButton.js#L37-L41

A conflict arises with the following property apply methods in the Atom superclass;

https://github.com/qooxdoo/qooxdoo/blob/b3553384ed4a5194e67d4addd41b1795ea73704f/source/class/qx/ui/basic/Atom.js#L280-L282
https://github.com/qooxdoo/qooxdoo/blob/b3553384ed4a5194e67d4addd41b1795ea73704f/source/class/qx/ui/basic/Atom.js#L291-L293
https://github.com/qooxdoo/qooxdoo/blob/b3553384ed4a5194e67d4addd41b1795ea73704f/source/class/qx/ui/basic/Atom.js#L296-L298

This is due to `qx.ui.basic.Atom` prusuming that it's layout will always be a `qx.ui.layout.Atom`, which is untrue and unenforced.

This restricts the use of included appearance entries, as if `TabButton` includes one of it's superclass' appearances, that superclass cannot safely define these properties in it's appearance.

**To Reproduce**

Steps to reproduce the behavior:
1. Add a TabView to a project
2. Target the TabView button in appearances and set a `gap` value (or include a superclass' appearance which has a `gap` value)
3. Observe the error

**Expected behavior**

The error should not be thrown, and the application of the `gap` property should be ignored. This mirrors the way in which the vast majority of layout-specific properties work in CSS.

This could be done by either detatching `TabButton` from the inheritance chain to `Atom`, or by modifying `Atom` to be permissive of alternative layouts (latter option implemented in this PR).

**This PR**

Provides a simple error prevention mechanism within the property applies in `qx.ui.basic.Atom` which ensures the layout supports the given property before attempting to set it, provides a warning in development environments if the layout does not support the property.