### PR TITLE
fix: global error handler causing test cases to resume when they shouldn't

### DIFF
--- a/source/class/qx/test/Promise.js
+++ b/source/class/qx/test/Promise.js
@@ -1165,6 +1165,7 @@ qx.Class.define("qx.test.Promise", {
       var t = this;
       qx.event.GlobalError.setErrorHandler(function (ex) {
         t.assertEquals(ex.message, "oops");
+        qx.event.GlobalError.setErrorHandler(null);
         t.resume();
       });
       var self = this;


### PR DESCRIPTION
This PR fixes the unit tests of qx.Promise (https://github.com/qooxdoo/qooxdoo/issues/10772) . The problem was that the test method `testReduceOneReject` was causing an unhandled promise rejection, which was acceptable, but that caused the global error handler to run in `testGlobalError`, which called `resume()` too early, which meant that the next test case started too early, and then the resume of the previous test case called, which knocked the whole process out of whack.

This fixes the problem by removing the global error handler as soon as it's called.

This problem wasn't happening before because `testReduceOneReject` was only recently introduced.

This wasn't happening in all browsers because different browsers handle unhandled promise rejections differently.