### PR TITLE
qx.bom.Input - missing input types

### DIFF
--- a/source/class/qx/bom/Input.js
+++ b/source/class/qx/bom/Input.js
@@ -44,19 +44,30 @@ qx.Bootstrap.define("qx.bom.Input", {
   statics: {
     /** @type {Map} Internal data structures with all supported input types */
     __types: {
-      text: 1,
-      textarea: 1,
-      select: 1,
-      checkbox: 1,
-      radio: 1,
-      password: 1,
-      hidden: 1,
-      submit: 1,
-      image: 1,
-      file: 1,
-      search: 1,
-      reset: 1,
-      button: 1
+      textarea: true,
+      select: true,
+      button: true,
+      checkbox: true,
+      color: true,
+      date: true,
+      "datetime-local": true,
+      email: true,
+      file: true,
+      hidden: true,
+      image: true,
+      month: true,
+      number: true,
+      password: true,
+      radio: true,
+      range: true,
+      reset: true,
+      search: true,
+      submit: true,
+      tel: true,
+      text: true,
+      time: true,
+      url: true,
+      week: true
     },
 
     /**


### PR DESCRIPTION
closes #10703

- adds the several missing html input types
- changes `1` to `true` as it is used for truthiness
