### PR TITLE
Fixed null value of `qx.version`

### DIFF
--- a/source/class/qx/tool/cli/commands/Compile.js
+++ b/source/class/qx/tool/cli/commands/Compile.js
@@ -1345,6 +1345,15 @@ Framework: v${await this.getQxVersion()} in ${await this.getQxPath()}`);
         if (data.environment) {
           maker.setEnvironment(data.environment);
         }
+
+        /*
+        Libraries have to be added first because there is qx library
+        which includes a framework version
+        */
+        for (let library of librariesArray) {
+          maker.getAnalyser().addLibrary(library);
+        }
+
         let targetEnvironment = {
           "qx.version": maker.getAnalyser().getQooxdooVersion(),
           "qx.compiler.targetType": target.getType(),
@@ -1404,10 +1413,6 @@ Framework: v${await this.getQxVersion()} in ${await this.getQxPath()}`);
           targetConfig["verboseCreatedAt"] || t.argv["verboseCreatedAt"];
         if (verboseCreatedAt) {
           maker.getAnalyser().setVerboseCreatedAt(true);
-        }
-
-        for (let library of librariesArray) {
-          maker.getAnalyser().addLibrary(library);
         }
 
         let allApplicationTypes = {};


### PR DESCRIPTION
Fixed #10726 . There are extracting qooxdoo version from analyser before it was filled with libraries.