### PR TITLE
Detect duplicate namespaces in libraries of Qooxdoo project

### DIFF
--- a/source/class/qx/tool/compiler/Analyser.js
+++ b/source/class/qx/tool/compiler/Analyser.js
@@ -1415,14 +1415,16 @@ qx.Class.define("qx.tool.compiler.Analyser", {
      * @param library
      */
     addLibrary(library) {
-      if (this.__librariesByNamespace[library.getNamespace()]) {
+      const existingLibrary =
+        this.__librariesByNamespace[library.getNamespace()];
+      if (existingLibrary) {
         throw new Error(
           "Multiple libraries with namespace " +
             library.getNamespace() +
             " found " +
             library.getRootDir() +
             " and " +
-            this.__librariesByNamespace[library.getNamespace()].getRootDir()
+            existingLibrary.getRootDir()
         );
       }
       this.__libraries.push(library);

--- a/source/class/qx/tool/compiler/Analyser.js
+++ b/source/class/qx/tool/compiler/Analyser.js
@@ -1415,6 +1415,16 @@ qx.Class.define("qx.tool.compiler.Analyser", {
      * @param library
      */
     addLibrary(library) {
+      if (this.__librariesByNamespace[library.getNamespace()]) {
+        throw new Error(
+          "Multiple libraries with namespace " +
+            library.getNamespace() +
+            " found " +
+            library.getRootDir() +
+            " and " +
+            this.__librariesByNamespace[library.getNamespace()].getRootDir()
+        );
+      }
       this.__libraries.push(library);
       this.__librariesByNamespace[library.getNamespace()] = library;
     },


### PR DESCRIPTION
This PR makes the compiler complain if there are two libraries within a Qx project which have the same namespace. This is because having a duplicate namespace causes some problems, such as the compiler not responding to changed source files.