### PR TITLE
quick and dirty addition to the quick and dirty dependency analysis tool

### DIFF
--- a/source/resource/qx/tool/website/build/diagnostics/dependson.html
+++ b/source/resource/qx/tool/website/build/diagnostics/dependson.html
@@ -92,6 +92,7 @@
     <option value="runtime">runtime</option>
     <option value="load">load</option>
 </select>
+<a href="#" onclick="showAll()">Expand all</a>
 
 <style>
     li {

--- a/source/resource/qx/tool/website/build/diagnostics/dependson.js
+++ b/source/resource/qx/tool/website/build/diagnostics/dependson.js
@@ -2,33 +2,64 @@ $(function () {
   var db;
   var appDb;
   var CLASSES = {};
+  var expanded = {};
+
+  function expand(parent) {
+    var $parent = $(parent);
+    var className = $parent.attr("data-classname");
+    var $ul = $("ul", parent);
+
+    expanded[className] = true;
+    if ($ul.length) {
+      $ul.remove();
+      return;
+    }
+    var $ul = $("<ul>");
+    $parent.append($ul);
+    show(className, $ul);
+    updateDisplay();
+  }
 
   function show(name, $list) {
     var def = db.classInfo[name];
     if (!def || !def.dependsOn) return;
     for (var depName in def.dependsOn) {
-      if (!CLASSES[depName]) continue;
+      if (!CLASSES[depName]) {
+        continue;
+      }
       var isLoad = def.dependsOn[depName].load;
       var $li = $("<li>").text(depName).attr("data-classname", depName);
-      if (isLoad) $li.addClass("load");
-      else $li.addClass("runtime");
+      if (isLoad) {
+        $li.addClass("load");
+      } else {
+        $li.addClass("runtime");
+      }
       $li.click(function (e) {
         e.stopPropagation();
-        var $this = $(this),
-          className = $this.attr("data-classname"),
-          $ul = $("ul", this);
-        if ($ul.length) {
-          $ul.remove();
-          return;
-        }
-        var $ul = $("<ul>");
-        $this.append($ul);
-        show(className, $ul);
-        updateDisplay();
+        expand(this);
       });
       $list.append($li);
     }
   }
+
+  function showAll($list) {
+    if (!$list) {
+      $list = $("#root ul");
+    }
+    $list.children("li").each(function () {
+      let $li = $(this);
+      if ($li.children("li").length != 0) {
+        return;
+      }
+      let classname = $li.attr("data-classname");
+      if (expanded[classname]) {
+        return;
+      }
+      expand($li);
+      showAll($("ul", $li));
+    });
+  }
+  window.showAll = showAll;
 
   function selectClass(name) {
     $("#root").append($("<h3>").text(name + " Depends On"));

--- a/source/resource/qx/tool/website/src/diagnostics/dependson.html
+++ b/source/resource/qx/tool/website/src/diagnostics/dependson.html
@@ -4,16 +4,16 @@ layout: default.dot
 
 <script src="dependson.js"></script>
 <select id="show">
-    <option value="both" selected>runtime and loadtime</option>
-    <option value="runtime">runtime</option>
-    <option value="load">load</option>
+  <option value="both" selected>runtime and loadtime</option>
+  <option value="runtime">runtime</option>
+  <option value="load">load</option>
 </select>
+<a href="#" onclick="showAll()">Expand all</a>
 
 <style>
-    li {
-        cursor: pointer;
-    }
+  li {
+    cursor: pointer;
+  }
 </style>
 
-<div id="root">
-</div>
+<div id="root"></div>

--- a/source/resource/qx/tool/website/src/diagnostics/dependson.js
+++ b/source/resource/qx/tool/website/src/diagnostics/dependson.js
@@ -2,33 +2,64 @@ $(function () {
   var db;
   var appDb;
   var CLASSES = {};
+  var expanded = {};
+
+  function expand(parent) {
+    var $parent = $(parent);
+    var className = $parent.attr("data-classname");
+    var $ul = $("ul", parent);
+
+    expanded[className] = true;
+    if ($ul.length) {
+      $ul.remove();
+      return;
+    }
+    var $ul = $("<ul>");
+    $parent.append($ul);
+    show(className, $ul);
+    updateDisplay();
+  }
 
   function show(name, $list) {
     var def = db.classInfo[name];
     if (!def || !def.dependsOn) return;
     for (var depName in def.dependsOn) {
-      if (!CLASSES[depName]) continue;
+      if (!CLASSES[depName]) {
+        continue;
+      }
       var isLoad = def.dependsOn[depName].load;
       var $li = $("<li>").text(depName).attr("data-classname", depName);
-      if (isLoad) $li.addClass("load");
-      else $li.addClass("runtime");
+      if (isLoad) {
+        $li.addClass("load");
+      } else {
+        $li.addClass("runtime");
+      }
       $li.click(function (e) {
         e.stopPropagation();
-        var $this = $(this),
-          className = $this.attr("data-classname"),
-          $ul = $("ul", this);
-        if ($ul.length) {
-          $ul.remove();
-          return;
-        }
-        var $ul = $("<ul>");
-        $this.append($ul);
-        show(className, $ul);
-        updateDisplay();
+        expand(this);
       });
       $list.append($li);
     }
   }
+
+  function showAll($list) {
+    if (!$list) {
+      $list = $("#root ul");
+    }
+    $list.children("li").each(function () {
+      let $li = $(this);
+      if ($li.children("li").length != 0) {
+        return;
+      }
+      let classname = $li.attr("data-classname");
+      if (expanded[classname]) {
+        return;
+      }
+      expand($li);
+      showAll($("ul", $li));
+    });
+  }
+  window.showAll = showAll;
 
   function selectClass(name) {
     $("#root").append($("<h3>").text(name + " Depends On"));


### PR DESCRIPTION
The dependency analysis tools are rather crude and simple, but when you need them you really need them.  Although it would be great to build a proper app instead of the slightly hacky approach that there is at present, this PR makes a minor change to allow you to "show all" so you can track down that elusive dependency - EG where you're bringing in `qx.ui.*` into your node application