### PR TITLE
add option singleLineBlocks to es6ify command

### DIFF
--- a/docs/development/cli/commands.md
+++ b/docs/development/cli/commands.md
@@ -171,7 +171,7 @@ if (foo)
 spam();
 ```
 becomes
-```
+```javascript
 if (foo) {
   bar();
 }

--- a/docs/development/cli/commands.md
+++ b/docs/development/cli/commands.md
@@ -163,6 +163,21 @@ sections of your code, and test carefully.
 If `--arrow-functions` is set to `careful` (the default), then functions are only switched to arrow 
 functions where the API is known  (e.g. `.addListener`).
 
+If `--single-line-blocks` is passed, this forces braces around single-line bodies for if, for, while, and do while. For example,
+```
+if (foo)
+  bar();
+
+spam();
+```
+becomes
+```
+if (foo) {
+  bar();
+}
+spam();
+```
+
 The final step is that the ES6ify will use https://prettier.io/ to reformat the code, and will use
 the nearest `prettierrc.json` for configuration
 

--- a/docs/development/cli/commands.md
+++ b/docs/development/cli/commands.md
@@ -164,7 +164,7 @@ If `--arrow-functions` is set to `careful` (the default), then functions are onl
 functions where the API is known  (e.g. `.addListener`).
 
 If `--single-line-blocks` is passed, this forces braces around single-line bodies for if, for, while, and do while. For example,
-```
+```javascript
 if (foo)
   bar();
 

--- a/docs/development/cli/commands.md
+++ b/docs/development/cli/commands.md
@@ -163,7 +163,7 @@ sections of your code, and test carefully.
 If `--arrow-functions` is set to `careful` (the default), then functions are only switched to arrow 
 functions where the API is known  (e.g. `.addListener`).
 
-If `--single-line-blocks` is passed, this forces braces around single-line bodies for if, for, while, and do while. For example,
+If `--single-line-blocks` is passed, this forces braces around single-line bodies for `if`, `for`, `while`, and `do while`. For example,
 ```javascript
 if (foo)
   bar();

--- a/source/class/qx/tool/cli/commands/Es6ify.js
+++ b/source/class/qx/tool/cli/commands/Es6ify.js
@@ -54,6 +54,13 @@ qx.Class.define("qx.tool.cli.commands.Es6ify", {
           arrowFunctions: {
             choices: ["never", "always", "careful", "aggressive"],
             default: "careful"
+          },
+
+          singleLineBlocks: {
+            type: "boolean",
+            default: false,
+            describe:
+              "Force braces around single line blocks for if, for, while, and do while"
           }
         }
       };
