### PR TITLE
add property `fallbackSource` to qx.ui.basic.Image

### DIFF
--- a/source/class/qx/io/ImageLoader.js
+++ b/source/class/qx/io/ImageLoader.js
@@ -161,12 +161,15 @@ qx.Bootstrap.define("qx.io.ImageLoader", {
      *   second parameter is the data entry which contains additional
      *   information about the image.
      * @param context {Object?} Context in which the given callback should be executed
+     * @param options {Map?} Optional configuration options:
+     * - retryFailed {boolean} Whether to retry loading of a failed image source
      */
-    load(source, callback, context) {
+    load(source, callback, context, options) {
+      options ??= {};
       // Shorthand
       var entry = this.__data[source];
 
-      if (!entry) {
+      if (!entry || (options.retryFailed && entry.failed)) {
         entry = this.__data[source] = {};
       }
 

--- a/source/class/qx/ui/basic/Image.js
+++ b/source/class/qx/ui/basic/Image.js
@@ -1026,7 +1026,9 @@ qx.Class.define("qx.ui.basic.Image", {
      * Tries to display the image in the `source` property again if it has failed to load.
      */
     tryReload() {
-      if (!this.__failedToLoad) return;
+      if (!this.__failedToLoad) {
+        return;
+      }
       this.__failedToLoad = false;
       this.__sourceToDisplay = this.getSource();
       qx.io.ImageLoader.load(

--- a/source/class/qx/ui/basic/Image.js
+++ b/source/class/qx/ui/basic/Image.js
@@ -144,6 +144,16 @@ qx.Class.define("qx.ui.basic.Image", {
     allowGrowY: {
       refine: true,
       init: false
+    },
+
+    /**
+     * Source of image to display if the image in the `source` property fails to load.
+     */
+    fallbackSource: {
+      check: "String",
+      init: null,
+      nullable: true,
+      event: "changeFallbackSource"
     }
   },
 
@@ -189,6 +199,19 @@ qx.Class.define("qx.ui.basic.Image", {
     __currentContentElement: null,
     __wrapper: null,
     __requestId: 0,
+    /**
+     * If the image in the `source` property failed to load.
+     */
+    __failedToLoad: false,
+
+    /**
+     * @type {string} The actual source of the image that we display.
+     * While the `source` property is what we want to display,
+     * this property is what we are actually showing.
+     * This can be the `source` property but it can also be the `fallbackSource` property
+     * if the image in the `source` property failed to load.
+     */
+    __sourceToDisplay: null,
 
     // overridden
     _onChangeTheme() {
@@ -225,7 +248,7 @@ qx.Class.define("qx.ui.basic.Image", {
     _applyDecorator(value, old) {
       super._applyDecorator(value, old);
 
-      var source = this.getSource();
+      var source = this.__sourceToDisplay;
       source = qx.util.AliasManager.getInstance().resolve(source);
       var el = this.getContentElement();
       if (this.__wrapper) {
@@ -307,7 +330,7 @@ qx.Class.define("qx.ui.basic.Image", {
     _applyEnabled(value, old) {
       super._applyEnabled(value, old);
 
-      if (this.getSource()) {
+      if (this.__sourceToDisplay) {
         this._styleSource();
       }
     },
@@ -321,6 +344,8 @@ qx.Class.define("qx.ui.basic.Image", {
         }
       }
 
+      this.__failedToLoad = false;
+      this.__sourceToDisplay = value;
       this._styleSource();
     },
 
@@ -345,7 +370,7 @@ qx.Class.define("qx.ui.basic.Image", {
      */
     __getMode() {
       if (this.__mode == null) {
-        var source = this.getSource();
+        var source = this.__sourceToDisplay;
 
         if (source && qx.lang.String.startsWith(source, "@")) {
           this.__mode = "font";
@@ -458,13 +483,12 @@ qx.Class.define("qx.ui.basic.Image", {
     /**
      * Applies the source to the clipped image instance or preload
      * an image to detect sizes and apply it afterwards.
-     *
      */
     _styleSource() {
       var AliasManager = qx.util.AliasManager.getInstance();
       var ResourceManager = qx.util.ResourceManager.getInstance();
 
-      var source = AliasManager.resolve(this.getSource());
+      var source = AliasManager.resolve(this.__sourceToDisplay);
 
       var element = this.getContentElement();
       if (this.__wrapper) {
@@ -791,7 +815,7 @@ qx.Class.define("qx.ui.basic.Image", {
         el.setStyle("fontSize", (width > height ? height : width) + "px");
       } else {
         var source = qx.util.AliasManager.getInstance().resolve(
-          this.getSource()
+          this.__sourceToDisplay
         );
 
         var sparts = source.split("/");
@@ -805,7 +829,8 @@ qx.Class.define("qx.ui.basic.Image", {
       super._applyDimension();
 
       var isFont =
-        this.getSource() && qx.lang.String.startsWith(this.getSource(), "@");
+        this.__sourceToDisplay &&
+        qx.lang.String.startsWith(this.__sourceToDisplay, "@");
       if (isFont) {
         var el = this.getContentElement();
         if (el) {
@@ -872,6 +897,11 @@ qx.Class.define("qx.ui.basic.Image", {
         ImageLoader.load(source, this.__loaderCallback, this);
       } else {
         this.__resetSource(el);
+        if (!this.__failedToLoad && this.getFallbackSource()) {
+          this.__failedToLoad = true;
+          this.__sourceToDisplay = this.getFallbackSource();
+          this._styleSource();
+        }
       }
     },
 
@@ -904,6 +934,7 @@ qx.Class.define("qx.ui.basic.Image", {
     },
 
     /**
+     * Sets image source on the DOM element
      * Combines the decorator's image styles with our own image to make sure
      * gradient and backgroundImage decorators work on Images.
      *
@@ -992,6 +1023,30 @@ qx.Class.define("qx.ui.basic.Image", {
     },
 
     /**
+     * Tries to display the image in the `source` property again if it has failed to load.
+     */
+    tryReload() {
+      if (!this.__failedToLoad) return;
+      this.__failedToLoad = false;
+      this.__sourceToDisplay = this.getSource();
+      qx.io.ImageLoader.load(
+        this.getSource(),
+        () => this._styleSource(),
+        undefined,
+        {
+          retryFailed: true
+        }
+      );
+    },
+
+    /**
+     * @returns {boolean} If the image in the `source` property failed to load.
+     */
+    hasFailedToLoad() {
+      return this.__failedToLoad;
+    },
+
+    /**
      * Event handler fired after the preloader has finished loading the icon
      *
      * @param source {String} Image source which was loaded
@@ -1005,7 +1060,8 @@ qx.Class.define("qx.ui.basic.Image", {
 
       // Ignore when the source has already been modified
       if (
-        source !== qx.util.AliasManager.getInstance().resolve(this.getSource())
+        source !==
+        qx.util.AliasManager.getInstance().resolve(this.__sourceToDisplay)
       ) {
         this.fireEvent("aborted");
         return;
@@ -1015,6 +1071,12 @@ qx.Class.define("qx.ui.basic.Image", {
       if (imageInfo.failed) {
         this.warn("Image could not be loaded: " + source);
         this.fireEvent("loadingFailed");
+        if (!this.__failedToLoad && this.getFallbackSource()) {
+          this.__failedToLoad = true;
+          this.__sourceToDisplay = this.getFallbackSource();
+          this._styleSource();
+          return;
+        }
       } else if (imageInfo.aborted) {
         this.fireEvent("aborted");
         return;


### PR DESCRIPTION
This non-breaking PR adds a property `fallbackSource` to qx.ui.basic.Image, which is a source of an image to display if the image defined by the `source` property fails to load. 

It also adds a method `tryReload` to qx.ui.basic.Image, which tries to reload the image in the `source` property and display it again.

Demo to help you test: 
[demo.zip](https://github.com/user-attachments/files/16390085/demo.zip)