### PR TITLE
Browserify options in compile.json

### DIFF
--- a/docs/development/compiler/configuration/compile.md
+++ b/docs/development/compiler/configuration/compile.md
@@ -210,6 +210,11 @@ be compiled. Each object can contain:
   will be provided with a stack trace at their time and place of creation, allowing
   for more detailed debugging.
 
+- `browserifyOptions` - (**optional**) options given to browserify. For details see here:
+  <https://github.com/browserify/browserify#usage> When setting
+  `browserifyOptions` on a target, they will be merged into the top-level
+  `browserify.options`.
+
 - `babelOptions` - (**optional**) options given to @babel/preset-env. With these
   options the output type of babel can be defined. For details see here:
   <https://babeljs.io/docs/en/babel-preset-env#options> When setting

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -35,7 +35,7 @@
         "async": "^2.6.3",
         "babelify": "^10.0.0",
         "better-ajv-errors": "^1.2.0",
-        "browserify": "^17.0.0",
+        "browserify": "^17.0.1",
         "chokidar": "^3.5.3",
         "cldr": "^7.4.1",
         "columnify": "^1.6.0",
@@ -3834,9 +3834,9 @@
       }
     },
     "node_modules/browserify": {
-      "version": "17.0.0",
-      "resolved": "https://registry.npmjs.org/browserify/-/browserify-17.0.0.tgz",
-      "integrity": "sha512-SaHqzhku9v/j6XsQMRxPyBrSP3gnwmE27gLJYZgMT2GeK3J0+0toN+MnuNYDfHwVGQfLiMZ7KSNSIXHemy905w==",
+      "version": "17.0.1",
+      "resolved": "https://registry.npmjs.org/browserify/-/browserify-17.0.1.tgz",
+      "integrity": "sha512-pxhT00W3ylMhCHwG5yfqtZjNnFuX5h2IJdaBfSo4ChaaBsIp9VLrEMQ1bHV+Xr1uLPXuNDDM1GlJkjli0qkRsw==",
       "dependencies": {
         "assert": "^1.4.0",
         "browser-pack": "^6.0.1",
@@ -3854,7 +3854,7 @@
         "duplexer2": "~0.1.2",
         "events": "^3.0.0",
         "glob": "^7.1.0",
-        "has": "^1.0.0",
+        "hasown": "^2.0.0",
         "htmlescape": "^1.1.0",
         "https-browserify": "^1.0.0",
         "inherits": "~2.0.1",

--- a/package.json
+++ b/package.json
@@ -79,7 +79,7 @@
     "async": "^2.6.3",
     "babelify": "^10.0.0",
     "better-ajv-errors": "^1.2.0",
-    "browserify": "^17.0.0",
+    "browserify": "^17.0.1",
     "chokidar": "^3.5.3",
     "cldr": "^7.4.1",
     "columnify": "^1.6.0",

--- a/source/class/qx/tool/cli/commands/Compile.js
+++ b/source/class/qx/tool/cli/commands/Compile.js
@@ -1404,6 +1404,14 @@ Framework: v${await this.getQxVersion()} in ${await this.getQxPath()}`);
 
         maker.getAnalyser().setBabelConfig(babelConfig);
 
+        let browserifyConfig = qx.lang.Object.clone(data.browserify || {}, true);
+        browserifyConfig.options = browserifyConfig.options || {};
+        qx.lang.Object.mergeWith(
+          browserifyConfig.options,
+          targetConfig.browserifyOptions || {}
+        );
+        maker.getAnalyser().setBrowserifyConfig(browserifyConfig);
+
         var addCreatedAt =
           targetConfig["addCreatedAt"] || t.argv["addCreatedAt"];
         if (addCreatedAt) {

--- a/source/class/qx/tool/compiler/Analyser.js
+++ b/source/class/qx/tool/compiler/Analyser.js
@@ -126,6 +126,13 @@ qx.Class.define("qx.tool.compiler.Analyser", {
       check: "Object"
     },
 
+    /** configuration of browserify */
+    browserifyConfig: {
+      init: null,
+      nullable: true,
+      check: "Object"
+    },
+
     /** list of global ignores */
     ignores: {
       init: [],

--- a/source/class/qx/tool/compiler/MetaExtraction.js
+++ b/source/class/qx/tool/compiler/MetaExtraction.js
@@ -109,11 +109,6 @@ qx.Class.define("qx.tool.compiler.MetaExtraction", {
 
       const babelCore = require("@babel/core");
       let src = await fs.promises.readFile(classFilename, "utf8");
-      let babelConfig = {
-        options: {
-          modules: false
-        }
-      };
 
       let plugins = [require("@babel/plugin-syntax-jsx"), this.__plugin()];
 

--- a/source/class/qx/tool/compiler/targets/meta/Browserify.js
+++ b/source/class/qx/tool/compiler/targets/meta/Browserify.js
@@ -166,7 +166,7 @@ qx.Class.define("qx.tool.compiler.targets.meta.Browserify", {
         };
         qx.lang.Object.mergeWith(
           options,
-          this.getAppMeta().getAnalyser().getBrowserifyConfig() || {}
+          this.getAppMeta().getAnalyser().getBrowserifyConfig()?.options || {}
         );
         let b = browserify([], options);
 

--- a/source/class/qx/tool/compiler/targets/meta/Browserify.js
+++ b/source/class/qx/tool/compiler/targets/meta/Browserify.js
@@ -166,7 +166,8 @@ qx.Class.define("qx.tool.compiler.targets.meta.Browserify", {
         };
         qx.lang.Object.mergeWith(
           options,
-          this.getAppMeta().getAnalyser().getBrowserifyConfig()?.options || {}
+          this.getAppMeta().getAnalyser().getBrowserifyConfig()?.options || {},
+          false
         );
         let b = browserify([], options);
 

--- a/source/class/qx/tool/compiler/targets/meta/Browserify.js
+++ b/source/class/qx/tool/compiler/targets/meta/Browserify.js
@@ -158,12 +158,17 @@ qx.Class.define("qx.tool.compiler.targets.meta.Browserify", {
       builtins.process = builtins._process;
 
       return new Promise((resolve, reject) => {
-        let b = browserify([], {
+        const options = {
           builtins: builtins,
           ignoreMissing: true,
           insertGlobals: true,
           detectGlobals: true
-        });
+        };
+        qx.lang.Object.mergeWith(
+          options,
+          this.getAppMeta().getAnalyser().getBrowserifyConfig() || {}
+        );
+        let b = browserify([], options);
 
         b._mdeps.on("missing", (id, parent) => {
           let message = [];

--- a/source/resource/qx/tool/schema/compile-1-0-0.json
+++ b/source/resource/qx/tool/schema/compile-1-0-0.json
@@ -318,6 +318,10 @@
             "type": "object",
             "description": "Options given to @babel/preset-env. With this options the output type of babel can be defined. For details see here: <https://babeljs.io/docs/en/babel-preset-env#options>. They can be overridden per target."
           },
+          "browserifyOptions": {
+            "type": "object",
+            "description": "Options given to browserify. For details see here: <https://github.com/browserify/browserify#usage>. They can be overridden per target."
+          },
           "parts": {
             "$ref": "#/properties/parts"
           }
@@ -457,6 +461,15 @@
       "type": "object",
       "description": "** DEPRECATED - See babel.options instead",
       "deprecated": true
+    },
+    "browserify": {
+      "type": "object",
+      "properties": {
+        "options": {
+          "type": "object",
+          "description": "Options given to browserify. For details see here: <https://github.com/browserify/browserify#usage>. They can be overridden per target."
+        }
+      }
     },
     "jsx": {
       "type": "object",


### PR DESCRIPTION
Implemented #10728 

Clarify moments:
1) In root of compile.json I did browserify.options like babel.options but there are no so far other section like babel.plugins . Should I make browserifyOptions instead of browserify.options?
2) Should I extend doc and write examples like for babel?
3) Should qx.lang.Object.mergeWith overwrite base browserify options? Now it doesn't.
4) Are there usage examples added like for babel? Or url reference is enough?
5) Take notice I updated version of browserify from 17.0.0 to 17.0.1. There  is change which I have introduced into Browserify repository.