### PR TITLE
fix: ArrayIndexSegment supports qx.data.IListData, not just qx.data.Array

### DIFF
--- a/source/class/qx/data/binding/ArrayIndexSegment.js
+++ b/source/class/qx/data/binding/ArrayIndexSegment.js
@@ -51,7 +51,7 @@ qx.Class.define("qx.data.binding.ArrayIndexSegment", {
   destruct() {
     let input = this.getInput();
     if (input) {
-      if (this.getInput() instanceof qx.data.Array) {
+      if (this.__isListData(this.getInput())) {
         this.getInput().removeListener("change", this.__onChangeContents, this);
       }
     }
@@ -71,19 +71,23 @@ qx.Class.define("qx.data.binding.ArrayIndexSegment", {
       return this.__string;
     },
 
+    __isListData(input) {
+      return qx.Interface.objectImplements(input, qx.data.IListData);
+    },
+
     /**
      * @override
      */
     _applyInput(value, oldValue) {
       if (oldValue) {
         this.setEventName(null);
-        if (oldValue instanceof qx.data.Array) {
+        if (this.__isListData(oldValue)) {
           oldValue.removeListener("change", this.__onChangeContents, this);
         }
       }
 
       if (value) {
-        if (value instanceof qx.data.Array) {
+        if (this.__isListData(value)) {
           value.addListener("change", this.__onChangeContents, this);
           this.setEventName("change");
         }
@@ -108,8 +112,10 @@ qx.Class.define("qx.data.binding.ArrayIndexSegment", {
         return undefined;
       }
 
-      if (input instanceof qx.data.Array) {
-        input = input.toArray();
+      if (this.__isListData(input)) {
+        const len = input.getLength();
+        const idx = this.__index === -1 ? len - 1 : this.__index;
+        return idx >= len ? undefined : input.getItem(idx);
       }
 
       if (this.__index >= input.length) {
@@ -126,11 +132,12 @@ qx.Class.define("qx.data.binding.ArrayIndexSegment", {
       if (!input) {
         return;
       }
-      let index = this.__index == -1 ? input.length - 1 : this.__index;
-      if (input instanceof qx.data.Array) {
-        input.setItem(index, targetValue);
+      if (this.__isListData(input)) {
+        const idx = this.__index === -1 ? input.getLength() - 1 : this.__index;
+        input.setItem(idx, targetValue);
       } else {
-        input[index] = targetValue;
+        const idx = this.__index === -1 ? input.length - 1 : this.__index;
+        input[idx] = targetValue;
       }
     },
 


### PR DESCRIPTION
## Problem

`ArrayIndexSegment` was written with `qx.data.Array` as the only
supported array-like type. All four spots in the class used
`instanceof qx.data.Array`, which caused a `TypeError` for any
custom `qx.data.IListData` implementation:

```
TypeError: input.at is not a function
```

The binding path `model[0].prop` works fine when `model` is a
`qx.data.Array`, but fails silently (or throws) for any other class
that fulfills the `IListData` contract.

## Fix

Introduce a private helper `__isListData(input)` that delegates to
`qx.Interface.objectImplements(input, qx.data.IListData)` and
replace all four `instanceof qx.data.Array` checks:

| Method | Change |
|---|---|
| `destruct()` | remove `change` listener for any IListData |
| `_applyInput()` | add/remove `change` listener for any IListData |
| `__get()` | read via `getItem()`/`getLength()` for any IListData |
| `setTargetValue()` | write via `setItem()` for any IListData |

## Backwards compatibility

`qx.data.Array` implements `qx.data.IListData`, so the new check
matches all existing usages. The native JS array fallback (`.length`/
`.at()`) is preserved for plain arrays.