### PR TITLE
keyboard: always fireInputEvent whenever a charcode is provided

### DIFF
--- a/source/class/qx/event/handler/Keyboard.js
+++ b/source/class/qx/event/handler/Keyboard.js
@@ -590,13 +590,12 @@ qx.Class.define("qx.event.handler.Keyboard", {
       var keyIdentifier;
 
       // Use: keyCode
-      let returnPromise = null;
       var tracker = {};
 
       if (keyCode || (!keyCode && !charCode)) {
         keyIdentifier = qx.event.util.Keyboard.keyCodeToIdentifier(keyCode);
 
-        returnPromise = qx.event.Utils.track(tracker, () =>
+        let returnPromise = qx.event.Utils.track(tracker, () =>
           this._fireSequenceEvent(domEvent, eventType, keyIdentifier)
         );
 
@@ -605,6 +604,7 @@ qx.Class.define("qx.event.handler.Keyboard", {
             this._fireInputEvent(domEvent, charCode)
           );
         }
+        return returnPromise;
       }
 
       // Use: charCode
@@ -620,8 +620,6 @@ qx.Class.define("qx.event.handler.Keyboard", {
           this._fireInputEvent(domEvent, charCode)
         );
       }
-
-      return returnPromise;
     },
 
     /*


### PR DESCRIPTION
This PR fixes an issue in qx.event.handler.Keyboard where, if both a non-0 keycode and non-0 charcode are passed into _idealKeyHandler, this._fireInputEvent will not run, even though a text character key has been pressed. This will not fire a "keyinput" event when it should be fired. This scenario only occurs in some browsers, such as Firefox but not Chrome.

I know that the current keyboard system uses things which are deprecated, so it will be necessary to rewrite it in the future, but do you all think that this is a good fix for now?