### PR TITLE
Fix extreme slowness in theme.manager tests

### DIFF
--- a/source/class/qx/test/theme/manager/Color.js
+++ b/source/class/qx/test/theme/manager/Color.js
@@ -21,33 +21,41 @@ qx.Class.define("qx.test.theme.manager.Color", {
 
   members: {
     __formerTheme: null,
-    __formerListener: null,
+    __savedListeners: null,
 
     setUp() {
       this.manager = qx.theme.manager.Color.getInstance();
       this.__formerTheme = this.manager.getTheme();
 
-      let listener = qx.event.Registration.getManager(
-        this.manager
-      ).getAllListeners();
-      let hash =
-        this.manager.$$hash || qx.core.ObjectRegistry.toHashCode(this.manager);
-      this.__formerListener = { ...listener[hash] };
-      delete listener[hash];
+      let eventMgr = qx.event.Registration.getManager(this.manager);
+
+      // Serialize listeners (Array of {handler, self, type, capture})
+      this.__savedListeners = eventMgr.serializeListeners(this.manager);
+
+      // Remove all listeners
+      eventMgr.removeAllListeners(this.manager);
     },
 
     tearDown() {
       qx.test.Theme.themes = null;
+
       this.manager.setTheme(this.__formerTheme);
       this.__formerTheme = null;
 
-      let listener = qx.event.Registration.getManager(
-        this.manager
-      ).getAllListeners();
-      let hash =
-        this.manager.$$hash || qx.core.ObjectRegistry.toHashCode(this.manager);
-      listener[hash] = this.__formerListener;
-      this.__formerListener = null;
+      // Restore all listeners
+      if (this.__savedListeners) {
+        this.__savedListeners.forEach(entry => {
+          qx.event.Registration.addListener(
+            this.manager,
+            entry.type,
+            entry.handler,
+            entry.self,
+            entry.capture
+          );
+        });
+        this.__savedListeners = null;
+      }
+
       qx.ui.core.queue.Manager.flush();
     },
 

--- a/source/class/qx/test/theme/manager/Decoration.js
+++ b/source/class/qx/test/theme/manager/Decoration.js
@@ -21,33 +21,41 @@ qx.Class.define("qx.test.theme.manager.Decoration", {
 
   members: {
     __formerTheme: null,
-    __formerListener: null,
+    __savedListeners: null,
 
     setUp() {
       this.manager = qx.theme.manager.Decoration.getInstance();
       this.__formerTheme = this.manager.getTheme();
 
-      let listener = qx.event.Registration.getManager(
-        this.manager
-      ).getAllListeners();
-      let hash =
-        this.manager.$$hash || qx.core.ObjectRegistry.toHashCode(this.manager);
-      this.__formerListener = { ...listener[hash] };
-      delete listener[hash];
+      let eventMgr = qx.event.Registration.getManager(this.manager);
+
+      // Serialize listeners (Array of {handler, self, type, capture})
+      this.__savedListeners = eventMgr.serializeListeners(this.manager);
+
+      // Remove all listeners
+      eventMgr.removeAllListeners(this.manager);
     },
 
     tearDown() {
       qx.test.Theme.themes = null;
+
       this.manager.setTheme(this.__formerTheme);
       this.__formerTheme = null;
 
-      let listener = qx.event.Registration.getManager(
-        this.manager
-      ).getAllListeners();
-      let hash =
-        this.manager.$$hash || qx.core.ObjectRegistry.toHashCode(this.manager);
-      listener[hash] = this.__formerListener;
-      this.__formerListener = null;
+      // Restore all listeners
+      if (this.__savedListeners) {
+        this.__savedListeners.forEach(entry => {
+          qx.event.Registration.addListener(
+            this.manager,
+            entry.type,
+            entry.handler,
+            entry.self,
+            entry.capture
+          );
+        });
+        this.__savedListeners = null;
+      }
+
       qx.ui.core.queue.Manager.flush();
     },
 

--- a/source/class/qx/test/theme/manager/Icon.js
+++ b/source/class/qx/test/theme/manager/Icon.js
@@ -21,33 +21,41 @@ qx.Class.define("qx.test.theme.manager.Icon", {
 
   members: {
     __formerTheme: null,
-    __formerListener: null,
+    __savedListeners: null,
 
     setUp() {
       this.manager = qx.theme.manager.Icon.getInstance();
       this.__formerTheme = this.manager.getTheme();
 
-      let listener = qx.event.Registration.getManager(
-        this.manager
-      ).getAllListeners();
-      let hash =
-        this.manager.$$hash || qx.core.ObjectRegistry.toHashCode(this.manager);
-      this.__formerListener = { ...listener[hash] };
-      delete listener[hash];
+      let eventMgr = qx.event.Registration.getManager(this.manager);
+
+      // Serialize listeners (Array of {handler, self, type, capture})
+      this.__savedListeners = eventMgr.serializeListeners(this.manager);
+
+      // Remove all listeners
+      eventMgr.removeAllListeners(this.manager);
     },
 
     tearDown() {
       qx.test.Theme.themes = null;
+
       this.manager.setTheme(this.__formerTheme);
       this.__formerTheme = null;
 
-      let listener = qx.event.Registration.getManager(
-        this.manager
-      ).getAllListeners();
-      let hash =
-        this.manager.$$hash || qx.core.ObjectRegistry.toHashCode(this.manager);
-      listener[hash] = this.__formerListener;
-      this.__formerListener = null;
+      // Restore all listeners
+      if (this.__savedListeners) {
+        this.__savedListeners.forEach(entry => {
+          qx.event.Registration.addListener(
+            this.manager,
+            entry.type,
+            entry.handler,
+            entry.self,
+            entry.capture
+          );
+        });
+        this.__savedListeners = null;
+      }
+
       qx.ui.core.queue.Manager.flush();
     },
 


### PR DESCRIPTION
## Problem
All qx.test.theme.manager tests were extremely slow, taking over 10 minutes per test when running the full test suite. This made development and CI pipelines impractical.

## Root Cause
Event listeners accumulate across test suites. When many UI elements and widgets are created during test execution, each element registers listeners on the theme managers. During tearDown(), when setTheme() is called to restore the previous theme, the theme manager fires a changeTheme event that iterates through thousands of accumulated listeners from previous tests.

## Previous Approach (Didn't Work)
The initial implementation attempted to manipulate listeners using getAllListeners():
```
let listener = qx.event.Registration.getManager(this.manager).getAllListeners();
let hash = this.manager.$$hash || qx.core.ObjectRegistry.toHashCode(this.manager);
this.__formerListener = { ...listener[hash] };
delete listener[hash];
```
This didn't work because getAllListeners() returns a copy of the listener map, not the original internal map. Modifications to the copy had no effect on the actual event dispatching.

## Solution
Use the existing qooxdoo event manager APIs properly:

serializeListeners() - Captures the current listener configuration as an array of objects
removeAllListeners() - Actually removes listeners from the internal map
addListener() - Restores each listener in tearDown()

## Implementation

In setUp():
```
let eventMgr = qx.event.Registration.getManager(this.manager);

// Serialize listeners (Array of {handler, self, type, capture})
this.__savedListeners = eventMgr.serializeListeners(this.manager);

// Remove all listeners
eventMgr.removeAllListeners(this.manager);
```
In tearDown():
```
// Restore all listeners
if (this.__savedListeners) {
  this.__savedListeners.forEach(entry => {
    qx.event.Registration.addListener(
      this.manager,
      entry.type,
      entry.handler,
      entry.self,
      entry.capture
    );
  });
  this.__savedListeners = null;
}
```