### PR TITLE
Fix compiler warnings for ES6 shorthand methods in delegate objects

### DIFF
--- a/source/class/qx/tool/compiler/ClassFile.js
+++ b/source/class/qx/tool/compiler/ClassFile.js
@@ -1529,6 +1529,9 @@ qx.Class.define("qx.tool.compiler.ClassFile", {
               });
             }
             path.traverse(VISITOR);
+          } else if (keyName == "delegate") {
+            path.skip();
+            path.traverse(VISITOR);
           } else if (keyName == "aliases") {
             path.skip();
             if (!prop.value.properties) {

--- a/test/tool/integrationtest/test-issues/issue10591/Manifest.json
+++ b/test/tool/integrationtest/test-issues/issue10591/Manifest.json
@@ -1,0 +1,22 @@
+{
+  "$schema": "https://qooxdoo.org/schema/Manifest-2-0-0.json",
+  "info": {
+    "name": "issue10591",
+    "summary": "Test for ES6 shorthand methods in delegate objects",
+    "description": "Tests that ES6 shorthand method syntax in delegate objects compiles without spurious unresolved symbol warnings",
+    "homepage": "https://github.com/qooxdoo/qooxdoo/issues/10591",
+    "license": "MIT license",
+    "authors": [],
+    "version": "1.0.0"
+  },
+  "provides": {
+    "namespace": "issue10591",
+    "encoding": "utf-8",
+    "class": "source/class",
+    "resource": "source/resource",
+    "translation": "source/translation"
+  },
+  "requires": {
+    "@qooxdoo/framework": "^8.0.0"
+  }
+}

--- a/test/tool/integrationtest/test-issues/issue10591/compile.json
+++ b/test/tool/integrationtest/test-issues/issue10591/compile.json
@@ -1,0 +1,22 @@
+{
+  "$schema": "https://qooxdoo.org/schema/compile-1-0-0.json",
+  "targets": [
+    {
+      "type": "source",
+      "outputPath": "compiled/source"
+    }
+  ],
+  "defaultTarget": "source",
+  "locales": ["en"],
+  "libraries": [
+    ".",
+    "../../../../.."
+  ],
+  "applications": [
+    {
+      "class": "issue10591.Application",
+      "theme": "qx.theme.Simple",
+      "name": "issue10591"
+    }
+  ]
+}

--- a/test/tool/integrationtest/test-issues/issue10591/readme.md
+++ b/test/tool/integrationtest/test-issues/issue10591/readme.md
@@ -1,0 +1,40 @@
+# issue10591
+
+Test for GitHub issue #10591: Compiler generates warning on map entry `get(x)` but not `get : function(x)`
+
+## Problem
+
+The qooxdoo compiler was generating spurious "Unresolved use of symbol" warnings when using ES6 shorthand method syntax in delegate objects:
+
+```javascript
+delegate: {
+  get(property) {  // Warning: Unresolved use of symbol property
+    return this[property];
+  }
+}
+```
+
+While traditional function syntax worked without warnings:
+
+```javascript
+delegate: {
+  get: function(property) {  // No warning
+    return this[property];
+  }
+}
+```
+
+## Fix
+
+Added explicit handling for the `delegate` property in the compiler's `ObjectProperty` visitor to ensure proper traversal of ES6 shorthand methods (ObjectMethod nodes).
+
+## Test
+
+This test creates a class with a `delegate` object using ES6 shorthand method syntax. The compilation should succeed without any "Unresolved use of symbol" warnings for the method parameters (`property`, `value`).
+
+Run the test with:
+```
+qx compile
+```
+
+The test passes if compilation completes without warnings about unresolved symbols in the delegate methods.

--- a/test/tool/integrationtest/test-issues/issue10591/source/class/issue10591/Application.js
+++ b/test/tool/integrationtest/test-issues/issue10591/source/class/issue10591/Application.js
@@ -1,0 +1,37 @@
+/* ************************************************************************
+
+   Copyright: 2023 qooxdoo developers
+
+   License: MIT license
+
+   Authors:
+
+************************************************************************ */
+
+/**
+ * Test for issue #10591 - ES6 shorthand methods in delegate objects
+ *
+ * This test verifies that the compiler correctly handles ES6 shorthand
+ * method syntax in delegate objects without generating spurious
+ * "Unresolved use of symbol" warnings for method parameters.
+ */
+qx.Class.define("issue10591.Application", {
+  extend: qx.application.Basic,
+
+  members: {
+    main() {
+      this.base(arguments);
+
+      // Test the delegate functionality
+      var testArray = new issue10591.TestArray([1, 2, 3]);
+
+      // Test array-like access using delegate
+      console.log("testArray[0] =", testArray[0]); // should be 1
+      testArray[1] = 99;
+      console.log("testArray[1] =", testArray[1]); // should be 99
+
+      // Test regular property access
+      console.log("testArray.getLength() =", testArray.getLength()); // should be 3
+    }
+  }
+});

--- a/test/tool/integrationtest/test-issues/issue10591/source/class/issue10591/TestArray.js
+++ b/test/tool/integrationtest/test-issues/issue10591/source/class/issue10591/TestArray.js
@@ -1,0 +1,75 @@
+/* ************************************************************************
+
+   Copyright: 2023 qooxdoo developers
+
+   License: MIT license
+
+   Authors:
+
+************************************************************************ */
+
+/**
+ * Test class with delegate using ES6 shorthand method syntax.
+ *
+ * This class demonstrates the use of ES6 shorthand methods in a delegate
+ * object, which previously caused spurious "Unresolved use of symbol"
+ * warnings for the method parameters (property, value).
+ */
+qx.Class.define("issue10591.TestArray", {
+  extend: qx.core.Object,
+
+  /**
+   * Delegate allows array-like access using ES6 shorthand method syntax.
+   * The compiler should NOT generate warnings about unresolved symbols
+   * for the parameters: property, value
+   */
+  delegate: {
+    get(property) {
+      // property should NOT be flagged as "Unresolved use of symbol property"
+      if (typeof property != "symbol" && +property === +property) {
+        return this.getItem(property);
+      } else {
+        return this[property];
+      }
+    },
+
+    set(property, value) {
+      // property and value should NOT be flagged as unresolved symbols
+      if (typeof property != "symbol" && +property === +property) {
+        this.setItem(property, value);
+      } else {
+        this[property] = value;
+      }
+    },
+
+    delete(property) {
+      // property should NOT be flagged as "Unresolved use of symbol property"
+      if (typeof property != "symbol" && +property === +property) {
+        this.setItem(property, undefined);
+      } else {
+        delete this[property];
+      }
+    }
+  },
+
+  construct(items) {
+    super();
+    this.__array = items || [];
+  },
+
+  members: {
+    __array: null,
+
+    getItem(index) {
+      return this.__array[index];
+    },
+
+    setItem(index, value) {
+      this.__array[index] = value;
+    },
+
+    getLength() {
+      return this.__array.length;
+    }
+  }
+});

--- a/test/tool/integrationtest/test-issues/issue10591/source/translation/readme.txt
+++ b/test/tool/integrationtest/test-issues/issue10591/source/translation/readme.txt
@@ -1,0 +1,1 @@
+This directory will contain translation (.po) files once they are created.


### PR DESCRIPTION
## Summary

Fixes compiler generating spurious "Unresolved use of symbol" warnings when using ES6 shorthand method syntax in delegate objects.

## Problem

The compiler was generating false warnings like:
- "Unresolved use of symbol property"
- "Unresolved use of symbol value"

When using ES6 shorthand method syntax in delegate objects:

```javascript
delegate: {
  get(property) {  // ❌ Warning: Unresolved use of symbol property
    return this[property];
  },
  set(property, value) {  // ❌ Warnings for property and value
    this[property] = value;
  }
}
While traditional function syntax worked without warnings:

delegate: {
  get: function(property) {  // ✅ No warning
    return this[property];
  }
}
This issue affected classes like qx.data.Array and made it impossible to use modern JavaScript syntax with auto-formatting tools.

Root Cause
The delegate property in class definitions didn't have explicit handling in the ObjectProperty visitor of CLASS_DEF_VISITOR. This meant its children (ObjectMethod nodes with ES6 shorthand syntax) weren't being properly traversed with the VISITOR, which is responsible for calling enterFunction() to register method parameters as declarations in the scope.

Solution
Added explicit handling for the delegate property in source/class/qx/tool/compiler/ClassFile.js to ensure proper traversal of ES6 shorthand methods:

} else if (keyName == "delegate") {
  path.skip();
  path.traverse(VISITOR);
This follows the same pattern as other class definition sections like events, properties, etc.

Changes
Fix: Added delegate property handling in ClassFile.js (3 lines)
Test: Created integration test in test/tool/integrationtest/test-issues/issue10591/ with:
TestArray class demonstrating ES6 shorthand methods in delegate
Application exercising the delegate functionality
Documentation explaining the issue and expected behavior
Testing
✅ Bootstrap compiler completes successfully ✅ Full compilation produces no "Unresolved use of symbol" warnings ✅ Integration test compiles without warnings ✅ Verified with qx.data.Array and custom delegate objects

Fixes
Closes #10591