### PR TITLE
fix: compiler generates invalid syntax with top-level key `constructor`

### DIFF
--- a/source/class/qx/Class.js
+++ b/source/class/qx/Class.js
@@ -840,7 +840,7 @@ qx.Bootstrap.define("qx.Class", {
             ? this.__staticAllowedKeys
             : this.__allowedKeys;
         for (var key in config) {
-          if (!allowed[key]) {
+          if (!(key in allowed)) {
             throw new Error(
               'The configuration key "' +
                 key +

--- a/source/class/qx/tool/compiler/ClassFile.js
+++ b/source/class/qx/tool/compiler/ClassFile.js
@@ -1349,8 +1349,12 @@ qx.Class.define("qx.tool.compiler.ClassFile", {
           t.__hasDefer = true;
           t.__inDefer = true;
         }
-        t.__classMeta.functionName = FUNCTION_NAMES[keyName] || keyName;
-        if (FUNCTION_NAMES[keyName] !== undefined) {
+        var isSpecialFunctionName =
+          Object.keys(FUNCTION_NAMES).includes(keyName);
+        t.__classMeta.functionName = isSpecialFunctionName
+          ? FUNCTION_NAMES[keyName]
+          : keyName;
+        if (isSpecialFunctionName) {
           makeMeta(keyName, null, functionNode);
         }
         enterFunction(path, functionNode);
@@ -1393,8 +1397,9 @@ qx.Class.define("qx.tool.compiler.ClassFile", {
           }
           var keyName = getKeyName(prop.key);
           checkValidTopLevel(path);
-
-          if (FUNCTION_NAMES[keyName] !== undefined) {
+          var isSpecialFunctionName =
+            Object.keys(FUNCTION_NAMES).includes(keyName);
+          if (isSpecialFunctionName) {
             let val = path.node.value;
             val.leadingComments = (path.node.leadingComments || []).concat(
               val.leadingComments || []


### PR DESCRIPTION
When accidentally typing `constructor` instead of `construct` as the key name for a qooxdoo class constructor function, the compiler would generate invalid code:

```js
  constructor() {
    // clearly, this won't parse in any engine
    my.alpha.Application.superclass.prototype.function Object() { [native code] }.call(this);
  }
```

This is following the correct pattern of `{classname}.superclass.prototype.{methodname}.call(this)`, however the `methodname` portion is coming from `FUNCTION_NAMES[keyName]`. Any POJO when indexed at `constructor` (the keyname in this case) will just return the native `Object` constructor.

This pr modifies the logic to check if the given keyname is a real field of the `FUNCTION_NAMES` object, not merely if there is any result from taking the index.

```js
  // now we can reach the runtime qx.Class warning against `constructor` as a top level key
  // without being hindered by engine syntax errors
  constructor() {
    my.alpha.Application.superclass.prototype.constructor.call(this);
  }
```