### PR TITLE
Consider size when caching widget placement.

### DIFF
--- a/source/class/qx/ui/core/MPlacement.js
+++ b/source/class/qx/ui/core/MPlacement.js
@@ -205,6 +205,7 @@ qx.Mixin.define("qx.ui.core.MPlacement", {
     __ptwLiveUpdateDisappearListener: null,
     /**@type {Record<"top" | "right" | "bottom" | "left", number> | null}*/
     __lastKnownCoords: null,
+    __lastKnownSize: null,
 
     /**
      * Returns the location data like {qx.bom.element.Location#get} does,
@@ -378,17 +379,23 @@ qx.Mixin.define("qx.ui.core.MPlacement", {
 
       var coords =
         target.getContentLocation() || this.getLayoutLocation(target);
+      var size = this.__getPlacementSize();
 
       if (coords != null) {
-        if (
-          coords.top === this.__lastKnownCoords?.top &&
-          coords.right === this.__lastKnownCoords?.right &&
-          coords.bottom === this.__lastKnownCoords?.bottom &&
-          coords.left === this.__lastKnownCoords?.left
-        ) {
+
+        const boundsAreEqual = (bound1, bound2) => bound1 && bound2 &&
+          bound1.top === bound2.top &&
+          bound1.right === bound2.right &&
+          bound1.bottom === bound2.bottom &&
+          bound1.left === bound2.left;
+
+        if (boundsAreEqual(coords, this.__lastKnownCoords) &&
+          boundsAreEqual(size, this.__lastKnownSize)) {
           return true;
         }
+
         this.__lastKnownCoords = coords;
+        this.__lastKnownSize = size;
         this._place(coords);
         return true;
       } else {
@@ -527,7 +534,7 @@ qx.Mixin.define("qx.ui.core.MPlacement", {
      * <code>_computePlacementSize</code>, which returns the size.
      *
      *  @param callback {Function} This function will be called with the size as
-     *    first argument
+     *    first argument. If it is null, the size is returned directly.
      */
     __getPlacementSize(callback) {
       var size = null;
@@ -536,6 +543,10 @@ qx.Mixin.define("qx.ui.core.MPlacement", {
         var size = this._computePlacementSize();
       } else if (this.isVisible()) {
         var size = this.getBounds();
+      }
+
+      if (!callback) {
+        return {...size};
       }
 
       if (size == null) {


### PR DESCRIPTION
After the update to Qooxdoo 7.8 I have encountered a problem with the right menu. It is not positioned correctly and part of it seems to be "outside" of the page.

This is what it Looked like in 7.7.2:
![Screenshot from 2025-02-18 11-46-47](https://github.com/user-attachments/assets/967542ff-4110-4a5c-8d1e-e695d8c9c3c5)

This is how it looks now in 7.8.0:
![Screenshot from 2025-02-18 11-47-42](https://github.com/user-attachments/assets/5895ef2b-1941-4b59-bf5f-920e385b1f11)

I pinpointed the cause to the following commit: https://github.com/qooxdoo/qooxdoo/pull/10722

After some debugging I found out that the problem is that when placing the menu, not only coordinates of `MenuButton`, but also the bounds of `Menu` are considered. The methods are called in this order:

`MPlacement.placeToWidget -> MPlacement._place -> MPlacement.__getPlacementSize -> Menu._computePlacementSize -> Menu._getMenuBounds -> Menu.getBounds()`

I think that when caching the `__lastKnownCoords` in the  `MPlacement.placeToWidget`, also the placement size should be cached. I've created a pull request that does that. 