### PR TITLE
Optional `requires` in Manifest

### DIFF
--- a/source/class/qx/tool/cli/commands/package/Install.js
+++ b/source/class/qx/tool/cli/commands/package/Install.js
@@ -538,6 +538,9 @@ qx.Class.define("qx.tool.cli.commands.package.Install", {
      * @return {Promise<Boolean>} Wether any libraries were installed
      */
     async __installDependenciesFromManifest(manifest) {
+      if (!manifest.requires) {
+        return false;
+      }
       for (let lib_uri of Object.getOwnPropertyNames(manifest.requires)) {
         let lib_range = manifest.requires[lib_uri];
         switch (lib_uri) {


### PR DESCRIPTION
```diff
+     if (!manifest.requires) {
+       return false;
+     }
      for (let lib_uri of Object.getOwnPropertyNames(manifest.requires)) {
```

If the argument to `Object.getOwnPropertyNames` is not an object (including if it's null), then a TypeError is thrown. This guard statement prevents the issue from occurring.