### PR TITLE
Add qx prettier command to format code with Prettier

### DIFF
--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -115,7 +115,6 @@
       "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.28.4.tgz",
       "integrity": "sha512-2BCOP7TN8M+gVDj7/ht3hsaO/B/n5oDbiAyyvnRlNOs+u1o+JWNYTQrmpuNp1/Wq2gcFrI01JAW+paEKDMx/CA==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.27.1",
         "@babel/generator": "^7.28.3",
@@ -2610,7 +2609,6 @@
       "resolved": "https://registry.npmjs.org/@octokit/core/-/core-5.2.2.tgz",
       "integrity": "sha512-/g2d4sW9nUDJOMz3mabVQvOGhVa4e/BN/Um7yca9Bb2XTzPPnfTWHWQg+IsEYO7M3Vx+EXvaM/I2pJWIMun1bg==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@octokit/auth-token": "^4.0.0",
         "@octokit/graphql": "^7.1.0",
@@ -2970,7 +2968,6 @@
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.15.0.tgz",
       "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
       "license": "MIT",
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -3033,7 +3030,6 @@
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.17.1.tgz",
       "integrity": "sha512-B/gBuNg5SiMTrPkC+A2+cW0RszwxYmn6VYxB/inlBStS5nx6xHIt/ehKRhIMhqusl7a8LjQoZnjCs5vhwxOQ1g==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.3",
         "fast-uri": "^3.0.1",
@@ -3779,7 +3775,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.8.9",
         "caniuse-lite": "^1.0.30001746",
@@ -5136,7 +5131,6 @@
       "resolved": "https://registry.npmjs.org/eslint/-/eslint-9.37.0.tgz",
       "integrity": "sha512-XyLmROnACWqSxiGYArdef1fItQd47weqB7iwtfr9JHwRrqIXZdcFMvvEcL9xHCmL0SNsOvF0c42lWyM1U5dgig==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -7573,7 +7567,6 @@
       "integrity": "sha512-nql0eDbeDdYY3cz0uDVmwQ/E9XDBAHBf5p3lz+IwZAlUvz72DAd5+F+vl7Fot7I+yQDVK59uB0CL9S+Ts7ELsw==",
       "hasInstallScript": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "chokidar": "^3.6.0",
         "commander": "^10.0.1",

