### PR TITLE
Fix issue #10816: Wrap assert calls with debug checks

### DIFF
--- a/source/class/qx/Interface.js
+++ b/source/class/qx/Interface.js
@@ -359,16 +359,18 @@ qx.Bootstrap.define("qx.Interface", {
      *  @param iface {Interface} The interface to verify
      */
     assertObject(object, iface) {
-      var clazz = object.constructor;
-      this.__checkMembers(object, clazz, iface, false, true);
-      this.__checkProperties(clazz, iface, true);
-      this.__checkEvents(clazz, iface, true);
+      if (qx.core.Environment.get("qx.debug")) {
+        var clazz = object.constructor;
+        this.__checkMembers(object, clazz, iface, false, true);
+        this.__checkProperties(clazz, iface, true);
+        this.__checkEvents(clazz, iface, true);
 
-      // Validate extends, recursive
-      var extend = iface.$$extends;
-      if (extend) {
-        for (var i = 0, l = extend.length; i < l; i++) {
-          this.assertObject(object, extend[i]);
+        // Validate extends, recursive
+        var extend = iface.$$extends;
+        if (extend) {
+          for (var i = 0, l = extend.length; i < l; i++) {
+            this.assertObject(object, extend[i]);
+          }
         }
       }
     },
@@ -382,15 +384,17 @@ qx.Bootstrap.define("qx.Interface", {
      *     check parameters etc.
      */
     assert(clazz, iface, wrap) {
-      this.__checkMembers(clazz.prototype, clazz, iface, wrap, true);
-      this.__checkProperties(clazz, iface, true);
-      this.__checkEvents(clazz, iface, true);
+      if (qx.core.Environment.get("qx.debug")) {
+        this.__checkMembers(clazz.prototype, clazz, iface, wrap, true);
+        this.__checkProperties(clazz, iface, true);
+        this.__checkEvents(clazz, iface, true);
 
-      // Validate extends, recursive
-      var extend = iface.$$extends;
-      if (extend) {
-        for (var i = 0, l = extend.length; i < l; i++) {
-          this.assert(clazz, extend[i], wrap);
+        // Validate extends, recursive
+        var extend = iface.$$extends;
+        if (extend) {
+          for (var i = 0, l = extend.length; i < l; i++) {
+            this.assert(clazz, extend[i], wrap);
+          }
         }
       }
     },

--- a/source/class/qx/data/SingleValueBinding.js
+++ b/source/class/qx/data/SingleValueBinding.js
@@ -278,11 +278,14 @@ qx.Class.define("qx.data.SingleValueBinding", {
 
         //Set the input on the first segment of the source path
         let promise = this.__sourceSegments[0].setInput(value);
-        const cb = () =>
-          this.assertNotNull(
-            this.__sourceSegments[0].getEventName(),
-            `Binding property ${this.__sourceSegments[0].toString()} of object ${value.classname} not possible. No event available.`
-          );
+        const cb = () => {
+          if (qx.core.Environment.get("qx.debug")) {
+            this.assertNotNull(
+              this.__sourceSegments[0].getEventName(),
+              `Binding property ${this.__sourceSegments[0].toString()} of object ${value.classname} not possible. No event available.`
+            );
+          }
+        };
 
         let out;
 

--- a/source/class/qx/data/binding/ArrayIndexSegment.js
+++ b/source/class/qx/data/binding/ArrayIndexSegment.js
@@ -29,7 +29,9 @@ qx.Class.define("qx.data.binding.ArrayIndexSegment", {
     super(binding);
     this.__string = segment;
 
-    this.assertTrue(segment.startsWith("[") && segment.endsWith("]"), "Array index segment must start with [ and end with ]: " + segment);
+    if (qx.core.Environment.get("qx.debug")) {
+      this.assertTrue(segment.startsWith("[") && segment.endsWith("]"), "Array index segment must start with [ and end with ]: " + segment);
+    }
 
     let index = segment.substring(1, segment.length - 1);
     if (index === "last") {

--- a/source/class/qx/event/IEventDispatcher.js
+++ b/source/class/qx/event/IEventDispatcher.js
@@ -32,8 +32,10 @@ qx.Interface.define("qx.event.IEventDispatcher", {
      * @return {Boolean} Whether the event dispatcher is responsible for the this event
      */
     canDispatchEvent(target, event, type) {
-      this.assertInstance(event, qx.event.type.Event);
-      this.assertString(type);
+      if (qx.core.Environment.get("qx.debug")) {
+        this.assertInstance(event, qx.event.type.Event);
+        this.assertString(type);
+      }
     },
 
     /**
@@ -45,8 +47,10 @@ qx.Interface.define("qx.event.IEventDispatcher", {
      * @return {qx.Promise?} a promise, if one or more of the event handlers returned a promise
      */
     dispatchEvent(target, event, type) {
-      this.assertInstance(event, qx.event.type.Event);
-      this.assertString(type);
+      if (qx.core.Environment.get("qx.debug")) {
+        this.assertInstance(event, qx.event.type.Event);
+        this.assertString(type);
+      }
     }
   }
 });

--- a/source/class/qx/ui/core/scroll/IScrollBar.js
+++ b/source/class/qx/ui/core/scroll/IScrollBar.js
@@ -67,7 +67,9 @@ qx.Interface.define("qx.ui.core.scroll.IScrollBar", {
      * @param duration {Number} The time in milliseconds the slide to should take.
      */
     scrollTo(position, duration) {
-      this.assertNumber(position);
+      if (qx.core.Environment.get("qx.debug")) {
+        this.assertNumber(position);
+      }
     },
 
     /**
@@ -80,7 +82,9 @@ qx.Interface.define("qx.ui.core.scroll.IScrollBar", {
      * @param duration {Number} The time in milliseconds the slide to should take.
      */
     scrollBy(offset, duration) {
-      this.assertNumber(offset);
+      if (qx.core.Environment.get("qx.debug")) {
+        this.assertNumber(offset);
+      }
     },
 
     /**
@@ -93,7 +97,9 @@ qx.Interface.define("qx.ui.core.scroll.IScrollBar", {
      * @param duration {Number} The time in milliseconds the slide to should take.
      */
     scrollBySteps(steps, duration) {
-      this.assertNumber(steps);
+      if (qx.core.Environment.get("qx.debug")) {
+        this.assertNumber(steps);
+      }
     }
   }
 });

--- a/source/class/qx/ui/form/IListItem.js
+++ b/source/class/qx/ui/form/IListItem.js
@@ -52,7 +52,9 @@ qx.Interface.define("qx.ui.form.IListItem", {
      * @return {Boolean|null}
      */
     setReadOnly(value) {
-      this.assertArgumentsCount(arguments, 1, 1);
+      if (qx.core.Environment.get("qx.debug")) {
+        this.assertArgumentsCount(arguments, 1, 1);
+      }
     },
 
     /**

--- a/source/class/qx/ui/form/IRadioItem.js
+++ b/source/class/qx/ui/form/IRadioItem.js
@@ -61,7 +61,9 @@ qx.Interface.define("qx.ui.form.IRadioItem", {
      *     manage the item.
      */
     setGroup(value) {
-      this.assertInstance(value, qx.ui.form.RadioGroup);
+      if (qx.core.Environment.get("qx.debug")) {
+        this.assertInstance(value, qx.ui.form.RadioGroup);
+      }
     },
 
     /**

--- a/source/class/qx/ui/tree/core/IVirtualTree.js
+++ b/source/class/qx/ui/tree/core/IVirtualTree.js
@@ -50,8 +50,10 @@ qx.Interface.define("qx.ui.tree.core.IVirtualTree", {
      *   </code>false</code> when item is a leaf.
      */
     isNode(item) {
-      this.assertArgumentsCount(arguments, 1, 1);
-      this.assertInterface(item, qx.core.Object);
+      if (qx.core.Environment.get("qx.debug")) {
+        this.assertArgumentsCount(arguments, 1, 1);
+        this.assertInterface(item, qx.core.Object);
+      }
     },
 
     /**

--- a/source/class/qx/ui/tree/provider/IVirtualTreeProvider.js
+++ b/source/class/qx/ui/tree/provider/IVirtualTreeProvider.js
@@ -44,8 +44,10 @@ qx.Interface.define("qx.ui.tree.provider.IVirtualTreeProvider", {
      * @param value {String} The child property name.
      */
     setChildProperty(value) {
-      this.assertArgumentsCount(arguments, 1, 1);
-      this.assertString(value);
+      if (qx.core.Environment.get("qx.debug")) {
+        this.assertArgumentsCount(arguments, 1, 1);
+        this.assertString(value);
+      }
     },
 
     /**
@@ -55,8 +57,10 @@ qx.Interface.define("qx.ui.tree.provider.IVirtualTreeProvider", {
      * @param value {String} The label path.
      */
     setLabelPath(value) {
-      this.assertArgumentsCount(arguments, 1, 1);
-      this.assertString(value);
+      if (qx.core.Environment.get("qx.debug")) {
+        this.assertArgumentsCount(arguments, 1, 1);
+        this.assertString(value);
+      }
     },
 
     /**
@@ -65,8 +69,10 @@ qx.Interface.define("qx.ui.tree.provider.IVirtualTreeProvider", {
      * @param row {Integer} row to style.
      */
     styleSelectabled(row) {
-      this.assertArgumentsCount(arguments, 1, 1);
-      this.assertInteger(row);
+      if (qx.core.Environment.get("qx.debug")) {
+        this.assertArgumentsCount(arguments, 1, 1);
+        this.assertInteger(row);
+      }
     },
 
     /**
@@ -75,8 +81,10 @@ qx.Interface.define("qx.ui.tree.provider.IVirtualTreeProvider", {
      * @param row {Integer} row to style.
      */
     styleUnselectabled(row) {
-      this.assertArgumentsCount(arguments, 1, 1);
-      this.assertInteger(row);
+      if (qx.core.Environment.get("qx.debug")) {
+        this.assertArgumentsCount(arguments, 1, 1);
+        this.assertInteger(row);
+      }
     },
 
     /**
@@ -87,8 +95,10 @@ qx.Interface.define("qx.ui.tree.provider.IVirtualTreeProvider", {
      *    <code>false</code> otherwise.
      */
     isSelectable(row) {
-      this.assertArgumentsCount(arguments, 1, 1);
-      this.assertInteger(row);
+      if (qx.core.Environment.get("qx.debug")) {
+        this.assertArgumentsCount(arguments, 1, 1);
+        this.assertInteger(row);
+      }
     }
   }
 });

--- a/source/class/qx/ui/virtual/core/ILayer.js
+++ b/source/class/qx/ui/virtual/core/ILayer.js
@@ -36,11 +36,13 @@ qx.Interface.define("qx.ui.virtual.core.ILayer", {
      * @param columnSizes {Integer[]} Array of widths for each column to display.
      */
     fullUpdate(firstRow, firstColumn, rowSizes, columnSizes) {
-      this.assertArgumentsCount(arguments, 6, 6);
-      this.assertPositiveInteger(firstRow);
-      this.assertPositiveInteger(firstColumn);
-      this.assertArray(rowSizes);
-      this.assertArray(columnSizes);
+      if (qx.core.Environment.get("qx.debug")) {
+        this.assertArgumentsCount(arguments, 6, 6);
+        this.assertPositiveInteger(firstRow);
+        this.assertPositiveInteger(firstColumn);
+        this.assertArray(rowSizes);
+        this.assertArray(columnSizes);
+      }
     },
 
     /**
@@ -59,11 +61,13 @@ qx.Interface.define("qx.ui.virtual.core.ILayer", {
      * @param columnSizes {Integer[]} Array of widths for each column to display.
      */
     updateLayerWindow(firstRow, firstColumn, rowSizes, columnSizes) {
-      this.assertArgumentsCount(arguments, 6, 6);
-      this.assertPositiveInteger(firstRow);
-      this.assertPositiveInteger(firstColumn);
-      this.assertArray(rowSizes);
-      this.assertArray(columnSizes);
+      if (qx.core.Environment.get("qx.debug")) {
+        this.assertArgumentsCount(arguments, 6, 6);
+        this.assertPositiveInteger(firstRow);
+        this.assertPositiveInteger(firstColumn);
+        this.assertArray(rowSizes);
+        this.assertArray(columnSizes);
+      }
     },
 
     /**

--- a/source/class/qx/ui/window/IDesktop.js
+++ b/source/class/qx/ui/window/IDesktop.js
@@ -27,7 +27,9 @@ qx.Interface.define("qx.ui.window.IDesktop", {
      * @param manager {qx.ui.window.IWindowManager} The window manager
      */
     setWindowManager(manager) {
-      this.assertInterface(manager, qx.ui.window.IWindowManager);
+      if (qx.core.Environment.get("qx.debug")) {
+        this.assertInterface(manager, qx.ui.window.IWindowManager);
+      }
     },
 
     /**
@@ -52,7 +54,9 @@ qx.Interface.define("qx.ui.window.IDesktop", {
      *     will be blocked
      */
     blockContent(zIndex) {
-      this.assertInteger(zIndex);
+      if (qx.core.Environment.get("qx.debug")) {
+        this.assertInteger(zIndex);
+      }
     },
 
     /**

--- a/source/class/qx/ui/window/IWindowManager.js
+++ b/source/class/qx/ui/window/IWindowManager.js
@@ -30,8 +30,10 @@ qx.Interface.define("qx.ui.window.IWindowManager", {
      * @param desktop {qx.ui.window.IDesktop|null} The connected desktop or null
      */
     setDesktop(desktop) {
-      if (desktop !== null) {
-        this.assertInterface(desktop, qx.ui.window.IDesktop);
+      if (qx.core.Environment.get("qx.debug")) {
+        if (desktop !== null) {
+          this.assertInterface(desktop, qx.ui.window.IDesktop);
+        }
       }
     },
 
@@ -54,7 +56,9 @@ qx.Interface.define("qx.ui.window.IWindowManager", {
      * @param win {qx.ui.window.Window} window to bring to front
      */
     bringToFront(win) {
-      this.assertInstance(win, qx.ui.window.Window);
+      if (qx.core.Environment.get("qx.debug")) {
+        this.assertInstance(win, qx.ui.window.Window);
+      }
     },
 
     /**
@@ -63,7 +67,9 @@ qx.Interface.define("qx.ui.window.IWindowManager", {
      * @param win {qx.ui.window.Window} window to sent to back
      */
     sendToBack(win) {
-      this.assertInstance(win, qx.ui.window.Window);
+      if (qx.core.Environment.get("qx.debug")) {
+        this.assertInstance(win, qx.ui.window.Window);
+      }
     }
   }
 });


### PR DESCRIPTION
This commit addresses issue #10816 where assertion statements were appearing in production builds. All `this.assert*` calls have been wrapped with `if (qx.core.Environment.get("qx.debug"))` checks to ensure they are stripped out in production builds.

Changes include:
- qx/Interface.js: Wrapped assertObject and assert method bodies
- qx/data/SingleValueBinding.js: Wrapped assertNotNull call
- qx/data/binding/ArrayIndexSegment.js: Wrapped assertTrue call
- 9 interface files: Wrapped all assertion calls in interface method stubs
  * qx/ui/tree/provider/IVirtualTreeProvider.js
  * qx/ui/tree/core/IVirtualTree.js
  * qx/ui/virtual/core/ILayer.js
  * qx/ui/form/IListItem.js
  * qx/ui/form/IRadioItem.js
  * qx/ui/window/IDesktop.js
  * qx/ui/window/IWindowManager.js
  * qx/ui/core/scroll/IScrollBar.js
  * qx/event/IEventDispatcher.js

This ensures that assertions do not appear in production builds, reducing bundle size and preventing potential runtime errors.

Fixes #10816