### PR TITLE
Add missing appearance entries for CheckedSelectBox, Tag, and selectbox-arrow-button

### DIFF
--- a/source/class/qx/theme/classic/Appearance.js
+++ b/source/class/qx/theme/classic/Appearance.js
@@ -1465,6 +1465,27 @@ qx.Theme.define("qx.theme.classic.Appearance", {
       }
     },
 
+    "selectbox-arrow-button": "widget",
+
+    /*
+    ---------------------------------------------------------------------------
+      CHECKED SELECT BOX
+    ---------------------------------------------------------------------------
+    */
+
+    "checked-selectbox": "selectbox",
+
+    "checked-selectbox/allNone": {
+      include: "button"
+    },
+
+    "checked-selectbox/tag": "tag",
+
+    tag: {
+      alias: "button",
+      include: "button"
+    },
+
     /*
     ---------------------------------------------------------------------------
       DATE CHOOSER

--- a/source/class/qx/theme/modern/Appearance.js
+++ b/source/class/qx/theme/modern/Appearance.js
@@ -1728,6 +1728,27 @@ qx.Theme.define("qx.theme.modern.Appearance", {
       }
     },
 
+    "selectbox-arrow-button": "widget",
+
+    /*
+    ---------------------------------------------------------------------------
+      CHECKED SELECT BOX
+    ---------------------------------------------------------------------------
+    */
+
+    "checked-selectbox": "selectbox",
+
+    "checked-selectbox/allNone": {
+      include: "button"
+    },
+
+    "checked-selectbox/tag": "tag",
+
+    tag: {
+      alias: "button",
+      include: "button"
+    },
+
     /*
     ---------------------------------------------------------------------------
       DATE CHOOSER

--- a/source/class/qx/theme/simple/Appearance.js
+++ b/source/class/qx/theme/simple/Appearance.js
@@ -1204,6 +1204,27 @@ qx.Theme.define("qx.theme.simple.Appearance", {
       }
     },
 
+    "selectbox-arrow-button": "widget",
+
+    /*
+    ---------------------------------------------------------------------------
+      CHECKED SELECT BOX
+    ---------------------------------------------------------------------------
+    */
+
+    "checked-selectbox": "selectbox",
+
+    "checked-selectbox/allNone": {
+      include: "button"
+    },
+
+    "checked-selectbox/tag": "tag",
+
+    tag: {
+      alias: "button",
+      include: "button"
+    },
+
     /*
     ---------------------------------------------------------------------------
       COMBO BOX

--- a/source/class/qx/theme/tangible/Appearance.js
+++ b/source/class/qx/theme/tangible/Appearance.js
@@ -1313,6 +1313,8 @@ qx.Theme.define("qx.theme.tangible.Appearance", {
       }
     },
 
+    "selectbox-arrow-button": "widget",
+
     /*
     ---------------------------------------------------------------------------
       CHECKED SELECT BOX


### PR DESCRIPTION
## Summary
- **CheckedSelectBox** and **Tag** widgets (added 2021) were only defined in the Tangible theme — all other themes (Classic, Modern, Simple, Indigo) had no appearance entries, causing them to render unstyled
- **selectbox-arrow-button** was referenced programmatically in `SelectBox.js` but missing from **all** themes including Tangible

## Changes
- **Classic, Modern, Simple** (+5 entries each): `checked-selectbox`, `checked-selectbox/allNone`, `checked-selectbox/tag`, `tag`, `selectbox-arrow-button`
- **Tangible** (+1 entry): `selectbox-arrow-button`
- Indigo themes inherit from Simple automatically

> **Note:** Consider backporting to `master` as the missing appearances also affect the current stable release.