### PR TITLE
adds a `privateArtifacts` option to `compile.json`

### DIFF
--- a/docs/development/compiler/configuration/compile.md
+++ b/docs/development/compiler/configuration/compile.md
@@ -579,7 +579,7 @@ It is up to you to implement the mapping inside your web server so that the
 
 ### Keeping all files within the application directory
 
-When the compiler generates an application(s), it creates `transpiled` and `resource`
+When the compiler generates applications, it creates `transpiled` and `resource`
 directories at the same level as the application name, and adds various working
 files, eg:
 

--- a/docs/development/compiler/configuration/compile.md
+++ b/docs/development/compiler/configuration/compile.md
@@ -577,6 +577,29 @@ is the URI.
 It is up to you to implement the mapping inside your web server so that the
 "/some/virtual/uri/path/qooxdoo" URI is able to load the files from `../qooxdoo`
 
+### Keeping all files within the application directory
+
+When the compiler generates an application(s), it creates `transpiled` and `resource`
+directories at the same level as the application name, and adds various working
+files, eg:
+
+```
+compiled/
+  source/
+    myAppName/
+    transpiled/
+    resource/
+    db.json
+    resource-db.json
+```
+
+This requires that you expose the `compiled/source` directory on your webserver, but 
+you can also make the `transpiled` and `resource` directories *appear* to be inside the
+application directory by setting `privateArtifacts: true` in the top level of `compile.json`
+
+You will have to configure your web server to serve `transpiled` and `resource` as virtual
+folders from within the URL that you use for `myAppName`.
+
 ## TypeScript
 
 ** Note that this has changed: you no longer add a new target ** TypeScript can

--- a/source/class/qx/tool/cli/commands/Compile.js
+++ b/source/class/qx/tool/cli/commands/Compile.js
@@ -1165,9 +1165,23 @@ Framework: v${await this.getQxVersion()} in ${await this.getQxPath()}`);
         if (data.environment) {
           maker.setEnvironment(data.environment);
         }
-        if (targetConfig.environment) {
-          target.setEnvironment(targetConfig.environment);
+        let targetEnvironment = {
+          "qx.version": maker.getAnalyser().getQooxdooVersion(),
+          "qx.compiler.targetType": target.getType(),
+          "qx.compiler.outputDir": target.getOutputDir(),
+          "qx.target.privateArtifacts": !!data["private-artifacts"]
+        };
+        if (data["private-artifacts"]) {
+          target.setPrivateArtifacts(true);
         }
+
+        qx.lang.Object.mergeWith(
+          targetEnvironment,
+          targetConfig.environment,
+          false
+        );
+        target.setEnvironment(targetEnvironment);
+
         if (targetConfig.preserveEnvironment) {
           target.setPreserveEnvironment(targetConfig.preserveEnvironment);
         }

--- a/source/class/qx/tool/compiler/targets/meta/Package.js
+++ b/source/class/qx/tool/compiler/targets/meta/Package.js
@@ -267,16 +267,30 @@ qx.Class.define("qx.tool.compiler.targets.meta.Package", {
       });
 
       let appRoot = this.__appMeta.getApplicationRoot();
+      let target = this.__appMeta.getTarget();
+      let privateArtifacts =
+        target.isPrivateArtifacts() &&
+        this.__appMeta.getApplication().getType() == "browser";
+      let transpiledDir = path.join(target.getOutputDir(), "transpiled");
+      let resourceDir = path.join(target.getOutputDir(), "resource");
       const toUri = filename => {
+        if (
+          privateArtifacts &&
+          (filename.startsWith(transpiledDir) ||
+            filename.startsWith(resourceDir))
+        ) {
+          let uri = path.relative(target.getOutputDir(), filename);
+          return uri;
+        }
+        let uri = path.relative(appRoot, filename);
         if (this.__appMeta.isAddTimestampsToUrls()) {
           let stat = fs.statSync(filename, { throwIfNoEntry: false });
-          let uri = path.relative(appRoot, filename);
           if (stat) {
             uri += "?" + stat.mtimeMs;
           }
           return uri;
         } else {
-          return path.relative(appRoot, filename);
+          return uri;
         }
       };
       if (!this.isEmbedAllJavascript()) {

--- a/source/resource/qx/tool/schema/compile-1-0-0.json
+++ b/source/resource/qx/tool/schema/compile-1-0-0.json
@@ -371,6 +371,10 @@
       },
       "examples": [{ "../qooxdoo": "/some/virtual/uri/path/qooxdoo" }]
     },
+    "private-artifacts": {
+      "description": "Whether the generated artifacts (ie resources and transpiled) are private to the application; this requires the web server to mount the resources and transpiled directories inside the application directory",
+      "type": "boolean"
+    },
     "locales": {
       "description": "Include other translations than 'en'",
       "type": "array",


### PR DESCRIPTION
This adds a `privateArtifacts` option to `compile.json` to allow all urls to be locked within an application directory