### PR TITLE
Fix for #10739

### DIFF
--- a/source/class/qx/io/exception/Transport.js
+++ b/source/class/qx/io/exception/Transport.js
@@ -23,6 +23,7 @@
 qx.Class.define("qx.io.exception.Transport", {
   extend: qx.io.exception.Exception,
   statics: {
+    FORWARDED: 0,
     TIMEOUT: 1,
     ABORTED: 2,
     NO_DATA: 3,

--- a/source/class/qx/io/jsonrpc/Client.js
+++ b/source/class/qx/io/jsonrpc/Client.js
@@ -157,8 +157,9 @@ qx.Class.define("qx.io.jsonrpc.Client", {
      * the default in v8: The returned promise is already resolved, and any rejection of the transport
      * promise will only be forwarded to the promise(s) of the request(s) contained in the the `message`
      * argument. The returned promise will never be rejected. This behavior can be enabled by setting
-     * the environment variable `qx.io.jsonrpc.forwardTransportPromiseRejectionToRequest` to `true` in v7,
-     * which will be deprecated in v8.
+     * the environment variable `qx.io.jsonrpc.forwardTransportPromiseRejectionToRequest` to `true` in v7.
+     * In v8, the default of `qx.io.jsonrpc.forwardTransportPromiseRejectionToRequest` will become `true`,
+     * and that environment variable will become deprecated.
      *
      * In any case, the result of the jsonrpc request is retrieved by awaiting {@link qx.io.jsonrpc.protocol.Request}'s
      * promise, which is resolved with the jsonrpc server's response or is rejected either  with a
@@ -400,8 +401,10 @@ qx.Class.define("qx.io.jsonrpc.Client", {
 
     /**
      * If true, forward transport errors to the running jsonrpc requests' promise instead of rejecting
-     * the promise returned by {@link #send}. Default is `false`. Behavior will change in v8 and this
-     * setting will be deprecated.
+     * the promise returned by {@link #send}. Default is `false`.
+
+     * @deprecated
+     * Behavior in v8 will be as if the environment variable value is `true`, but the environment variable will no longer be available.
      */
     "qx.io.jsonrpc.forwardTransportPromiseRejectionToRequest": false
   }

--- a/source/class/qx/io/jsonrpc/Client.js
+++ b/source/class/qx/io/jsonrpc/Client.js
@@ -262,7 +262,7 @@ qx.Class.define("qx.io.jsonrpc.Client", {
         // rethrow
         throw error;
       }
-      return 
+      return  result;
     },
 
     /**

--- a/source/class/qx/io/jsonrpc/Client.js
+++ b/source/class/qx/io/jsonrpc/Client.js
@@ -322,7 +322,7 @@ qx.Class.define("qx.io.jsonrpc.Client", {
       // handle the different message types
       if (message instanceof qx.io.jsonrpc.protocol.Result) {
         // resolve the individual promise
-        request.getPromise().resolve(message.getResult());
+        request.resolve(message.getResult());
       } else if (message instanceof qx.io.jsonrpc.protocol.Error) {
         let error = message.getError();
         let ex = new qx.io.exception.Protocol(
@@ -334,7 +334,7 @@ qx.Class.define("qx.io.jsonrpc.Client", {
         // inform listeners
         this.fireDataEvent("error", ex);
         // reject the individual promise
-        request.getPromise().reject(ex);
+        request.reject(ex);
       } else if (
         message instanceof qx.io.jsonrpc.protocol.Request ||
         message instanceof qx.io.jsonrpc.protocol.Notification

--- a/source/class/qx/io/jsonrpc/protocol/Request.js
+++ b/source/class/qx/io/jsonrpc/protocol/Request.js
@@ -69,16 +69,11 @@ qx.Class.define("qx.io.jsonrpc.protocol.Request", {
       id = ++qx.io.jsonrpc.protocol.Request.__current_request_id;
     }
     this.set({ id });
-    this.__promise = new qx.Promise((resolve, reject) => {
-      this.__promiseResolver = resolve;
-      this.__promiseRejector = reject;
-    });
+    this.__promise = new qx.Promise()
   },
 
   members: {
     __promise: null,
-    __promiseResolver: null,
-    __promiseRejector: null,
 
     /**
      * Getter for promise which resolves with the result to the request, if successful
@@ -88,21 +83,6 @@ qx.Class.define("qx.io.jsonrpc.protocol.Request", {
       return this.__promise;
     },
 
-    /**
-     * Resolves this request's Promise externally with a value
-     * @param {*} value
-     */
-    resolve(value) {
-      this.__promiseResolver(value);
-    },
-
-    /**
-     * Rejects this request's Promise externally with an error object
-     * @param {*} error
-     */
-    reject(error) {
-      this.__promiseRejector(error);
-    },
 
     /**
      * Determines how an exception during transport is handled. Standard
@@ -112,7 +92,7 @@ qx.Class.define("qx.io.jsonrpc.protocol.Request", {
      * @param {qx.io.exception.Transport} exception
      */
     handleTransportException(exception) {
-      this.__promiseRejector(exception);
+      this.__promise.reject(exception);
     }
   }
 });

--- a/source/class/qx/io/jsonrpc/protocol/Request.js
+++ b/source/class/qx/io/jsonrpc/protocol/Request.js
@@ -69,7 +69,7 @@ qx.Class.define("qx.io.jsonrpc.protocol.Request", {
       id = ++qx.io.jsonrpc.protocol.Request.__current_request_id;
     }
     this.set({ id });
-    this.__promise = new qx.Promise()
+    this.__promise = new qx.Promise();
   },
 
   members: {

--- a/source/class/qx/io/jsonrpc/protocol/Request.js
+++ b/source/class/qx/io/jsonrpc/protocol/Request.js
@@ -30,12 +30,6 @@ qx.Class.define("qx.io.jsonrpc.protocol.Request", {
     __current_request_id: 0,
 
     /**
-     * Which Promise constructor to use. Defaults to `qx.Promise
-     * Will switch to the native `Promise` for qooxdoo 8.0
-     */
-    __Promise_constructor: qx.Promise,
-
-    /**
      * Returns the current request id
      * @returns {Number}
      */
@@ -48,16 +42,6 @@ qx.Class.define("qx.io.jsonrpc.protocol.Request", {
      */
     resetId() {
       qx.io.jsonrpc.protocol.Request.__current_request_id = 0;
-    },
-
-    /**
-     * The default Promise constructor used in qx 7 is qx.Promise. Unfortunately,
-     * it has a bug/incompatibiity that leads to uncaught promise rejection errors
-     * Use call this static method to use the native Promise object instead. This
-     * will be the default in qooxdoo 8.0, when this function will we deprecated.
-     */
-    useNativePromise() {
-      qx.io.jsonrpc.protocol.Request.__Promise_constructor = Promise;
     }
   },
 
@@ -85,9 +69,7 @@ qx.Class.define("qx.io.jsonrpc.protocol.Request", {
       id = ++qx.io.jsonrpc.protocol.Request.__current_request_id;
     }
     this.set({ id });
-    const PromiseConstructor =
-      qx.io.jsonrpc.protocol.Request.__Promise_constructor;
-    this.__promise = new PromiseConstructor((resolve, reject) => {
+    this.__promise = new qx.Promise((resolve, reject) => {
       this.__promiseResolver = resolve;
       this.__promiseRejector = reject;
     });

--- a/source/class/qx/test/io/jsonrpc/Client.js
+++ b/source/class/qx/test/io/jsonrpc/Client.js
@@ -31,8 +31,6 @@ qx.Class.define("qx.test.io.jsonrpc.Client", {
       this.setUpRequest();
       this.setUpFakeTransport();
       qx.io.jsonrpc.protocol.Request.resetId();
-      // qx.Promise has a bug/incompatibiity that leads to uncaught promise rejection errors
-      qx.io.jsonrpc.protocol.Request.useNativePromise();
     },
 
     setUpRequest() {

--- a/source/class/qx/test/io/jsonrpc/Client.js
+++ b/source/class/qx/test/io/jsonrpc/Client.js
@@ -133,14 +133,14 @@ qx.Class.define("qx.test.io.jsonrpc.Client", {
       this.wait(100, () => {
         // in case of a transport error, ...
         const n = qx.core.Environment.select("qx.io.jsonrpc.forwardTransportPromiseRejectionToRequest", {
-          true: 1, // ... we are rejecting the request promise instead of the transport promise
-          false: 2 // ... both request promise and transport promise are rejected
+          true: 1, // ... we are rejecting the request promise only, v8 default
+          false: 2 // ... both request promise and transport promise are rejected, v7 default
         })
         if (
-          // the request promise will not be called since the promise is already rejected
+          // the request promise will not be rejected because it already is rejected in this special case
           exception === qx.io.exception.Transport.DUPLICATE_ID ||
-          // or the send promise will not be rejected because we have a server-side error
-          exception === qx.io.exception.Protocol
+          // or the send promise will not be rejected because we have a server-side error, v7 default only
+          (exception === qx.io.exception.Protocol && !qx.core.Environment.get("qx.io.jsonrpc.forwardTransportPromiseRejectionToRequest"))
         ) {
           this.assertCallCount(errorCallback, n);
         } else {

--- a/source/class/qx/test/io/jsonrpc/Protocol.js
+++ b/source/class/qx/test/io/jsonrpc/Protocol.js
@@ -25,11 +25,7 @@ qx.Class.define("qx.test.io.jsonrpc.Protocol", {
   },
   members: {
     "test: JSON-RPC request message object"() {
-      let message = new qx.io.jsonrpc.protocol.Request("foo", [
-        "bar",
-        1,
-        false
-      ]);
+      let message = new qx.io.jsonrpc.protocol.Request("foo", ["bar",1,false], 1);
 
       let expected = {
         id: 1,


### PR DESCRIPTION
This rewrites part of `qx.io.jsonrpc.(Client|Request)` in order to fix some incorrect Promise handling. ~~However, the bug cannot be fully fixed with the current use of `qx.Promise`, which has a bug/incompatibility that produces the "unhandled rejection" error. To make current code work, it is necessary to add `qx.io.jsonrpc.protocol.Request.useNativePromise();` to your code, which has been introduced to be able to switch to the native Promise implementation without breaking compatibility (although I very much doubt that anyone has been relying on this dependency). In qooxdoo 8.0, the implementation will use the native `Promise` implementation by default and this method will be deprecated.~~  See https://github.com/qooxdoo/qooxdoo/issues/10739#issuecomment-2581947780 for an update on the causes of the bug.