### PR TITLE
Placeholder text does not get correct theme color.

### DIFF
--- a/source/class/qx/ui/form/AbstractField.js
+++ b/source/class/qx/ui/form/AbstractField.js
@@ -41,10 +41,13 @@ qx.Class.define("qx.ui.form.AbstractField", {
      * Adds the CSS rules needed to style the native placeholder element.
      */
     __addPlaceholderRules() {
-      if (qx.ui.form.AbstractField.__addedPlaceholderRules === ajaxclient.ThemeLoader.getInstance().getCurrentThemeName()) {
+      const theme = qx.theme.manager.Meta.getInstance().getTheme();
+      const currentThemeName = theme ? theme.title || theme.name : "";
+
+      if (qx.ui.form.AbstractField.__addedPlaceholderRules === currentThemeName) {
         return;
       }
-      qx.ui.form.AbstractField.__addedPlaceholderRules = ajaxclient.ThemeLoader.getInstance().getCurrentThemeName();
+      qx.ui.form.AbstractField.__addedPlaceholderRules = currentThemeName;
       var engine = qx.core.Environment.get("engine.name");
       var browser = qx.core.Environment.get("browser.name");
       var colorManager = qx.theme.manager.Color.getInstance();

--- a/source/class/qx/ui/form/AbstractField.js
+++ b/source/class/qx/ui/form/AbstractField.js
@@ -35,19 +35,16 @@ qx.Class.define("qx.ui.form.AbstractField", {
   type: "abstract",
 
   statics: {
-    /** Stylesheet needed to style the native placeholder element. */
-    __stylesheet: null,
-
-    __addedPlaceholderRules: false,
+    __addedPlaceholderRules: "",
 
     /**
      * Adds the CSS rules needed to style the native placeholder element.
      */
     __addPlaceholderRules() {
-      if (qx.ui.form.AbstractField.__addedPlaceholderRules) {
+      if (qx.ui.form.AbstractField.__addedPlaceholderRules === ajaxclient.ThemeLoader.getInstance().getCurrentThemeName()) {
         return;
       }
-      qx.ui.form.AbstractField.__addedPlaceholderRules = true;
+      qx.ui.form.AbstractField.__addedPlaceholderRules = ajaxclient.ThemeLoader.getInstance().getCurrentThemeName();
       var engine = qx.core.Environment.get("engine.name");
       var browser = qx.core.Environment.get("browser.name");
       var colorManager = qx.theme.manager.Color.getInstance();
@@ -100,7 +97,9 @@ qx.Class.define("qx.ui.form.AbstractField", {
           "-ms-input-placeholder"
         ].join(separator);
       }
-
+      if(qx.ui.style.Stylesheet.getInstance().hasRule(selector)) {
+        qx.ui.style.Stylesheet.getInstance().removeRule(selector);
+      }
       qx.ui.style.Stylesheet.getInstance().addRule(
         selector,
         "color: " + color + " !important"
@@ -931,9 +930,7 @@ qx.Class.define("qx.ui.form.AbstractField", {
         this._placeholder.dispose();
         this._placeholder = null;
       }
-      if (!this.__useQxPlaceholder && qx.ui.form.AbstractField.__stylesheet) {
-        qx.bom.Stylesheet.removeSheet(qx.ui.form.AbstractField.__stylesheet);
-        qx.ui.form.AbstractField.__stylesheet = null;
+      if (!this.__useQxPlaceholder) {
         qx.ui.form.AbstractField.__addPlaceholderRules();
       }
     },


### PR DESCRIPTION
Code in ui/form/AbstractField.js looks broken for some time to me (11th March 2013). __stylesheet was replaced on most places by using "global stylesheet" code.

But the _onChangeTheme() function still contains this if statement: if (!this.__useQxPlaceholder && qx.ui.form.AbstractField.__stylesheet) (which is not used any more) So the color from the loaded theme is never applied.

Now using the theme name to check when an update is needed.

Issue: #10694