### PR TITLE
improve mixin member super() logic

### DIFF
--- a/source/class/qx/Mixin.js
+++ b/source/class/qx/Mixin.js
@@ -371,16 +371,18 @@ qx.Bootstrap.define("qx.Mixin", {
               break;
             }
           }
+
           // Try looking in the class itself
           if (!fn && mixedInAt.prototype[methodName]) {
-            fn = mixedInAt.prototype[methodName].base;
-            // if fn.self is set fn is an overloaded mixin method from
-            // another mixin. In this case fn.base contains the original
-            // class method.
-            if (fn && fn.self) {
+            fn = mixedInAt.prototype[methodName];
+            for (let i = 0; i < mixedInAt.$$flatIncludes.length; i++) {
+              if (!mixedInAt.$$flatIncludes[i].$$members[methodName]) {
+                continue;
+              }
               fn = fn.base;
             }
           }
+
           // Try looking in the superclass
           if (!fn && mixedInAt.superclass) {
             fn = mixedInAt.superclass.prototype[methodName];

--- a/source/class/qx/lang/Function.js
+++ b/source/class/qx/lang/Function.js
@@ -173,7 +173,7 @@ qx.Bootstrap.define("qx.lang.Function", {
         return func;
       }
 
-      return function (event) {
+      let result = function (event) {
         if (qx.core.Environment.get("qx.debug")) {
           function testSelf(self) {
             if (
@@ -233,6 +233,10 @@ qx.Bootstrap.define("qx.lang.Function", {
           return func.apply(options.self || this, args);
         }
       };
+      if (qx.core.Environment.get("qx.debug")) {
+        result.$$original = func;
+      }
+      return result;
     },
 
     /**

--- a/source/class/qx/test/Mixin.js
+++ b/source/class/qx/test/Mixin.js
@@ -610,6 +610,266 @@ qx.Class.define("qx.test.Mixin", {
       var o = new qx.D();
       this.assertEquals("Double MA MB", o.sayJuhu());
       o.dispose();
+    },
+
+    testDoubleMixinWithSuperStruct() {
+      qx.Class.define("qx.E1", {
+        extend: qx.core.Object,
+        members: {
+          sayJuhu() {
+            return "E1";
+          }
+        }
+      });
+      qx.Mixin.define("qx.ME1a", {
+        members: {
+          sayJuhu() {
+            return `${super.sayJuhu()} ME1`;
+          }
+        }
+      });
+      qx.Mixin.define("qx.ME1b", {
+        members: {
+          // does not implement `sayJuhu`
+        }
+      });
+
+      qx.Class.define("qx.E2", {
+        extend: qx.E1,
+        members: {
+          sayJuhu() {
+            return `${super.sayJuhu()} E2`;
+          }
+        }
+      });
+      qx.Mixin.define("qx.ME2a", {
+        members: {
+          sayJuhu() {
+            return `${super.sayJuhu()} ME2a`;
+          }
+        }
+      });
+      qx.Mixin.define("qx.ME2b", {
+        members: {
+          sayJuhu() {
+            return `${super.sayJuhu()} ME2b`;
+          }
+        }
+      });
+
+      qx.Class.patch(qx.E1, qx.ME1a);
+      qx.Class.patch(qx.E1, qx.ME1b);
+      qx.Class.patch(qx.E2, qx.ME2a);
+      qx.Class.patch(qx.E2, qx.ME2b);
+
+      const e = new qx.E2();
+      this.assertEquals("E1 ME1 E2 ME2a ME2b", e.sayJuhu());
+      e.dispose();
+    },
+
+    /**
+     * tests a large structure to ensure that combinations of patch order,
+     * presence of given method, nor patched class count have an impact on
+     * the behavior of `super` in mixin methods.
+     */
+    testLotsMixinLotsSuper() {
+      qx.Class.define("qx.G1", {
+        extend: qx.core.Object,
+        members: {
+          sayJuhu() {
+            return "G1";
+          }
+        }
+      });
+      qx.Mixin.define("qx.M1G1", {
+        members: {
+          sayJuhu() {
+            return `${super.sayJuhu()} M1G1`;
+          }
+        }
+      });
+      qx.Class.patch(qx.G1, qx.M1G1);
+      qx.Mixin.define("qx.M2G1", {
+        members: {
+          sayJuhu() {
+            return `${super.sayJuhu()} M2G1`;
+          }
+        }
+      });
+      qx.Class.patch(qx.G1, qx.M2G1);
+      qx.Mixin.define("qx.M3G1", {
+        members: {
+          sayJuhu() {
+            return `${super.sayJuhu()} M3G1`;
+          }
+        }
+      });
+      qx.Class.patch(qx.G1, qx.M3G1);
+      qx.Mixin.define("qx.M4G1", {
+        members: {
+          sayJuhu() {
+            return `${super.sayJuhu()} M4G1`;
+          }
+        }
+      });
+      qx.Class.patch(qx.G1, qx.M4G1);
+      qx.Mixin.define("qx.M5G1", {
+        members: {
+          // does not implement `sayJuhu`
+        }
+      });
+      qx.Class.patch(qx.G1, qx.M5G1);
+      qx.Mixin.define("qx.M6G1", {
+        members: {
+          // does not implement `sayJuhu`
+        }
+      });
+      qx.Class.patch(qx.G1, qx.M6G1);
+
+      qx.Class.define("qx.G2", {
+        extend: qx.G1,
+        members: {
+          sayJuhu() {
+            return `${super.sayJuhu()} G2`;
+          }
+        }
+      });
+      qx.Mixin.define("qx.M1G2", {
+        members: {
+          sayJuhu() {
+            return `${super.sayJuhu()} M1G2`;
+          }
+        }
+      });
+      qx.Class.patch(qx.G2, qx.M1G2);
+      qx.Mixin.define("qx.M2G2", {
+        members: {
+          sayJuhu() {
+            return `${super.sayJuhu()} M2G2`;
+          }
+        }
+      });
+      qx.Class.patch(qx.G2, qx.M2G2);
+      qx.Mixin.define("qx.M3G2", {
+        members: {
+          // does not implement `sayJuhu`
+        }
+      });
+      qx.Class.patch(qx.G2, qx.M3G2);
+      qx.Mixin.define("qx.M4G2", {
+        members: {
+          sayJuhu() {
+            return `${super.sayJuhu()} M4G2`;
+          }
+        }
+      });
+      qx.Class.patch(qx.G2, qx.M4G2);
+      qx.Mixin.define("qx.M5G2", {
+        members: {
+          sayJuhu() {
+            return `${super.sayJuhu()} M5G2`;
+          }
+        }
+      });
+      qx.Class.patch(qx.G2, qx.M5G2);
+
+      qx.Class.define("qx.G3", {
+        extend: qx.G2,
+        members: {
+          sayJuhu() {
+            return `${super.sayJuhu()} G3`;
+          }
+        }
+      });
+      qx.Mixin.define("qx.M1G3", {
+        members: {
+          // does not implement `sayJuhu`
+        }
+      });
+      qx.Class.patch(qx.G3, qx.M1G3);
+      qx.Mixin.define("qx.M2G3", {
+        members: {
+          sayJuhu() {
+            return `${super.sayJuhu()} M2G3`;
+          }
+        }
+      });
+      qx.Class.patch(qx.G3, qx.M2G3);
+      qx.Mixin.define("qx.M3G3", {
+        members: {
+          sayJuhu() {
+            return `${super.sayJuhu()} M3G3`;
+          }
+        }
+      });
+      qx.Class.patch(qx.G3, qx.M3G3);
+      qx.Mixin.define("qx.M4G3", {
+        members: {
+          // does not implement `sayJuhu`
+        }
+      });
+      qx.Class.patch(qx.G3, qx.M4G3);
+
+      qx.Class.define("qx.G4", {
+        extend: qx.G3,
+        members: {
+          sayJuhu() {
+            return `${super.sayJuhu()} G4`;
+          }
+        }
+      });
+      qx.Mixin.define("qx.M1G4", {
+        members: {
+          sayJuhu() {
+            return `${super.sayJuhu()} M1G4`;
+          }
+        }
+      });
+      qx.Class.patch(qx.G4, qx.M1G4);
+      qx.Mixin.define("qx.M2G4", {
+        members: {
+          // does not implement `sayJuhu`
+        }
+      });
+      qx.Class.patch(qx.G4, qx.M2G4);
+      qx.Mixin.define("qx.M3G4", {
+        members: {
+          sayJuhu() {
+            return `${super.sayJuhu()} M3G4`;
+          }
+        }
+      });
+      qx.Class.patch(qx.G4, qx.M3G4);
+
+      qx.Class.define("qx.G5", {
+        extend: qx.G4,
+        members: {
+          sayJuhu() {
+            return `${super.sayJuhu()} G5`;
+          }
+        }
+      });
+      qx.Mixin.define("qx.M1G5", {
+        members: {
+          sayJuhu() {
+            return `${super.sayJuhu()} M1G5`;
+          }
+        }
+      });
+      qx.Class.patch(qx.G5, qx.M1G5);
+      qx.Mixin.define("qx.M2G5", {
+        members: {
+          // does not implement `sayJuhu`
+        }
+      });
+      qx.Class.patch(qx.G5, qx.M2G5);
+
+      const g5 = new qx.G5();
+      this.assertEquals(
+        "G1 M1G1 M2G1 M3G1 M4G1 G2 M1G2 M2G2 M4G2 M5G2 G3 M2G3 M3G3 G4 M1G4 M3G4 G5 M1G5",
+        g5.sayJuhu()
+      );
+      g5.dispose();
     }
   }
 });


### PR DESCRIPTION
See #10362, #10363

This commit fixes an issue with how the super of a member is determined from within a mixin.

We found that when patching mixins to multiple classes in the same inheritance chain, mixins on parent classes were completely skipped over.

Instead of going `class patched mixin -> class -> superclass' patched mixin -> superclass`, it was skipping over the superclass' patched mixin entirely, which is inconsistent with how an instance of that superclass would behave.