### PR TITLE
force line height to be 1 for qx.ui.basic.Image for font mode

### DIFF
--- a/source/class/qx/ui/basic/Image.js
+++ b/source/class/qx/ui/basic/Image.js
@@ -413,6 +413,7 @@ qx.Class.define("qx.ui.basic.Image", {
 
       if (mode == "font") {
         element.setRich(true);
+        element.setStyle("line-height", "1");
       } else {
         element.setScale(scale);
 


### PR DESCRIPTION
For qx.ui.basic.Image with a font source, this makes the `line-height` style property of its content element to be set to 1 (i.e. line height same as font height). This is because, currently, `line-height` is set to its default `normal`, which is around 1.2 in most browsers. This causes the glyph to be shifted downwards by a few pixels, and sometimes slightly bottom-cropped. Only happens in some browsers, such as Firefox. Images:.
<img width="40" alt="Screenshot 2024-03-11 at 16 03 08" src="https://github.com/qooxdoo/qooxdoo/assets/29703546/8c86bae9-423c-45eb-b791-f46783b9e017">
<img width="37" alt="Screenshot 2024-03-11 at 16 03 44" src="https://github.com/qooxdoo/qooxdoo/assets/29703546/034d6c7a-21c0-4d8e-bb04-74839b0d3c9c">

To reproduce, open <https://zenesisuk.github.io/zx-ui-theme-avocado.github.io/> in Firefox. You should be able to notice that most icons are slightly too low. Try setting the CSS `line-height` properties of the icons to '1' and it should fix this issue.