### PR TITLE
fix: apply field placeholder styles in all engines

### DIFF
--- a/source/class/qx/ui/form/AbstractField.js
+++ b/source/class/qx/ui/form/AbstractField.js
@@ -99,11 +99,12 @@ qx.Class.define("qx.ui.form.AbstractField", {
           "-ms-input-placeholder, textarea.qx-placeholder-color",
           "-ms-input-placeholder"
         ].join(separator);
-        qx.ui.style.Stylesheet.getInstance().addRule(
-          selector,
-          "color: " + color + " !important"
-        );
       }
+
+      qx.ui.style.Stylesheet.getInstance().addRule(
+        selector,
+        "color: " + color + " !important"
+      );
     }
   },
 
@@ -127,7 +128,7 @@ qx.Class.define("qx.ui.form.AbstractField", {
     }
     let el = this.getContentElement();
     el.addListener("change", this._onChangeContent, this);
-    
+
     // use qooxdoo placeholder if no native placeholder is supported
     if (this.__useQxPlaceholder) {
       // assign the placeholder text after the appearance has been applied


### PR DESCRIPTION
related: #10210, https://github.com/qooxdoo/qooxdoo/pull/10210#issuecomment-1383673762

Placeholder styles were broken on Gecko and Webkit engines due to missing `addRule` calls after determining the appropriate selector.

Side note; it may make sense to default to `::placeholder` for all browsers, and only fallback to the engine-specific selector if a version or engine is detected which does not support the standard `::placeholder` pseudo selector ([browser compatibility table](https://developer.mozilla.org/en-US/docs/Web/CSS/::placeholder#browser_compatibility)). *This is not something which this PR implements*.