### PR TITLE
Use Map instead of Array to register event listeners

### DIFF
--- a/source/class/qx/ui/basic/Label.js
+++ b/source/class/qx/ui/basic/Label.js
@@ -79,7 +79,7 @@ qx.Class.define("qx.ui.basic.Label", {
     }
 
     if (qx.core.Environment.get("qx.dynlocale")) {
-      qx.locale.Manager.getInstance().addListener(
+      this.__changeLocaleLabelListenerId = qx.locale.Manager.getInstance().addListener(
         "changeLocale",
         this._onChangeLocale,
         this
@@ -529,11 +529,9 @@ qx.Class.define("qx.ui.basic.Label", {
   */
 
   destruct() {
-    if (qx.core.Environment.get("qx.dynlocale")) {
-      qx.locale.Manager.getInstance().removeListener(
-        "changeLocale",
-        this._onChangeLocale,
-        this
+    if (qx.core.Environment.get("qx.dynlocale") && this.__changeLocaleLabelListenerId) {
+      qx.locale.Manager.getInstance().removeListenerById(
+        this.__changeLocaleLabelListenerId
       );
     }
 

--- a/source/class/qx/ui/control/DateChooser.js
+++ b/source/class/qx/ui/control/DateChooser.js
@@ -102,7 +102,7 @@ qx.Class.define("qx.ui.control.DateChooser", {
 
     // listen for locale changes
     if (qx.core.Environment.get("qx.dynlocale")) {
-      qx.locale.Manager.getInstance().addListener(
+      this.__changeLocaleDatePaneListenerId = qx.locale.Manager.getInstance().addListener(
         "changeLocale",
         this._updateDatePane,
         this
@@ -782,11 +782,9 @@ qx.Class.define("qx.ui.control.DateChooser", {
   */
 
   destruct() {
-    if (qx.core.Environment.get("qx.dynlocale")) {
-      qx.locale.Manager.getInstance().removeListener(
-        "changeLocale",
-        this._updateDatePane,
-        this
+    if (qx.core.Environment.get("qx.dynlocale") && this.__changeLocaleDatePaneListenerId) {
+      qx.locale.Manager.getInstance().removeListenerById(
+        this.__changeLocaleDatePaneListenerId
       );
     }
 

--- a/source/class/qx/ui/core/Blocker.js
+++ b/source/class/qx/ui/core/Blocker.js
@@ -63,7 +63,7 @@ qx.Class.define("qx.ui.core.Blocker", {
 
     // dynamic theme switch
     if (qx.core.Environment.get("qx.dyntheme")) {
-      qx.theme.manager.Meta.getInstance().addListener(
+      this.__changeThemeBlockerListenerId = qx.theme.manager.Meta.getInstance().addListener(
         "changeTheme",
         this._onChangeTheme,
         this
@@ -499,11 +499,9 @@ qx.Class.define("qx.ui.core.Blocker", {
 
   destruct() {
     // remove dynamic theme listener
-    if (qx.core.Environment.get("qx.dyntheme")) {
-      qx.theme.manager.Meta.getInstance().removeListener(
-        "changeTheme",
-        this._onChangeTheme,
-        this
+    if (qx.core.Environment.get("qx.dyntheme") && this.__changeThemeBlockerListenerId) {
+      qx.theme.manager.Meta.getInstance().removeListenerById(
+        this.__changeThemeBlockerListenerId
       );
     }
 

--- a/source/class/qx/ui/core/LayoutItem.js
+++ b/source/class/qx/ui/core/LayoutItem.js
@@ -30,7 +30,7 @@ qx.Class.define("qx.ui.core.LayoutItem", {
 
     // dynamic theme switch
     if (qx.core.Environment.get("qx.dyntheme")) {
-      qx.theme.manager.Meta.getInstance().addListener(
+      this.__changeThemeLayoutItemListenerId = qx.theme.manager.Meta.getInstance().addListener(
         "changeTheme",
         this._onChangeTheme,
         this
@@ -933,11 +933,9 @@ qx.Class.define("qx.ui.core.LayoutItem", {
 
   destruct() {
     // remove dynamic theme listener
-    if (qx.core.Environment.get("qx.dyntheme")) {
-      qx.theme.manager.Meta.getInstance().removeListener(
-        "changeTheme",
-        this._onChangeTheme,
-        this
+    if (qx.core.Environment.get("qx.dyntheme") && this.__changeThemeLayoutItemListenerId) {
+      qx.theme.manager.Meta.getInstance().removeListenerById(
+        this.__changeThemeLayoutItemListenerId
       );
     }
     this.$$parent =

--- a/source/class/qx/ui/form/AbstractField.js
+++ b/source/class/qx/ui/form/AbstractField.js
@@ -144,7 +144,7 @@ qx.Class.define("qx.ui.form.AbstractField", {
 
     // translation support
     if (qx.core.Environment.get("qx.dynlocale")) {
-      qx.locale.Manager.getInstance().addListener(
+      this.__changeLocaleAbstractFieldListenerId = qx.locale.Manager.getInstance().addListener(
         "changeLocale",
         this._onChangeLocale,
         this
@@ -1074,11 +1074,9 @@ qx.Class.define("qx.ui.form.AbstractField", {
 
     this._placeholder = this.__font = null;
 
-    if (qx.core.Environment.get("qx.dynlocale")) {
-      qx.locale.Manager.getInstance().removeListener(
-        "changeLocale",
-        this._onChangeLocale,
-        this
+    if (qx.core.Environment.get("qx.dynlocale") && this.__changeLocaleAbstractFieldListenerId) {
+      qx.locale.Manager.getInstance().removeListenerById(
+        this.__changeLocaleAbstractFieldListenerId
       );
     }
 

--- a/source/class/qx/ui/form/MForm.js
+++ b/source/class/qx/ui/form/MForm.js
@@ -22,7 +22,7 @@
 qx.Mixin.define("qx.ui.form.MForm", {
   construct() {
     if (qx.core.Environment.get("qx.dynlocale")) {
-      qx.locale.Manager.getInstance().addListener(
+      this.__changeLocaleMFormListenerId = qx.locale.Manager.getInstance().addListener(
         "changeLocale",
         this.__onChangeLocale,
         this
@@ -103,11 +103,9 @@ qx.Mixin.define("qx.ui.form.MForm", {
   },
 
   destruct() {
-    if (qx.core.Environment.get("qx.dynlocale")) {
-      qx.locale.Manager.getInstance().removeListener(
-        "changeLocale",
-        this.__onChangeLocale,
-        this
+    if (qx.core.Environment.get("qx.dynlocale") && this.__changeLocaleMFormListenerId) {
+      qx.locale.Manager.getInstance().removeListenerById(
+        this.__changeLocaleMFormListenerId
       );
     }
   }

--- a/source/class/qx/ui/form/Spinner.js
+++ b/source/class/qx/ui/form/Spinner.js
@@ -87,7 +87,7 @@ qx.Class.define("qx.ui.form.Spinner", {
     this.addListener("roll", this._onRoll, this);
 
     if (qx.core.Environment.get("qx.dynlocale")) {
-      qx.locale.Manager.getInstance().addListener(
+      this.__changeLocaleSpinnerListenerId = qx.locale.Manager.getInstance().addListener(
         "changeLocale",
         this._onChangeLocale,
         this
@@ -800,11 +800,9 @@ qx.Class.define("qx.ui.form.Spinner", {
       nf.removeListener("changeNumberFormat", this._onChangeNumberFormat, this);
     }
 
-    if (qx.core.Environment.get("qx.dynlocale")) {
-      qx.locale.Manager.getInstance().removeListener(
-        "changeLocale",
-        this._onChangeLocale,
-        this
+    if (qx.core.Environment.get("qx.dynlocale") && this.__changeLocaleSpinnerListenerId) {
+      qx.locale.Manager.getInstance().removeListenerById(
+        this.__changeLocaleSpinnerListenerId
       );
     }
   }

--- a/source/class/qx/ui/form/renderer/AbstractRenderer.js
+++ b/source/class/qx/ui/form/renderer/AbstractRenderer.js
@@ -38,7 +38,7 @@ qx.Class.define("qx.ui.form.renderer.AbstractRenderer", {
 
     // translation support
     if (qx.core.Environment.get("qx.dynlocale")) {
-      qx.locale.Manager.getInstance().addListener(
+      this.__changeLocaleRendererListenerId = qx.locale.Manager.getInstance().addListener(
         "changeLocale",
         this._onChangeLocale,
         this
@@ -190,11 +190,9 @@ qx.Class.define("qx.ui.form.renderer.AbstractRenderer", {
   */
 
   destruct() {
-    if (qx.core.Environment.get("qx.dynlocale")) {
-      qx.locale.Manager.getInstance().removeListener(
-        "changeLocale",
-        this._onChangeLocale,
-        this
+    if (qx.core.Environment.get("qx.dynlocale") && this.__changeLocaleRendererListenerId) {
+      qx.locale.Manager.getInstance().removeListenerById(
+        this.__changeLocaleRendererListenerId
       );
     }
     this._names = null;

--- a/source/class/qx/ui/menu/AbstractButton.js
+++ b/source/class/qx/ui/menu/AbstractButton.js
@@ -265,17 +265,15 @@ qx.Class.define("qx.ui.menu.AbstractButton", {
       if (qx.core.Environment.get("qx.dynlocale")) {
         var oldCommand = e.getOldData();
         if (!oldCommand) {
-          qx.locale.Manager.getInstance().addListener(
+          this.__changeLocaleCommandListenerId = qx.locale.Manager.getInstance().addListener(
             "changeLocale",
             this._onChangeLocale,
             this
           );
         }
-        if (!command) {
-          qx.locale.Manager.getInstance().removeListener(
-            "changeLocale",
-            this._onChangeLocale,
-            this
+        if (!command && this.__changeLocaleCommandListenerId) {
+          qx.locale.Manager.getInstance().removeListenerById(
+            this.__changeLocaleCommandListenerId
           );
         }
       }
@@ -397,11 +395,9 @@ qx.Class.define("qx.ui.menu.AbstractButton", {
       }
     }
 
-    if (qx.core.Environment.get("qx.dynlocale")) {
-      qx.locale.Manager.getInstance().removeListener(
-        "changeLocale",
-        this._onChangeLocale,
-        this
+    if (qx.core.Environment.get("qx.dynlocale") && this.__changeLocaleCommandListenerId) {
+      qx.locale.Manager.getInstance().removeListenerById(
+        this.__changeLocaleCommandListenerId
       );
     }
   }

--- a/source/class/qx/ui/mobile/basic/Label.js
+++ b/source/class/qx/ui/mobile/basic/Label.js
@@ -51,7 +51,7 @@ qx.Class.define("qx.ui.mobile.basic.Label", {
     this.initWrap();
 
     if (qx.core.Environment.get("qx.dynlocale")) {
-      qx.locale.Manager.getInstance().addListener(
+      this.__changeLocaleLabelListenerId = qx.locale.Manager.getInstance().addListener(
         "changeLocale",
         this._onChangeLocale,
         this
@@ -145,11 +145,9 @@ qx.Class.define("qx.ui.mobile.basic.Label", {
   */
 
   destruct() {
-    if (qx.core.Environment.get("qx.dynlocale")) {
-      qx.locale.Manager.getInstance().removeListener(
-        "changeLocale",
-        this._onChangeLocale,
-        this
+    if (qx.core.Environment.get("qx.dynlocale") && this.__changeLocaleLabelListenerId) {
+      qx.locale.Manager.getInstance().removeListenerById(
+        this.__changeLocaleLabelListenerId
       );
     }
   }

--- a/source/class/qx/ui/mobile/form/Label.js
+++ b/source/class/qx/ui/mobile/form/Label.js
@@ -71,7 +71,7 @@ qx.Class.define("qx.ui.mobile.form.Label", {
     this.initWrap();
 
     if (qx.core.Environment.get("qx.dynlocale")) {
-      qx.locale.Manager.getInstance().addListener(
+      this.__changeLocaleLabelListenerId = qx.locale.Manager.getInstance().addListener(
         "changeLocale",
         this._onChangeLocale,
         this
@@ -242,11 +242,9 @@ qx.Class.define("qx.ui.mobile.form.Label", {
 
       this.__forWidget = null;
     }
-    if (qx.core.Environment.get("qx.dynlocale")) {
-      qx.locale.Manager.getInstance().removeListener(
-        "changeLocale",
-        this._onChangeLocale,
-        this
+    if (qx.core.Environment.get("qx.dynlocale") && this.__changeLocaleLabelListenerId) {
+      qx.locale.Manager.getInstance().removeListenerById(
+        this.__changeLocaleLabelListenerId
       );
     }
   }

--- a/source/class/qx/ui/mobile/list/List.js
+++ b/source/class/qx/ui/mobile/list/List.js
@@ -89,7 +89,7 @@ qx.Class.define("qx.ui.mobile.list.List", {
     }
 
     if (qx.core.Environment.get("qx.dynlocale")) {
-      qx.locale.Manager.getInstance().addListener(
+      this.__changeLocaleListListenerId = qx.locale.Manager.getInstance().addListener(
         "changeLocale",
         this._onChangeLocale,
         this
@@ -615,11 +615,9 @@ qx.Class.define("qx.ui.mobile.list.List", {
   destruct() {
     this.__trackElement = null;
     this._disposeObjects("__provider");
-    if (qx.core.Environment.get("qx.dynlocale")) {
-      qx.locale.Manager.getInstance().removeListener(
-        "changeLocale",
-        this._onChangeLocale,
-        this
+    if (qx.core.Environment.get("qx.dynlocale") && this.__changeLocaleListListenerId) {
+      qx.locale.Manager.getInstance().removeListenerById(
+        this.__changeLocaleListListenerId
       );
     }
   }

--- a/source/class/qx/ui/progressive/renderer/table/cell/Boolean.js
+++ b/source/class/qx/ui/progressive/renderer/table/cell/Boolean.js
@@ -32,7 +32,7 @@ qx.Class.define("qx.ui.progressive.renderer.table.cell.Boolean", {
 
     // dynamic theme switch
     if (qx.core.Environment.get("qx.dyntheme")) {
-      qx.theme.manager.Meta.getInstance().addListener(
+      this.__changeThemeBooleanCellListenerId = qx.theme.manager.Meta.getInstance().addListener(
         "changeTheme",
         this._resolveImages,
         this
@@ -177,11 +177,9 @@ qx.Class.define("qx.ui.progressive.renderer.table.cell.Boolean", {
     this._iconUrlTrue = this._iconUrlFalse = null;
 
     // remove dynamic theme listener
-    if (qx.core.Environment.get("qx.dyntheme")) {
-      qx.theme.manager.Meta.getInstance().removeListener(
-        "changeTheme",
-        this._resolveImages,
-        this
+    if (qx.core.Environment.get("qx.dyntheme") && this.__changeThemeBooleanCellListenerId) {
+      qx.theme.manager.Meta.getInstance().removeListenerById(
+        this.__changeThemeBooleanCellListenerId
       );
     }
   }

--- a/source/class/qx/ui/table/Table.js
+++ b/source/class/qx/ui/table/Table.js
@@ -205,7 +205,7 @@ qx.Class.define("qx.ui.table.Table", {
 
     // add an event listener which updates the table content on locale change
     if (qx.core.Environment.get("qx.dynlocale")) {
-      qx.locale.Manager.getInstance().addListener(
+      this.__changeLocaleTableListenerId = qx.locale.Manager.getInstance().addListener(
         "changeLocale",
         this._onChangeLocale,
         this
@@ -2164,11 +2164,9 @@ qx.Class.define("qx.ui.table.Table", {
 
   destruct() {
     // remove the event listener which handled the locale change
-    if (qx.core.Environment.get("qx.dynlocale")) {
-      qx.locale.Manager.getInstance().removeListener(
-        "changeLocale",
-        this._onChangeLocale,
-        this
+    if (qx.core.Environment.get("qx.dynlocale") && this.__changeLocaleTableListenerId) {
+      qx.locale.Manager.getInstance().removeListenerById(
+        this.__changeLocaleTableListenerId
       );
     }
 

--- a/source/class/qx/ui/table/cellrenderer/Abstract.js
+++ b/source/class/qx/ui/table/cellrenderer/Abstract.js
@@ -38,7 +38,7 @@ qx.Class.define("qx.ui.table.cellrenderer.Abstract", {
 
       // add dynamic theme listener
       if (qx.core.Environment.get("qx.dyntheme")) {
-        qx.theme.manager.Meta.getInstance().addListener(
+        this.__changeThemeCellRendererListenerId = qx.theme.manager.Meta.getInstance().addListener(
           "changeTheme",
           this._onChangeTheme,
           this
@@ -242,11 +242,9 @@ qx.Class.define("qx.ui.table.cellrenderer.Abstract", {
 
   destruct() {
     // remove dynamic theme listener
-    if (qx.core.Environment.get("qx.dyntheme")) {
-      qx.theme.manager.Meta.getInstance().removeListener(
-        "changeTheme",
-        this._onChangeTheme,
-        this
+    if (qx.core.Environment.get("qx.dyntheme") && this.__changeThemeCellRendererListenerId) {
+      qx.theme.manager.Meta.getInstance().removeListenerById(
+        this.__changeThemeCellRendererListenerId
       );
     }
   }

--- a/source/class/qx/ui/table/cellrenderer/Boolean.js
+++ b/source/class/qx/ui/table/cellrenderer/Boolean.js
@@ -39,7 +39,7 @@ qx.Class.define("qx.ui.table.cellrenderer.Boolean", {
 
     // dynamic theme switch
     if (qx.core.Environment.get("qx.dyntheme")) {
-      qx.theme.manager.Meta.getInstance().addListener(
+      this.__changeThemeBoolCellRendererListenerId = qx.theme.manager.Meta.getInstance().addListener(
         "changeTheme",
         this._onChangeTheme,
         this
@@ -172,11 +172,9 @@ qx.Class.define("qx.ui.table.cellrenderer.Boolean", {
   destruct() {
     this.__aliasManager = null;
     // remove dynamic theme listener
-    if (qx.core.Environment.get("qx.dyntheme")) {
-      qx.theme.manager.Meta.getInstance().removeListener(
-        "changeTheme",
-        this._onChangeTheme,
-        this
+    if (qx.core.Environment.get("qx.dyntheme") && this.__changeThemeBoolCellRendererListenerId) {
+      qx.theme.manager.Meta.getInstance().removeListenerById(
+        this.__changeThemeBoolCellRendererListenerId
       );
     }
   }

--- a/source/class/qx/ui/table/rowrenderer/Default.js
+++ b/source/class/qx/ui/table/rowrenderer/Default.js
@@ -38,7 +38,7 @@ qx.Class.define("qx.ui.table.rowrenderer.Default", {
 
     // dynamic theme switch
     if (qx.core.Environment.get("qx.dyntheme")) {
-      qx.theme.manager.Meta.getInstance().addListener(
+      this.__changeThemeRowRendererListenerId = qx.theme.manager.Meta.getInstance().addListener(
         "changeTheme",
         this.initThemeValues,
         this
@@ -254,11 +254,9 @@ qx.Class.define("qx.ui.table.rowrenderer.Default", {
     this._colors = this._fontStyle = this._fontStyleString = null;
 
     // remove dynamic theme listener
-    if (qx.core.Environment.get("qx.dyntheme")) {
-      qx.theme.manager.Meta.getInstance().removeListener(
-        "changeTheme",
-        this.initThemeValues,
-        this
+    if (qx.core.Environment.get("qx.dyntheme") && this.__changeThemeRowRendererListenerId) {
+      qx.theme.manager.Meta.getInstance().removeListenerById(
+        this.__changeThemeRowRendererListenerId
       );
     }
   }


### PR DESCRIPTION
To fix https://github.com/qooxdoo/qooxdoo/issues/10620, change the storage of event listener callbacks from an Array to using a Map, keyed by the unique Id. I think I've made sure the exposed APIs return the same as before.

The real speed-up comes from them storing the unique IDs for the added listeners and then using those for the removal from the Map. This makes a huge difference where there are many listeners in the Array (Map now) for the `qx.theme.manager.Meta` or the `qx.locale.Manager` when dynamic theming or locales are enabled.