### PR TITLE
`readOnly` for Select Boxes

### DIFF
--- a/source/class/qx/data/controller/CheckedList.js
+++ b/source/class/qx/data/controller/CheckedList.js
@@ -322,10 +322,10 @@ qx.Class.define("qx.data.controller.CheckedList", {
       let bindData = itemModel.getUserData(this.classname + ".bindData");
       if (bindData) {
         if (bindData.checkedLabelId) {
-          itemModel.removeListenerById(bindData.checkedLabelId);
+          itemModel.removeBinding(bindData.checkedLabelId);
         }
         if (bindData.checkedIconId) {
-          itemModel.removeListenerById(bindData.checkedIconId);
+          itemModel.removeBinding(bindData.checkedIconId);
         }
         itemModel.setUserData(this.classname + ".bindData", null);
       }

--- a/source/class/qx/test/data/controller/ListReverse.js
+++ b/source/class/qx/test/data/controller/ListReverse.js
@@ -36,6 +36,12 @@ qx.Class.define("qx.test.data.controller.ListReverse", {
         children: {
           event: "changeChildren",
           nullable: true
+        },
+
+        readOnly: {
+          check: "Boolean",
+          init: false,
+          event: "changeReadOnly"
         }
       }
     });

--- a/source/class/qx/theme/classic/Appearance.js
+++ b/source/class/qx/theme/classic/Appearance.js
@@ -300,11 +300,14 @@ qx.Theme.define("qx.theme.classic.Appearance", {
       alias: "atom",
 
       style(states) {
+        let useSelectionState = !states.readonly && states.selected;
         return {
           gap: 4,
           padding: states.lead ? [2, 4] : [3, 5],
-          backgroundColor: states.selected ? "background-selected" : undefined,
-          textColor: states.selected ? "text-selected" : undefined,
+          backgroundColor: useSelectionState
+            ? "background-selected"
+            : undefined,
+          textColor: useSelectionState ? "text-selected" : undefined,
           decorator: states.lead ? "lead-item" : undefined,
           opacity: states.drag ? 0.5 : undefined
         };

--- a/source/class/qx/theme/modern/Appearance.js
+++ b/source/class/qx/theme/modern/Appearance.js
@@ -830,10 +830,11 @@ qx.Theme.define("qx.theme.modern.Appearance", {
       alias: "atom",
 
       style(states) {
+        let useSelectionState = !states.readonly && states.selected;
         return {
           padding: states.dragover ? [4, 4, 2, 4] : 4,
-          textColor: states.selected ? "text-selected" : undefined,
-          decorator: states.selected ? "selected" : undefined,
+          textColor: useSelectionState ? "text-selected" : undefined,
+          decorator: useSelectionState ? "selected" : undefined,
           opacity: states.drag ? 0.5 : undefined
         };
       }

--- a/source/class/qx/theme/simple/Appearance.js
+++ b/source/class/qx/theme/simple/Appearance.js
@@ -1350,6 +1350,7 @@ qx.Theme.define("qx.theme.simple.Appearance", {
       alias: "atom",
 
       style(states) {
+        let useSelectionState = !states.readonly && states.selected;
         var padding = [3, 5, 3, 5];
         if (states.lead) {
           padding = [2, 4, 2, 4];
@@ -1359,7 +1360,7 @@ qx.Theme.define("qx.theme.simple.Appearance", {
         }
 
         var backgroundColor;
-        if (states.selected) {
+        if (useSelectionState) {
           backgroundColor = "background-selected";
           if (states.disabled) {
             backgroundColor += "-disabled";
@@ -1369,7 +1370,7 @@ qx.Theme.define("qx.theme.simple.Appearance", {
           gap: 4,
           padding: padding,
           backgroundColor: backgroundColor,
-          textColor: states.selected ? "text-selected" : undefined,
+          textColor: useSelectionState ? "text-selected" : undefined,
           decorator: states.lead
             ? "lead-item"
             : states.dragover

--- a/source/class/qx/theme/tangible/Appearance.js
+++ b/source/class/qx/theme/tangible/Appearance.js
@@ -1453,6 +1453,7 @@ qx.Theme.define("qx.theme.tangible.Appearance", {
       alias: "atom",
 
       style(states) {
+        let useSelectionState = !states.readonly && states.selected;
         var padding = [3, 5, 3, 5];
         if (states.lead) {
           padding = [2, 4, 2, 4];
@@ -1464,12 +1465,12 @@ qx.Theme.define("qx.theme.tangible.Appearance", {
         return {
           gap: 4,
           padding: padding,
-          backgroundColor: states.selected
+          backgroundColor: useSelectionState
             ? states.disabled
               ? "primary-disabled"
               : "primary"
             : "transparent",
-          textColor: states.selected
+          textColor: useSelectionState
             ? "text-on-primary"
             : "text-primary-on-surface",
           decorator: states.lead

--- a/source/class/qx/ui/form/AbstractSelectBox.js
+++ b/source/class/qx/ui/form/AbstractSelectBox.js
@@ -102,6 +102,16 @@ qx.Class.define("qx.ui.form.AbstractSelectBox", {
         return this._defaultFormat(item);
       },
       nullable: true
+    },
+
+    /**
+     * Whether the field is read only
+     */
+    readOnly: {
+      check: "Boolean",
+      event: "changeReadOnly",
+      apply: "_applyReadOnly",
+      init: false
     }
   },
 
@@ -128,6 +138,8 @@ qx.Class.define("qx.ui.form.AbstractSelectBox", {
             quickSelection: true
           });
 
+          this.bind("readOnly", control, "readOnly");
+
           const listId = "list-" + control.toHashCode();
           const childrenContainerEl = control
             .getChildrenContainer()
@@ -143,7 +155,12 @@ qx.Class.define("qx.ui.form.AbstractSelectBox", {
             this
           );
 
-          control.addListener("pointerdown", this._onListPointerDown, this);
+          control.addListener(
+            "pointerdown",
+            this.__onListPointerDownImpl,
+            this
+          );
+
           control.getChildControl("pane").addListener("tap", this.close, this);
           break;
         }
@@ -174,6 +191,10 @@ qx.Class.define("qx.ui.form.AbstractSelectBox", {
     // property apply
     _applyMaxListHeight(value, old) {
       this.getChildControl("list").setMaxHeight(value);
+    },
+
+    _applyReadOnly() {
+      // no-op
     },
 
     /*
@@ -337,6 +358,12 @@ qx.Class.define("qx.ui.form.AbstractSelectBox", {
       throw new Error("Abstract method: _onListChangeSelection()");
     },
 
+    __onListPointerDownImpl(e) {
+      if (this.getReadOnly()) {
+        return;
+      }
+      this._onListPointerDown(e);
+    },
     /**
      * Redirects pointerdown event from the list to this widget.
      *

--- a/source/class/qx/ui/form/CheckedList.js
+++ b/source/class/qx/ui/form/CheckedList.js
@@ -127,7 +127,7 @@ qx.Class.define("qx.ui.form.CheckedList", {
           item,
           qx.ui.form.CheckBox,
           this.classname +
-            " only supports instances of qx.ui.core.CheckBox as children"
+            " only supports instances of qx.ui.form.CheckBox as children"
         );
       }
       if (item.getValue()) {

--- a/source/class/qx/ui/form/List.js
+++ b/source/class/qx/ui/form/List.js
@@ -76,6 +76,7 @@ qx.Class.define("qx.ui.form.List", {
 
     // initialize the search string
     this.__pressedString = "";
+    this.__childrenBindings = new Map();
   },
 
   /*
@@ -190,13 +191,20 @@ qx.Class.define("qx.ui.form.List", {
       return this.__content;
     },
 
+    __childrenBindings: null,
     /**
      * Handle child widget adds on the content pane
      *
      * @param e {qx.event.type.Data} the event instance
      */
     _onAddChild(e) {
-      this.fireDataEvent("addItem", e.getData());
+      const child = e.getData();
+      this.__childrenBindings.set(
+        child.toHashCode(),
+        this.bind("readOnly", child, "readOnly")
+      );
+
+      this.fireDataEvent("addItem", child);
     },
 
     /**
@@ -205,7 +213,10 @@ qx.Class.define("qx.ui.form.List", {
      * @param e {qx.event.type.Data} the event instance
      */
     _onRemoveChild(e) {
-      this.fireDataEvent("removeItem", e.getData());
+      const child = e.getData();
+      child.removeBinding(this.__childrenBindings.get(child.toHashCode()));
+      this.__childrenBindings.delete(child.toHashCode());
+      this.fireDataEvent("removeItem", child);
     },
 
     /*

--- a/source/class/qx/ui/form/ListItem.js
+++ b/source/class/qx/ui/form/ListItem.js
@@ -69,6 +69,16 @@ qx.Class.define("qx.ui.form.ListItem", {
     appearance: {
       refine: true,
       init: "listitem"
+    },
+
+    /**
+     * Whether the field is read only
+     */
+    readOnly: {
+      check: "Boolean",
+      event: "changeReadOnly",
+      apply: "_applyReadOnly",
+      init: false
     }
   },
 
@@ -85,11 +95,21 @@ qx.Class.define("qx.ui.form.ListItem", {
       dragover: true
     },
 
+    _applyReadOnly(value) {
+      if (value) {
+        this.addState("readonly");
+      } else {
+        this.removeState("readonly");
+      }
+    },
+
     /**
      * Event handler for the pointer over event.
      */
     _onPointerOver() {
-      this.addState("hovered");
+      if (!this.getReadOnly()) {
+        this.addState("hovered");
+      }
     },
 
     /**

--- a/source/class/qx/ui/form/ToggleButton.js
+++ b/source/class/qx/ui/form/ToggleButton.js
@@ -124,6 +124,15 @@ qx.Class.define("qx.ui.form.ToggleButton", {
     executeBehavior: {
       check: ["cycle", "toggle"],
       init: "toggle"
+    },
+
+    /**
+     * Whether the field is read only
+     */
+    readOnly: {
+      check: "Boolean",
+      event: "changeReadOnly",
+      init: false
     }
   },
 
@@ -183,6 +192,9 @@ qx.Class.define("qx.ui.form.ToggleButton", {
      * @param e {qx.event.type.Event} The execute event.
      */
     _onExecute(e) {
+      if (this.getReadOnly()) {
+        return;
+      }
       if (this.isTriState() && this.getExecuteBehavior() === "cycle") {
         let newValue;
         let currentValue = this.getValue();
@@ -210,6 +222,9 @@ qx.Class.define("qx.ui.form.ToggleButton", {
      */
     _onPointerOver(e) {
       if (e.getTarget() !== this) {
+        return;
+      }
+      if (this.getReadOnly()) {
         return;
       }
 
@@ -261,6 +276,9 @@ qx.Class.define("qx.ui.form.ToggleButton", {
       if (!e.isLeftPressed()) {
         return;
       }
+      if (this.getReadOnly()) {
+        return;
+      }
 
       // Activate capturing if the button get a pointerout while
       // the button is pressed.
@@ -303,6 +321,9 @@ qx.Class.define("qx.ui.form.ToggleButton", {
      * @param e {Event} Key event
      */
     _onKeyDown(e) {
+      if (this.getReadOnly()) {
+        return;
+      }
       switch (e.getKeyIdentifier()) {
         case "Enter":
         case "Space":


### PR DESCRIPTION
- adds the `readOnly` property to `qx.ui.form.AbstractSelectBox`
- fixes a bug in `qx.data.controller.CheckedList` where an error is thrown when deselecting an item
- corrects an error message in `qx.data.controller.CheckedList` to refer to the correct class

By using read only on select boxes, the select box will appear as if it is enabled, however the list items will not be selectable and (in supported themes) will not change visually when hovered over.