### PR TITLE
Change focused row color so it doesn't appear selected

### DIFF
--- a/source/class/qx/theme/indigo/ColorDark.js
+++ b/source/class/qx/theme/indigo/ColorDark.js
@@ -95,7 +95,7 @@ qx.Theme.define("qx.theme.indigo.ColorDark", {
     // used in table code
     "table-header-cell": "#ebeadb",
     "table-row-background-focused-selected": "#666666",
-    "table-row-background-focused": "#666666",
+    "table-row-background-focused": "#444444",
     "table-row-background-selected": "#666666",
     "table-row-background-even": "#333333",
     "table-row-background-odd": "#333333",


### PR DESCRIPTION
Right now in the Indigo dark theme, having a row selected and then resetting the table selection will still leave the last selected rows looking like they're selected as those rows become "focused" only.