### PR TITLE
fastFail for lint

### DIFF
--- a/.github/workflows/test-framework.yml
+++ b/.github/workflows/test-framework.yml
@@ -28,7 +28,6 @@ jobs:
       matrix:
         os: [ubuntu-latest, windows-latest]
         node-version: [18.x, 20.x, 22.x]
-        browser: [chromium, firefox]
 
     steps:
       - name: checkout
@@ -43,4 +42,4 @@ jobs:
         run:  npm  ci
 
       - name: install and run tests with ${{ matrix.browser }}
-        run:  npm test -- --browsers=${{ matrix.browser }} --terse --headless --set-env qx.test.delay.scale=10
+        run:  npm test -- --browsers=chromium,firefox --terse --headless --set-env qx.test.delay.scale=10

--- a/.github/workflows/test-framework.yml
+++ b/.github/workflows/test-framework.yml
@@ -14,16 +14,12 @@ on:
     types: 
       - opened
       - reopened
-    paths:
-      - 'compile.*'
-      - 'source/**'
-      - 'test/**'
 
   workflow_dispatch:
 
 jobs:
   test:
-    name: ${{ matrix.os }}, node ${{ matrix.node-version }}, ${{ matrix.browser }}
+    name: ${{ matrix.os }}, node ${{ matrix.node-version }}
     runs-on: ${{ matrix.os }}
     if: "!contains(github.event.head_commit.message, 'skip ci')"
 
@@ -44,6 +40,6 @@ jobs:
       - name: install dependencies
         run:  npm  ci
 
-      - name: install and run tests with ${{ matrix.browser }}
+      - name: install and run tests
         run:  npm test -- --browsers=chromium,firefox,webkit --terse --headless --set-env qx.test.delay.scale=10
         shell: bash

--- a/.github/workflows/test-framework.yml
+++ b/.github/workflows/test-framework.yml
@@ -42,4 +42,5 @@ jobs:
         run:  npm  ci
 
       - name: install and run tests with ${{ matrix.browser }}
-        run:  npm test -- --browsers=chromium,firefox --terse --headless --set-env qx.test.delay.scale=10
+        run:  npm test -- --browsers=chromium,firefox,webkit --terse --headless --set-env qx.test.delay.scale=10
+        shell: bash

--- a/.github/workflows/test-framework.yml
+++ b/.github/workflows/test-framework.yml
@@ -11,6 +11,9 @@ on:
       - 'test/**'
 
   pull_request:
+    types: 
+      - opened
+      - reopened
     paths:
       - 'compile.*'
       - 'source/**'

--- a/.github/workflows/test-framework.yml
+++ b/.github/workflows/test-framework.yml
@@ -42,5 +42,5 @@ jobs:
         run:  npm  ci
 
       - name: install and run tests with ${{ matrix.browser }}
-        run:  npm test -- --browsers=chromium,firefox,webkit --terse --set-env qx.test.delay.scale=10
+        run:  npm test -- --browsers=chromium,firefox,webkit --terse --headless --set-env qx.test.delay.scale=10
         shell: bash

--- a/.github/workflows/test-framework.yml
+++ b/.github/workflows/test-framework.yml
@@ -42,5 +42,5 @@ jobs:
         run:  npm  ci
 
       - name: install and run tests with ${{ matrix.browser }}
-        run:  npm test -- --browsers=chromium,firefox,webkit --terse --headless --set-env qx.test.delay.scale=10
+        run:  npm test -- --browsers=chromium,firefox,webkit --terse --set-env qx.test.delay.scale=10
         shell: bash

--- a/.github/workflows/test-framework.yml
+++ b/.github/workflows/test-framework.yml
@@ -27,8 +27,8 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, windows-latest]
-        node-version: [16.x, 18.x, 19.x]
-        browser: [chromium]
+        node-version: [18.x, 20.x, 22.x]
+        browser: [chromium, firefox]
 
     steps:
       - name: checkout

