### PR TITLE
add cycle behaviour to ToggleButton

### DIFF
--- a/source/class/qx/ui/form/ToggleButton.js
+++ b/source/class/qx/ui/form/ToggleButton.js
@@ -114,6 +114,16 @@ qx.Class.define("qx.ui.form.ToggleButton", {
       apply: "_applyTriState",
       nullable: true,
       init: null
+    },
+
+    /**
+     * The behavior when the button is clicked. Only useful for tri-state checkboxes.
+     * If "cycle" is set, the button cycles through the states "disabled", "undetermined", and "enabled"
+     * If "toggle" is set, the button toggles between "disabled" and "enabled".
+     */
+    clickBehavior: {
+      check: ["cycle", "toggle"],
+      init: "toggle"
     }
   },
 
@@ -173,7 +183,20 @@ qx.Class.define("qx.ui.form.ToggleButton", {
      * @param e {qx.event.type.Event} The execute event.
      */
     _onExecute(e) {
-      this.toggleValue();
+      if (this.isTriState() && this.getClickBehavior() === "cycle") {
+        let newValue;
+        let currentValue = this.getValue();
+        if (currentValue === null) {
+          newValue = true;
+        } else if (currentValue === true) {
+          newValue = false;
+        } else {
+          newValue = null;
+        }
+        this.setValue(newValue);
+      } else {
+        this.toggleValue();
+      }
     },
 
     /**

--- a/source/class/qx/ui/form/ToggleButton.js
+++ b/source/class/qx/ui/form/ToggleButton.js
@@ -117,11 +117,11 @@ qx.Class.define("qx.ui.form.ToggleButton", {
     },
 
     /**
-     * The behavior when the button is clicked. Only useful for tri-state checkboxes.
+     * The behavior when the button is executed (e.g. clicked). Only useful for tri-state checkboxes.
      * If "cycle" is set, the button cycles through the states "disabled", "undetermined", and "enabled"
      * If "toggle" is set, the button toggles between "disabled" and "enabled".
      */
-    clickBehavior: {
+    executeBehavior: {
       check: ["cycle", "toggle"],
       init: "toggle"
     }
@@ -183,7 +183,7 @@ qx.Class.define("qx.ui.form.ToggleButton", {
      * @param e {qx.event.type.Event} The execute event.
      */
     _onExecute(e) {
-      if (this.isTriState() && this.getClickBehavior() === "cycle") {
+      if (this.isTriState() && this.getExecuteBehavior() === "cycle") {
         let newValue;
         let currentValue = this.getValue();
         if (currentValue === null) {


### PR DESCRIPTION
This PR gives the programmer the ability to control the behaviour of tristate checkboxes when they are clicked. Currently, they only toggle between the enabled/disabled state, but it is impossible for the end user to enter the undetermined state.

This adds a new property to ToggleButton, clickBehaviour, which can either be set to "toggle" (reflects current behaviour), or "cycle" (cycle between disabled, undetermined, enabled).

