### PR TITLE
Add svg to the qx.io.ImageLoader class data url regexp tag options.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,7 +32,6 @@ tmp/
 /tmp
 /bootstrap
 /qx
-/ville
 
 # CSS compiler
 /source/resource/qx/mobile/scss/.sass-cache/

--- a/.gitignore
+++ b/.gitignore
@@ -32,6 +32,7 @@ tmp/
 /tmp
 /bootstrap
 /qx
+/ville
 
 # CSS compiler
 /source/resource/qx/mobile/scss/.sass-cache/

--- a/source/class/qx/io/ImageLoader.js
+++ b/source/class/qx/io/ImageLoader.js
@@ -41,7 +41,7 @@ qx.Bootstrap.define("qx.io.ImageLoader", {
     __knownImageTypesRegExp: /\.(png|gif|jpg|jpeg|bmp)\b/i,
 
     /** @type {RegExp} Image types of a data URL */
-    __dataUrlRegExp: /^data:image\/(png|gif|jpg|jpeg|bmp)\b/i,
+    __dataUrlRegExp: /^data:image\/(png|gif|jpg|jpeg|bmp|svg)\b/i,
 
     /**
      * Whether the given image has previously been loaded using the

--- a/source/class/qx/io/ImageLoader.js
+++ b/source/class/qx/io/ImageLoader.js
@@ -41,7 +41,7 @@ qx.Bootstrap.define("qx.io.ImageLoader", {
     __knownImageTypesRegExp: /\.(png|gif|jpg|jpeg|bmp)\b/i,
 
     /** @type {RegExp} Image types of a data URL */
-    __dataUrlRegExp: /^data:image\/(png|gif|jpg|jpeg|bmp|svg)\b/i,
+    __dataUrlRegExp: /^data:image\/(png|gif|jpg|jpeg|bmp)\b/i,
 
     /**
      * Whether the given image has previously been loaded using the


### PR DESCRIPTION
This would allow "svg+xml" data uri option for all objects and properties that accept an image URL string as a value.