### PR TITLE
fix: prevent `.placeToWidget(..., true)` from eating cpu

### DIFF
--- a/source/class/qx/ui/core/MPlacement.js
+++ b/source/class/qx/ui/core/MPlacement.js
@@ -203,6 +203,8 @@ qx.Mixin.define("qx.ui.core.MPlacement", {
     __ptwLiveUpdater: null,
     __ptwLiveDisappearListener: null,
     __ptwLiveUpdateDisappearListener: null,
+    /**@type {Record<"top" | "right" | "bottom" | "left", number> | null}*/
+    __lastKnownCoords: null,
 
     /**
      * Returns the location data like {qx.bom.element.Location#get} does,
@@ -378,6 +380,15 @@ qx.Mixin.define("qx.ui.core.MPlacement", {
         target.getContentLocation() || this.getLayoutLocation(target);
 
       if (coords != null) {
+        if (
+          coords.top === this.__lastKnownCoords?.top &&
+          coords.right === this.__lastKnownCoords?.right &&
+          coords.bottom === this.__lastKnownCoords?.bottom &&
+          coords.left === this.__lastKnownCoords?.left
+        ) {
+          return true;
+        }
+        this.__lastKnownCoords = coords;
         this._place(coords);
         return true;
       } else {


### PR DESCRIPTION
We noticed an issue when using `qx.ui.menu.Menu`; when the menu is open, the browser tab's cpu usage spikes, then when the menu is closed again the cpu usage drops back down.

I've traced this back to `qx.ui.core.MPlacement.placeToWidget`, which is called with the second parameter `liveupdate` set to `true` in `qx.ui.menu.Menu._onResize`.
By logging `coords` immediately before the call to `this._place` it became clear that this code was doing a lot of unnecessary work - many times a second it would re-run all the calculations to place itself in the exact same position it is already in.

This commit simply caches the input coordinates of the most recent placement, and if the current placement is targeting the same input coords then there is no need to move the widget.