### PR TITLE
fix output path for default qooxdoo.d.ts path

### DIFF
--- a/source/class/qx/tool/cli/commands/Compile.js
+++ b/source/class/qx/tool/cli/commands/Compile.js
@@ -885,9 +885,12 @@ Framework: v${await this.getQxVersion()} in ${await this.getQxPath()}`);
 
       if (qx.lang.Type.isBoolean(data?.meta?.typescript)) {
         this.__typescriptEnabled = data.meta.typescript;
-      } else if (qx.lang.Type.isString(data?.typescript)) {
+      } else if (qx.lang.Type.isString(data?.meta?.typescript)) {
         this.__typescriptEnabled = true;
-        this.__typescriptFile = data.typescript;
+        this.__typescriptFile = path.relative(
+          process.cwd(),
+          path.resolve(data?.meta?.typescript)
+        );
       }
       if (qx.lang.Type.isBoolean(this.argv.typescript)) {
         this.__typescriptEnabled = this.argv.typescript;

--- a/source/class/qx/tool/cli/commands/Compile.js
+++ b/source/class/qx/tool/cli/commands/Compile.js
@@ -806,7 +806,7 @@ Framework: v${await this.getQxVersion()} in ${await this.getQxPath()}`);
         if (this.__typescriptFile) {
           tsWriter.setOutputTo(this.__typescriptFile);
         } else {
-          tsWriter.setOutputTo(path.join("compiled", "qooxdoo.d.ts"));
+          tsWriter.setOutputTo(path.join(this.__metaDir, "..", "qooxdoo.d.ts"));
         }
         await tsWriter.process();
       }

--- a/source/class/qx/tool/compiler/targets/TypeScriptWriter.js
+++ b/source/class/qx/tool/compiler/targets/TypeScriptWriter.js
@@ -21,7 +21,7 @@
  *
  * *********************************************************************** */
 
-var path = require("path");
+var path = require("upath");
 
 var fs = require("fs");
 const { promisify } = require("util");
@@ -77,13 +77,8 @@ qx.Class.define("qx.tool.compiler.targets.TypeScriptWriter", {
       this.__outputStream.on("close", () =>
         this.__outputStreamClosed.resolve()
       );
-
       this.write(`// Generated declaration file at ${time}\n`);
-
-      let str = qx.util.ResourceManager.getInstance().toUri(
-        "qx/tool/cli/templates/TypeScriptWriter-base_declaration.d.ts"
-      );
-
+      let str = path.join(qx.tool.utils.Utils.getTemplateDir(), "TypeScriptWriter-base_declaration.d.ts")
       let baseDeclaration = await fs.promises.readFile(str, "utf8");
       this.write(baseDeclaration + "\n");
     },


### PR DESCRIPTION
in doc the default output path is meta/.. 
In reality it is somewhere in the file system with not existing path if you use target path in compile.json.

This PR changes default to meta/.. path