### PR TITLE
Fix behaviour of qx.data.controller.List when allowSelectionNotInModel is set to true

### DIFF
--- a/source/class/qx/data/controller/List.js
+++ b/source/class/qx/data/controller/List.js
@@ -414,12 +414,14 @@ qx.Class.define("qx.data.controller.List", {
         var target = this.getTarget();
         // if the model is set to null, we should remove all items in the target
         if (target != null) {
+          if (this.getAllowSelectionNotInModel()) this._startSelectionModification();
           // we need to remove the bindings too so use the controller method
           // for removing items
           var length = target.getChildren().length;
           for (var i = 0; i < length; i++) {
             this.__removeItem();
           }
+          if (this.getAllowSelectionNotInModel()) this._endSelectionModification();
         }
       }
     },
@@ -436,6 +438,8 @@ qx.Class.define("qx.data.controller.List", {
     _applyTarget(value, old) {
       // add a listener for the target change
       this._addChangeTargetListener(value, old);
+
+      if (this.getAllowSelectionNotInModel()) this._startSelectionModification();
 
       // if there was an old target
       if (old != undefined) {
@@ -456,6 +460,8 @@ qx.Class.define("qx.data.controller.List", {
           }
         }
       }
+
+      if (this.getAllowSelectionNotInModel()) this._endSelectionModification();
     },
 
     /*
@@ -524,6 +530,7 @@ qx.Class.define("qx.data.controller.List", {
       var newLength = this.__lookupTable.length;
       var currentLength = this.getTarget().getChildren().length;
 
+      if (this.getAllowSelectionNotInModel()) this._startSelectionModification();
       // if there are more item
       if (newLength > currentLength) {
         // add the new elements
@@ -537,6 +544,8 @@ qx.Class.define("qx.data.controller.List", {
           this.__removeItem();
         }
       }
+
+      if (this.getAllowSelectionNotInModel()) this._endSelectionModification();
 
       // build up the look up table
       this.__buildUpLookupTable();

--- a/source/class/qx/data/controller/List.js
+++ b/source/class/qx/data/controller/List.js
@@ -414,14 +414,18 @@ qx.Class.define("qx.data.controller.List", {
         var target = this.getTarget();
         // if the model is set to null, we should remove all items in the target
         if (target != null) {
-          if (this.getAllowSelectionNotInModel()) this._startSelectionModification();
+          if (this.getAllowSelectionNotInModel()) {
+            this._startSelectionModification();
+          }
           // we need to remove the bindings too so use the controller method
           // for removing items
           var length = target.getChildren().length;
           for (var i = 0; i < length; i++) {
             this.__removeItem();
           }
-          if (this.getAllowSelectionNotInModel()) this._endSelectionModification();
+          if (this.getAllowSelectionNotInModel()) {
+            this._endSelectionModification();
+          }
         }
       }
     },
@@ -439,7 +443,9 @@ qx.Class.define("qx.data.controller.List", {
       // add a listener for the target change
       this._addChangeTargetListener(value, old);
 
-      if (this.getAllowSelectionNotInModel()) this._startSelectionModification();
+      if (this.getAllowSelectionNotInModel()) {
+        this._startSelectionModification();
+      }
 
       // if there was an old target
       if (old != undefined) {
@@ -461,7 +467,9 @@ qx.Class.define("qx.data.controller.List", {
         }
       }
 
-      if (this.getAllowSelectionNotInModel()) this._endSelectionModification();
+      if (this.getAllowSelectionNotInModel()) {
+        this._endSelectionModification();
+      }
     },
 
     /*
@@ -530,7 +538,9 @@ qx.Class.define("qx.data.controller.List", {
       var newLength = this.__lookupTable.length;
       var currentLength = this.getTarget().getChildren().length;
 
-      if (this.getAllowSelectionNotInModel()) this._startSelectionModification();
+      if (this.getAllowSelectionNotInModel()) {
+        this._startSelectionModification();
+      }
       // if there are more item
       if (newLength > currentLength) {
         // add the new elements
@@ -545,7 +555,9 @@ qx.Class.define("qx.data.controller.List", {
         }
       }
 
-      if (this.getAllowSelectionNotInModel()) this._endSelectionModification();
+      if (this.getAllowSelectionNotInModel()) {
+        this._endSelectionModification();
+      }
 
       // build up the look up table
       this.__buildUpLookupTable();


### PR DESCRIPTION
This is a bug fix for a PR which I did before (https://github.com/qooxdoo/qooxdoo/pull/10708), whic allows qx.data.controller.List to have a selection which is not in its model and to keep its selection property when its model is changed.

The problem is that when the controller is used with a qx.ui.form.SelectBox instead of qx.data.controller.List, the controller fires changeSelection when the model is initially set and it's not supposed to. This is because SelectBoxes fire changeSelection when the first child list item is added, whereas Lists do not. Therefore, when the model of the controller is set, children are added in the SelectBox, so the selectbox fires a "changeSelection" event, hence the controller fires "changeSelection". 

I have only tested this PR with qx.ui.form.List initially, hence I didn't spot this bug!

Therefore, I have called this.{_start,stop}selectionModification around block of code which add/remove children from the target widget, which prevents the controller's selection from being updated, but only when allowSelectionNotInModel is set to true.

Here is the [demo zip] (https://github.com/user-attachments/files/17094809/demo.zip) again. This time, I have replaced the qx.ui.form.List's with SelectBoxes where you select the car's style. Note that the initial theme of Lamborghini should be Huracan (around line 50 of Database.js). Before this fix, it would be wrongly displaying as "Adventador", but it will show correctly after this fix.