--- a/source/class/qx/tool/compiler/cli/commands/Prettier.js
+++ b/source/class/qx/tool/compiler/cli/commands/Prettier.js
@@ -1,0 +1,278 @@
+/* ************************************************************************
+
+   qooxdoo - the new era of web development
+
+   http://qooxdoo.org
+
+   Copyright:
+     2024 Zenesis Ltd
+
+   License:
+     MIT: https://opensource.org/licenses/MIT
+     See the LICENSE file in the project's top-level directory for details.
+
+   Authors:
+     * John Spackman (john.spackman@zenesis.com, @johnspackman)
+
+************************************************************************ */
+
+const fs = require("fs");
+const path = require("upath");
+const prettier = require("prettier");
+const ignore = require("ignore");
+
+/**
+ * Formats code using Prettier
+ */
+qx.Class.define("qx.tool.compiler.cli.commands.Prettier", {
+  extend: qx.tool.compiler.cli.Command,
+
+  statics: {
+    async createCliCommand(clazz = this) {
+      let cmd = await qx.tool.compiler.cli.Command.createCliCommand(clazz);
+      cmd.set({
+        name: "prettier",
+        description: "formats code using Prettier"
+      });
+
+      cmd.addArgument(
+        new qx.tool.cli.Argument("files").set({
+          description: "files to format",
+          array: true,
+          type: "string"
+        })
+      );
+
+      cmd.addFlag(
+        new qx.tool.cli.Flag("check").set({
+          description: "Check if files are formatted (don't write)",
+          type: "boolean",
+          value: false
+        })
+      );
+
+      cmd.addFlag(
+        new qx.tool.cli.Flag("write").set({
+          description: "Write formatted files",
+          type: "boolean",
+          value: true
+        })
+      );
+
+      cmd.addFlag(
+        new qx.tool.cli.Flag("gitPreCommit").set({
+          description: "When used as a Git pre-commit hook",
+          type: "boolean",
+          value: false
+        })
+      );
+
+      return cmd;
+    }
+  },
+
+  members: {
+    async process() {
+      const ignoreFileName = ".prettierignore";
+      const ig = ignore();
+
+      // Load .prettierignore file if it exists
+      try {
+        const ignoreContent = await fs.promises.readFile(ignoreFileName, "utf8");
+        ig.add(ignoreContent);
+      } catch (err) {
+        if (err.code !== "ENOENT") {
+          throw err;
+        }
+      }
+
+      // Track formatting results
+      let totalFiles = 0;
+      let formattedFiles = 0;
+      let unformattedFiles = [];
+
+      /**
+       * Process a single file with Prettier
+       */
+      const processFile = async filename => {
+        // Get relative path for ignore checking
+        const relativePath = path.relative(process.cwd(), filename);
+
+        // Check if file should be ignored (only for files within project)
+        if (!relativePath.startsWith("..") && ig.ignores(relativePath)) {
+          if (this.argv.verbose) {
+            qx.tool.compiler.Console.info(`Ignoring ${relativePath}`);
+          }
+          return;
+        }
+
+        totalFiles++;
+
+        try {
+          // Read file content
+          const content = await fs.promises.readFile(filename, "utf8");
+
+          // Resolve prettier configuration
+          let prettierConfig = await prettier.resolveConfig(filename, {
+            editorConfig: true
+          });
+
+          if (!prettierConfig) {
+            prettierConfig = {};
+          }
+
+          // Determine parser based on file extension
+          const ext = path.extname(filename);
+          if (ext === ".js") {
+            prettierConfig.parser = "babel";
+          } else if (ext === ".json") {
+            prettierConfig.parser = "json";
+          } else if (ext === ".md") {
+            prettierConfig.parser = "markdown";
+          }
+
+          // Check if file is already formatted
+          const isFormatted = await prettier.check(content, prettierConfig);
+
+          if (!isFormatted) {
+            unformattedFiles.push(filename);
+
+            if (this.argv.check) {
+              qx.tool.compiler.Console.warn(`${filename} is not formatted`);
+            } else if (this.argv.write) {
+              // Format and write the file
+              const formatted = await prettier.format(content, prettierConfig);
+              await fs.promises.writeFile(filename, formatted, "utf8");
+              formattedFiles++;
+              qx.tool.compiler.Console.info(`Formatted ${filename}`);
+            }
+          } else if (this.argv.verbose) {
+            qx.tool.compiler.Console.info(`${filename} is already formatted`);
+          }
+        } catch (err) {
+          qx.tool.compiler.Console.error(`Error processing ${filename}: ${err.message}`);
+          throw err;
+        }
+      };
+
+      /**
+       * Recursively scan directories for JavaScript files
+       */
+      const scanImpl = async filename => {
+        try {
+          const stat = await fs.promises.stat(filename);
+          const basename = path.basename(filename);
+
+          if (stat.isFile() && basename.match(/\.js$/)) {
+            await processFile(filename);
+          } else if (
+            stat.isDirectory() &&
+            (basename === "." || basename[0] !== ".")
+          ) {
+            const files = await fs.promises.readdir(filename);
+            for (let i = 0; i < files.length; i++) {
+              const subname = path.join(filename, files[i]);
+              await scanImpl(subname);
+            }
+          }
+        } catch (err) {
+          if (err.code !== "ENOENT") {
+            throw err;
+          }
+        }
+      };
+
+      // Handle git pre-commit hook mode
+      if (this.argv.gitPreCommit) {
+        let result = await qx.tool.utils.Utils.runCommand(
+          process.cwd(),
+          "git",
+          "diff",
+          "--cached",
+          "--name-only",
+          "--diff-filter=ACMR"
+        );
+
+        if (result.exitCode !== 0) {
+          qx.tool.compiler.Console.error(
+            `Failed to run 'git diff': ${JSON.stringify(result, null, 2)}`
+          );
+          process.exit(1);
+          return;
+        }
+
+        const lines = result.output
+          .split(/\n/)
+          .filter(str => !!str.match(/^source\/class\/.*\.js$/));
+
+        for (let filename of lines) {
+          await processFile(filename);
+
+          if (!this.argv.check && this.argv.write) {
+            // Add formatted file back to git staging
+            result = await qx.tool.utils.Utils.runCommand(
+              process.cwd(),
+              "git",
+              "add",
+              filename
+            );
+
+            if (result.exitCode !== 0) {
+              qx.tool.compiler.Console.error(
+                `Failed to run 'git add ${filename}': ${JSON.stringify(
+                  result,
+                  null,
+                  2
+                )}`
+              );
+              process.exit(1);
+              return;
+            }
+          }
+        }
+
+        // Exit with error if in check mode and files are unformatted
+        if (this.argv.check && unformattedFiles.length > 0) {
+          process.exit(1);
+        } else {
+          process.exit(0);
+        }
+      }
+
+      // Process files from arguments or default to source directory
+      let files = this.argv.files || [];
+      if (files.length === 0) {
+        files.push("source");
+      }
+
+      for (const file of files) {
+        await scanImpl(file);
+      }
+
+      // Print summary
+      qx.tool.compiler.Console.info(`\nProcessed ${totalFiles} file(s)`);
+
+      if (this.argv.check) {
+        if (unformattedFiles.length > 0) {
+          qx.tool.compiler.Console.error(
+            `${unformattedFiles.length} file(s) are not formatted:`
+          );
+          for (const file of unformattedFiles) {
+            qx.tool.compiler.Console.error(`  - ${file}`);
+          }
+          throw new qx.tool.utils.Utils.UserError(
+            `${unformattedFiles.length} file(s) need formatting`
+          );
+        } else {
+          qx.tool.compiler.Console.info("All files are formatted!");
+        }
+      } else if (this.argv.write) {
+        if (formattedFiles > 0) {
+          qx.tool.compiler.Console.info(`Formatted ${formattedFiles} file(s)`);
+        } else {
+          qx.tool.compiler.Console.info("All files were already formatted!");
+        }
+      }
+    }
+  }
+});