@@ -89,7 +96,8 @@ qx.Class.define("qx.tool.cli.commands.Es6ify", {
         let ify = new qx.tool.compiler.Es6ify(filename);
         ify.set({
           arrowFunctions: this.argv.arrowFunctions,
-          overwrite: this.argv.overwrite
+          overwrite: this.argv.overwrite,
+          singleLineBlocks: this.argv.singleLineBlocks
         });
 
         await ify.transform();

--- a/source/class/qx/tool/cli/commands/Es6ify.js
+++ b/source/class/qx/tool/cli/commands/Es6ify.js
@@ -60,7 +60,7 @@ qx.Class.define("qx.tool.cli.commands.Es6ify", {
             type: "boolean",
             default: false,
             describe:
-              "Force braces around single line blocks for if, for, while, and do while"
+              "Force braces around single line bodies for if, for, while, and do while"
           }
         }
       };

--- a/source/class/qx/tool/compiler/Es6ify.js
+++ b/source/class/qx/tool/compiler/Es6ify.js
@@ -339,6 +339,7 @@ qx.Class.define("qx.tool.compiler.Es6ify", {
                   callee == "qx.core.Assert.assertEventFired" ||
                   (isTest && callee.endsWith(".resume"))
                 ) {
+                  return;
                 }
               }
             } else if (arrowFunctions == "careful") {

--- a/source/class/qx/tool/compiler/Es6ify.js
+++ b/source/class/qx/tool/compiler/Es6ify.js
@@ -117,7 +117,7 @@ qx.Class.define("qx.tool.compiler.Es6ify", {
       nullable: true
     },
 
-    /** Whether for forces braces around single line blocks for if, for, while, and do while */
+    /** Whether to force braces around single line bodies for if, for, while, and do while */
     singleLineBlocks: {
       init: false,
       check: "Boolean"

--- a/source/class/qx/tool/compiler/Es6ify.js
+++ b/source/class/qx/tool/compiler/Es6ify.js
@@ -117,6 +117,12 @@ qx.Class.define("qx.tool.compiler.Es6ify", {
       nullable: true
     },
 
+    /** Whether for forces braces around single line blocks for if, for, while, and do while */
+    singleLineBlocks: {
+      init: false,
+      check: "Boolean"
+    },
+
     /** Whether to overwrite the original file */
     overwrite: {
       init: false,
@@ -144,6 +150,11 @@ qx.Class.define("qx.tool.compiler.Es6ify", {
       }
       plugins.push(this.__pluginRemoveUnnecessaryThis());
       plugins.push(this.__pluginSwitchToSuper());
+
+      if (this.getSingleLineBlocks()) {
+        plugins.push(this.__pluginSingleLineBlocks());
+      }
+
       var config = {
         ast: true,
         babelrc: false,
@@ -272,6 +283,26 @@ qx.Class.define("qx.tool.compiler.Es6ify", {
       return replacement;
     },
 
+    __pluginSingleLineBlocks() {
+      function loopStatement(path) {
+        if (path.node.body.type == "BlockStatement") return;
+        let block = types.blockStatement([path.node.body]);
+        path.node.body = block;
+      }
+      return {
+        visitor: {
+          IfStatement(path) {
+            if (path.node.consequent.type == "BlockStatement") return;
+            let block = types.blockStatement([path.node.consequent]);
+            path.node.consequent = block;
+          },
+          DoWhileStatement: loopStatement,
+          ForStatement: loopStatement,
+          WhileStatement: loopStatement
+        }
+      };
+    },
+
     /**
      * Tries to convert functions into arrow functions
      * @returns
@@ -281,7 +312,6 @@ qx.Class.define("qx.tool.compiler.Es6ify", {
       const isTest = this.__filename.indexOf("/test/") > -1;
       let arrowFunctions = this.getArrowFunctions();
       let knownApiFunctions = this.__knownApiFunctions;
-
       return {
         visitor: {
           CallExpression(path) {
@@ -309,7 +339,6 @@ qx.Class.define("qx.tool.compiler.Es6ify", {
                   callee == "qx.core.Assert.assertEventFired" ||
                   (isTest && callee.endsWith(".resume"))
                 ) {
-                  return;
                 }
               }
             } else if (arrowFunctions == "careful") {

--- a/source/class/qx/tool/compiler/Es6ify.js
+++ b/source/class/qx/tool/compiler/Es6ify.js
@@ -285,14 +285,18 @@ qx.Class.define("qx.tool.compiler.Es6ify", {
 
     __pluginSingleLineBlocks() {
       function loopStatement(path) {
-        if (path.node.body.type == "BlockStatement") return;
+        if (path.node.body.type == "BlockStatement") {
+          return;
+        }
         let block = types.blockStatement([path.node.body]);
         path.node.body = block;
       }
       return {
         visitor: {
           IfStatement(path) {
-            if (path.node.consequent.type == "BlockStatement") return;
+            if (path.node.consequent.type == "BlockStatement") {
+              return;
+            }
             let block = types.blockStatement([path.node.consequent]);
             path.node.consequent = block;
           },


### PR DESCRIPTION
This PR adds a command line option `singleLineBlocks` to the `es6ify` command. If enabled, it will force `if` statements or loops which are not followed by a block statement to have a single-line block statement. It is disabled by default, so it's non-breaking.

For example, it will turn this:
```
if (foo) 
  bar();
```   
into this:
```
if (foo) {
  bar();
}
```   

This is to ensure that the code is formatted by Prettier as per Qooxdoo's standards.