### PR TITLE
Fix #10411: Correct blocker positioning in blockContent()

### DIFF
--- a/source/class/qx/test/ui/core/Blocker.js
+++ b/source/class/qx/test/ui/core/Blocker.js
@@ -236,6 +236,127 @@ qx.Class.define("qx.test.ui.core.Blocker", {
 
       txt.destroy();
       this.flush();
+    },
+
+    testBlockContent() {
+      // Create a container widget with specific position
+      var container = new qx.ui.container.Composite(new qx.ui.layout.Canvas());
+      this.getRoot().add(container, { left: 100, top: 50 });
+      container.setWidth(200);
+      container.setHeight(150);
+      this.flush();
+
+      // Create blocker for the container
+      var blocker = new qx.ui.core.Blocker(container);
+      var blockerElement = blocker.getBlockerElement();
+
+      // Block content
+      blocker.blockContent(10);
+      this.flush();
+
+      this.assertTrue(blocker.isBlocked(), "blocker should be blocked");
+      this.assertTrue(blockerElement.isIncluded(), "blocker element should be included");
+
+      // Verify blocker dimensions match container
+      var styles = blockerElement.getStyles();
+      this.assertEquals("200px", styles.width, "blocker width should match container width");
+      this.assertEquals("150px", styles.height, "blocker height should match container height");
+
+      // Verify blocker position is 0,0 (relative to container, not layout parent)
+      // This is the fix for issue #10411
+      this.assertEquals("0px", styles.left, "blocker left should be 0 when blocking content");
+      this.assertEquals("0px", styles.top, "blocker top should be 0 when blocking content");
+
+      // Cleanup
+      blocker.unblock();
+      blocker.dispose();
+      container.destroy();
+      this.flush();
+    },
+
+    testBlockContentPositioning() {
+      // Create a container at a non-zero position
+      var container = new qx.ui.container.Composite(new qx.ui.layout.Canvas());
+      this.getRoot().add(container, { left: 150, top: 100 });
+      container.setWidth(300);
+      container.setHeight(200);
+      this.flush();
+
+      var blocker = new qx.ui.core.Blocker(container);
+      var blockerElement = blocker.getBlockerElement();
+
+      // Block the content
+      blocker.blockContent(5);
+      this.flush();
+
+      var styles = blockerElement.getStyles();
+
+      // The blocker should be positioned at 0,0 relative to the container
+      // NOT at the container's position (150, 100)
+      this.assertEquals("0px", styles.left, "blocker should be at left: 0");
+      this.assertEquals("0px", styles.top, "blocker should be at top: 0");
+      this.assertEquals("300px", styles.width, "blocker width should match container");
+      this.assertEquals("200px", styles.height, "blocker height should match container");
+
+      // Cleanup
+      blocker.unblock();
+      blocker.dispose();
+      container.destroy();
+      this.flush();
+    },
+
+    testNormalBlockVsBlockContent() {
+      // Create two containers to compare normal block vs blockContent
+      var container1 = new qx.ui.container.Composite(new qx.ui.layout.Canvas());
+      var container2 = new qx.ui.container.Composite(new qx.ui.layout.Canvas());
+
+      this.getRoot().add(container1, { left: 50, top: 50 });
+      this.getRoot().add(container2, { left: 300, top: 50 });
+
+      container1.setWidth(100);
+      container1.setHeight(100);
+      container2.setWidth(100);
+      container2.setHeight(100);
+
+      this.flush();
+
+      var blocker1 = new qx.ui.core.Blocker(container1);
+      var blocker2 = new qx.ui.core.Blocker(container2);
+
+      // Normal block - blocker is added to layout parent
+      blocker1.block();
+      this.flush();
+
+      var styles1 = blocker1.getBlockerElement().getStyles();
+
+      // BlockContent - blocker is added to the widget itself
+      blocker2.blockContent(5);
+      this.flush();
+
+      var styles2 = blocker2.getBlockerElement().getStyles();
+
+      // Normal block: blocker positioned at container's position in layout parent
+      this.assertEquals("50px", styles1.left, "normal block uses container's left position");
+      this.assertEquals("50px", styles1.top, "normal block uses container's top position");
+
+      // BlockContent: blocker positioned at 0,0 relative to container
+      this.assertEquals("0px", styles2.left, "blockContent uses 0 for left position");
+      this.assertEquals("0px", styles2.top, "blockContent uses 0 for top position");
+
+      // Both should have same dimensions as their containers
+      this.assertEquals("100px", styles1.width);
+      this.assertEquals("100px", styles1.height);
+      this.assertEquals("100px", styles2.width);
+      this.assertEquals("100px", styles2.height);
+
+      // Cleanup
+      blocker1.unblock();
+      blocker2.unblock();
+      blocker1.dispose();
+      blocker2.dispose();
+      container1.destroy();
+      container2.destroy();
+      this.flush();
     }
   }
 });

--- a/source/class/qx/test/ui/core/Blocker.js
+++ b/source/class/qx/test/ui/core/Blocker.js
@@ -258,7 +258,7 @@ qx.Class.define("qx.test.ui.core.Blocker", {
       this.assertTrue(blockerElement.isIncluded(), "blocker element should be included");
 
       // Verify blocker dimensions match container
-      var styles = blockerElement.getStyles();
+      var styles = blockerElement.getAllStyles();
       this.assertEquals("200px", styles.width, "blocker width should match container width");
       this.assertEquals("150px", styles.height, "blocker height should match container height");
 
@@ -289,7 +289,7 @@ qx.Class.define("qx.test.ui.core.Blocker", {
       blocker.blockContent(5);
       this.flush();
 
-      var styles = blockerElement.getStyles();
+      var styles = blockerElement.getAllStyles();
 
       // The blocker should be positioned at 0,0 relative to the container
       // NOT at the container's position (150, 100)
@@ -327,13 +327,13 @@ qx.Class.define("qx.test.ui.core.Blocker", {
       blocker1.block();
       this.flush();
 
-      var styles1 = blocker1.getBlockerElement().getStyles();
+      var styles1 = blocker1.getBlockerElement().getAllStyles();
 
       // BlockContent - blocker is added to the widget itself
       blocker2.blockContent(5);
       this.flush();
 
-      var styles2 = blocker2.getBlockerElement().getStyles();
+      var styles2 = blocker2.getBlockerElement().getAllStyles();
 
       // Normal block: blocker positioned at container's position in layout parent
       this.assertEquals("50px", styles1.left, "normal block uses container's left position");


### PR DESCRIPTION
## Summary

Fixes #10411 - `qx.ui.core.Blocker.blockContent()` was misplacing the blocker element due to incorrect positioning calculation.

### Problem
When `blockContent()` was called, the blocker element became a child of the target widget rather than its layout parent. The blocker was positioned using the widget's bounds (left, top coordinates), which caused a double offset since the blocker was already positioned relative to the widget.

### Solution
- Added `__blockingContent` member variable to track when the blocker is in content blocking mode
- Modified `_updateBlockerBounds()` to use `left: 0, top: 0` when `__blockingContent` is true (blocker is child of widget)
- Fixed `_block()` to properly pass the `blockContent` parameter to the appear listener binding
- Reset `__blockingContent` to false in `__unblock()`

## Test Plan

Added three new test cases:
- [x] `testBlockContent()` - Verifies basic blockContent functionality and correct 0,0 positioning
- [x] `testBlockContentPositioning()` - Tests with container at non-zero position (150, 100) to ensure blocker is still positioned at 0,0
- [x] `testNormalBlockVsBlockContent()` - Compares normal `block()` vs `blockContent()` to verify different positioning behaviors

