### PR TITLE
Event listener map

### DIFF
--- a/source/class/qx/event/Manager.js
+++ b/source/class/qx/event/Manager.js
@@ -66,7 +66,7 @@ qx.Class.define("qx.event.Manager", {
     }
 
     // Registry for event listeners
-    this.__listeners = {};
+    this.__listeners = new Map();
 
     // The handler and dispatcher instances
     this.__handlers = {};
@@ -264,18 +264,17 @@ qx.Class.define("qx.event.Manager", {
      *       null when no listener were found.
      */
     getListeners(target, type, capture) {
-      var targetKey =
-        target.$$hash || qx.core.ObjectRegistry.toHashCode(target);
-      var targetMap = this.__listeners[targetKey];
+      var targetKey = target.$$hash || qx.core.ObjectRegistry.toHashCode(target);
+      var targetMap = this.__listeners.get(targetKey);
 
       if (!targetMap) {
         return null;
       }
 
       var entryKey = type + (capture ? "|capture" : "|bubble");
-      var entryList = targetMap[entryKey];
+      var entryMap = targetMap.get(entryKey);
 
-      return entryList ? entryList.concat() : null;
+      return (entryMap && entryMap.size > 0) ? [...entryMap.values()] : null;
     },
 
     /**
@@ -283,7 +282,7 @@ qx.Class.define("qx.event.Manager", {
      *
      * @internal
      *
-     * @return {Map} All registered listeners. The key is the hash code form an object.
+     * @return {Map} All registered listeners. The key is the hash code for an object.
      */
     getAllListeners() {
       return this.__listeners;
@@ -297,28 +296,25 @@ qx.Class.define("qx.event.Manager", {
      *   <code>handler</code>, <code>self</code>, <code>type</code> and <code>capture</code>.
      */
     serializeListeners(target) {
-      var targetKey =
-        target.$$hash || qx.core.ObjectRegistry.toHashCode(target);
-      var targetMap = this.__listeners[targetKey];
+      var targetKey = target.$$hash || qx.core.ObjectRegistry.toHashCode(target);
+      var targetMap = this.__listeners.get(targetKey);
       var result = [];
 
       if (targetMap) {
-        var indexOf, type, capture, entryList, entry;
-        for (var entryKey in targetMap) {
+        var indexOf, type, capture;
+        for (const [entryKey, entryMap] of targetMap) {
           indexOf = entryKey.indexOf("|");
           type = entryKey.substring(0, indexOf);
-          capture = entryKey.charAt(indexOf + 1) == "c";
-          entryList = targetMap[entryKey];
-
-          for (var i = 0, l = entryList.length; i < l; i++) {
-            entry = entryList[i];
-            result.push({
-              self: entry.context,
-              handler: entry.handler,
-              type: type,
-              capture: capture
-            });
-          }
+          capture = entryKey.charAt(indexOf + 1) === "c";
+          result = result.concat(
+            [...entryMap.values().map(entry => ({
+                self: entry.context,
+                handler: entry.handler,
+                type: type,
+                capture: capture
+              })
+            )]
+          );
         }
       }
 
@@ -339,17 +335,15 @@ qx.Class.define("qx.event.Manager", {
      * @param enable {Boolean} Whether to enable or disable the events
      */
     toggleAttachedEvents(target, enable) {
-      var targetKey =
-        target.$$hash || qx.core.ObjectRegistry.toHashCode(target);
-      var targetMap = this.__listeners[targetKey];
+      var targetKey = target.$$hash || qx.core.ObjectRegistry.toHashCode(target);
+      var targetMap = this.__listeners.get(targetKey);
 
       if (targetMap) {
-        var indexOf, type, capture, entryList;
-        for (var entryKey in targetMap) {
+        var indexOf, type, capture;
+        for (const entryKey of targetMap.keys()) {
           indexOf = entryKey.indexOf("|");
           type = entryKey.substring(0, indexOf);
           capture = entryKey.charCodeAt(indexOf + 1) === 99; // checking for character "c".
-          entryList = targetMap[entryKey];
 
           if (enable) {
             this.__registerAtHandler(target, type, capture);
@@ -378,18 +372,17 @@ qx.Class.define("qx.event.Manager", {
         }
       }
 
-      var targetKey =
-        target.$$hash || qx.core.ObjectRegistry.toHashCode(target);
-      var targetMap = this.__listeners[targetKey];
+      var targetKey = target.$$hash || qx.core.ObjectRegistry.toHashCode(target);
+      var targetMap = this.__listeners.get(targetKey);
 
       if (!targetMap) {
         return false;
       }
 
       var entryKey = type + (capture ? "|capture" : "|bubble");
-      var entryList = targetMap[entryKey];
+      var entryMap = targetMap.get(entryKey);
 
-      return !!(entryList && entryList.length > 0);
+      return Boolean(entryMap && entryMap.size > 0);
     },
 
     /**
@@ -415,32 +408,40 @@ qx.Class.define("qx.event.Manager", {
         }
       }
 
-      var targetKey =
-        target.$$hash || qx.core.ObjectRegistry.toHashCode(target);
-      var targetMap = (this.__listeners[targetKey] = {});
-      var clazz = qx.event.Manager;
+      var targetKey = target.$$hash || qx.core.ObjectRegistry.toHashCode(target);
+      var targetMap = this.__listeners.get(targetKey);
+
+      if (!targetMap) {
+        targetMap = new Map();
+        this.__listeners.set(targetKey, targetMap);
+      }
 
       for (var listKey in list) {
         var item = list[listKey];
 
         var entryKey = item.type + (item.capture ? "|capture" : "|bubble");
-        var entryList = targetMap[entryKey];
+        var entryMap = targetMap.get(entryKey);
 
-        if (!entryList) {
-          entryList = targetMap[entryKey] = [];
+        if (!entryMap) {
+          entryMap = new Map();
+          targetMap.set(entryKey, entryMap)
+        }
 
+        if (entryMap.size === 0) {
           // This is the first event listener for this type and target
           // Inform the event handler about the new event
           // they perform the event registration at DOM level if needed
           this.__registerAtHandler(target, item.type, item.capture);
         }
 
-        // Append listener to list
-        entryList.push({
-          handler: item.listener,
-          context: item.self,
-          unique: item.unique || clazz.__lastUnique++ + ""
-        });
+        // Add listener to map
+        var unique = item.unique || qx.event.Manager.getNextUniqueId();
+        entryMap.set(unique, {
+            handler: item.listener,
+            context: item.self,
+            unique: unique
+          }
+        );
       }
     },
 
@@ -486,37 +487,37 @@ qx.Class.define("qx.event.Manager", {
         }
       }
 
-      var targetKey =
-        target.$$hash || qx.core.ObjectRegistry.toHashCode(target);
-      var targetMap = this.__listeners[targetKey];
+      var targetKey = target.$$hash || qx.core.ObjectRegistry.toHashCode(target);
+      var targetMap = this.__listeners.get(targetKey);
 
       if (!targetMap) {
-        targetMap = this.__listeners[targetKey] = {};
+        targetMap = new Map();
+        this.__listeners.set(targetKey, targetMap);
       }
 
       var entryKey = type + (capture ? "|capture" : "|bubble");
-      var entryList = targetMap[entryKey];
+      var entryMap = targetMap.get(entryKey);
 
-      if (!entryList) {
-        entryList = targetMap[entryKey] = [];
+      if (!entryMap) {
+        entryMap = new Map();
+        targetMap.set(entryKey, entryMap)
       }
 
-      // This is the first event listener for this type and target
-      // Inform the event handler about the new event
-      // they perform the event registration at DOM level if needed
-      if (entryList.length === 0) {
+      if (entryMap.size === 0) {
+        // This is the first event listener for this type and target
+        // Inform the event handler about the new event
+        // they perform the event registration at DOM level if needed
         this.__registerAtHandler(target, type, capture);
       }
 
-      // Append listener to list
-      var unique = qx.event.Manager.__lastUnique++ + "";
-      var entry = {
-        handler: listener,
-        context: self,
-        unique: unique
-      };
-
-      entryList.push(entry);
+      // Add listener to map
+      var unique = qx.event.Manager.getNextUniqueId();
+      entryMap.set(unique, {
+          handler: listener,
+          context: self,
+          unique: unique
+        }
+      );
 
       return entryKey + "|" + unique;
     },
@@ -524,7 +525,7 @@ qx.Class.define("qx.event.Manager", {
     /**
      * Get the event handler class matching the given event target and type
      *
-     * @param target {var} The event target
+     * @param target {Object} The event target
      * @param type {String} The event type
      * @return {qx.event.IEventHandler|null} The best matching event handler or
      *     <code>null</code>.
@@ -683,38 +684,29 @@ qx.Class.define("qx.event.Manager", {
         }
       }
 
-      var targetKey =
-        target.$$hash || qx.core.ObjectRegistry.toHashCode(target);
-      var targetMap = this.__listeners[targetKey];
+      var targetKey = target.$$hash || qx.core.ObjectRegistry.toHashCode(target);
+      var targetMap = this.__listeners.get(targetKey);
 
       if (!targetMap) {
         return false;
       }
-
       var entryKey = type + (capture ? "|capture" : "|bubble");
-      var entryList = targetMap[entryKey];
+      var entryMap = targetMap.get(entryKey);
 
-      if (!entryList) {
+      if (!entryMap) {
         return false;
       }
+      var deleted = false;
 
-      var entry;
-      for (var i = 0, l = entryList.length; i < l; i++) {
-        entry = entryList[i];
-
-        if (entry.handler === listener && entry.context === self) {
-          qx.lang.Array.removeAt(entryList, i);
-          this.__addToBlacklist(entry.unique);
-
-          if (entryList.length == 0) {
-            this.__unregisterAtHandler(target, type, capture);
-          }
-
-          return true;
+      for (const [entryKey, entry] of entryMap.entries().filter(([eK, e]) => e.handler === listener && e.context === self)) {
+        deleted = true;
+        entryMap.delete(entryKey);
+        this.__addToBlacklist(entryKey);
+        if (entryMap.size === 0) {
+          this.__unregisterAtHandler(target, type, capture);
         }
       }
-
-      return false;
+      return deleted;
     },
 
     /**
@@ -741,40 +733,32 @@ qx.Class.define("qx.event.Manager", {
 
       var split = id.split("|");
       var type = split[0];
-      var capture = split[1].charCodeAt(0) == 99; // detect leading "c"
+      var capture = split[1].charCodeAt(0) === 99; // detect leading "c"
       var unique = split[2];
 
-      var targetKey =
-        target.$$hash || qx.core.ObjectRegistry.toHashCode(target);
-      var targetMap = this.__listeners[targetKey];
+      var targetKey = target.$$hash || qx.core.ObjectRegistry.toHashCode(target);
+      var targetMap = this.__listeners.get(targetKey);
 
       if (!targetMap) {
         return false;
       }
 
       var entryKey = type + (capture ? "|capture" : "|bubble");
-      var entryList = targetMap[entryKey];
+      var entryMap = targetMap.get(entryKey);
 
-      if (!entryList) {
+      if (!entryMap) {
         return false;
       }
 
-      var entry;
-      for (var i = 0, l = entryList.length; i < l; i++) {
-        entry = entryList[i];
-
-        if (entry.unique === unique) {
-          qx.lang.Array.removeAt(entryList, i);
-          this.__addToBlacklist(entry.unique);
-
-          if (entryList.length == 0) {
-            this.__unregisterAtHandler(target, type, capture);
-          }
-
-          return true;
+      var entry = entryMap.get(unique);
+      if (entry) {
+        entryMap.delete(unique);
+        this.__addToBlacklist(entry.unique);
+        if (entryMap.size === 0) {
+          this.__unregisterAtHandler(target, type, capture);
         }
+        return true;
       }
-
       return false;
     },
 
@@ -785,23 +769,23 @@ qx.Class.define("qx.event.Manager", {
      * @return {Boolean} Whether the events were existant and were removed successfully.
      */
     removeAllListeners(target) {
-      var targetKey =
-        target.$$hash || qx.core.ObjectRegistry.toHashCode(target);
-      var targetMap = this.__listeners[targetKey];
+      var targetKey = target.$$hash || qx.core.ObjectRegistry.toHashCode(target);
+      var targetMap = this.__listeners.get(targetKey);
       if (!targetMap) {
         return false;
       }
 
       // Deregister from event handlers
       var split, type, capture;
-      for (var entryKey in targetMap) {
-        if (targetMap[entryKey].length > 0) {
+      for (const [entryKey, entryMap] of targetMap) {
+        if (entryMap && entryMap.size > 0) {
           // This is quite expensive, see bug #1283
           split = entryKey.split("|");
 
-          targetMap[entryKey].forEach(function (entry) {
-            this.__addToBlacklist(entry.unique);
-          }, this);
+          for (const uniqueKey of entryMap.keys()) {
+            this.__addToBlacklist(uniqueKey);
+          }
+          entryMap.clear();
 
           type = split[0];
           capture = split[1] === "capture";
@@ -810,7 +794,7 @@ qx.Class.define("qx.event.Manager", {
         }
       }
 
-      delete this.__listeners[targetKey];
+      this.__listeners.delete(targetKey);
       return true;
     },
 
@@ -824,7 +808,7 @@ qx.Class.define("qx.event.Manager", {
      * @internal
      */
     deleteAllListeners(targetKey) {
-      delete this.__listeners[targetKey];
+      this.__listeners.delete(targetKey);
     },
 
     /**
@@ -1002,7 +986,7 @@ qx.Class.define("qx.event.Manager", {
     /**
      * Add event to blacklist.
      *
-     * @param uid {number} unique event id
+     * @param uid {String} unique event id
      */
     __addToBlacklist(uid) {
       if (this.__blacklist === null) {
@@ -1015,7 +999,7 @@ qx.Class.define("qx.event.Manager", {
     /**
      * Check if the event with the given id has been removed and is therefore blacklisted for event handling
      *
-     * @param uid {number} unique event id
+     * @param uid {String} unique event id
      * @return {boolean}
      */
     isBlacklisted(uid) {

--- a/source/class/qx/test/theme/manager/Color.js
+++ b/source/class/qx/test/theme/manager/Color.js
@@ -32,8 +32,8 @@ qx.Class.define("qx.test.theme.manager.Color", {
       ).getAllListeners();
       let hash =
         this.manager.$$hash || qx.core.ObjectRegistry.toHashCode(this.manager);
-      this.__formerListener = { ...listener[hash] };
-      delete listener[hash];
+      this.__formerListener = listener.get(hash);
+      listener.delete(hash);
     },
 
     tearDown() {
@@ -46,7 +46,7 @@ qx.Class.define("qx.test.theme.manager.Color", {
       ).getAllListeners();
       let hash =
         this.manager.$$hash || qx.core.ObjectRegistry.toHashCode(this.manager);
-      listener[hash] = this.__formerListener;
+      listener.set(hash, this.__formerListener);
       this.__formerListener = null;
       qx.ui.core.queue.Manager.flush();
     },

--- a/source/class/qx/test/theme/manager/Decoration.js
+++ b/source/class/qx/test/theme/manager/Decoration.js
@@ -32,8 +32,8 @@ qx.Class.define("qx.test.theme.manager.Decoration", {
       ).getAllListeners();
       let hash =
         this.manager.$$hash || qx.core.ObjectRegistry.toHashCode(this.manager);
-      this.__formerListener = { ...listener[hash] };
-      delete listener[hash];
+      this.__formerListener = listener.get(hash);
+      listener.delete(hash);
     },
 
     tearDown() {
@@ -46,7 +46,7 @@ qx.Class.define("qx.test.theme.manager.Decoration", {
       ).getAllListeners();
       let hash =
         this.manager.$$hash || qx.core.ObjectRegistry.toHashCode(this.manager);
-      listener[hash] = this.__formerListener;
+      listener.set(hash, this.__formerListener);
       this.__formerListener = null;
       qx.ui.core.queue.Manager.flush();
     },

--- a/source/class/qx/test/theme/manager/Font.js
+++ b/source/class/qx/test/theme/manager/Font.js
@@ -32,8 +32,8 @@ qx.Class.define("qx.test.theme.manager.Font", {
       ).getAllListeners();
       let hash =
         this.manager.$$hash || qx.core.ObjectRegistry.toHashCode(this.manager);
-      this.__formerListener = { ...listener[hash] };
-      delete listener[hash];
+      this.__formerListener = listener.get(hash);
+      listener.delete(hash);
     },
 
     tearDown() {
@@ -46,7 +46,7 @@ qx.Class.define("qx.test.theme.manager.Font", {
       ).getAllListeners();
       let hash =
         this.manager.$$hash || qx.core.ObjectRegistry.toHashCode(this.manager);
-      listener[hash] = this.__formerListener;
+      listener.set(hash, this.__formerListener);
       this.__formerListener = null;
       qx.ui.core.queue.Manager.flush();
     },

--- a/source/class/qx/test/theme/manager/Icon.js
+++ b/source/class/qx/test/theme/manager/Icon.js
@@ -32,8 +32,8 @@ qx.Class.define("qx.test.theme.manager.Icon", {
       ).getAllListeners();
       let hash =
         this.manager.$$hash || qx.core.ObjectRegistry.toHashCode(this.manager);
-      this.__formerListener = { ...listener[hash] };
-      delete listener[hash];
+      this.__formerListener = listener.get(hash);
+      listener.delete(hash);
     },
 
     tearDown() {
@@ -46,7 +46,7 @@ qx.Class.define("qx.test.theme.manager.Icon", {
       ).getAllListeners();
       let hash =
         this.manager.$$hash || qx.core.ObjectRegistry.toHashCode(this.manager);
-      listener[hash] = this.__formerListener;
+      listener.set(hash, this.__formerListener);
       this.__formerListener = null;
       qx.ui.core.queue.Manager.flush();
     },

--- a/source/class/qx/test/theme/manager/Meta.js
+++ b/source/class/qx/test/theme/manager/Meta.js
@@ -102,8 +102,8 @@ qx.Class.define("qx.test.theme.manager.Meta", {
       ).getAllListeners();
       let hash =
         this.manager.$$hash || qx.core.ObjectRegistry.toHashCode(this.manager);
-      this.__formerListener = { ...listener[hash] };
-      delete listener[hash];
+      this.__formerListener = listener.get(hash);
+      listener.delete(hash);
       // add a theme able widget
       this.__button = new qx.ui.form.Button("Foo").set({
         appearance: "test-button-gradient"
@@ -122,7 +122,7 @@ qx.Class.define("qx.test.theme.manager.Meta", {
       ).getAllListeners();
       let hash =
         this.manager.$$hash || qx.core.ObjectRegistry.toHashCode(this.manager);
-      listener[hash] = this.__formerListener;
+      listener.set(hash, this.__formerListener);
       this.__formerListener = null;
       qx.ui.core.queue.Manager.flush();
     },
@@ -189,7 +189,7 @@ qx.Class.define("qx.test.theme.manager.Meta", {
         {
           qx.theme.manager.Meta.getInstance().setTheme(qx.test.theme.manager.MockDecoration);
           qx.ui.core.queue.Manager.flush();
-    
+
           // mocked decoration theme defines a border radius of 10 pixel
           var elem = this.__button.getContentElement().getDomElement();
           this.assertEquals(qx.bom.element.Style.get(elem, "borderTopLeftRadius"), "10px");

--- a/source/class/qx/ui/basic/Label.js
+++ b/source/class/qx/ui/basic/Label.js
@@ -79,7 +79,7 @@ qx.Class.define("qx.ui.basic.Label", {
     }
 
     if (qx.core.Environment.get("qx.dynlocale")) {
-      qx.locale.Manager.getInstance().addListener(
+      this.__changeLocaleLabelListenerId = qx.locale.Manager.getInstance().addListener(
         "changeLocale",
         this._onChangeLocale,
         this
@@ -530,10 +530,8 @@ qx.Class.define("qx.ui.basic.Label", {
 
   destruct() {
     if (qx.core.Environment.get("qx.dynlocale")) {
-      qx.locale.Manager.getInstance().removeListener(
-        "changeLocale",
-        this._onChangeLocale,
-        this
+      qx.locale.Manager.getInstance().removeListenerById(
+        this.__changeLocaleLabelListenerId
       );
     }
 

--- a/source/class/qx/ui/control/DateChooser.js
+++ b/source/class/qx/ui/control/DateChooser.js
@@ -102,7 +102,7 @@ qx.Class.define("qx.ui.control.DateChooser", {
 
     // listen for locale changes
     if (qx.core.Environment.get("qx.dynlocale")) {
-      qx.locale.Manager.getInstance().addListener(
+      this.__changeLocaleDatePaneListenerId = qx.locale.Manager.getInstance().addListener(
         "changeLocale",
         this._updateDatePane,
         this
@@ -783,10 +783,8 @@ qx.Class.define("qx.ui.control.DateChooser", {
 
   destruct() {
     if (qx.core.Environment.get("qx.dynlocale")) {
-      qx.locale.Manager.getInstance().removeListener(
-        "changeLocale",
-        this._updateDatePane,
-        this
+      qx.locale.Manager.getInstance().removeListenerById(
+        this.__changeLocaleDatePaneListenerId
       );
     }
 

--- a/source/class/qx/ui/core/Blocker.js
+++ b/source/class/qx/ui/core/Blocker.js
@@ -63,7 +63,7 @@ qx.Class.define("qx.ui.core.Blocker", {
 
     // dynamic theme switch
     if (qx.core.Environment.get("qx.dyntheme")) {
-      qx.theme.manager.Meta.getInstance().addListener(
+      this.__changeThemeBlockerListenerId = qx.theme.manager.Meta.getInstance().addListener(
         "changeTheme",
         this._onChangeTheme,
         this
@@ -500,10 +500,8 @@ qx.Class.define("qx.ui.core.Blocker", {
   destruct() {
     // remove dynamic theme listener
     if (qx.core.Environment.get("qx.dyntheme")) {
-      qx.theme.manager.Meta.getInstance().removeListener(
-        "changeTheme",
-        this._onChangeTheme,
-        this
+      qx.theme.manager.Meta.getInstance().removeListenerById(
+        this.__changeThemeBlockerListenerId
       );
     }
 

--- a/source/class/qx/ui/core/LayoutItem.js
+++ b/source/class/qx/ui/core/LayoutItem.js
@@ -30,7 +30,7 @@ qx.Class.define("qx.ui.core.LayoutItem", {
 
     // dynamic theme switch
     if (qx.core.Environment.get("qx.dyntheme")) {
-      qx.theme.manager.Meta.getInstance().addListener(
+      this.__changeThemeLayoutItemListenerId = qx.theme.manager.Meta.getInstance().addListener(
         "changeTheme",
         this._onChangeTheme,
         this
@@ -934,10 +934,8 @@ qx.Class.define("qx.ui.core.LayoutItem", {
   destruct() {
     // remove dynamic theme listener
     if (qx.core.Environment.get("qx.dyntheme")) {
-      qx.theme.manager.Meta.getInstance().removeListener(
-        "changeTheme",
-        this._onChangeTheme,
-        this
+      qx.theme.manager.Meta.getInstance().removeListenerById(
+        this.__changeThemeLayoutItemListenerId
       );
     }
     this.$$parent =

--- a/source/class/qx/ui/form/AbstractField.js
+++ b/source/class/qx/ui/form/AbstractField.js
@@ -144,7 +144,7 @@ qx.Class.define("qx.ui.form.AbstractField", {
 
     // translation support
     if (qx.core.Environment.get("qx.dynlocale")) {
-      qx.locale.Manager.getInstance().addListener(
+      this.__changeLocaleAbstractFieldListenerId = qx.locale.Manager.getInstance().addListener(
         "changeLocale",
         this._onChangeLocale,
         this
@@ -1075,10 +1075,8 @@ qx.Class.define("qx.ui.form.AbstractField", {
     this._placeholder = this.__font = null;
 
     if (qx.core.Environment.get("qx.dynlocale")) {
-      qx.locale.Manager.getInstance().removeListener(
-        "changeLocale",
-        this._onChangeLocale,
-        this
+      qx.locale.Manager.getInstance().removeListenerById(
+        this.__changeLocaleAbstractFieldListenerId
       );
     }
 

--- a/source/class/qx/ui/form/MForm.js
+++ b/source/class/qx/ui/form/MForm.js
@@ -22,7 +22,7 @@
 qx.Mixin.define("qx.ui.form.MForm", {
   construct() {
     if (qx.core.Environment.get("qx.dynlocale")) {
-      qx.locale.Manager.getInstance().addListener(
+      this.__changeLocaleMFormListenerId = qx.locale.Manager.getInstance().addListener(
         "changeLocale",
         this.__onChangeLocale,
         this
@@ -104,10 +104,8 @@ qx.Mixin.define("qx.ui.form.MForm", {
 
   destruct() {
     if (qx.core.Environment.get("qx.dynlocale")) {
-      qx.locale.Manager.getInstance().removeListener(
-        "changeLocale",
-        this.__onChangeLocale,
-        this
+      qx.locale.Manager.getInstance().removeListenerById(
+        this.__changeLocaleMFormListenerId
       );
     }
   }

--- a/source/class/qx/ui/form/Spinner.js
+++ b/source/class/qx/ui/form/Spinner.js
@@ -87,7 +87,7 @@ qx.Class.define("qx.ui.form.Spinner", {
     this.addListener("roll", this._onRoll, this);
 
     if (qx.core.Environment.get("qx.dynlocale")) {
-      qx.locale.Manager.getInstance().addListener(
+      this.__changeLocaleSpinnerListenerId = qx.locale.Manager.getInstance().addListener(
         "changeLocale",
         this._onChangeLocale,
         this
@@ -801,10 +801,8 @@ qx.Class.define("qx.ui.form.Spinner", {
     }
 
     if (qx.core.Environment.get("qx.dynlocale")) {
-      qx.locale.Manager.getInstance().removeListener(
-        "changeLocale",
-        this._onChangeLocale,
-        this
+      qx.locale.Manager.getInstance().removeListenerById(
+        this.__changeLocaleSpinnerListenerId
       );
     }
   }

--- a/source/class/qx/ui/form/renderer/AbstractRenderer.js
+++ b/source/class/qx/ui/form/renderer/AbstractRenderer.js
@@ -38,7 +38,7 @@ qx.Class.define("qx.ui.form.renderer.AbstractRenderer", {
 
     // translation support
     if (qx.core.Environment.get("qx.dynlocale")) {
-      qx.locale.Manager.getInstance().addListener(
+      this.__changeLocaleRendererListenerId = qx.locale.Manager.getInstance().addListener(
         "changeLocale",
         this._onChangeLocale,
         this
@@ -191,10 +191,8 @@ qx.Class.define("qx.ui.form.renderer.AbstractRenderer", {
 
   destruct() {
     if (qx.core.Environment.get("qx.dynlocale")) {
-      qx.locale.Manager.getInstance().removeListener(
-        "changeLocale",
-        this._onChangeLocale,
-        this
+      qx.locale.Manager.getInstance().removeListenerById(
+        this.__changeLocaleRendererListenerId
       );
     }
     this._names = null;

--- a/source/class/qx/ui/menu/AbstractButton.js
+++ b/source/class/qx/ui/menu/AbstractButton.js
@@ -265,17 +265,15 @@ qx.Class.define("qx.ui.menu.AbstractButton", {
       if (qx.core.Environment.get("qx.dynlocale")) {
         var oldCommand = e.getOldData();
         if (!oldCommand) {
-          qx.locale.Manager.getInstance().addListener(
+          this.__changeLocaleCommandListenerId = qx.locale.Manager.getInstance().addListener(
             "changeLocale",
             this._onChangeLocale,
             this
           );
         }
         if (!command) {
-          qx.locale.Manager.getInstance().removeListener(
-            "changeLocale",
-            this._onChangeLocale,
-            this
+          qx.locale.Manager.getInstance().removeListenerById(
+            this.__changeLocaleCommandListenerId
           );
         }
       }
@@ -398,10 +396,8 @@ qx.Class.define("qx.ui.menu.AbstractButton", {
     }
 
     if (qx.core.Environment.get("qx.dynlocale")) {
-      qx.locale.Manager.getInstance().removeListener(
-        "changeLocale",
-        this._onChangeLocale,
-        this
+      qx.locale.Manager.getInstance().removeListenerById(
+        this.__changeLocaleCommandListenerId
       );
     }
   }

--- a/source/class/qx/ui/mobile/basic/Label.js
+++ b/source/class/qx/ui/mobile/basic/Label.js
@@ -51,7 +51,7 @@ qx.Class.define("qx.ui.mobile.basic.Label", {
     this.initWrap();
 
     if (qx.core.Environment.get("qx.dynlocale")) {
-      qx.locale.Manager.getInstance().addListener(
+      this.__changeLocaleLabelListenerId = qx.locale.Manager.getInstance().addListener(
         "changeLocale",
         this._onChangeLocale,
         this
@@ -146,10 +146,8 @@ qx.Class.define("qx.ui.mobile.basic.Label", {
 
   destruct() {
     if (qx.core.Environment.get("qx.dynlocale")) {
-      qx.locale.Manager.getInstance().removeListener(
-        "changeLocale",
-        this._onChangeLocale,
-        this
+      qx.locale.Manager.getInstance().removeListenerById(
+        this.__changeLocaleLabelListenerId
       );
     }
   }

--- a/source/class/qx/ui/mobile/form/Label.js
+++ b/source/class/qx/ui/mobile/form/Label.js
@@ -71,7 +71,7 @@ qx.Class.define("qx.ui.mobile.form.Label", {
     this.initWrap();
 
     if (qx.core.Environment.get("qx.dynlocale")) {
-      qx.locale.Manager.getInstance().addListener(
+      this.__changeLocaleLabelListenerId = qx.locale.Manager.getInstance().addListener(
         "changeLocale",
         this._onChangeLocale,
         this
@@ -243,10 +243,8 @@ qx.Class.define("qx.ui.mobile.form.Label", {
       this.__forWidget = null;
     }
     if (qx.core.Environment.get("qx.dynlocale")) {
-      qx.locale.Manager.getInstance().removeListener(
-        "changeLocale",
-        this._onChangeLocale,
-        this
+      qx.locale.Manager.getInstance().removeListenerById(
+        this.__changeLocaleLabelListenerId
       );
     }
   }

--- a/source/class/qx/ui/mobile/list/List.js
+++ b/source/class/qx/ui/mobile/list/List.js
@@ -89,7 +89,7 @@ qx.Class.define("qx.ui.mobile.list.List", {
     }
 
     if (qx.core.Environment.get("qx.dynlocale")) {
-      qx.locale.Manager.getInstance().addListener(
+      this.__changeLocaleListListenerId = qx.locale.Manager.getInstance().addListener(
         "changeLocale",
         this._onChangeLocale,
         this
@@ -616,10 +616,8 @@ qx.Class.define("qx.ui.mobile.list.List", {
     this.__trackElement = null;
     this._disposeObjects("__provider");
     if (qx.core.Environment.get("qx.dynlocale")) {
-      qx.locale.Manager.getInstance().removeListener(
-        "changeLocale",
-        this._onChangeLocale,
-        this
+      qx.locale.Manager.getInstance().removeListenerById(
+        this.__changeLocaleListListenerId
       );
     }
   }

--- a/source/class/qx/ui/progressive/renderer/table/cell/Boolean.js
+++ b/source/class/qx/ui/progressive/renderer/table/cell/Boolean.js
@@ -32,7 +32,7 @@ qx.Class.define("qx.ui.progressive.renderer.table.cell.Boolean", {
 
     // dynamic theme switch
     if (qx.core.Environment.get("qx.dyntheme")) {
-      qx.theme.manager.Meta.getInstance().addListener(
+      this.__changeThemeBooleanCellListenerId = qx.theme.manager.Meta.getInstance().addListener(
         "changeTheme",
         this._resolveImages,
         this
@@ -178,10 +178,8 @@ qx.Class.define("qx.ui.progressive.renderer.table.cell.Boolean", {
 
     // remove dynamic theme listener
     if (qx.core.Environment.get("qx.dyntheme")) {
-      qx.theme.manager.Meta.getInstance().removeListener(
-        "changeTheme",
-        this._resolveImages,
-        this
+      qx.theme.manager.Meta.getInstance().removeListenerById(
+        this.__changeThemeBooleanCellListenerId
       );
     }
   }

--- a/source/class/qx/ui/table/Table.js
+++ b/source/class/qx/ui/table/Table.js
@@ -205,7 +205,7 @@ qx.Class.define("qx.ui.table.Table", {
 
     // add an event listener which updates the table content on locale change
     if (qx.core.Environment.get("qx.dynlocale")) {
-      qx.locale.Manager.getInstance().addListener(
+      this.__changeLocaleTableListenerId = qx.locale.Manager.getInstance().addListener(
         "changeLocale",
         this._onChangeLocale,
         this
@@ -2165,10 +2165,8 @@ qx.Class.define("qx.ui.table.Table", {
   destruct() {
     // remove the event listener which handled the locale change
     if (qx.core.Environment.get("qx.dynlocale")) {
-      qx.locale.Manager.getInstance().removeListener(
-        "changeLocale",
-        this._onChangeLocale,
-        this
+      qx.locale.Manager.getInstance().removeListenerById(
+        this.__changeLocaleTableListenerId
       );
     }
 

--- a/source/class/qx/ui/table/cellrenderer/Abstract.js
+++ b/source/class/qx/ui/table/cellrenderer/Abstract.js
@@ -38,7 +38,7 @@ qx.Class.define("qx.ui.table.cellrenderer.Abstract", {
 
       // add dynamic theme listener
       if (qx.core.Environment.get("qx.dyntheme")) {
-        qx.theme.manager.Meta.getInstance().addListener(
+        this.__changeThemeCellRendererListenerId = qx.theme.manager.Meta.getInstance().addListener(
           "changeTheme",
           this._onChangeTheme,
           this
@@ -243,10 +243,8 @@ qx.Class.define("qx.ui.table.cellrenderer.Abstract", {
   destruct() {
     // remove dynamic theme listener
     if (qx.core.Environment.get("qx.dyntheme")) {
-      qx.theme.manager.Meta.getInstance().removeListener(
-        "changeTheme",
-        this._onChangeTheme,
-        this
+      qx.theme.manager.Meta.getInstance().removeListenerById(
+        this.__changeThemeCellRendererListenerId
       );
     }
   }

--- a/source/class/qx/ui/table/cellrenderer/Boolean.js
+++ b/source/class/qx/ui/table/cellrenderer/Boolean.js
@@ -39,7 +39,7 @@ qx.Class.define("qx.ui.table.cellrenderer.Boolean", {
 
     // dynamic theme switch
     if (qx.core.Environment.get("qx.dyntheme")) {
-      qx.theme.manager.Meta.getInstance().addListener(
+      this.__changeThemeBoolCellRendererListenerId = qx.theme.manager.Meta.getInstance().addListener(
         "changeTheme",
         this._onChangeTheme,
         this
@@ -173,10 +173,8 @@ qx.Class.define("qx.ui.table.cellrenderer.Boolean", {
     this.__aliasManager = null;
     // remove dynamic theme listener
     if (qx.core.Environment.get("qx.dyntheme")) {
-      qx.theme.manager.Meta.getInstance().removeListener(
-        "changeTheme",
-        this._onChangeTheme,
-        this
+      qx.theme.manager.Meta.getInstance().removeListenerById(
+        this.__changeThemeBoolCellRendererListenerId
       );
     }
   }

--- a/source/class/qx/ui/table/rowrenderer/Default.js
+++ b/source/class/qx/ui/table/rowrenderer/Default.js
@@ -38,7 +38,7 @@ qx.Class.define("qx.ui.table.rowrenderer.Default", {
 
     // dynamic theme switch
     if (qx.core.Environment.get("qx.dyntheme")) {
-      qx.theme.manager.Meta.getInstance().addListener(
+      this.__changeThemeRowRendererListenerId = qx.theme.manager.Meta.getInstance().addListener(
         "changeTheme",
         this.initThemeValues,
         this
@@ -255,10 +255,8 @@ qx.Class.define("qx.ui.table.rowrenderer.Default", {
 
     // remove dynamic theme listener
     if (qx.core.Environment.get("qx.dyntheme")) {
-      qx.theme.manager.Meta.getInstance().removeListener(
-        "changeTheme",
-        this.initThemeValues,
-        this
+      qx.theme.manager.Meta.getInstance().removeListenerById(
+        this.__changeThemeRowRendererListenerId
       );
     }
   }


### PR DESCRIPTION
To fix https://github.com/qooxdoo/qooxdoo/issues/10620, change the storage of event listener callbacks from an Array to using a Map, keyed by the unique Id. I think I've made sure the exposed APIs return the same as before. 

The real speed-up comes from them storing the unique IDs for the added listeners and then using those for the removal from the Map. This makes a huge difference where there are many listeners in the Array (Map now) for the `qx.theme.manager.Meta` or the `qx.locale.Manager` when dynamic theming or locales are enabled.