### PR TITLE
Compiler incorrectly flagging JavaScript labels in continue statements (Issue #10727)

### DIFF
--- a/source/class/qx/tool/compiler/ClassFile.js
+++ b/source/class/qx/tool/compiler/ClassFile.js
@@ -1716,7 +1716,8 @@ qx.Class.define("qx.tool.compiler.ClassFile", {
             ClassDeclaration: 1,
             ClassMethod: 1,
             LabeledStatement: 1,
-            BreakStatement: 1
+            BreakStatement: 1,
+            ContinueStatement: 1
           };
 
           // These are AST node types we expect to find at the root of the identifier, and which will

--- a/test/tool/unittest/compiler/classIssue10727.js
+++ b/test/tool/unittest/compiler/classIssue10727.js
@@ -1,0 +1,42 @@
+qx.Class.define("classIssue10727",
+{
+  extend: qx.core.Object,
+
+  members: {
+    // Test case from issue #10727: JavaScript labels should not generate
+    // "Unresolved use of symbol" warnings when used with continue/break statements
+    labeledLoop() {
+      $outer: for (let x = 0; x < 10; x++) {
+        for (let y = 0; y < 10; y++) {
+          if (x ** y > 100000) {
+            continue $outer;
+          }
+        }
+      }
+    },
+
+    // Additional test cases for label handling
+    labeledLoopWithBreak() {
+      outerLoop: for (let i = 0; i < 5; i++) {
+        for (let j = 0; j < 5; j++) {
+          if (i * j > 10) {
+            break outerLoop;
+          }
+        }
+      }
+    },
+
+    // Test with while loop
+    labeledWhile() {
+      myLabel: while (true) {
+        let count = 0;
+        while (count < 10) {
+          count++;
+          if (count === 5) {
+            break myLabel;
+          }
+        }
+      }
+    }
+  }
+});


### PR DESCRIPTION
## Summary
Fixes #10727 - Resolves false "Unresolved use of symbol" warnings for JavaScript labels in continue statements.

## Problem
Valid code like this incorrectly generates warnings:
```javascript
$outer: for (let x = 0; x < 10; x++) {
  for (let y = 0; y < 10; y++) {
    if (x ** y > 100000) {
      continue $outer;  // Warning: Unresolved use of symbol $outer
    }
  }
}
Root Cause
ContinueStatement was missing from the CHECK_FOR_UNDEFINED list in ClassFile.js, while BreakStatement and LabeledStatement were already included. This inconsistency caused label identifiers to be incorrectly checked as variable references.