--- a/compile.js
+++ b/compile.js
@@ -135,7 +135,6 @@ qx.Class.define("qx.compiler.CompilerApi", {
         cwd: ".",
         cmd: "npm",
         args: args,
-        shell: true,
         env: env,
         log: console.log,
         error: console.log
@@ -191,13 +190,16 @@ qx.Class.define("qx.compiler.CompilerApi", {
       command.addTest(
         new qx.tool.cli.api.Test("compiler test", async function () {
           qx.tool.compiler.Console.log("# ******** running compiler test");
-          result = await qx.tool.utils.Utils.runCommand({
+          let args = argList;
+          let curArgs = that.__getArgs(command, args);
+          if (command.argv.verbose) {
+             console.log(curArgs);
+          }
+        result = await qx.tool.utils.Utils.runCommand({
             cwd: "test/tool",
             cmd: "node",
-            args: that.__getArgs(command, argList),
-            shell: true
+            args: curArgs
           });
-
           this.setExitCode(result.exitCode);
         })
       );
@@ -205,16 +207,20 @@ qx.Class.define("qx.compiler.CompilerApi", {
         command.addTest(
           new qx.tool.cli.api.Test("framework test", async function () {
             console.log("# ******** running framework test");
+            this.setFailFast(true);  
             let args = argList.slice();
             args.push("browsers");
             args.push("headless");
+            let curArgs = that.__getArgs(command, args);
+            curArgs.push("--fail-fast");
+            if (command.argv.verbose) {
+               console.log(curArgs);
+            }
             result = await qx.tool.utils.Utils.runCommand({
               cwd: "test/framework",
               cmd: "node",
-              args: that.__getArgs(command, args),
-              shell: true
+              args: curArgs
             });
-
             this.setExitCode(result.exitCode);
           })
         );

--- a/compile.js
+++ b/compile.js
@@ -152,6 +152,7 @@ qx.Class.define("qx.compiler.CompilerApi", {
       command.addTest(
         new qx.tool.cli.api.Test("lint", async function () {
           console.log("# ********* running lint ");
+          this.setFailFast(true);  
           result = await qx.tool.utils.Utils.runCommand({
             cwd: ".",
             cmd: "node",

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -5158,9 +5158,10 @@
       }
     },
     "node_modules/dset": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/dset/-/dset-3.1.2.tgz",
-      "integrity": "sha512-g/M9sqy3oHe477Ar4voQxWtaPIFw1jTdKZuomOjhCcBx9nHUNn0pu6NopuFFrTh/TRZIKEj+76vLWFu9BNKk+Q==",
+      "version": "3.1.4",
+      "resolved": "https://registry.npmjs.org/dset/-/dset-3.1.4.tgz",
+      "integrity": "sha512-2QF/g9/zTaPDc3BjNcVTGoBbXBgYfMTTceLaYcFJ/W9kggFUkhxD/hMEeuLKbugyef9SqAx8cpgwlIP/jinUTA==",
+      "license": "MIT",
       "engines": {
         "node": ">=4"
       }
@@ -5199,9 +5200,10 @@
       "integrity": "sha512-eS5t4ulWOBfVHdq9SW2dxEaFarj1lPjvJ8PaYMOjY0DecBaj/t4ARziL2IPpDr4atyWwjLFGQ2vo/VCgQFezVQ=="
     },
     "node_modules/elliptic": {
-      "version": "6.5.5",
-      "resolved": "https://registry.npmjs.org/elliptic/-/elliptic-6.5.5.tgz",
-      "integrity": "sha512-7EjbcmUm17NQFu4Pmgmq2olYMj8nwMnpcddByChSUjArp8F5DQWcIcpriwO4ZToLNAJig0yiyjswfyGNje/ixw==",
+      "version": "6.6.1",
+      "resolved": "https://registry.npmjs.org/elliptic/-/elliptic-6.6.1.tgz",
+      "integrity": "sha512-RaddvvMatK2LJHqFJ+YA4WysVN5Ita9E35botqIYspQ4TkRAlCicdzKOjlyv/1Za5RyTNn7di//eEV0uTAfe3g==",
+      "license": "MIT",
       "dependencies": {
         "bn.js": "^4.11.9",
         "brorand": "^1.1.0",
@@ -8083,11 +8085,12 @@
       }
     },
     "node_modules/micromatch": {
-      "version": "4.0.5",
-      "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.5.tgz",
-      "integrity": "sha512-DMy+ERcEW2q8Z2Po+WNXuw3c5YaUSFjAO5GsJqfEl7UjvtIuFKO6ZrKvcItdy98dwFI2N1tg3zNIdKaQT+aNdA==",
+      "version": "4.0.8",
+      "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.8.tgz",
+      "integrity": "sha512-PXwfBhYu0hBCPw8Dn0E+WDYb7af3dSLVWKi3HGv84IdF4TyFoC0ysxFd0Goxw7nSv4T/PzEJQxsYsEiFCKo2BA==",
+      "license": "MIT",
       "dependencies": {
-        "braces": "^3.0.2",
+        "braces": "^3.0.3",
         "picomatch": "^2.3.1"
       },
       "engines": {

--- a/source/class/qx/test/bom/client/Pdfjs.js
+++ b/source/class/qx/test/bom/client/Pdfjs.js
@@ -31,11 +31,11 @@ qx.Class.define("qx.test.bom.client.Pdfjs", {
 
   members: {
     "test: is PDF.js available"() {
+      this.require(["firefox"]);
+
       if (navigator.plugins.length == 0) {
         this.skip("test disabled on headless browsers");
       }
-
-      this.require(["firefox"]);
 
       qx.core.Environment.getAsync(
         "plugin.pdfjs",

--- a/source/class/qx/test/bom/client/Pdfjs.js
+++ b/source/class/qx/test/bom/client/Pdfjs.js
@@ -31,6 +31,10 @@ qx.Class.define("qx.test.bom.client.Pdfjs", {
 
   members: {
     "test: is PDF.js available"() {
+      if (navigator.plugins.length == 0) {
+        this.skip("test disabled on headless browsers");
+      }
+
       this.require(["firefox"]);
 
       qx.core.Environment.getAsync(

--- a/source/class/qx/test/bom/element/AnimationJs.js
+++ b/source/class/qx/test/bom/element/AnimationJs.js
@@ -66,6 +66,9 @@ qx.Class.define("qx.test.bom.element.AnimationJs", {
       if (qx.core.Environment.get("browser.name") == "chrome") {
         throw new qx.dev.unit.RequirementError();
       }
+      if (qx.core.Environment.get("browser.name") == "safari") {
+        throw new qx.dev.unit.RequirementError();
+      }
 
       var handle = qx.bom.element.Animation.animate(this.__el, {
         duration: 100,

--- a/source/class/qx/test/bom/element/Style.js
+++ b/source/class/qx/test/bom/element/Style.js
@@ -98,6 +98,7 @@ qx.Class.define("qx.test.bom.element.Style", {
         qx.core.Environment.get("browser.version") < 6;
 
       if (
+        engine == "gecko" ||
         engine == "opera" ||
         (engine == "webkit" &&
           !isOldSafari &&

--- a/source/class/qx/test/bom/media/MediaTestCase.js
+++ b/source/class/qx/test/bom/media/MediaTestCase.js
@@ -202,6 +202,12 @@ qx.Class.define("qx.test.bom.media.MediaTestCase", {
           "HTML5 audio/video playback must be triggered by user interaction in Chrome on Android."
         );
       }
+      if (qx.core.Environment.get("browser.name") == "safari") {
+        this.skip(
+          "we can not detect headless mode in safari"
+        );
+      }
+
       this.assertTrue(this._media.isPaused());
 
       this._media.addListener("play", e => {

--- a/source/class/qx/test/io/jsonrpc/Client.js
+++ b/source/class/qx/test/io/jsonrpc/Client.js
@@ -380,7 +380,7 @@ qx.Class.define("qx.test.io.jsonrpc.Client", {
       });
       sendRequest();
       this.wait(
-        100,
+        250,
         function () {
           this.assertCalledTwice(sendRequest);
           this.assertCalledOnce(successCallback);

--- a/source/class/qx/test/ui/embed/Iframe.js
+++ b/source/class/qx/test/ui/embed/Iframe.js
@@ -145,7 +145,7 @@ qx.Class.define("qx.test.ui.embed.Iframe", {
             this.assertEquals("Hello World!", innerText);
           });
         }.bind(this),
-        4000
+        5000
       );
 
       this.wait(10000);

--- a/source/class/qx/test/ui/form/TextArea.js
+++ b/source/class/qx/test/ui/form/TextArea.js
@@ -267,9 +267,6 @@ qx.Class.define("qx.test.ui.form.TextArea", {
       if (!this.__supportsLiveWrap()) {
         this.skip();
       }
-      if (navigator.plugins.length == 0) {
-        this.skip("test disabled on headless browsers");
-      }
 
       var textArea = this.__textArea;
       textArea.setAutoSize(true);
@@ -295,6 +292,10 @@ qx.Class.define("qx.test.ui.form.TextArea", {
       this.require(["noBuggyIe"]);
       if (!this.__supportsLiveWrap()) {
         this.skip();
+      }
+
+      if ((qx.core.Environment.get("engine.name") === "gecko") && (navigator.plugins.length == 0)) {
+        this.skip("test disabled on headless firefox browser");
       }
 
       var textArea = this.__textArea;

--- a/source/class/qx/test/ui/form/TextArea.js
+++ b/source/class/qx/test/ui/form/TextArea.js
@@ -267,6 +267,9 @@ qx.Class.define("qx.test.ui.form.TextArea", {
       if (!this.__supportsLiveWrap()) {
         this.skip();
       }
+      if (navigator.plugins.length == 0) {
+        this.skip("test disabled on headless browsers");
+      }
 
       var textArea = this.__textArea;
       textArea.setAutoSize(true);

--- a/source/class/qx/test/util/DeferredCall.js
+++ b/source/class/qx/test/util/DeferredCall.js
@@ -24,6 +24,12 @@ qx.Class.define("qx.test.util.DeferredCall", {
       if (navigator.plugins.length == 0) {
         this.skip("test disabled on headless browsers");
       }
+      
+      if (qx.core.Environment.get("browser.name") == "safari") {
+        this.skip(
+          "we can not detect headless mode in safari"
+        );
+      }
 
       var fail = function () {
         throw new Error("fail");

--- a/source/class/qx/test/util/Function.js
+++ b/source/class/qx/test/util/Function.js
@@ -30,7 +30,7 @@ qx.Class.define("qx.test.util.Function", {
       this.assertNotCalled(test);
       debouncedTest(false);
       this.wait(
-        100,
+        250,
         function () {
           this.assertCalledOnce(test);
           this.assertCalledWith(test, false);
@@ -52,7 +52,7 @@ qx.Class.define("qx.test.util.Function", {
       debouncedTest(true);
       debouncedTest(false);
       this.wait(
-        100,
+        250,
         function () {
           this.assertCalledTwice(test);
           this.assertCalledWith(test, false);

--- a/source/class/qx/tool/cli/api/Test.js
+++ b/source/class/qx/tool/cli/api/Test.js
@@ -1,3 +1,16 @@
+/* ************************************************************************
+
+   qooxdoo - the new era of web development
+
+   http://qooxdoo.org
+
+   Copyright:
+     2020 Henner Kollmann
+
+   License:
+     MIT: https://opensource.org/licenses/MIT
+     See the LICENSE file in the project"s top-level directory for details.
+************************************************************************ */
 /**
  * This is used to add an test case for qx test
  */
@@ -45,6 +58,15 @@ qx.Class.define("qx.tool.cli.api.Test", {
       check: "Boolean",
       nullable: false,
       init: true
+    },
+
+    /**
+     * If this special test fails exit process
+     */
+    failFast: {
+      check: "Boolean",
+      nullable: false,
+      init: false
     },
 
     /**

--- a/source/class/qx/tool/cli/commands/Test.js
+++ b/source/class/qx/tool/cli/commands/Test.js
@@ -152,6 +152,9 @@ qx.Class.define("qx.tool.cli.commands.Test", {
         }
         // overwrite error code only in case of errors
         if (exitCode !== 0) {
+          if (test.getFailFast()) {
+            process.exit(exitCode);
+          }  
           this.setExitCode(exitCode);
         }
       });

--- a/source/class/qx/tool/cli/commands/Test.js
+++ b/source/class/qx/tool/cli/commands/Test.js
@@ -99,7 +99,7 @@ qx.Class.define("qx.tool.cli.commands.Test", {
       let exitCode = evt.getData();
       // overwrite error code only in case of errors
       if (exitCode !== 0 && argv.failFast) {
-        process.exit(exitCode);
+        process.exit(Math.min(255, exitCode));
       }
     });
   },
@@ -153,7 +153,7 @@ qx.Class.define("qx.tool.cli.commands.Test", {
         // overwrite error code only in case of errors
         if (exitCode !== 0) {
           if (test.getFailFast()) {
-            process.exit(exitCode);
+            this.argv.failFast = true;
           }  
           this.setExitCode(exitCode);
         }
@@ -197,6 +197,9 @@ qx.Class.define("qx.tool.cli.commands.Test", {
 
       this.addListener("afterStart", async () => {
         qx.tool.compiler.Console.info(`Running unit tests`);
+        if (this.argv.verbose) {
+          console.log(this.argv);
+        }
         await this.fireDataEventAsync("runTests", this);
         if (
           this.getCompilerApi() &&

--- a/test/framework/package.json
+++ b/test/framework/package.json
@@ -1,6 +1,6 @@
 {
   "dependencies": {
-    "playwright": "^1.40.1",
+    "playwright": "^1.49.1",
     "v8-to-istanbul": "^9.2.0"
   }
 }

--- a/test/framework/package.json
+++ b/test/framework/package.json
@@ -1,6 +1,6 @@
 {
   "dependencies": {
     "playwright": "^1.49.1",
-    "v8-to-istanbul": "^9.2.0"
+    "v8-to-istanbul": "^9.3.0"
   }
 }

--- a/test/framework/qx-lock.json
+++ b/test/framework/qx-lock.json
@@ -2,11 +2,11 @@
   "libraries": [
     {
       "library_name": "Commandline Testrunner for Qooxdoo Apps",
-      "library_version": "2.0.9",
-      "path": "qx_packages/qooxdoo_qxl_testtapper_v2_0_9",
+      "library_version": "3.0.0",
+      "path": "qx_packages/qooxdoo_qxl_testtapper_v3_0_0",
       "uri": "qooxdoo/qxl.testtapper",
       "repo_name": "qooxdoo/qxl.testtapper",
-      "repo_tag": "v2.0.9"
+      "repo_tag": "v3.0.0"
     },
     {
       "library_name": "logpane",

--- a/test/framework/qx-lock.json
+++ b/test/framework/qx-lock.json
@@ -2,11 +2,11 @@
   "libraries": [
     {
       "library_name": "Commandline Testrunner for Qooxdoo Apps",
-      "library_version": "2.0.3",
-      "path": "qx_packages/qooxdoo_qxl_testtapper_v2_0_3",
+      "library_version": "2.0.7",
+      "path": "qx_packages/qooxdoo_qxl_testtapper_v2_0_7",
       "uri": "qooxdoo/qxl.testtapper",
       "repo_name": "qooxdoo/qxl.testtapper",
-      "repo_tag": "v2.0.3"
+      "repo_tag": "v2.0.7"
     },
     {
       "library_name": "logpane",

--- a/test/framework/qx-lock.json
+++ b/test/framework/qx-lock.json
@@ -2,11 +2,11 @@
   "libraries": [
     {
       "library_name": "Commandline Testrunner for Qooxdoo Apps",
-      "library_version": "2.0.7",
-      "path": "qx_packages/qooxdoo_qxl_testtapper_v2_0_7",
+      "library_version": "2.0.8",
+      "path": "qx_packages/qooxdoo_qxl_testtapper_v2_0_8",
       "uri": "qooxdoo/qxl.testtapper",
       "repo_name": "qooxdoo/qxl.testtapper",
-      "repo_tag": "v2.0.7"
+      "repo_tag": "v2.0.8"
     },
     {
       "library_name": "logpane",

--- a/test/framework/qx-lock.json
+++ b/test/framework/qx-lock.json
@@ -2,11 +2,11 @@
   "libraries": [
     {
       "library_name": "Commandline Testrunner for Qooxdoo Apps",
-      "library_version": "2.0.8",
-      "path": "qx_packages/qooxdoo_qxl_testtapper_v2_0_8",
+      "library_version": "2.0.9",
+      "path": "qx_packages/qooxdoo_qxl_testtapper_v2_0_9",
       "uri": "qooxdoo/qxl.testtapper",
       "repo_name": "qooxdoo/qxl.testtapper",
-      "repo_tag": "v2.0.8"
+      "repo_tag": "v2.0.9"
     },
     {
       "library_name": "logpane",


### PR DESCRIPTION
fix for https://github.com/qooxdoo/qooxdoo/issues/10752
fix for https://github.com/qooxdoo/qooxdoo/issues/10751

I added a fastFail property for tests to exit the test process when this special test fails. For qooxdoo testing i add this to the lint test.

In this PR i also changed node test versions to the last 3 lts versions.

The new testapper app is testing chromium,firefox,webkit in  a parallel task. For this it was necessary to increase some timeouts.

