### PR TITLE
Allow runtime environment mutations for testing (issue 10747)

### DIFF
--- a/source/class/qx/core/Environment.js
+++ b/source/class/qx/core/Environment.js
@@ -913,7 +913,8 @@ qx.Bootstrap.define("qx.core.Environment", {
       "qx.promise.warnings": true,
       "qx.promise.longStackTraces": true,
       "qx.command.bindEnabled": false,
-      "qx.headless": false
+      "qx.headless": false,
+      "qx.environment.allowRuntimeMutations": false
     },
 
     /**
@@ -1210,6 +1211,63 @@ qx.Bootstrap.define("qx.core.Environment", {
       return this._asyncChecks;
     },
 
+    // mutation of environment settings at runtime
+
+    /**
+     * Sets the environment setting for the given key to the given value. This method is only available if
+     * "qx.environment.allowRuntimeMutations" is set to true.
+     *
+     * @param key {String} The key of the environment setting to set.
+     * @param value {var} The value to set the environment setting to.
+     */
+    set: qx.Bootstrap.getEnvironmentSetting("qx.environment.allowRuntimeMutations") ? function(key, value) {
+      if (key === undefined) {
+        throw new TypeError("Key must be provided to set an environment setting.");
+      }
+      if (this.$$environmentBackup === undefined) {
+        qx.Bootstrap.warn("Modifying environment settings at runtime is enabled. This is a security risk and should not be done in production code.");
+        this.$$environmentBackup = Object.assign({}, this.__cache);
+      }
+      this.__cache[key] = value;
+    }: undefined,
+
+    /**
+     * Removes the environment setting for the given key. This method is only available if "qx.environment.allowRuntimeMutations" is set to true.
+     *
+     * @param key {String} The key of the environment setting to remove.
+     */
+    remove: qx.Bootstrap.getEnvironmentSetting("qx.environment.allowRuntimeMutations") ? function(key) {
+      if (key === undefined) {
+        throw new TypeError("Key must be provided to remove an environment setting.");
+      }
+      if (this.$$environmentBackup === undefined || this.$$environmentBackup[key] === undefined) {
+        throw new TypeError(`Environment setting "${key}" does not exist.`);
+      }
+      delete this.__cache[key];
+    }: undefined,
+
+    /**
+     * Resets the environment settings to their original values. If a key is provided, only that key is reset.
+     * This method is only available if "qx.environment.allowRuntimeMutations" is set to true.
+     *
+     * @param key {String?} The key of the environment setting to reset. If not provided, all settings are reset.
+     */
+    reset: qx.Bootstrap.getEnvironmentSetting("qx.environment.allowRuntimeMutations") ? function(key) {
+      if (this.$$environmentBackup === undefined) {
+        // no backup available, nothing to reset
+        return;
+      }
+      if (key !== undefined && this.$$environmentBackup[key] === undefined) {
+        throw new TypeError(`Environment setting "${key}" does not exist.`);
+        return;
+      }
+      if (key === undefined) {
+        this.__cache = this.$$environmentBackup;
+        return;
+      }
+      this.__cache[key] = this.$$environmentBackup[key];
+    }: undefined,
+
     /**
      * Initializer for the default values of the framework settings.
      */
@@ -1296,5 +1354,17 @@ qx.Bootstrap.define("qx.core.Environment", {
     if (statics.get("qx.allowUrlSettings") === true) {
       statics.__importFromUrl();
     }
+  },
+
+  environment: {
+    /**
+     * By setting this key to true, the environment variables can be mutated at runtime, using the {@link #set} method,
+     * which is otherwise not available. This is only useful for testing and debugging purposes. We strongly advise
+     * against enabling this in production code. You have been warned.
+     * Note: This enviroment key declaration is only for documentation purposes and is not used during bootstrapping, so
+     * changing the value here will have no effect.
+     */
+    "qx.environment.allowRuntimeMutations": false,
   }
+
 });

