### PR TITLE
fix: don't destroy configured CSS `display` mode on render

### DIFF
--- a/source/class/qx/html/Element.js
+++ b/source/class/qx/html/Element.js
@@ -251,7 +251,11 @@ qx.Class.define("qx.html.Element", {
         // hiding or showing an object and deleting it right after that may
         // cause an disposed object in the visibility queue [BUG #3607]
         if (!obj.$$disposed) {
-          element.style.display = obj.isVisible() ? "" : "none";
+          element.style.display = obj.isVisible()
+            ? element.style.display == "none"
+              ? ""
+              : element.style.display
+            : "none";
           // also hide the element (fixed some rendering problem in IE<8 & IE8 quirks)
           if (qx.core.Environment.get("engine.name") == "mshtml") {
             if (!(document.documentMode >= 8)) {

--- a/source/class/qx/html/Factory.js
+++ b/source/class/qx/html/Factory.js
@@ -105,14 +105,20 @@ qx.Class.define("qx.html.Factory", {
 
         var styles = {};
         if (attributes.style) {
-          attributes.style.split(/;/).forEach(function (seg) {
-            var pos = seg.indexOf(":");
-            var key = seg.substring(0, pos);
-            var value = seg.substring(pos + 1).trim();
-            if (key) {
+          let styleArray = attributes.style
+            .replace(/\/\*.*?\*\//g, "")
+            .split(";");
+          for (let styleRule of styleArray) {
+            let pos = styleRule.indexOf(":");
+            if (pos === -1) {
+              continue;
+            }
+            let key = styleRule.substring(0, pos).trim();
+            let value = styleRule.substring(pos + 1).trim();
+            if (key.length) {
               styles[key] = value;
             }
-          });
+          }
           delete attributes.style;
         }
 

--- a/source/class/qx/html/Jsx.js
+++ b/source/class/qx/html/Jsx.js
@@ -22,6 +22,7 @@
 ************************************************************************ */
 
 /**
+ * @ignore(Window)
  * This class includes work from on https://github.com/alecsgone/jsx-render; at the time of writing,
  * the https://github.com/alecsgone/jsx-render repo is available under an MIT license.
  */
@@ -194,6 +195,11 @@ qx.Class.define("qx.html.Jsx", {
           tagname,
           newAttrs
         );
+        // if we're in a browser, create a dom element with the same tagname as the resulting `element`
+        if (typeof Window !== "undefined") {
+          let domElem = document.createElement(element.getNodeName());
+          element.useNode(domElem);
+        }
       }
 
       // SLOT

--- a/source/class/qx/html/Jsx.js
+++ b/source/class/qx/html/Jsx.js
@@ -195,9 +195,11 @@ qx.Class.define("qx.html.Jsx", {
           tagname,
           newAttrs
         );
-        // if we're in a browser, create a dom element with the same tagname as the resulting `element`
         if (typeof Window !== "undefined") {
           let domElem = document.createElement(element.getNodeName());
+          for (const key in newAttrs) {
+            domElem.setAttribute(key, newAttrs[key]);
+          }
           element.useNode(domElem);
         }
       }

--- a/source/class/qx/test/html/Element.js
+++ b/source/class/qx/test/html/Element.js
@@ -213,28 +213,18 @@ qx.Class.define("qx.test.html.Element", {
         return res;
       };
 
-      let elem = new qx.test.html.ExampleElement().set({
+      const elem = new qx.test.html.ExampleElement().set({
         qxObjectId: "rootExample"
       });
+      const expectedSerialized =
+        '<div data-qx-object-id="rootExample"><div id="elem-a1" data-qx-object-id="a1"><div id="elem-a2" data-qx-object-id="../a2"><div id="elem-a3" data-qx-object-id="../a3">Group A end</div></div></div><div id="elem-b1" data-qx-object-id="b1"><div id="elem-b2" data-qx-object-id="b2"><div id="elem-b3" data-qx-object-id="b3">Group B end</div></div></div></div>';
+      this.assertTrue(elem.serialize() === expectedSerialized);
 
-      let html = elem.serialize();
-      let dom = parseHtml(html);
-      let tmp;
-
-      elem.useNode(dom);
-      this.assertTrue(dom === elem.getDomElement(false));
-
-      tmp = dom.querySelector(`div[id="elem-a1"]`);
-      this.assertTrue(tmp && tmp === elem.getQxObject(`a1`).getDomElement());
-      tmp = dom.querySelector(`div[id="elem-a2"]`);
-      this.assertTrue(tmp && tmp === elem.getQxObject(`a2`).getDomElement());
-      tmp = dom.querySelector(`div[id="elem-a3"]`);
-      this.assertTrue(tmp && tmp === elem.getQxObject(`a3`).getDomElement());
-
-      tmp = dom.querySelector(`div[id="elem-b3"]`);
-      this.assertTrue(
-        tmp && tmp === elem.getQxObject(`b1/b2/b3`).getDomElement()
-      );
+      const copyElem = new qx.html.Element();
+      const expectedCopySerialized =
+        '<div><div id="elem-a1"><div id="elem-a2"><div id="elem-a3">Group A end</div></div></div><div id="elem-b1"><div id="elem-b2"><div id="elem-b3">Group B end</div></div></div></div>';
+      copyElem.useNode(parseHtml(expectedCopySerialized));
+      this.assertTrue(copyElem.serialize() === expectedCopySerialized);
     },
 
     testBasics() {


### PR DESCRIPTION
The expected behavior of the following Jsx is to create four squares in a 2-by-2 grid, each with a different color;

```jsx
let myContent = (
  <div style="display: grid; grid-template-columns: 1fr 1fr;">
    <div style="width: 5rem; aspect-ratio: 1 / 1; background: red"></div>
    <div style="width: 5rem; aspect-ratio: 1 / 1; background: green"></div>
    <div style="width: 5rem; aspect-ratio: 1 / 1; background: blue"></div>
    <div style="width: 5rem; aspect-ratio: 1 / 1; background: yellow"></div>
  </div>
);
```

The actual behavior of this Jsx is to behave as if the CSS `display; grid;` property was omitted. This results in 4 squares stacked on top of each other - clearly not what the author intended.

This happens because in `qx.html.Element.flush()`, every element will have it's CSS `display` property forced into one of two values based on the `visible` property; all elements will have a `display` value of either `""` or `"none"`.

This PR fixes this problem and elements may keep their `display` property. This allows for CSS layouts to be used in Jsx.

This PR intentionally doesn't cache the initial value of `element.style.display`.
It's tempting to think that we should cache it; if it was originally `"flex"`, then this code sets it to `"none"`, shouldn't set it back to `"flex"` later, rather than an empty `""`?
Realistically, the `visible` qooxdoo property wouldn't be used explicitly in conjunction with Jsx, meaning this code will always find the path to line 257 `: element.style.display`.

The changes to `qx.html.Jsx` ensure that the call to `qx.html.Element._copyData` is called with arguments `(true, true)` by going via `useNode` rather than [the `if (!this._domNode)` case in `qx.html.Node.flush`](https://github.com/qooxdoo/qooxdoo/blob/22214e21b69d5f3daeb797c29fddb8b01e67a950/source/class/qx/html/Node.js#L481), which would pass the arguments `(false, false)`.

This means that in the below permalinked block (from `qx.html.Element._copyData`), the `else` path will be taken when creating elements via Jsx. This ensures that regardless of the configured CSS `display` property (including `"none"` or no value) the `qx.html.Element` will respect and conform to it (this does not apply to elements created outside of Jsx, which continue to behave as they otherwise would without this PR).

https://github.com/qooxdoo/qooxdoo/blob/22214e21b69d5f3daeb797c29fddb8b01e67a950/source/class/qx/html/Element.js#L871-L881

This change doesn't appear to have any effect on regular qooxdoo apps. I've been using 7d2621b (change to element) for several days and not noticed any issues, and 7327dad (change to jsx) will only effect elements created via jsx. 