### PR TITLE
 Fix compiler crash on object rest parameters (issue #10623) 

### DIFF
--- a/source/class/qx/test/compiler/ClassFile.js
+++ b/source/class/qx/test/compiler/ClassFile.js
@@ -92,6 +92,19 @@ qx.Class.define("qx.test.compiler.ClassFile", {
       this.assert(!dbClassInfo.unresolved);
     },
 
+    async "test issue 10623"() {
+      var classFile = new qx.tool.compiler.ClassFile(
+        this.__analyser,
+        "classIssue10623",
+        this.__lib
+      );
+
+      await qx.tool.utils.Promisify.call(cb => classFile.load(cb));
+      var dbClassInfo = {};
+      classFile.writeDbInfo(dbClassInfo);
+      this.assert(!dbClassInfo.unresolved);
+    },
+
     __lib: null,
     __analyser: null
   }

--- a/source/class/qx/tool/compiler/ClassFile.js
+++ b/source/class/qx/tool/compiler/ClassFile.js
@@ -810,7 +810,13 @@ qx.Class.define("qx.tool.compiler.ClassFile", {
           } else if (param.type == "ArrayPattern") {
             param.elements.forEach(elem => addDecl(elem));
           } else if (param.type == "ObjectPattern") {
-            param.properties.forEach(prop => addDecl(prop.value));
+            param.properties.forEach(prop => {
+              if (prop.type == "RestElement") {
+                addDecl(prop);
+              } else {
+                addDecl(prop.value);
+              }
+            });
           } else {
             t.addMarker("testForFunctionParameterType", node.loc, param.type);
           }
@@ -2400,7 +2406,9 @@ qx.Class.define("qx.tool.compiler.ClassFile", {
                 // Object destructuring `var {a,b} = {...}`
               } else if (decl.id.type == "ObjectPattern") {
                 decl.id.properties.forEach(prop => {
-                  if (prop.value.type == "AssignmentPattern") {
+                  if (prop.type == "RestElement") {
+                    t.addDeclaration(prop.argument.name);
+                  } else if (prop.value.type == "AssignmentPattern") {
                     t.addDeclaration(prop.value.left.name);
                   } else {
                     t.addDeclaration(prop.value.name);

--- a/test/tool/unittest/compiler/classIssue10623.js
+++ b/test/tool/unittest/compiler/classIssue10623.js
@@ -1,0 +1,28 @@
+qx.Class.define("classIssue10623", {
+  statics: {
+    // Test function parameter with object rest
+    testFunctionParam({ destruct1, destruct2, ...restDestruct }) {
+      console.log(destruct1, destruct2, restDestruct);
+      return { destruct1, destruct2, restDestruct };
+    },
+
+    // Test variable declaration with object rest
+    testVariableDecl(arg0) {
+      const { destruct1, destruct2, ...restDestruct } = arg0;
+      console.log(destruct1, destruct2, restDestruct);
+      return { destruct1, destruct2, restDestruct };
+    },
+
+    // Test nested object rest in function params
+    testNestedParam({ a, b, nested: { c, d, ...restNested }, ...rest }) {
+      console.log(a, b, c, d, restNested, rest);
+      return { a, b, c, d, restNested, rest };
+    },
+
+    // Test object rest with default values
+    testWithDefaults({ a = 1, b = 2, ...rest }) {
+      console.log(a, b, rest);
+      return { a, b, rest };
+    }
+  }
+});


### PR DESCRIPTION
## Summary

This PR fixes issue #10623 where the Qooxdoo compiler crashes with `TypeError: Cannot read properties of undefined (reading 'type')` when processing valid ES6+ object rest parameters in destructuring patterns.

**Changes:**
- Fixed function parameter handling to properly detect and process `RestElement` in object destructuring
- Fixed variable declaration handling to support object rest parameters  
- Added comprehensive test cases to prevent regression
- Aligned object destructuring behavior with array destructuring (which already handled rest parameters correctly)

**Root Cause:**
The compiler was attempting to access `prop.value` on all properties in object destructuring patterns, but `RestElement` nodes use `prop.argument` instead of `prop.value`, causing the undefined error.

**Files Modified:**
- `source/class/qx/tool/compiler/ClassFile.js` - Core compiler fix (2 locations)
- `source/class/qx/test/compiler/ClassFile.js` - Added regression test
- `test/tool/unittest/compiler/classIssue10623.js` - Test file with multiple rest parameter scenarios

## Test Plan

- [x] Created test file with object rest in function parameters: `function({ a, b, ...rest })`
- [x] Created test file with object rest in variable declarations: `const { a, b, ...rest } = obj`
- [x] Created test file with nested object rest patterns
- [x] Created test file with object rest combined with default values
- [x] Verified AST parsing works correctly with standalone test
- [x] Compiler bootstrap completes successfully
- [x] Added unit test `qx.test.compiler.ClassFile.test issue 10623` for regression testing

## Related Issues

Fixes #10623