### PR TITLE
Label size cache

### DIFF
--- a/source/class/qx/bom/Label.js
+++ b/source/class/qx/bom/Label.js
@@ -317,8 +317,7 @@ qx.Bootstrap.define("qx.bom.Label", {
      */
     getTextSize(text, styles) {
       let cacheKey = this.__getCacheKey(styles);
-      let cache = qx.bom.Label.__sizeCache[cacheKey];
-      let size = cache?.sizes[text];
+      let size = this.__getCachedSize(cacheKey, text);
       if (size !== undefined) {
         return size;
       }

--- a/source/class/qx/bom/Label.js
+++ b/source/class/qx/bom/Label.js
@@ -39,6 +39,9 @@ qx.Bootstrap.define("qx.bom.Label", {
       letterSpacing: 1
     },
 
+    /** @type{Object<String,Object>} cache of label sizes */
+    __sizeCache: {},
+
     /**
      * Generates the helper DOM element for text measuring
      *
@@ -286,6 +289,13 @@ qx.Bootstrap.define("qx.bom.Label", {
      * @return {Map} A map with preferred <code>width</code> and <code>height</code>.
      */
     getHtmlSize(content, styles, width) {
+      let cacheKey = this.__getCacheKey(styles, width);
+      let cache = qx.bom.Label.__sizeCache[cacheKey];
+      let size = cache?.sizes[content];
+      if (size !== undefined) {
+        return size;
+      }
+
       var element = this._htmlElement || this.__prepareHtml();
 
       // apply width
@@ -293,7 +303,9 @@ qx.Bootstrap.define("qx.bom.Label", {
       // insert content
       element.innerHTML = content;
 
-      return this.__measureSize(element, styles);
+      size = this.__measureSize(element, styles);
+      this.__storeCacheSize(cacheKey, content, size);
+      return size;
     },
 
     /**
@@ -304,6 +316,13 @@ qx.Bootstrap.define("qx.bom.Label", {
      * @return {Map} A map with preferred <code>width</code> and <code>height</code>.
      */
     getTextSize(text, styles) {
+      let cacheKey = this.__getCacheKey(styles);
+      let cache = qx.bom.Label.__sizeCache[cacheKey];
+      let size = cache?.sizes[text];
+      if (size !== undefined) {
+        return size;
+      }
+
       var element = this._textElement || this.__prepareText();
 
       if (
@@ -315,7 +334,58 @@ qx.Bootstrap.define("qx.bom.Label", {
         qx.bom.element.Attribute.set(element, "text", text);
       }
 
-      return this.__measureSize(element, styles);
+      size = this.__measureSize(element, styles);
+      this.__storeCacheSize(cacheKey, text, size);
+      return size;
+    },
+
+    /**
+     * Returns a key for a specific set of styles, used in the caching of size calculations
+     *
+     * @param {*} styles
+     * @param {Integer?} width optional width
+     * @returns
+     */
+    __getCacheKey(styles, width) {
+      let cacheKey = [];
+      for (let key in styles) {
+        let value = styles[key];
+        if (value !== null) {
+          cacheKey.push(key + ":" + value);
+        }
+      }
+      if (width !== undefined) {
+        cacheKey.push("width:" + width);
+      }
+      return cacheKey.join(",");
+    },
+
+    __getCachedSize(cacheKey, text) {
+      let cache = qx.bom.Label.__sizeCache[cacheKey];
+      return cache?.sizes[text];
+    },
+
+    __storeCacheSize(cacheKey, text, size) {
+      if (!size) {
+        return;
+      }
+
+      let cache = qx.bom.Label.__sizeCache[cacheKey];
+      if (cache === undefined) {
+        cache = qx.bom.Label.__sizeCache[cacheKey] = {
+          sizes: {},
+          lru: []
+        };
+      }
+      cache.sizes[text] = size;
+      cache.lru.push(text);
+    },
+
+    /**
+     * Flushes the size cache - use this when something changes, for example webfonts have been loaded
+     */
+    flushSizeCache() {
+      qx.bom.Label.__sizeCache = {};
     },
 
     /**

--- a/source/class/qx/bom/Label.js
+++ b/source/class/qx/bom/Label.js
@@ -290,7 +290,7 @@ qx.Bootstrap.define("qx.bom.Label", {
      */
     getHtmlSize(content, styles, width) {
       let cacheKey = this.__getCacheKey(styles, width);
-      let size = this.__getCachedSize(cacheKey, text);      
+      let size = this.__getCachedSize(cacheKey, content);
       if (size !== undefined) {
         return size;
       }
@@ -385,12 +385,10 @@ qx.Bootstrap.define("qx.bom.Label", {
       let cache = qx.bom.Label.__sizeCache[cacheKey];
       if (cache === undefined) {
         cache = qx.bom.Label.__sizeCache[cacheKey] = {
-          sizes: {},
-          lru: []
+          sizes: {}
         };
       }
       cache.sizes[text] = size;
-      cache.lru.push(text);
     },
 
     /**

--- a/source/class/qx/bom/Label.js
+++ b/source/class/qx/bom/Label.js
@@ -360,11 +360,25 @@ qx.Bootstrap.define("qx.bom.Label", {
       return cacheKey.join(",");
     },
 
+    /**
+     * Returns the cached size of the given text
+     *
+     * @param {String} cacheKey
+     * @param {String} text
+     * @returns {*} size object
+     */
     __getCachedSize(cacheKey, text) {
       let cache = qx.bom.Label.__sizeCache[cacheKey];
       return cache?.sizes[text];
     },
 
+    /**
+     * Stores the size of the given text in the cache
+     *
+     * @param {String} cacheKey
+     * @param {String} text
+     * @param {*} size
+     */
     __storeCacheSize(cacheKey, text, size) {
       if (!size) {
         return;

--- a/source/class/qx/bom/Label.js
+++ b/source/class/qx/bom/Label.js
@@ -290,8 +290,7 @@ qx.Bootstrap.define("qx.bom.Label", {
      */
     getHtmlSize(content, styles, width) {
       let cacheKey = this.__getCacheKey(styles, width);
-      let cache = qx.bom.Label.__sizeCache[cacheKey];
-      let size = cache?.sizes[content];
+      let size = this.__getCachedSize(cacheKey, text);      
       if (size !== undefined) {
         return size;
       }

--- a/source/class/qx/bom/webfonts/WebFont.js
+++ b/source/class/qx/bom/webfonts/WebFont.js
@@ -112,6 +112,7 @@ qx.Class.define("qx.bom.webfonts.WebFont", {
     },
 
     __applyValid(value) {
+      qx.bom.Label.flushSizeCache();
       this.fireDataEvent("changeStatus", {
         family: this.getFamily(),
         valid: value


### PR DESCRIPTION
This PR adds caching to the label size calculations, which can have a huge effect on performance.  In our app, we had a dashboard with multiple datagrid trees, and on reasonably good i9 laptops could see CPU usage spikes for 20-30 seconds.  My Apple Silicon M2 Max would see spikes to 20%.

