### PR TITLE
Added checking content on undefined value to fix testRedefineItem

### DIFF
--- a/source/class/qx/ui/core/Widget.js
+++ b/source/class/qx/ui/core/Widget.js
@@ -2128,7 +2128,13 @@ qx.Class.define("qx.ui.core.Widget", {
     }, // property apply
     _applyVisibility(value, old) {
       var content = this.getContentElement();
-      if (value === "visible") {
+      if (content) {
+        if (value === "visible") {
+          content.show();
+        } else {
+          content.hide();
+        } // only force a layout update if visibility change from/to "exclude"
+      }
         content.show();
       } else {
         if (content){

--- a/source/class/qx/ui/core/Widget.js
+++ b/source/class/qx/ui/core/Widget.js
@@ -2131,7 +2131,9 @@ qx.Class.define("qx.ui.core.Widget", {
       if (value === "visible") {
         content.show();
       } else {
-        content.hide();
+        if (content){
+          content.hide();
+        }
       } // only force a layout update if visibility change from/to "exclude"
       var parent = this.$$parent;
       if (

--- a/source/class/qx/ui/core/Widget.js
+++ b/source/class/qx/ui/core/Widget.js
@@ -2135,12 +2135,6 @@ qx.Class.define("qx.ui.core.Widget", {
           content.hide();
         } // only force a layout update if visibility change from/to "exclude"
       }
-        content.show();
-      } else {
-        if (content){
-          content.hide();
-        }
-      } // only force a layout update if visibility change from/to "exclude"
       var parent = this.$$parent;
       if (
         parent &&


### PR DESCRIPTION
Fast fix for unit test `testRedefineItem` which I've spotted in my pull request https://github.com/qooxdoo/qooxdoo/pull/10730.
It is not only one test if I get rid of this test next failed test is also related with `qx.ui.form.Form`. It happens not because of my changes. If I only create new branch from master and try to run tests they are failed too. I've checked requests before and suddenly they were passed. I don't know where to dig in. I think if there is no solution found then I think this request has to be merged.
These failed tests are passed fine locally (if copying them to other qooxdoo project and run) and with different node versions. Is there a way to show debug traces in tests on remote server?