### PR TITLE
qx.data.marshal.Json | ignore non-pojo objects when marshalling

### DIFF
--- a/source/class/qx/Bootstrap.js
+++ b/source/class/qx/Bootstrap.js
@@ -867,8 +867,8 @@ qx.Bootstrap.define("qx.Bootstrap", {
     },
 
     /**
-     * Whether the value is an object. Note that built-in types like Window are
-     * not reported to be objects.
+     * Whether the value is an object i.e. Object.prototype is its prototype or Object.prototype in its prototype chain.
+     * Note that built-in types like Window are not reported to be objects.
      *
      * @param value {var} Value to check.
      * @return {Boolean} Whether the value is an object.
@@ -878,6 +878,20 @@ qx.Bootstrap.define("qx.Bootstrap", {
         value !== undefined &&
         value !== null &&
         qx.Bootstrap.getClass(value) === "Object"
+      );
+    },
+
+    /**
+     * Whether the value is strictly a POJO. It's prototype must not inherit from Object.prototype but be strictly Object.prototype.
+
+     * @param {*} value
+     * @returns {boolean} Whether the value is strictly a POJO. 
+     */
+    isPojo(value) {
+      return (
+        value !== undefined &&
+        value !== null &&
+        Object.getPrototypeOf(value) === Object.prototype
       );
     },
 

--- a/source/class/qx/Bootstrap.js
+++ b/source/class/qx/Bootstrap.js
@@ -867,10 +867,13 @@ qx.Bootstrap.define("qx.Bootstrap", {
     },
 
     /**
-     * Whether the value is an object i.e. Object.prototype is its prototype or Object.prototype in its prototype chain.
-     * Note that built-in types like Window are not reported to be objects.
+     * Whether the value is an POJO (ie {foo: 1})
+     * or an object which is created from a ES6-style class or prototypical-inheritance-based class;
+     * If you need to determine whether something is a POJO and not created from a class, use isPojo instead
      *
-     * @param value {var} Value to check.
+     * Note that built-in types like Window are not deemed to be objects.
+     *
+     * @param {*} value value to check.
      * @return {Boolean} Whether the value is an object.
      */
     isObject(value) {

--- a/source/class/qx/Bootstrap.js
+++ b/source/class/qx/Bootstrap.js
@@ -882,20 +882,6 @@ qx.Bootstrap.define("qx.Bootstrap", {
     },
 
     /**
-     * Whether the value is strictly a POJO. It's prototype must not inherit from Object.prototype but be strictly Object.prototype.
-
-     * @param {*} value
-     * @returns {boolean} Whether the value is strictly a POJO. 
-     */
-    isPojo(value) {
-      return (
-        value !== undefined &&
-        value !== null &&
-        Object.getPrototypeOf(value) === Object.prototype
-      );
-    },
-
-    /**
      * Whether the value is a function.
      *
      * @param value {var} Value to check.

--- a/source/class/qx/core/Environment.js
+++ b/source/class/qx/core/Environment.js
@@ -891,6 +891,7 @@ qx.Bootstrap.define("qx.core.Environment", {
       "qx.dynlocale": true,
       "qx.dyntheme": true,
       "qx.blankpage": "qx/static/blank.html",
+      "qx.data.marshal.Json.breakOnNonPojos": false,
       "qx.debug.databinding": false,
       "qx.debug.dispose": false,
       "qx.debug.startupTimings": false,

--- a/source/class/qx/data/marshal/Json.js
+++ b/source/class/qx/data/marshal/Json.js
@@ -170,9 +170,9 @@ qx.Class.define("qx.data.marshal.Json", {
      * @param depth {Number} The depth of the data relative to the data's root.
      */
     __toClass(data, includeBubbleEvents, parentProperty, depth) {
-      // break on all primitive json types and qooxdoo objects
+      // break on all primitive json types and non-POJO objects
       if (
-        !qx.lang.Type.isObject(data) ||
+        !qx.lang.Type.isPojo(data) ||
         !!data.$$isString || // check for localized strings
         data instanceof qx.core.Object
       ) {
@@ -405,12 +405,12 @@ qx.Class.define("qx.data.marshal.Json", {
      * @return {qx.core.Object} The created model object.
      */
     __toModel(data, includeBubbleEvents, parentProperty, depth) {
-      var isObject = qx.lang.Type.isObject(data);
+      var isPojo = qx.lang.Type.isPojo(data);
       var isArray =
         data instanceof Array || qx.Bootstrap.getClass(data) == "Array";
 
       if (
-        (!isObject && !isArray) ||
+        (!isPojo && !isArray) ||
         !!data.$$isString || // check for localized strings
         data instanceof qx.core.Object
       ) {
@@ -451,7 +451,7 @@ qx.Class.define("qx.data.marshal.Json", {
           );
         }
         return array;
-      } else if (isObject) {
+      } else if (isPojo) {
         // create an instance for the object
         var hash = this.__jsonToBestHash(data, includeBubbleEvents);
         var model = this.__createInstance(hash, data, parentProperty, depth);

--- a/source/class/qx/data/marshal/Json.js
+++ b/source/class/qx/data/marshal/Json.js
@@ -37,6 +37,10 @@ qx.Class.define("qx.data.marshal.Json", {
   },
 
   statics: {
+    /**
+     * Set to true when a warning has been shown that we are using the deprecated behaviour of trying to marshall non-POJO objects into Qooxdoo objects.
+     */
+    __shownNotBreakingOnNonPojosWarning: false,
     $$instance: null,
 
     /**
@@ -76,6 +80,25 @@ qx.Class.define("qx.data.marshal.Json", {
         Object.keys(data).sort().join('"') +
         (includeBubbleEvents === true ? "♥" : "")
       );
+    },
+
+    /**
+     * If the environment setting "qx.data.marshal.Json.breakOnNonPojos" is not set,
+     * it means we are using the old behaviour of marshalling non-POJO objects.
+     * A warning is shown if it hasn't been shown already.
+     */
+    checkIfWarnAboutNotBreakingOnNonPojos() {
+      if (
+        !qx.core.Environment.get("qx.data.marshal.Json.breakOnNonPojos") &&
+        !this.__shownNotBreakingOnNonPojosWarning
+      ) {
+        console.warn(
+          `Using deprecated behaviour of not breaking on non-POJOs when marshalling.
+          Please set the environment setting "qx.data.marshal.Json.breakOnNonPojos" to enable the new behaviour.
+          The old behaviour will be removed in the next major release of Qooxdoo.`
+        );
+        this.__shownNotBreakingOnNonPojosWarning = true;
+      }
     }
   },
 
@@ -170,12 +193,26 @@ qx.Class.define("qx.data.marshal.Json", {
      * @param depth {Number} The depth of the data relative to the data's root.
      */
     __toClass(data, includeBubbleEvents, parentProperty, depth) {
-      // break on all primitive json types and non-POJO objects
-      if (
-        !qx.lang.Type.isPojo(data) ||
-        !!data.$$isString || // check for localized strings
-        data instanceof qx.core.Object
-      ) {
+      const breakOnNonPojos = qx.core.Environment.get(
+        "qx.data.marshal.Json.breakOnNonPojos"
+      );
+      this.constructor.checkIfWarnAboutNotBreakingOnNonPojos();
+
+      // break on all primitive json types and qooxdoo objects
+      let shouldBreak;
+      if (breakOnNonPojos) {
+        shouldBreak =
+          !qx.lang.Type.isPojo(data) ||
+          !!data.$$isString || // check for localized strings
+          data instanceof qx.core.Object;
+      } else {
+        shouldBreak =
+          !qx.lang.Type.isObject(data) ||
+          !!data.$$isString || // check for localized strings
+          data instanceof qx.core.Object;
+      }
+
+      if (shouldBreak) {
         // check for arrays
         if (data instanceof Array || qx.Bootstrap.getClass(data) == "Array") {
           for (var i = 0; i < data.length; i++) {
@@ -405,15 +442,31 @@ qx.Class.define("qx.data.marshal.Json", {
      * @return {qx.core.Object} The created model object.
      */
     __toModel(data, includeBubbleEvents, parentProperty, depth) {
+      const breakOnNonPojos = qx.core.Environment.get(
+        "qx.data.marshal.Json.breakOnNonPojos"
+      );
+      this.constructor.checkIfWarnAboutNotBreakingOnNonPojos();
+
+      var isObject = qx.lang.Type.isObject(data);
       var isPojo = qx.lang.Type.isPojo(data);
+
       var isArray =
         data instanceof Array || qx.Bootstrap.getClass(data) == "Array";
 
-      if (
-        (!isPojo && !isArray) ||
-        !!data.$$isString || // check for localized strings
-        data instanceof qx.core.Object
-      ) {
+      let shouldBreak;
+      if (breakOnNonPojos) {
+        shouldBreak =
+          (!isPojo && !isArray) ||
+          !!data.$$isString || // check for localized strings
+          data instanceof qx.core.Object;
+      } else {
+        shouldBreak =
+          (!isObject && !isArray) ||
+          !!data.$$isString || // check for localized strings
+          data instanceof qx.core.Object;
+      }
+
+      if (shouldBreak) {
         return data;
 
         // ignore rules
@@ -451,7 +504,7 @@ qx.Class.define("qx.data.marshal.Json", {
           );
         }
         return array;
-      } else if (isPojo) {
+      } else if (breakOnNonPojos ? isPojo : isObject) {
         // create an instance for the object
         var hash = this.__jsonToBestHash(data, includeBubbleEvents);
         var model = this.__createInstance(hash, data, parentProperty, depth);

--- a/source/class/qx/lang/Type.js
+++ b/source/class/qx/lang/Type.js
@@ -52,14 +52,22 @@ qx.Bootstrap.define("qx.lang.Type", {
     isArray: qx.Bootstrap.isArray,
 
     /**
-     * Whether the value is an object. Note that built-in types like Window are
-     * not reported to be objects.
+     * Whether the value is an object i.e. Object.prototype is its prototype or Object.prototype is in its prototype chain.
+     * Note that built-in types like Window are not reported to be objects.
      *
      * @signature function(value)
-     * @param value {var} Value to check.
+     * @param {*} value value to check.
      * @return {Boolean} Whether the value is an object.
      */
     isObject: qx.Bootstrap.isObject,
+
+    /**
+     * Whether the value is strictly a POJO. It's prototype must not inherit from Object.prototype but be strictly Object.prototype.
+     * @signature function(value)
+     * @param {*} value
+     * @returns {Boolean} Whether the value is strictly a POJO.
+     */
+    isPojo: qx.Bootstrap.isPojo,
 
     /**
      * Whether the value is a function.

--- a/source/class/qx/lang/Type.js
+++ b/source/class/qx/lang/Type.js
@@ -62,12 +62,32 @@ qx.Bootstrap.define("qx.lang.Type", {
     isObject: qx.Bootstrap.isObject,
 
     /**
-     * Whether the value is strictly a POJO. It's prototype must not inherit from Object.prototype but be strictly Object.prototype.
-     * @signature function(value)
+     * Whether the value is strictly a POJO.
+     * Its prototype chain must not contain any constructors which are not the Object constructor i.e. traditional prototype-based classes or ES6 classes.
+     *
      * @param {*} value
      * @returns {Boolean} Whether the value is strictly a POJO.
      */
-    isPojo: qx.Bootstrap.isPojo,
+    isPojo(value) {
+      if (qx.Bootstrap.getClass(value) != "Object") return false;
+
+      let prototype = Object.getPrototypeOf(value);
+      while (true) {
+        if (prototype === Object.prototype) {
+          return true;
+        }
+
+        if (
+          prototype.constructor &&
+          prototype.constructor !== Object.prototype.constructor
+        ) {
+          return false;
+        }
+
+        //loop tail
+        prototype = Object.getPrototypeOf(prototype);
+      }
+    },
 
     /**
      * Whether the value is a function.

--- a/source/class/qx/lang/Type.js
+++ b/source/class/qx/lang/Type.js
@@ -52,9 +52,12 @@ qx.Bootstrap.define("qx.lang.Type", {
     isArray: qx.Bootstrap.isArray,
 
     /**
-     * Whether the value is an object i.e. Object.prototype is its prototype or Object.prototype is in its prototype chain.
-     * Note that built-in types like Window are not reported to be objects.
      *
+     * Whether the value is an POJO (ie {})
+     * or an object which is created from a ES6-style class or prototypical-inheritance-based class;
+     * if you need to determine whether something is a POJO and not created from a class, use isPojo instead
+     *
+     * Note that built-in types like Window are not deemed to be objects.
      * @signature function(value)
      * @param {*} value value to check.
      * @return {Boolean} Whether the value is an object.

--- a/source/class/qx/lang/Type.js
+++ b/source/class/qx/lang/Type.js
@@ -72,7 +72,9 @@ qx.Bootstrap.define("qx.lang.Type", {
      * @returns {Boolean} Whether the value is strictly a POJO.
      */
     isPojo(value) {
-      if (qx.Bootstrap.getClass(value) != "Object") return false;
+      if (qx.Bootstrap.getClass(value) != "Object") {
+        return false;
+      }
 
       let prototype = Object.getPrototypeOf(value);
       while (true) {

--- a/source/class/qx/test/data/controller/List.js
+++ b/source/class/qx/test/data/controller/List.js
@@ -25,7 +25,13 @@ qx.Class.define("qx.test.data.controller.List", {
   include: qx.dev.unit.MMock,
 
   members: {
+    /**
+     * @type {qx.ui.form.List}
+     */
     __list: null,
+    /**
+     * @type {qx.data.controller.List}
+     */
     __controller: null,
     __data: null,
     __model: null,

--- a/source/class/qx/test/data/marshal/Json.js
+++ b/source/class/qx/test/data/marshal/Json.js
@@ -1498,6 +1498,35 @@ qx.Class.define("qx.test.data.marshal.Json", {
 
       model.dispose();
       qx.Class.undefine("qx.test.Array");
+    },
+
+    testNonPojoObjects() {
+      function NativeClass() {
+        this.foo = "bar";
+      }
+
+      NativeClass.prototype.myMethod = function () {
+        return "method";
+      };
+
+      let data = {
+        name: "Michael",
+        nonPojo: new NativeClass()
+      };
+
+      this.__marshaler.dispose();
+      this.__marshaler = new qx.data.marshal.Json();
+      this.__marshaler.toClass(data);
+      var model = this.__marshaler.toModel(data);
+
+      this.assertEquals("Michael", model.getName());
+
+      if (qx.core.Environment.get("qx.data.marshal.Json.breakOnNonPojos")) {
+        this.assertEquals("method", model.getNonPojo().myMethod());
+        this.assertEquals("bar", model.getNonPojo().foo);
+      } else {
+        this.assertEquals("bar", model.getNonPojo().getFoo());
+      }
     }
   }
 });

--- a/source/class/qx/test/lang/Type.js
+++ b/source/class/qx/test/lang/Type.js
@@ -184,7 +184,7 @@ qx.Class.define("qx.test.lang.Type", {
         }
 
         method() {
-          return "method";
+          return "method: " + this.foo;
         }
       }
 

--- a/source/class/qx/test/lang/Type.js
+++ b/source/class/qx/test/lang/Type.js
@@ -42,6 +42,156 @@ qx.Class.define("qx.test.lang.Type", {
       this.assertFalse(Type.isString(document.getElementById("ReturenedNull")));
     },
 
+    testIsPojo() {
+      var isPojo = qx.lang.Type.isPojo;
+
+      //Class Person extends Object
+      function Person() {
+        this.name = "Mary";
+        this.surname = "Berry";
+      }
+
+      Person.prototype.getFullName = function () {
+        return this.name + " " + this.surname;
+      };
+
+      Person.prototype.properties = function () {
+        return "Properties";
+      };
+
+      //Class Child extends Person
+      function Child() {
+        Person.call(this);
+      }
+
+      Child.prototype = Object.create(Person.prototype);
+      Child.prototype.constructor = Child;
+
+      Child.prototype.childMethod = function () {
+        return "Child method";
+      };
+
+      // Simple POJO, should return true
+      this.assertTrue(isPojo({ foo: 1 }));
+
+      //Arrays, strings, numbers, and booleans are not POJOs
+      this.assertFalse(isPojo([]));
+      this.assertFalse(isPojo(null));
+      this.assertFalse(isPojo(new qx.data.Array()));
+      this.assertFalse(isPojo("hello"));
+      this.assertFalse(isPojo(12));
+      this.assertFalse(isPojo(true));
+
+      //Class instance which does not inherit
+      var nonInheritance = new Person();
+      this.assertFalse(isPojo(nonInheritance));
+
+      //Class instance with class that inherits
+      var withInheritance = new Child();
+      this.assertFalse(isPojo(withInheritance));
+
+      //POJO with class prototype
+      var pojoWithClassPrototype = { age: 22 };
+      Object.setPrototypeOf(pojoWithClassPrototype, Person.prototype);
+      this.assertFalse(isPojo(pojoWithClassPrototype));
+
+      //POJO with an object prototype
+      //Should return true
+      var pojoWithObjectPrototype = { extraproperty: "Nuts" };
+      var proto = {
+        protoMethod() {
+          return "protomethod";
+        }
+      };
+      Object.setPrototypeOf(pojoWithObjectPrototype, proto);
+      this.assertTrue(isPojo(pojoWithObjectPrototype));
+
+      //Object which has a POJO prototype, which in turn has a class prototype
+      //Should return false
+      var prototypeIsObjectThenConstructor = { extraproperty: "Nuts" };
+      var proto = {
+        protoMethod() {
+          return "protomethod";
+        }
+      };
+
+      Object.setPrototypeOf(prototypeIsObjectThenConstructor, proto);
+      Object.setPrototypeOf(proto, Person.prototype);
+      this.assertFalse(isPojo(prototypeIsObjectThenConstructor));
+
+      //Object which has a POJO prototype, which in turn has a POJO prototype
+      //Should return true
+      var obj = {
+        nuts: 345
+      };
+
+      var proto1 = {
+        myMethod() {
+          return "proto1.myMethod";
+        }
+      };
+
+      Object.setPrototypeOf(obj, proto1);
+      var proto2 = {
+        myMethod() {
+          return "proto2.myMethod";
+        },
+
+        method2() {
+          return "proto2.method2";
+        }
+      };
+
+      Object.setPrototypeOf(proto1, proto2);
+
+      this.assertEquals("proto1.myMethod", obj.myMethod());
+      this.assertEquals("proto2.method2", obj.method2());
+      this.assertTrue(isPojo(obj));
+
+      //Object which is instance of a class, where the class has a prototype which is not Object.prototype
+      //Must return false
+      function NonObjectPrototype() {
+        this.foo = "foo";
+      }
+
+      var proto = {
+        myMethod() {
+          return "proto.myMethod";
+        }
+      };
+
+      NonObjectPrototype.prototype = proto;
+      NonObjectPrototype.prototype.constructor = NonObjectPrototype;
+      NonObjectPrototype.prototype.extraMethod = function () {
+        return "extraMethod";
+      };
+
+      var obj = new NonObjectPrototype();
+
+      this.assertEquals("proto.myMethod", obj.myMethod());
+      this.assertEquals("extraMethod", obj.extraMethod());
+      this.assertEquals("foo", obj.foo);
+      this.assertFalse(isPojo(obj));
+
+      //Qooxdoo objects must not be POJOs
+      var obj = new qx.core.Object();
+      this.assertFalse(isPojo(obj));
+
+      //ES6 class must not be a POJO
+      class ES6Class {
+        constructor() {
+          this.foo = "bar";
+        }
+
+        method() {
+          return "method";
+        }
+      }
+
+      var obj = new ES6Class();
+      this.assertFalse(isPojo(obj));
+    },
+
     testIsArray() {
       var Type = qx.lang.Type;
 
@@ -64,6 +214,7 @@ qx.Class.define("qx.test.lang.Type", {
     },
 
     testIsObject() {
+      //note: old testIsObject
       var Type = qx.lang.Type;
 
       this.assertTrue(Type.isObject({}));


### PR DESCRIPTION
This PR causes non-POJO objects to be ignored from the POJO that we pass into qx.data.marshal.Json.createModel. This behaviour is almost always undesired because we may have third party library objects in the POJO, which we don't want the marshaller to touch. 

Here is a demo qx browser app. Try running it on both this PR branch and master and compare the results.
[pr-demo.zip](https://github.com/user-attachments/files/15889696/pr-demo.zip)
