### PR TITLE
Fix touch events triggered on non-touch devices (closes #10774)

### DIFF
--- a/source/class/qx/event/handler/TouchCore.js
+++ b/source/class/qx/event/handler/TouchCore.js
@@ -115,7 +115,9 @@ qx.Bootstrap.define("qx.event.handler.TouchCore", {
         "touchcancel"
       ];
 
-      if (qx.core.Environment.get("event.mspointer")) {
+      // Ensure the workaround applies to IE only as intended
+      // See: https://github.com/qooxdoo/qooxdoo/issues/10774
+      if (qx.core.Environment.get("engine.name") == "mshtml" && qx.core.Environment.get("event.mspointer")) {
         var engineVersion = parseInt(
           qx.core.Environment.get("engine.version"),
           10


### PR DESCRIPTION
This PR fixes the bug reported in #10774 so that touch events are no longer triggered along with mouse/pointer events on non-touch devices in modern browsers.

The fix ensures the IE workaround from `qx.event.handler.TouchCore._initTouchObserver` is no longer accidentally accessed by non-IE browsers.