### PR TITLE
Fix " The environment key 'qx.test.delay.scale' is undefined."  warning

### DIFF
--- a/source/class/qx/dev/unit/AsyncWrapper.js
+++ b/source/class/qx/dev/unit/AsyncWrapper.js
@@ -85,5 +85,13 @@ qx.Class.define("qx.dev.unit.AsyncWrapper", {
       nullable: false,
       init: 10000
     }
+  },
+
+  environment: {
+    /**
+     * The factor by which any delay is multiplied or false or zero if no such
+     * factor should be applied.
+     */
+    "qx.test.delay.scale": false
   }
 });


### PR DESCRIPTION
During the running of the framework tests, the warning " The environment key 'qx.test.delay.scale' is undefined." often pops up. The key seems to be only used in `qx.dev.unit.AsyncWrapper.js`, and no default value is given. This PR adds a default `false` - it could also be `0` but that could be misunderstood to set all delays to 0, which is not the case (the factor is ignored on zero). 