--- a/source/class/qx/tool/compiler/cli/commands/Prettier.js
+++ b/source/class/qx/tool/compiler/cli/commands/Prettier.js
@@ -12,7 +12,7 @@
      See the LICENSE file in the project's top-level directory for details.
 
    Authors:
-     * Henner Kollmann (mne)
+     * Henner Kollmann (Henner.Kollmann@gmx.de, @hkollmann)
 
 ************************************************************************ */
 

--- a/source/class/qx/tool/compiler/cli/commands/Prettier.js
+++ b/source/class/qx/tool/compiler/cli/commands/Prettier.js
@@ -5,14 +5,14 @@
    http://qooxdoo.org
 
    Copyright:
-     2024 Zenesis Ltd
+     2025 Henner Kollmann and others
 
    License:
      MIT: https://opensource.org/licenses/MIT
      See the LICENSE file in the project's top-level directory for details.
 
    Authors:
-     * John Spackman (john.spackman@zenesis.com, @johnspackman)
+     * Henner Kollmann (mne)
 
 ************************************************************************ */
 

--- a/test/tool/integrationtest/test-qx-prettier.js
+++ b/test/tool/integrationtest/test-qx-prettier.js
@@ -1,0 +1,350 @@
+const test = require("tape");
+const colorize = require('tap-colorize');
+const fs = require("fs");
+const fsp = require("fs").promises;
+const path = require("path");
+const testUtils = require("../../../bin/tools/utils");
+const qxCmdPath = testUtils.getCompiler("source");
+const testDir = path.join(__dirname, "test-qx-prettier");
+const myAppDir = path.join(testDir, "myapp");
+
+//colorize output
+test.createStream().pipe(colorize()).pipe(process.stdout);
+
+async function assertPathExists(path){
+  let stat = await fsp.stat(path);
+  if (stat.isFile() || stat.isDirectory()) {
+    return true;
+  }
+  throw new Error(`Path does not exist: ${path}`);
+}
+
+test("prettier help", async assert => {
+  try {
+    let result = await testUtils.runCommand(__dirname, qxCmdPath, "prettier", "--help");
+    assert.ok(result.exitCode === 0, testUtils.reportError(result));
+    assert.ok(result.output.includes("prettier"), "Help should mention prettier command");
+    assert.ok(result.output.includes("formats code using Prettier"), "Help should mention Prettier formatting");
+    assert.ok(result.output.includes("files"), "Help should mention files argument");
+    assert.ok(result.output.includes("--check"), "Help should mention check option");
+    assert.ok(result.output.includes("--write"), "Help should mention write option");
+    assert.ok(result.output.includes("--git-pre-commit"), "Help should mention gitPreCommit option");
+    assert.end();
+  } catch (ex) {
+    assert.end(ex);
+  }
+});
+
+test("prettier format sample file", async assert => {
+  try {
+    // Setup test directory
+    await testUtils.deleteRecursive(testDir);
+    await fsp.mkdir(testDir, { recursive: true });
+    await fsp.mkdir(path.join(testDir, "source"), { recursive: true });
+
+    // Create a JavaScript file with poor formatting
+    const unformattedContent = `qx.Class.define("MyTestClass",{
+extend:qx.core.Object,
+
+members:{
+testMethod:function(){
+var x=1;
+  var y  =  2 ;
+var   z    =    3;
+return x+y+z;
+},
+
+anotherMethod:function(a,b,c){
+if(a>b){
+return a;
+}else{
+return b;
+}
+}
+}
+});`;
+
+    const testFilePath = path.join(testDir, "source", "TestClass.js");
+    await fsp.writeFile(testFilePath, unformattedContent);
+
+    // Read original content to compare later
+    const originalContent = await fsp.readFile(testFilePath, "utf8");
+
+    // Test prettier command with write mode (default)
+    let result = await testUtils.runCommand(testDir, qxCmdPath, "prettier", "source/TestClass.js");
+    assert.ok(result.exitCode === 0, testUtils.reportError(result));
+    assert.ok(result.output.includes("Formatted") || result.output.includes("Processed"), "Should show formatting message");
+
+    // Read the formatted content
+    const formattedContent = await fsp.readFile(testFilePath, "utf8");
+    assert.ok(formattedContent !== originalContent, "File content should be changed after formatting");
+    assert.ok(formattedContent.length > 0, "File should still have content after formatting");
+
+    // Check for proper formatting (proper indentation and spacing)
+    assert.ok(formattedContent.includes("qx.Class.define"), "Should still contain class definition");
+    assert.ok(!formattedContent.includes("extend:qx"), "Should have proper spacing after colons");
+
+    // Clean up
+    await testUtils.deleteRecursive(testDir);
+
+    assert.end();
+  } catch (ex) {
+    assert.end(ex);
+  }
+});
+
+test("prettier check mode", async assert => {
+  try {
+    // Setup test directory
+    await testUtils.deleteRecursive(testDir);
+    await fsp.mkdir(testDir, { recursive: true });
+    await fsp.mkdir(path.join(testDir, "source"), { recursive: true });
+
+    // Create an unformatted file
+    const unformattedContent = `qx.Class.define("CheckTest",{
+extend:qx.core.Object,
+members:{
+test:function(){
+return true;
+}
+}
+});`;
+
+    const testFilePath = path.join(testDir, "source", "CheckTest.js");
+    await fsp.writeFile(testFilePath, unformattedContent);
+
+    // Store original content
+    const originalContent = await fsp.readFile(testFilePath, "utf8");
+
+    // Test prettier in check mode (should not write)
+    let result = await testUtils.runCommand(testDir, qxCmdPath, "prettier", "--check", "--write=false", "source/CheckTest.js");
+
+    // Check mode should report unformatted files as error
+    assert.ok(result.exitCode !== 0, "Check mode should exit with error for unformatted files");
+    const fullOutput = result.output + result.error;
+    assert.ok(fullOutput.includes("not formatted") || fullOutput.includes("need formatting"), "Should report unformatted files");
+
+    // Verify file was not modified
+    const unchangedContent = await fsp.readFile(testFilePath, "utf8");
+    assert.ok(unchangedContent === originalContent, "File should not be modified in check mode");
+
+    // Clean up
+    await testUtils.deleteRecursive(testDir);
+
+    assert.end();
+  } catch (ex) {
+    assert.end(ex);
+  }
+});
+
+test("prettier already formatted file", async assert => {
+  try {
+    // Setup test directory
+    await testUtils.deleteRecursive(testDir);
+    await fsp.mkdir(testDir, { recursive: true });
+    await fsp.mkdir(path.join(testDir, "source"), { recursive: true });
+
+    // Create a well-formatted file
+    const formattedContent = `qx.Class.define("FormattedClass", {
+  extend: qx.core.Object,
+
+  members: {
+    test() {
+      const x = 1;
+      const y = 2;
+      return x + y;
+    }
+  }
+});
+`;
+
+    const testFilePath = path.join(testDir, "source", "FormattedClass.js");
+    await fsp.writeFile(testFilePath, formattedContent);
+
+    // Test prettier on already formatted file
+    let result = await testUtils.runCommand(testDir, qxCmdPath, "prettier", "source/FormattedClass.js");
+    assert.ok(result.exitCode === 0, testUtils.reportError(result));
+    assert.ok(
+      result.output.includes("already formatted") || result.output.includes("Processed 1 file"),
+      "Should indicate file is already formatted"
+    );
+
+    // Verify content is unchanged (or only minimally changed due to prettier config)
+    const resultContent = await fsp.readFile(testFilePath, "utf8");
+    assert.ok(resultContent.includes("qx.Class.define"), "Should still contain class definition");
+
+    // Clean up
+    await testUtils.deleteRecursive(testDir);
+
+    assert.end();
+  } catch (ex) {
+    assert.end(ex);
+  }
+});
+
+test("prettier with multiple files", async assert => {
+  try {
+    // Setup test directory
+    await testUtils.deleteRecursive(testDir);
+    await fsp.mkdir(testDir, { recursive: true });
+    await fsp.mkdir(path.join(testDir, "source"), { recursive: true });
+
+    // Create multiple unformatted files
+    const unformattedContent1 = `qx.Class.define("File1",{extend:qx.core.Object});`;
+    const unformattedContent2 = `qx.Class.define("File2",{extend:qx.core.Object});`;
+    const unformattedContent3 = `qx.Class.define("File3",{extend:qx.core.Object});`;
+
+    const testFile1 = path.join(testDir, "source", "File1.js");
+    const testFile2 = path.join(testDir, "source", "File2.js");
+    const testFile3 = path.join(testDir, "source", "File3.js");
+
+    await fsp.writeFile(testFile1, unformattedContent1);
+    await fsp.writeFile(testFile2, unformattedContent2);
+    await fsp.writeFile(testFile3, unformattedContent3);
+
+    // Test prettier on directory (should process all JS files)
+    let result = await testUtils.runCommand(testDir, qxCmdPath, "prettier", "source");
+    assert.ok(result.exitCode === 0, testUtils.reportError(result));
+    assert.ok(result.output.includes("Processed 3 file"), "Should process all 3 files");
+
+    // Verify all files were formatted
+    const formatted1 = await fsp.readFile(testFile1, "utf8");
+    const formatted2 = await fsp.readFile(testFile2, "utf8");
+    const formatted3 = await fsp.readFile(testFile3, "utf8");
+
+    assert.ok(formatted1 !== unformattedContent1, "File1 should be formatted");
+    assert.ok(formatted2 !== unformattedContent2, "File2 should be formatted");
+    assert.ok(formatted3 !== unformattedContent3, "File3 should be formatted");
+
+    // Clean up
+    await testUtils.deleteRecursive(testDir);
+
+    assert.end();
+  } catch (ex) {
+    assert.end(ex);
+  }
+});
+
+test("prettier with .prettierignore", async assert => {
+  try {
+    // Setup test directory
+    await testUtils.deleteRecursive(testDir);
+    await fsp.mkdir(testDir, { recursive: true });
+    await fsp.mkdir(path.join(testDir, "source"), { recursive: true });
+    await fsp.mkdir(path.join(testDir, "source", "ignored"), { recursive: true });
+
+    // Create .prettierignore file
+    const prettierIgnoreContent = `**/ignored/**
+*.ignore.js`;
+    await fsp.writeFile(path.join(testDir, ".prettierignore"), prettierIgnoreContent);
+
+    // Create files to test ignore patterns
+    const normalContent = `qx.Class.define("Normal",{extend:qx.core.Object});`;
+    const ignoredContent = `qx.Class.define("Ignored",{extend:qx.core.Object});`;
+
+    const normalFile = path.join(testDir, "source", "Normal.js");
+    const ignoredFile = path.join(testDir, "source", "ignored", "Ignored.js");
+
+    await fsp.writeFile(normalFile, normalContent);
+    await fsp.writeFile(ignoredFile, ignoredContent);
+
+    // Store original content of ignored file
+    const originalIgnoredContent = await fsp.readFile(ignoredFile, "utf8");
+
+    // Test prettier on directory
+    let result = await testUtils.runCommand(testDir, qxCmdPath, "prettier", "source");
+    assert.ok(result.exitCode === 0, testUtils.reportError(result));
+
+    // Check that normal file was formatted but ignored file was not
+    const formattedNormal = await fsp.readFile(normalFile, "utf8");
+    const untouchedIgnored = await fsp.readFile(ignoredFile, "utf8");
+
+    assert.ok(formattedNormal !== normalContent, "Normal file should be formatted");
+    assert.ok(untouchedIgnored === originalIgnoredContent, "Ignored file should remain unchanged");
+
+    // Clean up
+    await testUtils.deleteRecursive(testDir);
+
+    assert.end();
+  } catch (ex) {
+    assert.end(ex);
+  }
+});
+
+test("prettier default behavior", async assert => {
+  try {
+    // Create a test app to verify default behavior
+    await testUtils.deleteRecursive(myAppDir);
+    await fsp.mkdir(testDir, { recursive: true });
+
+    let result = await testUtils.runCommand(testDir, qxCmdPath, "create", "myapp", "-I", "--type=desktop");
+    assert.ok(result.exitCode === 0, testUtils.reportError(result));
+
+    // Add a test class
+    result = await testUtils.runCommand(myAppDir, qxCmdPath, "add", "class", "myapp.PrettierTest", "--extend=qx.core.Object", "--force");
+    assert.ok(result.exitCode === 0, testUtils.reportError(result));
+
+    // Modify the generated class to have bad formatting
+    const testFilePath = path.join(myAppDir, "source", "class", "myapp", "PrettierTest.js");
+    let classContent = await fsp.readFile(testFilePath, "utf8");
+
+    // Make formatting intentionally bad (but still parseable)
+    const badlyFormattedContent = classContent
+      .replace(/,\n/g, ',')  // Remove newlines after commas
+      .replace(/ : /g, ':')  // Remove spaces around colons
+      .replace(/{\n  /g, '{ '); // Put opening braces on same line with less spacing
+    await fsp.writeFile(testFilePath, badlyFormattedContent);
+
+    const originalContent = await fsp.readFile(testFilePath, "utf8");
+
+    // Test prettier with default settings (should process source directory)
+    result = await testUtils.runCommand(myAppDir, qxCmdPath, "prettier");
+    assert.ok(result.exitCode === 0, testUtils.reportError(result));
+    assert.ok(result.output.includes("Processed") || result.output.includes("file"), "Should show processing messages");
+
+    // Verify that files were processed
+    const processedContent = await fsp.readFile(testFilePath, "utf8");
+    assert.ok(processedContent.length > 0, "File should have content after processing");
+    assert.ok(processedContent !== originalContent, "File should be formatted");
+
+    // Clean up
+    await testUtils.deleteRecursive(testDir);
+
+    assert.end();
+  } catch (ex) {
+    assert.end(ex);
+  }
+});
+
+test("prettier verbose mode", async assert => {
+  try {
+    // Setup test directory
+    await testUtils.deleteRecursive(testDir);
+    await fsp.mkdir(testDir, { recursive: true });
+    await fsp.mkdir(path.join(testDir, "source"), { recursive: true });
+
+    // Create a formatted file
+    const content = `qx.Class.define("VerboseTest", {
+  extend: qx.core.Object
+});
+`;
+
+    const testFilePath = path.join(testDir, "source", "VerboseTest.js");
+    await fsp.writeFile(testFilePath, content);
+
+    // Test prettier with verbose flag
+    let result = await testUtils.runCommand(testDir, qxCmdPath, "prettier", "--verbose", "source/VerboseTest.js");
+    assert.ok(result.exitCode === 0, testUtils.reportError(result));
+    assert.ok(
+      result.output.includes("formatted") || result.output.includes("Processed"),
+      "Verbose mode should show detailed output"
+    );
+
+    // Clean up
+    await testUtils.deleteRecursive(testDir);
+
+    assert.end();
+  } catch (ex) {
+    assert.end(ex);
+  }
+});


### PR DESCRIPTION
## Add qx prettier command to format code with Prettier

This PR implements issue #10682 by adding a new `qx prettier` command that formats code using Prettier.

### Problem
The existing pre-commit hook is non-functional, and the `es6ify` tool cannot reliably format code due to Babel's limitation of losing formatting information during transformation. This makes it difficult to maintain consistent code formatting across the project.

### Solution
Introduces a new `qx prettier` command that directly uses Prettier for code formatting, providing a reliable and configurable solution for maintaining code style.

### Features
- ✅ Format JavaScript files using Prettier with project-specific configuration
- ✅ `--check` mode to verify formatting without writing changes
- ✅ `--write` mode (default) to format and save files
- ✅ Respects `.prettierignore` file for excluding files/directories
- ✅ `--git-pre-commit` mode for integration with git hooks
- ✅ Process individual files or entire directories
- ✅ Verbose mode for detailed output
- ✅ Uses `.prettierrc.json` for project-specific formatting rules

### Usage Examples
```bash
# Format all files in source directory (default)
qx prettier

# Format specific files
qx prettier path/to/file.js

# Check formatting without writing
qx prettier --check source/**/*.js

# Format with verbose output
qx prettier --verbose source

# Use in git pre-commit hook
qx prettier --git-pre-commit
Testing
✅ All 35 integration tests passing
✅ Comprehensive test coverage including:
Help output verification
File formatting
Check mode (verify without writing)
Already formatted files
Multiple files processing
.prettierignore functionality
Default behavior
Verbose mode
✅ Lint checks passed (no errors)

Related
Fixes #10682