### PR TITLE
wait async for writtenMetaData event

### DIFF
--- a/source/class/qx/tool/cli/commands/Compile.js
+++ b/source/class/qx/tool/cli/commands/Compile.js
@@ -796,7 +796,7 @@ Framework: v${await this.getQxVersion()} in ${await this.getQxPath()}`);
       }
       await metaDb.reparseAll();
       await metaDb.save();
-      this.fireDataEvent("writtenMetaData", metaDb);
+      await this.fireDataEventAsync("writtenMetaData", metaDb);
 
       // Do the inital write
       let tsWriter = null;


### PR DESCRIPTION
All other events in compiler are fired with ```await fireDataEventAsync```
writtenMetaData should use the same mechanism. Otherwise it can not be used in compile.js.

This is needed to fix apiviewer!