### PR TITLE
Fix #10411: Correct blocker positioning in blockContent()

### DIFF
--- a/.github/workflows/test-framework.yml
+++ b/.github/workflows/test-framework.yml
@@ -24,6 +24,7 @@ jobs:
     if: "!contains(github.event.head_commit.message, 'skip ci')"
 
     strategy:
+      fail-fast: false
       matrix:
         os: [ubuntu-latest, windows-latest]
         node-version: [18.x, 20.x, 22.x]

--- a/.github/workflows/test-framework.yml
+++ b/.github/workflows/test-framework.yml
@@ -14,6 +14,7 @@ on:
     types: 
       - opened
       - reopened
+      - synchronize
 
   workflow_dispatch:
 

--- a/Manifest.json
+++ b/Manifest.json
@@ -79,7 +79,7 @@
         "email": "dietrich.streifert@visionet.de"
       }
     ],
-    "version": "7.9.1",
+    "version": "7.9.2",
     "sourceViewUri": "https://github.com/qooxdoo/qooxdoo/blob/%{qxGitBranch}/framework/source/class/%{classFilePath}#L%{lineNumber}"
   },
   "provides": {

--- a/docs/_variables.json
+++ b/docs/_variables.json
@@ -1,5 +1,5 @@
 {
   "qooxdoo": {
-    "version": "7.9.1"
+    "version": "7.9.2"
   }
 }

--- a/docs/release-notes.7.0.md
+++ b/docs/release-notes.7.0.md
@@ -1,5 +1,9 @@
 # Qooxdoo Release Notes
 
+## New feature for v7.9.2
+
+For a full list of changes see https://github.com/qooxdoo/qooxdoo/commits/master?branch=master&qualified_name=refs%2Fheads%2Fmaster&since=2025-05-15&until=2025-10-15
+
 ## New feature for v7.9.0
    - Add the possibility to use native promises instead of Bluebird (##10766)
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@qooxdoo/framework",
-  "version": "7.9.1",
+  "version": "7.9.2",
   "description": "The JS Framework for Coders",
   "author": "The qooxdoo project",
   "keywords": [

--- a/source/class/qx/test/theme/manager/Color.js
+++ b/source/class/qx/test/theme/manager/Color.js
@@ -21,33 +21,41 @@ qx.Class.define("qx.test.theme.manager.Color", {
 
   members: {
     __formerTheme: null,
-    __formerListener: null,
+    __savedListeners: null,
 
     setUp() {
       this.manager = qx.theme.manager.Color.getInstance();
       this.__formerTheme = this.manager.getTheme();
 
-      let listener = qx.event.Registration.getManager(
-        this.manager
-      ).getAllListeners();
-      let hash =
-        this.manager.$$hash || qx.core.ObjectRegistry.toHashCode(this.manager);
-      this.__formerListener = { ...listener[hash] };
-      delete listener[hash];
+      let eventMgr = qx.event.Registration.getManager(this.manager);
+
+      // Serialize listeners (Array of {handler, self, type, capture})
+      this.__savedListeners = eventMgr.serializeListeners(this.manager);
+
+      // Remove all listeners
+      eventMgr.removeAllListeners(this.manager);
     },
 
     tearDown() {
       qx.test.Theme.themes = null;
+
       this.manager.setTheme(this.__formerTheme);
       this.__formerTheme = null;
 
-      let listener = qx.event.Registration.getManager(
-        this.manager
-      ).getAllListeners();
-      let hash =
-        this.manager.$$hash || qx.core.ObjectRegistry.toHashCode(this.manager);
-      listener[hash] = this.__formerListener;
-      this.__formerListener = null;
+      // Restore all listeners
+      if (this.__savedListeners) {
+        this.__savedListeners.forEach(entry => {
+          qx.event.Registration.addListener(
+            this.manager,
+            entry.type,
+            entry.handler,
+            entry.self,
+            entry.capture
+          );
+        });
+        this.__savedListeners = null;
+      }
+
       qx.ui.core.queue.Manager.flush();
     },
 

--- a/source/class/qx/test/theme/manager/Decoration.js
+++ b/source/class/qx/test/theme/manager/Decoration.js
@@ -21,33 +21,41 @@ qx.Class.define("qx.test.theme.manager.Decoration", {
 
   members: {
     __formerTheme: null,
-    __formerListener: null,
+    __savedListeners: null,
 
     setUp() {
       this.manager = qx.theme.manager.Decoration.getInstance();
       this.__formerTheme = this.manager.getTheme();
 
-      let listener = qx.event.Registration.getManager(
-        this.manager
-      ).getAllListeners();
-      let hash =
-        this.manager.$$hash || qx.core.ObjectRegistry.toHashCode(this.manager);
-      this.__formerListener = { ...listener[hash] };
-      delete listener[hash];
+      let eventMgr = qx.event.Registration.getManager(this.manager);
+
+      // Serialize listeners (Array of {handler, self, type, capture})
+      this.__savedListeners = eventMgr.serializeListeners(this.manager);
+
+      // Remove all listeners
+      eventMgr.removeAllListeners(this.manager);
     },
 
     tearDown() {
       qx.test.Theme.themes = null;
+
       this.manager.setTheme(this.__formerTheme);
       this.__formerTheme = null;
 
-      let listener = qx.event.Registration.getManager(
-        this.manager
-      ).getAllListeners();
-      let hash =
-        this.manager.$$hash || qx.core.ObjectRegistry.toHashCode(this.manager);
-      listener[hash] = this.__formerListener;
-      this.__formerListener = null;
+      // Restore all listeners
+      if (this.__savedListeners) {
+        this.__savedListeners.forEach(entry => {
+          qx.event.Registration.addListener(
+            this.manager,
+            entry.type,
+            entry.handler,
+            entry.self,
+            entry.capture
+          );
+        });
+        this.__savedListeners = null;
+      }
+
       qx.ui.core.queue.Manager.flush();
     },
 

--- a/source/class/qx/test/theme/manager/Icon.js
+++ b/source/class/qx/test/theme/manager/Icon.js
@@ -21,33 +21,41 @@ qx.Class.define("qx.test.theme.manager.Icon", {
 
   members: {
     __formerTheme: null,
-    __formerListener: null,
+    __savedListeners: null,
 
     setUp() {
       this.manager = qx.theme.manager.Icon.getInstance();
       this.__formerTheme = this.manager.getTheme();
 
-      let listener = qx.event.Registration.getManager(
-        this.manager
-      ).getAllListeners();
-      let hash =
-        this.manager.$$hash || qx.core.ObjectRegistry.toHashCode(this.manager);
-      this.__formerListener = { ...listener[hash] };
-      delete listener[hash];
+      let eventMgr = qx.event.Registration.getManager(this.manager);
+
+      // Serialize listeners (Array of {handler, self, type, capture})
+      this.__savedListeners = eventMgr.serializeListeners(this.manager);
+
+      // Remove all listeners
+      eventMgr.removeAllListeners(this.manager);
     },
 
     tearDown() {
       qx.test.Theme.themes = null;
+
       this.manager.setTheme(this.__formerTheme);
       this.__formerTheme = null;
 
-      let listener = qx.event.Registration.getManager(
-        this.manager
-      ).getAllListeners();
-      let hash =
-        this.manager.$$hash || qx.core.ObjectRegistry.toHashCode(this.manager);
-      listener[hash] = this.__formerListener;
-      this.__formerListener = null;
+      // Restore all listeners
+      if (this.__savedListeners) {
+        this.__savedListeners.forEach(entry => {
+          qx.event.Registration.addListener(
+            this.manager,
+            entry.type,
+            entry.handler,
+            entry.self,
+            entry.capture
+          );
+        });
+        this.__savedListeners = null;
+      }
+
       qx.ui.core.queue.Manager.flush();
     },
 

--- a/source/class/qx/test/ui/core/Blocker.js
+++ b/source/class/qx/test/ui/core/Blocker.js
@@ -235,6 +235,127 @@ qx.Class.define("qx.test.ui.core.Blocker", {
 
       txt.destroy();
       this.flush();
+    },
+
+    testBlockContent() {
+      // Create a container widget with specific position
+      var container = new qx.ui.container.Composite(new qx.ui.layout.Canvas());
+      this.getRoot().add(container, { left: 100, top: 50 });
+      container.setWidth(200);
+      container.setHeight(150);
+      this.flush();
+
+      // Create blocker for the container
+      var blocker = new qx.ui.core.Blocker(container);
+      var blockerElement = blocker.getBlockerElement();
+
+      // Block content
+      blocker.blockContent(10);
+      this.flush();
+
+      this.assertTrue(blocker.isBlocked(), "blocker should be blocked");
+      this.assertTrue(blockerElement.isIncluded(), "blocker element should be included");
+
+      // Verify blocker dimensions match container
+      var styles = blockerElement.getStyles();
+      this.assertEquals("200px", styles.width, "blocker width should match container width");
+      this.assertEquals("150px", styles.height, "blocker height should match container height");
+
+      // Verify blocker position is 0,0 (relative to container, not layout parent)
+      // This is the fix for issue #10411
+      this.assertEquals("0px", styles.left, "blocker left should be 0 when blocking content");
+      this.assertEquals("0px", styles.top, "blocker top should be 0 when blocking content");
+
+      // Cleanup
+      blocker.unblock();
+      blocker.dispose();
+      container.destroy();
+      this.flush();
+    },
+
+    testBlockContentPositioning() {
+      // Create a container at a non-zero position
+      var container = new qx.ui.container.Composite(new qx.ui.layout.Canvas());
+      this.getRoot().add(container, { left: 150, top: 100 });
+      container.setWidth(300);
+      container.setHeight(200);
+      this.flush();
+
+      var blocker = new qx.ui.core.Blocker(container);
+      var blockerElement = blocker.getBlockerElement();
+
+      // Block the content
+      blocker.blockContent(5);
+      this.flush();
+
+      var styles = blockerElement.getStyles();
+
+      // The blocker should be positioned at 0,0 relative to the container
+      // NOT at the container's position (150, 100)
+      this.assertEquals("0px", styles.left, "blocker should be at left: 0");
+      this.assertEquals("0px", styles.top, "blocker should be at top: 0");
+      this.assertEquals("300px", styles.width, "blocker width should match container");
+      this.assertEquals("200px", styles.height, "blocker height should match container");
+
+      // Cleanup
+      blocker.unblock();
+      blocker.dispose();
+      container.destroy();
+      this.flush();
+    },
+
+    testNormalBlockVsBlockContent() {
+      // Create two containers to compare normal block vs blockContent
+      var container1 = new qx.ui.container.Composite(new qx.ui.layout.Canvas());
+      var container2 = new qx.ui.container.Composite(new qx.ui.layout.Canvas());
+
+      this.getRoot().add(container1, { left: 50, top: 50 });
+      this.getRoot().add(container2, { left: 300, top: 50 });
+
+      container1.setWidth(100);
+      container1.setHeight(100);
+      container2.setWidth(100);
+      container2.setHeight(100);
+
+      this.flush();
+
+      var blocker1 = new qx.ui.core.Blocker(container1);
+      var blocker2 = new qx.ui.core.Blocker(container2);
+
+      // Normal block - blocker is added to layout parent
+      blocker1.block();
+      this.flush();
+
+      var styles1 = blocker1.getBlockerElement().getStyles();
+
+      // BlockContent - blocker is added to the widget itself
+      blocker2.blockContent(5);
+      this.flush();
+
+      var styles2 = blocker2.getBlockerElement().getStyles();
+
+      // Normal block: blocker positioned at container's position in layout parent
+      this.assertEquals("50px", styles1.left, "normal block uses container's left position");
+      this.assertEquals("50px", styles1.top, "normal block uses container's top position");
+
+      // BlockContent: blocker positioned at 0,0 relative to container
+      this.assertEquals("0px", styles2.left, "blockContent uses 0 for left position");
+      this.assertEquals("0px", styles2.top, "blockContent uses 0 for top position");
+
+      // Both should have same dimensions as their containers
+      this.assertEquals("100px", styles1.width);
+      this.assertEquals("100px", styles1.height);
+      this.assertEquals("100px", styles2.width);
+      this.assertEquals("100px", styles2.height);
+
+      // Cleanup
+      blocker1.unblock();
+      blocker2.unblock();
+      blocker1.dispose();
+      blocker2.dispose();
+      container1.destroy();
+      container2.destroy();
+      this.flush();
     }
   }
 });

--- a/source/class/qx/test/util/DateFormat.js
+++ b/source/class/qx/test/util/DateFormat.js
@@ -969,7 +969,7 @@ qx.Class.define("qx.test.util.DateFormat", {
         var timezoneOffset = date.getTimezoneOffset();
         var timezoneSign = timezoneOffset > 0 ? 1 : -1;
         var timezoneHours = Math.floor(Math.abs(timezoneOffset) / 60);
-        var timezoneMinutes = Math.abs(timezoneOffset) % 60;
+        var timezoneMinutes = Math.trunc(Math.abs(timezoneOffset)) % 60;
 
         var localTimeZone =
           "GMT" +

--- a/source/class/qx/util/format/DateFormat.js
+++ b/source/class/qx/util/format/DateFormat.js
@@ -476,8 +476,9 @@ qx.Class.define("qx.util.format.DateFormat", {
 
       var timezoneOffset = date.getTimezoneOffset();
       var timezoneSign = timezoneOffset > 0 ? 1 : -1;
-      var timezoneHours = Math.floor(Math.abs(timezoneOffset) / 60);
-      var timezoneMinutes = Math.abs(timezoneOffset) % 60;
+      var absTitmezoneOffset = Math.abs(timezoneOffset);
+      var timezoneHours = Math.floor(absTitmezoneOffset / 60);
+      var timezoneMinutes = Math.trunc(absTitmezoneOffset) % 60;
 
       // Create the output
       this.__initFormatTree();

--- a/source/class/qx/util/format/DateFormat.js
+++ b/source/class/qx/util/format/DateFormat.js
@@ -476,9 +476,9 @@ qx.Class.define("qx.util.format.DateFormat", {
 
       var timezoneOffset = date.getTimezoneOffset();
       var timezoneSign = timezoneOffset > 0 ? 1 : -1;
-      var absTitmezoneOffset = Math.abs(timezoneOffset);
-      var timezoneHours = Math.floor(absTitmezoneOffset / 60);
-      var timezoneMinutes = Math.trunc(absTitmezoneOffset) % 60;
+      var absTimezoneOffset = Math.abs(timezoneOffset);
+      var timezoneHours = Math.floor(absTimezoneOffset / 60);
+      var timezoneMinutes = Math.trunc(absTimezoneOffset) % 60;
 
       // Create the output
       this.__initFormatTree();


### PR DESCRIPTION
## Summary

Fixes #10411 - `qx.ui.core.Blocker.blockContent()` was misplacing the blocker element due to incorrect positioning calculation.

### Problem
When `blockContent()` was called, the blocker element became a child of the target widget rather than its layout parent. The blocker was positioned using the widget's bounds (left, top coordinates), which caused a double offset since the blocker was already positioned relative to the widget.

### Solution
- Added `__blockingContent` member variable to track when the blocker is in content blocking mode
- Modified `_updateBlockerBounds()` to use `left: 0, top: 0` when `__blockingContent` is true (blocker is child of widget)
- Fixed `_block()` to properly pass the `blockContent` parameter to the appear listener binding
- Reset `__blockingContent` to false in `__unblock()`

## Test Plan

Added three new test cases:
- [x] `testBlockContent()` - Verifies basic blockContent functionality and correct 0,0 positioning
- [x] `testBlockContentPositioning()` - Tests with container at non-zero position (150, 100) to ensure blocker is still positioned at 0,0
- [x] `testNormalBlockVsBlockContent()` - Compares normal `block()` vs `blockContent()` to verify different positioning behaviors

