### PR TITLE
`CatchClause` visitor: permit catch block without thrown value trap

### DIFF
--- a/source/class/qx/tool/compiler/ClassFile.js
+++ b/source/class/qx/tool/compiler/ClassFile.js
@@ -2390,7 +2390,9 @@ qx.Class.define("qx.tool.compiler.ClassFile", {
         CatchClause: {
           enter(path) {
             t.pushScope(null, path.node);
-            t.addDeclaration(path.node.param.name);
+            if (path.node.param) {
+              t.addDeclaration(path.node.param.name);
+            }
           },
           exit(path) {
             t.popScope(path.node);


### PR DESCRIPTION
The object at `path.node.param` is `null` for the below code, as it intends to refer to the `(err)` part of some `catch (err) {}` clause. 
The call `t.addDeclaration(path.node.param.name)` will fail with `TypeError: Cannot read properties of null (reading 'name')`, this commit resolve this issue.

```js
//...

try {
  // ...
} catch { // note: not using `catch (err) {`
  // ...
}
```