### PR TITLE
(a very small) fix: qx.tool.utils.Utils.formatTime s/m/H trimming

### DIFF
--- a/source/class/qx/tool/utils/Utils.js
+++ b/source/class/qx/tool/utils/Utils.js
@@ -91,9 +91,11 @@ qx.Class.define("qx.tool.utils.Utils", {
      */
     formatTime(millisec) {
       var seconds = Math.floor(millisec / 1000);
-      var minutes = Math.floor(seconds / 60);
-      var hours = Math.floor(minutes / 60);
       millisec %= 1000;
+      var minutes = Math.floor(seconds / 60);
+      seconds %= 60;
+      var hours = Math.floor(minutes / 60);
+      minutes %= 60;
 
       var result = "";
       if (hours) {


### PR DESCRIPTION
I've noticed that when compiling a lot of classes (eg, enough that it takes longer than 60s to compile) the duration in the message is a little odd.

For example, earlier when clean compiling qooxdoo, the compilation took around 143s to complete - that's 2m 23s, right?

```txt
>>> Compiled 1451 classes in 02m 143.532s
```

According to that message though it seems to say that it took 2 mins plus 143 secs.

It turns out that seconds/minutes which should have been counted only for a larger minute/hour were also being counted for the seconds/minutes themselves.

I added this commit, clean compiled again, this time the compilation took a little longer, around 147s - 2m 27s.

```txt
>>> Compiled 1451 classes in 02m 27.667s
```

That's much better, the seconds which make up those 2 mins are no longer being counted in the seconds value.