--- a/source/class/qx/core/Environment.js
+++ b/source/class/qx/core/Environment.js
@@ -1214,25 +1214,31 @@ qx.Bootstrap.define("qx.core.Environment", {
     // mutation of environment settings at runtime
 
     /**
-     * Sets the environment setting for the given key to the given value. This method is only available if
-     * "qx.environment.allowRuntimeMutations" is set to true.
+     * Sets the environment setting for the given key to the given value. This deletes any check function
+     * associated with this key. 
+     * 
+     * This method is only available if "qx.environment.allowRuntimeMutations" is set to true.
      *
      * @param key {String} The key of the environment setting to set.
-     * @param value {var} The value to set the environment setting to.
+     * @param value {var} The value to set the environment setting to. Must be a scalar value.
      */
     set: qx.Bootstrap.getEnvironmentSetting("qx.environment.allowRuntimeMutations") ? function(key, value) {
       if (key === undefined) {
         throw new TypeError("Key must be provided to set an environment setting.");
       }
-      if (this.$$environmentBackup === undefined) {
+      if (this.__environmentBackup === undefined) {
         qx.Bootstrap.warn("Modifying environment settings at runtime is enabled. This is a security risk and should not be done in production code.");
-        this.$$environmentBackup = Object.assign({}, this.__cache);
+        this.__environmentBackup = Object.assign({}, this.__cache);
+        this.__checksBackup = Object.assign({}, this._checks);
       }
       this.__cache[key] = value;
+      delete this._checks[key];
+      delete this._checksMap[key];
     }: undefined,
 
     /**
-     * Removes the environment setting for the given key. This method is only available if "qx.environment.allowRuntimeMutations" is set to true.
+     * Removes the environment setting for the given key, and any check function associated with it. 
+     * This method is only available if "qx.environment.allowRuntimeMutations" is set to true.
      *
      * @param key {String} The key of the environment setting to remove.
      */
@@ -1240,10 +1246,12 @@ qx.Bootstrap.define("qx.core.Environment", {
       if (key === undefined) {
         throw new TypeError("Key must be provided to remove an environment setting.");
       }
-      if (this.$$environmentBackup === undefined || this.$$environmentBackup[key] === undefined) {
+      if (this.__environmentBackup === undefined || this.__environmentBackup[key] === undefined) {
         throw new TypeError(`Environment setting "${key}" does not exist.`);
       }
       delete this.__cache[key];
+      delete this._checks[key];
+      delete this._checksMap[key];
     }: undefined,
 
     /**
@@ -1253,19 +1261,23 @@ qx.Bootstrap.define("qx.core.Environment", {
      * @param key {String?} The key of the environment setting to reset. If not provided, all settings are reset.
      */
     reset: qx.Bootstrap.getEnvironmentSetting("qx.environment.allowRuntimeMutations") ? function(key) {
-      if (this.$$environmentBackup === undefined) {
+      if (this.__environmentBackup === undefined) {
         // no backup available, nothing to reset
         return;
       }
-      if (key !== undefined && this.$$environmentBackup[key] === undefined) {
+      if (key !== undefined && this.__environmentBackup[key] === undefined) {
         throw new TypeError(`Environment setting "${key}" does not exist.`);
         return;
       }
       if (key === undefined) {
-        this.__cache = this.$$environmentBackup;
+        // reset all keys
+        this.__cache = Object.assign({}, this.__environmentBackup);
+        this._checks = Object.assign({}, this.__checksBackup);
         return;
       }
-      this.__cache[key] = this.$$environmentBackup[key];
+      // only reset the particular key 
+      this.__cache[key] = this.__environmentBackup[key];
+      this._checks[key] = this.__checksBackup[key];
     }: undefined,
 
     /**

--- a/source/class/qx/core/Environment.js
+++ b/source/class/qx/core/Environment.js
@@ -1267,7 +1267,6 @@ qx.Bootstrap.define("qx.core.Environment", {
       }
       if (key !== undefined && this.__environmentBackup[key] === undefined) {
         throw new TypeError(`Environment setting "${key}" does not exist.`);
-        return;
       }
       if (key === undefined) {
         // reset all keys

--- a/source/class/qx/test/core/Environment.js
+++ b/source/class/qx/test/core/Environment.js
@@ -537,6 +537,49 @@ qx.Class.define("qx.test.core.Environment", {
 
       // 3d transform support
       this.assertBoolean(qx.core.Environment.get("css.transform.3d"));
+    },
+
+    /**
+     * This test is only run if "qx.environment.allowRuntimeMutations" is false which you need to
+     * manually set in the test runner configuration.
+     */
+    testRuntimeMutationsIfNotAvailable() {
+      if (qx.core.Environment.get("qx.environment.allowRuntimeMutations") === false) {
+        // the mutation methods should not be available
+        for (let key in ['set', 'remove', 'reset']) {
+          this.assertUndefined(qx.core.Environment[key], `The method "qx.core.Environment.${key}()" should not be available.`);
+        }
+      } else {
+        this.skip("Runtime mutations are enabled.");
+      }
+    },
+
+    testRuntimeMutationsIfAvailable() {
+      if (qx.core.Environment.get("qx.environment.allowRuntimeMutations") === false) {
+        this.skip("Runtime mutations are disabled.");
+      }
+      // compile-time environment
+      const qxVersion = qx.core.Environment.get("qx.version");
+      qx.core.Environment.set("qx.version", "1.0");
+      this.assertEquals("1.0", qx.core.Environment.get("qx.version"));
+      qx.core.Environment.reset("qx.version");
+      this.assertEquals(qxVersion, qx.core.Environment.get("qx.version"));
+      qx.core.Environment.remove("qx.version");
+      this.assertUndefined(qx.core.Environment.get("qx.version"));
+
+      // runtime environment
+      const browserName = qx.core.Environment.get("browser.name");
+      qx.core.Environment.set("browser.name", "lynx");
+      this.assertEquals("lynx", qx.core.Environment.get("browser.name"));
+      qx.core.Environment.reset("browser.name");
+      this.assertEquals(browserName, qx.core.Environment.get("browser.name"));
+      qx.core.Environment.remove("browser.name");
+      this.assertUndefined(qx.core.Environment.get("browser.name"));
+
+      // cleanup
+      qx.core.Environment.reset();
+      this.assertEquals(qxVersion, qx.core.Environment.get("qx.version"));
+      this.assertEquals(browserName, qx.core.Environment.get("browser.name"));
     }
   }
 });

--- a/source/class/qx/test/core/Environment.js
+++ b/source/class/qx/test/core/Environment.js
@@ -557,6 +557,7 @@ qx.Class.define("qx.test.core.Environment", {
     testRuntimeMutationsIfAvailable() {
       if (qx.core.Environment.get("qx.environment.allowRuntimeMutations") === false) {
         this.skip("Runtime mutations are disabled.");
+        return;
       }
       // compile-time environment
       const qxVersion = qx.core.Environment.get("qx.version");

--- a/source/class/qx/tool/compiler/ClassFile.js
+++ b/source/class/qx/tool/compiler/ClassFile.js
@@ -28,7 +28,6 @@ var babelCore = require("@babel/core");
 var types = require("@babel/types");
 var babylon = require("@babel/parser");
 var async = require("async");
-const e = require("express");
 
 var log = qx.tool.utils.LogManager.createLog("analyser");
 

--- a/source/class/qx/tool/compiler/ClassFile.js
+++ b/source/class/qx/tool/compiler/ClassFile.js
@@ -28,6 +28,7 @@ var babelCore = require("@babel/core");
 var types = require("@babel/types");
 var babylon = require("@babel/parser");
 var async = require("async");
+const e = require("express");
 
 var log = qx.tool.utils.LogManager.createLog("analyser");
 
@@ -962,14 +963,15 @@ qx.Class.define("qx.tool.compiler.ClassFile", {
 
         CallExpression(path) {
           const name = collapseMemberExpression(path.node.callee);
+          const env = t.__analyser.getEnvironment();
 
           if (
+            env["qx.environment.allowRuntimeMutations"] !== true &&
             (name === "qx.core.Environment.select" ||
               name === "qx.core.Environment.get") &&
-            types.isLiteral(path.node.arguments[0])
+            types.isLiteral(path.node.arguments[0]) 
           ) {
             const arg = path.node.arguments[0];
-            const env = t.__analyser.getEnvironment();
             const envValue = env[arg.value];
 
             if (envValue !== undefined) {

--- a/test/framework/compile.json
+++ b/test/framework/compile.json
@@ -42,7 +42,8 @@
       "environment": {
         "qx.icontheme": "Tango",
         "qxl.testtapper.testNameSpace": "qx.test",
-        "qxl.testtapper.browsers": ["chromium"]
+        "qxl.testtapper.browsers": ["chromium"],
+        "qx.environment.allowRuntimeMutations": true
       },
       "include": [
         "qx.test.*"


### PR DESCRIPTION
Fixes #10747

@johnspackman In the compiler, I have added an exception for environment value optimization if "qx.environment.allowRuntimeMutations" is true. This is enough to implement the feature. If you want to change the behaviour more generally, I can wait for that or you'll later modify my addition. 