### PR TITLE
Fix issue #9390: VirtualTree doesn't render with hideRoot when adding nodes dynamically

### DIFF
--- a/source/class/qx/test/ui/tree/virtual/Tree.js
+++ b/source/class/qx/test/ui/tree/virtual/Tree.js
@@ -260,6 +260,42 @@ qx.Class.define("qx.test.ui.tree.virtual.Tree", {
       this.__testBuildLookupTable(expected);
     },
 
+    /**
+     * Test for issue #9390: VirtualTree doesn't render if hideRoot is true
+     * when adding nodes dynamically
+     */
+    testDynamicNodesWithHiddenRoot() {
+      // Create initial model
+      var root = this.createModelAndSetModel(1);
+
+      // Set hideRoot before adding nodes
+      this.tree.setHideRoot(true);
+
+      // Flush to ensure initial rendering
+      this.flush();
+
+      // Get initial visible items (should be root's children)
+      var expectedBefore = this.getVisibleItemsFrom(root, [root]);
+      this.__testBuildLookupTable(expectedBefore);
+
+      // Dynamically add a new branch to the root
+      var newBranch = new qx.test.ui.tree.virtual.Node("Dynamic Branch");
+      this._createNodes(newBranch, 1);
+      root.getChildren().push(newBranch);
+
+      // The tree should automatically update without calling refresh()
+      // Expected items should now include the new branch
+      var expectedAfter = this.getVisibleItemsFrom(root, [root]);
+      this.__testBuildLookupTable(expectedAfter);
+
+      // Verify the new branch is in the lookup table
+      var lookupTable = this.tree.getLookupTable();
+      this.assertTrue(
+        lookupTable.contains(newBranch),
+        "New dynamically added branch should be visible in tree with hidden root"
+      );
+    },
+
     testBuildLookupWithoutLeafs() {
       var root = this.createModelAndSetModel(2);
 

--- a/source/class/qx/ui/tree/VirtualTree.js
+++ b/source/class/qx/ui/tree/VirtualTree.js
@@ -760,7 +760,10 @@ qx.Class.define("qx.ui.tree.VirtualTree", {
           }
         }
 
-        if (this.__lookupTable.indexOf(item) != -1) {
+        // Issue #9390: When hideRoot is true, the root is not in the lookup table,
+        // but we still need to update when its children change
+        var isRootAndHidden = this.isHideRoot() && item === this.getModel();
+        if (this.__lookupTable.indexOf(item) != -1 || isRootAndHidden) {
           this.__applyModelChanges();
         }
       }


### PR DESCRIPTION
## Summary

closes #9390

This PR fixes a bug where VirtualTree doesn't render when `hideRoot` is set to `true` and nodes are added dynamically to the root.

### Root Cause

When `hideRoot` is `true`, the root node is not included in the lookup table. The `_onChangeBubble` event handler only checked if the affected item was in the lookup table before rebuilding it. This caused changes to the root's children to be ignored when the root was hidden.

### Solution

Added a check in `_onChangeBubble` to also update the lookup table when:
- `hideRoot` is `true` AND
- The affected item is the root node

This ensures that when children are dynamically added to a hidden root, the lookup table is properly rebuilt and the tree updates correctly.
