### PR TITLE
fix: replace tape with node:test in integration tests

### DIFF
--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -68,7 +68,6 @@
         "set-value": "^4.1.0",
         "showdown": "^1.9.1",
         "source-map-js": "^1.0.2",
-        "tap-colorize": "^1.2.0",
         "terser": "^5.22.0",
         "tmp": "^0.2.5",
         "unset-value": "^1.0.0",
@@ -84,7 +83,6 @@
         "baseline-browser-mapping": "^2.10.0",
         "dirsum": "^0.1.1",
         "source-map-support": "^0.5.21",
-        "tape": "^5.9.0",
         "tree-kill": "^1.2.2"
       }
     },
@@ -2399,19 +2397,19 @@
       }
     },
     "node_modules/@eslint/eslintrc": {
-      "version": "3.3.3",
-      "resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-3.3.3.tgz",
-      "integrity": "sha512-Kr+LPIUVKz2qkx1HAMH8q1q6azbqBAsXJUxBl/ODDuVPX45Z9DfwB8tPjTi6nNZ8BuM3nbJxC5zCAg5elnBUTQ==",
+      "version": "3.3.4",
+      "resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-3.3.4.tgz",
+      "integrity": "sha512-4h4MVF8pmBsncB60r0wSJiIeUKTSD4m7FmTFThG8RHlsg9ajqckLm9OraguFGZE4vVdpiI1Q4+hFnisopmG6gQ==",
       "license": "MIT",
       "dependencies": {
-        "ajv": "^6.12.4",
+        "ajv": "^6.14.0",
         "debug": "^4.3.2",
         "espree": "^10.0.1",
         "globals": "^14.0.0",
         "ignore": "^5.2.0",
         "import-fresh": "^3.2.1",
         "js-yaml": "^4.1.1",
-        "minimatch": "^3.1.2",
+        "minimatch": "^3.1.3",
         "strip-json-comments": "^3.1.1"
       },
       "engines": {
@@ -2922,33 +2920,6 @@
       "resolved": "https://registry.npmjs.org/@jspm/core/-/core-2.1.0.tgz",
       "integrity": "sha512-3sRl+pkyFY/kLmHl0cgHiFp2xEqErA8N3ECjMs7serSUBmoJ70lBa0PG5t0IM6WJgdZNyyI0R8YFfi5wM8+mzg==",
       "license": "Apache-2.0"
-    },
-    "node_modules/@ljharb/resumer": {
-      "version": "0.1.3",
-      "resolved": "https://registry.npmjs.org/@ljharb/resumer/-/resumer-0.1.3.tgz",
-      "integrity": "sha512-d+tsDgfkj9X5QTriqM4lKesCkMMJC3IrbPKHvayP00ELx2axdXvDfWkqjxrLXIzGcQzmj7VAUT1wopqARTvafw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@ljharb/through": "^2.3.13",
-        "call-bind": "^1.0.7"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      }
-    },
-    "node_modules/@ljharb/through": {
-      "version": "2.3.14",
-      "resolved": "https://registry.npmjs.org/@ljharb/through/-/through-2.3.14.tgz",
-      "integrity": "sha512-ajBvlKpWucBB17FuQYUShqpqy8GRgYEpJW0vWJbUu1CV9lWyrDCapy0lScU8T8Z6qn49sSwJB3+M+evYIdGg+A==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "call-bind": "^1.0.8"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      }
     },
     "node_modules/@metalsmith/layouts": {
       "version": "2.7.0",
@@ -3729,65 +3700,6 @@
       "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
       "license": "Python-2.0"
     },
-    "node_modules/array-buffer-byte-length": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/array-buffer-byte-length/-/array-buffer-byte-length-1.0.2.tgz",
-      "integrity": "sha512-LHE+8BuR7RYGDKvnrmcuSq3tDcKv9OFEXQt/HpbZhY7V6h0zlUXutnAD82GiFx9rdieCMjkvtcsPqBwgUl1Iiw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "call-bound": "^1.0.3",
-        "is-array-buffer": "^3.0.5"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/array.prototype.every": {
-      "version": "1.1.7",
-      "resolved": "https://registry.npmjs.org/array.prototype.every/-/array.prototype.every-1.1.7.tgz",
-      "integrity": "sha512-BIP72rKvrKd08ptbetLb4qvrlGjkv30yOKgKcTtOIbHyQt3shr/jyOzdApiCOh3LPYrpJo5M6i0zmVldOF2pUw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "call-bound": "^1.0.2",
-        "define-properties": "^1.2.1",
-        "es-abstract": "^1.23.5",
-        "es-object-atoms": "^1.0.0",
-        "is-string": "^1.1.0"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/arraybuffer.prototype.slice": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/arraybuffer.prototype.slice/-/arraybuffer.prototype.slice-1.0.4.tgz",
-      "integrity": "sha512-BNoCY6SXXPQ7gF2opIP4GBE+Xw7U+pHMYKuzjgCN3GwiaIR09UUeKfheyIry77QtrCBlC0KK0q5/TER/tYh3PQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "array-buffer-byte-length": "^1.0.1",
-        "call-bind": "^1.0.8",
-        "define-properties": "^1.2.1",
-        "es-abstract": "^1.23.5",
-        "es-errors": "^1.3.0",
-        "get-intrinsic": "^1.2.6",
-        "is-array-buffer": "^3.0.4"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
     "node_modules/asap": {
       "version": "2.0.6",
       "resolved": "https://registry.npmjs.org/asap/-/asap-2.0.6.tgz",
@@ -3801,32 +3713,6 @@
       "license": "MIT",
       "dependencies": {
         "lodash": "^4.17.14"
-      }
-    },
-    "node_modules/async-function": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/async-function/-/async-function-1.0.0.tgz",
-      "integrity": "sha512-hsU18Ae8CDTR6Kgu9DYf0EbCr/a5iGL0rytQDobUcdpYOKokk8LEjVphnXkDkgpi0wYVsqrXuP0bZxJaTqdgoA==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.4"
-      }
-    },
-    "node_modules/available-typed-arrays": {
-      "version": "1.0.7",
-      "resolved": "https://registry.npmjs.org/available-typed-arrays/-/available-typed-arrays-1.0.7.tgz",
-      "integrity": "sha512-wvUjBtSGN7+7SjNpq/9M2Tg350UZD3q62IFZLbRAR1bSMlCo1ZaeW+BJ+D090e4hIIZLBcTDWe4Mh4jvUDajzQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "possible-typed-array-names": "^1.0.0"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/babel-plugin-polyfill-corejs2": {
@@ -4486,12 +4372,6 @@
       "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
       "license": "MIT"
     },
-    "node_modules/colornames": {
-      "version": "0.0.2",
-      "resolved": "https://registry.npmjs.org/colornames/-/colornames-0.0.2.tgz",
-      "integrity": "sha512-aeaoTql364CeoC6VHeRJd8uUiOVZDDtCyTP2dwXPD3WIt8UuPcXzmBB5gEhLDLaJS3MW152O7DfYm1a2HQv11g==",
-      "license": "MIT"
-    },
     "node_modules/columnify": {
       "version": "1.6.0",
       "resolved": "https://registry.npmjs.org/columnify/-/columnify-1.6.0.tgz",
@@ -4639,12 +4519,6 @@
         "url": "https://opencollective.com/core-js"
       }
     },
-    "node_modules/core-util-is": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.3.tgz",
-      "integrity": "sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ==",
-      "license": "MIT"
-    },
     "node_modules/cross-spawn": {
       "version": "7.0.6",
       "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
@@ -4684,60 +4558,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/data-view-buffer": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/data-view-buffer/-/data-view-buffer-1.0.2.tgz",
-      "integrity": "sha512-EmKO5V3OLXh1rtK2wgXRansaK1/mtVdTUEiEI0W8RkvgT05kfxaH29PliLnpLP73yYO6142Q72QNa8Wx/A5CqQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "call-bound": "^1.0.3",
-        "es-errors": "^1.3.0",
-        "is-data-view": "^1.0.2"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/data-view-byte-length": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/data-view-byte-length/-/data-view-byte-length-1.0.2.tgz",
-      "integrity": "sha512-tuhGbE6CfTM9+5ANGf+oQb72Ky/0+s3xKUpHvShfiz2RxMFgFPjsXuRLBVMtvMs15awe45SRb83D6wH4ew6wlQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "call-bound": "^1.0.3",
-        "es-errors": "^1.3.0",
-        "is-data-view": "^1.0.2"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/inspect-js"
-      }
-    },
-    "node_modules/data-view-byte-offset": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/data-view-byte-offset/-/data-view-byte-offset-1.0.1.tgz",
-      "integrity": "sha512-BS8PfmtDGnrgYdOonGZQdLZslWIeCGFP9tpan0hi1Co2Zr2NKADsvGYA8XxuG/4UWgJ6Cjtv+YJnB6MM69QGlQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "call-bound": "^1.0.2",
-        "es-errors": "^1.3.0",
-        "is-data-view": "^1.0.1"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/debug": {
@@ -4791,39 +4611,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/deep-equal": {
-      "version": "2.2.3",
-      "resolved": "https://registry.npmjs.org/deep-equal/-/deep-equal-2.2.3.tgz",
-      "integrity": "sha512-ZIwpnevOurS8bpT4192sqAowWM76JDKSHYzMLty3BZGSswgq6pBaH3DhCSW5xVAZICZyKdOBPjwww5wfgT/6PA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "array-buffer-byte-length": "^1.0.0",
-        "call-bind": "^1.0.5",
-        "es-get-iterator": "^1.1.3",
-        "get-intrinsic": "^1.2.2",
-        "is-arguments": "^1.1.1",
-        "is-array-buffer": "^3.0.2",
-        "is-date-object": "^1.0.5",
-        "is-regex": "^1.1.4",
-        "is-shared-array-buffer": "^1.0.2",
-        "isarray": "^2.0.5",
-        "object-is": "^1.1.5",
-        "object-keys": "^1.1.1",
-        "object.assign": "^4.1.4",
-        "regexp.prototype.flags": "^1.5.1",
-        "side-channel": "^1.0.4",
-        "which-boxed-primitive": "^1.0.2",
-        "which-collection": "^1.0.1",
-        "which-typed-array": "^1.1.13"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/deep-extend": {
@@ -4905,16 +4692,6 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
-    "node_modules/defined": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/defined/-/defined-1.0.1.tgz",
-      "integrity": "sha512-hsBd2qSVCRE+5PmNdHt1uzyrFu5d3RwmFDKzyNZMFq/EwDNJF7Ee5+D5oEKF0hU6LhtoUF1macFvOe4AskQC1Q==",
-      "dev": true,
-      "license": "MIT",
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
     "node_modules/depd": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/depd/-/depd-2.0.0.tgz",
@@ -4976,19 +4753,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/dotignore": {
-      "version": "0.1.2",
-      "resolved": "https://registry.npmjs.org/dotignore/-/dotignore-0.1.2.tgz",
-      "integrity": "sha512-UGGGWfSauusaVJC+8fgV+NVvBXkCTmVv7sk6nojDZZvuOUNGUy0Zk4UpHQD6EDjS0jpBwcACvH4eofvyzBcRDw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "minimatch": "^3.0.4"
-      },
-      "bin": {
-        "ignored": "bin/ignored"
       }
     },
     "node_modules/dset": {
@@ -5053,75 +4817,6 @@
         "node": ">= 0.8"
       }
     },
-    "node_modules/es-abstract": {
-      "version": "1.24.0",
-      "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.24.0.tgz",
-      "integrity": "sha512-WSzPgsdLtTcQwm4CROfS5ju2Wa1QQcVeT37jFjYzdFz1r9ahadC8B8/a4qxJxM+09F18iumCdRmlr96ZYkQvEg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "array-buffer-byte-length": "^1.0.2",
-        "arraybuffer.prototype.slice": "^1.0.4",
-        "available-typed-arrays": "^1.0.7",
-        "call-bind": "^1.0.8",
-        "call-bound": "^1.0.4",
-        "data-view-buffer": "^1.0.2",
-        "data-view-byte-length": "^1.0.2",
-        "data-view-byte-offset": "^1.0.1",
-        "es-define-property": "^1.0.1",
-        "es-errors": "^1.3.0",
-        "es-object-atoms": "^1.1.1",
-        "es-set-tostringtag": "^2.1.0",
-        "es-to-primitive": "^1.3.0",
-        "function.prototype.name": "^1.1.8",
-        "get-intrinsic": "^1.3.0",
-        "get-proto": "^1.0.1",
-        "get-symbol-description": "^1.1.0",
-        "globalthis": "^1.0.4",
-        "gopd": "^1.2.0",
-        "has-property-descriptors": "^1.0.2",
-        "has-proto": "^1.2.0",
-        "has-symbols": "^1.1.0",
-        "hasown": "^2.0.2",
-        "internal-slot": "^1.1.0",
-        "is-array-buffer": "^3.0.5",
-        "is-callable": "^1.2.7",
-        "is-data-view": "^1.0.2",
-        "is-negative-zero": "^2.0.3",
-        "is-regex": "^1.2.1",
-        "is-set": "^2.0.3",
-        "is-shared-array-buffer": "^1.0.4",
-        "is-string": "^1.1.1",
-        "is-typed-array": "^1.1.15",
-        "is-weakref": "^1.1.1",
-        "math-intrinsics": "^1.1.0",
-        "object-inspect": "^1.13.4",
-        "object-keys": "^1.1.1",
-        "object.assign": "^4.1.7",
-        "own-keys": "^1.0.1",
-        "regexp.prototype.flags": "^1.5.4",
-        "safe-array-concat": "^1.1.3",
-        "safe-push-apply": "^1.0.0",
-        "safe-regex-test": "^1.1.0",
-        "set-proto": "^1.0.0",
-        "stop-iteration-iterator": "^1.1.0",
-        "string.prototype.trim": "^1.2.10",
-        "string.prototype.trimend": "^1.0.9",
-        "string.prototype.trimstart": "^1.0.8",
-        "typed-array-buffer": "^1.0.3",
-        "typed-array-byte-length": "^1.0.3",
-        "typed-array-byte-offset": "^1.0.4",
-        "typed-array-length": "^1.0.7",
-        "unbox-primitive": "^1.1.0",
-        "which-typed-array": "^1.1.19"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
     "node_modules/es-define-property": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
@@ -5140,27 +4835,6 @@
         "node": ">= 0.4"
       }
     },
-    "node_modules/es-get-iterator": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/es-get-iterator/-/es-get-iterator-1.1.3.tgz",
-      "integrity": "sha512-sPZmqHBe6JIiTfN5q2pEi//TwxmAFHwj/XEuYjTuse78i8KxaqMTTzxPoFKuzRpDpTJ+0NAbpfenkmH2rePtuw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "call-bind": "^1.0.2",
-        "get-intrinsic": "^1.1.3",
-        "has-symbols": "^1.0.3",
-        "is-arguments": "^1.1.1",
-        "is-map": "^2.0.2",
-        "is-set": "^2.0.2",
-        "is-string": "^1.0.7",
-        "isarray": "^2.0.5",
-        "stop-iteration-iterator": "^1.0.0"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
     "node_modules/es-object-atoms": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.1.tgz",
@@ -5171,40 +4845,6 @@
       },
       "engines": {
         "node": ">= 0.4"
-      }
-    },
-    "node_modules/es-set-tostringtag": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/es-set-tostringtag/-/es-set-tostringtag-2.1.0.tgz",
-      "integrity": "sha512-j6vWzfrGVfyXxge+O0x5sh6cvxAog0a/4Rdd2K36zCMV5eJ+/+tOAngRO8cODMNWbVRdVlmGZQL2YS3yR8bIUA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "es-errors": "^1.3.0",
-        "get-intrinsic": "^1.2.6",
-        "has-tostringtag": "^1.0.2",
-        "hasown": "^2.0.2"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      }
-    },
-    "node_modules/es-to-primitive": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/es-to-primitive/-/es-to-primitive-1.3.0.tgz",
-      "integrity": "sha512-w+5mJ3GuFL+NjVtJlvydShqE1eN3h3PbI7/5LAsYJP/2qtuMXjfL2LpHSRqo4b4eSF5K/DH1JXKUAHSB2UW50g==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "is-callable": "^1.2.7",
-        "is-date-object": "^1.0.5",
-        "is-symbol": "^1.0.4"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/es6-promise-pool": {
@@ -5820,22 +5460,6 @@
         "unicode-trie": "^2.0.0"
       }
     },
-    "node_modules/for-each": {
-      "version": "0.3.5",
-      "resolved": "https://registry.npmjs.org/for-each/-/for-each-0.3.5.tgz",
-      "integrity": "sha512-dKx12eRCVIzqCxFGplyFKJMPvLEWgmNtUrpTiJIR5u97zEhRG8ySrtboPHZXx7daLxQVrl643cTzbab2tkQjxg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "is-callable": "^1.2.7"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
     "node_modules/form-data-encoder": {
       "version": "2.1.4",
       "resolved": "https://registry.npmjs.org/form-data-encoder/-/form-data-encoder-2.1.4.tgz",
@@ -5869,13 +5493,6 @@
       "integrity": "sha512-twe20eF1OxVxp/ML/kq2p1uc6KvFK/+vs8WjEbeKmV2He22MKm7YF2ANIt+EOqhJ5L3K/SuuPhk0hWQDjOM23g==",
       "license": "MIT"
     },
-    "node_modules/fs.realpath": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
-      "integrity": "sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==",
-      "dev": true,
-      "license": "ISC"
-    },
     "node_modules/fsevents": {
       "version": "2.3.3",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
@@ -5897,47 +5514,6 @@
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/function.prototype.name": {
-      "version": "1.1.8",
-      "resolved": "https://registry.npmjs.org/function.prototype.name/-/function.prototype.name-1.1.8.tgz",
-      "integrity": "sha512-e5iwyodOHhbMr/yNrc7fDYG4qlbIvI5gajyzPnb5TCwyhjApznQh1BMFou9b30SevY43gCJKXycoCBjMbsuW0Q==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "call-bind": "^1.0.8",
-        "call-bound": "^1.0.3",
-        "define-properties": "^1.2.1",
-        "functions-have-names": "^1.2.3",
-        "hasown": "^2.0.2",
-        "is-callable": "^1.2.7"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/functions-have-names": {
-      "version": "1.2.3",
-      "resolved": "https://registry.npmjs.org/functions-have-names/-/functions-have-names-1.2.3.tgz",
-      "integrity": "sha512-xckBUXyTIqT97tq2x2AMb+g163b5JFysYk0x4qxNFwbfQkmNZoiRHb6sPzI9/QV33WeuvVYBUIiD4NzNIyqaRQ==",
-      "dev": true,
-      "license": "MIT",
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/generator-function": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/generator-function/-/generator-function-2.0.1.tgz",
-      "integrity": "sha512-SFdFmIJi+ybC0vjlHN0ZGVGHc3lgE0DxPAT0djjVg+kjOnSqclqmj0KQ7ykTOLP6YxoqOvuAODGdcHJn+43q3g==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.4"
       }
     },
     "node_modules/gensync": {
@@ -5994,16 +5570,6 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
-    "node_modules/get-package-type": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/get-package-type/-/get-package-type-0.1.0.tgz",
-      "integrity": "sha512-pjzuKtY64GYfWizNAJ0fr9VqttZkNiK2iS430LtIHzjBEr6bX8Am2zm4sW4Ro5wjWW5cAlRL1qAMTcXbjNAO2Q==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=8.0.0"
-      }
-    },
     "node_modules/get-proto": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/get-proto/-/get-proto-1.0.1.tgz",
@@ -6027,24 +5593,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/get-symbol-description": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/get-symbol-description/-/get-symbol-description-1.1.0.tgz",
-      "integrity": "sha512-w9UMqWwJxHNOvoNzSJ2oPF5wvYcvP7jUvYzhp67yEhTi17ZDBBC1z9pTdGuzjD+EFIqLSYRweZjqfiPzQ06Ebg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "call-bound": "^1.0.3",
-        "es-errors": "^1.3.0",
-        "get-intrinsic": "^1.2.6"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/get-value": {
@@ -6247,37 +5795,6 @@
         "js-yaml": "bin/js-yaml.js"
       }
     },
-    "node_modules/has-bigints": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/has-bigints/-/has-bigints-1.1.0.tgz",
-      "integrity": "sha512-R3pbpkcIqv2Pm3dUwgjclDRVmWpTJW2DcMzcIhEXEx1oh/CEMObMm3KLmRJOdvhM7o4uQBnwr8pzRK2sJWIqfg==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/has-dynamic-import": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/has-dynamic-import/-/has-dynamic-import-2.1.1.tgz",
-      "integrity": "sha512-DuTCn6K/RW8S27npDMumGKsjG6HE7MxzedZka5tJP+9dqfxks+UMqKBmeCijHtIhsBEZPlbMg0qMHi2nKYVtKQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "call-bind": "^1.0.8",
-        "call-bound": "^1.0.3",
-        "get-intrinsic": "^1.2.6"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
     "node_modules/has-flag": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
@@ -6299,43 +5816,11 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
-    "node_modules/has-proto": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/has-proto/-/has-proto-1.2.0.tgz",
-      "integrity": "sha512-KIL7eQPfHQRC8+XluaIw7BHUwwqL19bQn4hzNgdr+1wXoU0KKj6rufu47lhY7KbJR2C6T6+PfyN0Ea7wkSS+qQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "dunder-proto": "^1.0.0"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
     "node_modules/has-symbols": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
       "integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==",
       "license": "MIT",
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/has-tostringtag": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/has-tostringtag/-/has-tostringtag-1.0.2.tgz",
-      "integrity": "sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "has-symbols": "^1.0.3"
-      },
       "engines": {
         "node": ">= 0.4"
       },
@@ -6551,18 +6036,6 @@
         "node": ">=0.8.19"
       }
     },
-    "node_modules/inflight": {
-      "version": "1.0.6",
-      "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
-      "integrity": "sha512-k92I/b08q4wvFscXCLvqfsHCrjrF7yiXsQuIVvVE7N82W3+aqpzuUdBbfhWcy/FZR3/4IgflMgKLOsvPDrGCJA==",
-      "deprecated": "This module is not supported, and leaks memory. Do not use it. Check out lru-cache if you want a good and tested way to coalesce async requests by a key value, which is much more comprehensive and powerful.",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "once": "^1.3.0",
-        "wrappy": "1"
-      }
-    },
     "node_modules/inherits": {
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
@@ -6616,21 +6089,6 @@
         }
       }
     },
-    "node_modules/internal-slot": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/internal-slot/-/internal-slot-1.1.0.tgz",
-      "integrity": "sha512-4gd7VpWNQNB4UKKCFFVcp1AVv+FMOgs9NKzjHKusc8jTMhd5eL1NqQqOpE0KzMds804/yHlglp3uxgluOqAPLw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "es-errors": "^1.3.0",
-        "hasown": "^2.0.2",
-        "side-channel": "^1.1.0"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      }
-    },
     "node_modules/ipaddr.js": {
       "version": "1.9.1",
       "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.9.1.tgz",
@@ -6638,77 +6096,6 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.10"
-      }
-    },
-    "node_modules/is-arguments": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/is-arguments/-/is-arguments-1.2.0.tgz",
-      "integrity": "sha512-7bVbi0huj/wrIAOzb8U1aszg9kdi3KN/CyU19CTI7tAoZYEZoL9yCDXpbXN+uPsuWnP02cyug1gleqq+TU+YCA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "call-bound": "^1.0.2",
-        "has-tostringtag": "^1.0.2"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/is-array-buffer": {
-      "version": "3.0.5",
-      "resolved": "https://registry.npmjs.org/is-array-buffer/-/is-array-buffer-3.0.5.tgz",
-      "integrity": "sha512-DDfANUiiG2wC1qawP66qlTugJeL5HyzMpfr8lLK+jMQirGzNod0B12cFB/9q838Ru27sBwfw78/rdoU7RERz6A==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "call-bind": "^1.0.8",
-        "call-bound": "^1.0.3",
-        "get-intrinsic": "^1.2.6"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/is-async-function": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/is-async-function/-/is-async-function-2.1.1.tgz",
-      "integrity": "sha512-9dgM/cZBnNvjzaMYHVoxxfPj2QXt22Ev7SuuPrs+xav0ukGB0S6d4ydZdEiM48kLx5kDV+QBPrpVnFyefL8kkQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "async-function": "^1.0.0",
-        "call-bound": "^1.0.3",
-        "get-proto": "^1.0.1",
-        "has-tostringtag": "^1.0.2",
-        "safe-regex-test": "^1.1.0"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/is-bigint": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/is-bigint/-/is-bigint-1.1.0.tgz",
-      "integrity": "sha512-n4ZT37wG78iz03xPRKJrHTdZbe3IicyucEtdRsV5yglwc3GyUfbAfpSeD0FJ41NbUNSt5wbhqfp1fS+BgnvDFQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "has-bigints": "^1.0.2"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/is-binary-path": {
@@ -6721,36 +6108,6 @@
       },
       "engines": {
         "node": ">=8"
-      }
-    },
-    "node_modules/is-boolean-object": {
-      "version": "1.2.2",
-      "resolved": "https://registry.npmjs.org/is-boolean-object/-/is-boolean-object-1.2.2.tgz",
-      "integrity": "sha512-wa56o2/ElJMYqjCjGkXri7it5FbebW5usLw/nPmCMs5DeZ7eziSYZhSmPRn0txqeW4LnAmQQU7FgqLpsEFKM4A==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "call-bound": "^1.0.3",
-        "has-tostringtag": "^1.0.2"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/is-callable": {
-      "version": "1.2.7",
-      "resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.2.7.tgz",
-      "integrity": "sha512-1BC0BVFhS/p0qtw6enp8e+8OD0UrK0oFLztSjNzhcKA3WDuJxxAPXzPuPtKkjEY9UUoEWlX/8fgKeu2S8i9JTA==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/is-ci": {
@@ -6780,41 +6137,6 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
-    "node_modules/is-data-view": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/is-data-view/-/is-data-view-1.0.2.tgz",
-      "integrity": "sha512-RKtWF8pGmS87i2D6gqQu/l7EYRlVdfzemCJN/P3UOs//x1QE7mfhvzHIApBTRf7axvT6DMGwSwBXYCT0nfB9xw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "call-bound": "^1.0.2",
-        "get-intrinsic": "^1.2.6",
-        "is-typed-array": "^1.1.13"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/is-date-object": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/is-date-object/-/is-date-object-1.1.0.tgz",
-      "integrity": "sha512-PwwhEakHVKTdRNVOw+/Gyh0+MzlCl4R6qKvkhuvLtPMggI1WAHt9sOwZxQLSGpUaDnrdyDsomoRgNnCfKNSXXg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "call-bound": "^1.0.2",
-        "has-tostringtag": "^1.0.2"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
     "node_modules/is-extendable": {
       "version": "0.1.1",
       "resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-0.1.1.tgz",
@@ -6833,22 +6155,6 @@
         "node": ">=0.10.0"
       }
     },
-    "node_modules/is-finalizationregistry": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/is-finalizationregistry/-/is-finalizationregistry-1.1.1.tgz",
-      "integrity": "sha512-1pC6N8qWJbWoPtEjgcL2xyhQOP491EQjeUo3qTKcmV8YSDDJrOepfG8pcC7h/QgnQHYSv0mJ3Z/ZWxmatVrysg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "call-bound": "^1.0.3"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
     "node_modules/is-fullwidth-code-point": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
@@ -6856,26 +6162,6 @@
       "license": "MIT",
       "engines": {
         "node": ">=8"
-      }
-    },
-    "node_modules/is-generator-function": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/is-generator-function/-/is-generator-function-1.1.2.tgz",
-      "integrity": "sha512-upqt1SkGkODW9tsGNG5mtXTXtECizwtS2kA161M+gJPc1xdb/Ax629af6YrTwcOeQHbewrPNlE5Dx7kzvXTizA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "call-bound": "^1.0.4",
-        "generator-function": "^2.0.0",
-        "get-proto": "^1.0.1",
-        "has-tostringtag": "^1.0.2",
-        "safe-regex-test": "^1.1.0"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/is-glob": {
@@ -6918,32 +6204,6 @@
         "node": ">=12"
       }
     },
-    "node_modules/is-map": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/is-map/-/is-map-2.0.3.tgz",
-      "integrity": "sha512-1Qed0/Hr2m+YqxnM09CjA2d/i6YZNfF6R2oRAOj36eUdS6qIV/huPJNSEpKbupewFs+ZsJlxsjjPbc0/afW6Lw==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/is-negative-zero": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/is-negative-zero/-/is-negative-zero-2.0.3.tgz",
-      "integrity": "sha512-5KoIu2Ngpyek75jXodFvnafB6DJgr3u8uuK0LEZJjrU19DrMD3EVERaR8sjz8CCGgpZvxPl9SuE1GMVPFHx1mw==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
     "node_modules/is-npm": {
       "version": "6.1.0",
       "resolved": "https://registry.npmjs.org/is-npm/-/is-npm-6.1.0.tgz",
@@ -6963,23 +6223,6 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.12.0"
-      }
-    },
-    "node_modules/is-number-object": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/is-number-object/-/is-number-object-1.1.1.tgz",
-      "integrity": "sha512-lZhclumE1G6VYD8VHe35wFaIif+CTy5SJIi5+3y4psDgWu4wPDoBhF8NxUOinEc7pHgiTsT6MaBb92rKhhD+Xw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "call-bound": "^1.0.3",
-        "has-tostringtag": "^1.0.2"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/is-obj": {
@@ -7027,105 +6270,6 @@
       "integrity": "sha512-+lP4/6lKUBfQjZ2pdxThZvLUAafmZb8OAxFb8XXtiQmS35INgr85hdOGoEs124ez1FCnZJt6jau/T+alh58QFQ==",
       "license": "MIT"
     },
-    "node_modules/is-regex": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.2.1.tgz",
-      "integrity": "sha512-MjYsKHO5O7mCsmRGxWcLWheFqN9DJ/2TmngvjKXihe6efViPqc274+Fx/4fYj/r03+ESvBdTXK0V6tA3rgez1g==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "call-bound": "^1.0.2",
-        "gopd": "^1.2.0",
-        "has-tostringtag": "^1.0.2",
-        "hasown": "^2.0.2"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/is-set": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/is-set/-/is-set-2.0.3.tgz",
-      "integrity": "sha512-iPAjerrse27/ygGLxw+EBR9agv9Y6uLeYVJMu+QNCoouJ1/1ri0mGrcWpfCqFZuzzx3WjtwxG098X+n4OuRkPg==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/is-shared-array-buffer": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/is-shared-array-buffer/-/is-shared-array-buffer-1.0.4.tgz",
-      "integrity": "sha512-ISWac8drv4ZGfwKl5slpHG9OwPNty4jOWPRIhBpxOoD+hqITiwuipOQ2bNthAzwA3B4fIjO4Nln74N0S9byq8A==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "call-bound": "^1.0.3"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/is-string": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/is-string/-/is-string-1.1.1.tgz",
-      "integrity": "sha512-BtEeSsoaQjlSPBemMQIrY1MY0uM6vnS1g5fmufYOtnxLGUZM2178PKbhsk7Ffv58IX+ZtcvoGwccYsh0PglkAA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "call-bound": "^1.0.3",
-        "has-tostringtag": "^1.0.2"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/is-symbol": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/is-symbol/-/is-symbol-1.1.1.tgz",
-      "integrity": "sha512-9gGx6GTtCQM73BgmHQXfDmLtfjjTUDSyoxTCbp5WtoixAhfgsDirWIcVQ/IHpvI5Vgd5i/J5F7B9cN/WlVbC/w==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "call-bound": "^1.0.2",
-        "has-symbols": "^1.1.0",
-        "safe-regex-test": "^1.1.0"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/is-typed-array": {
-      "version": "1.1.15",
-      "resolved": "https://registry.npmjs.org/is-typed-array/-/is-typed-array-1.1.15.tgz",
-      "integrity": "sha512-p3EcsicXjit7SaskXHs1hA91QxgTw46Fv6EFKKGS5DRFLD8yKnohjF3hxoju94b/OcMZoQukzpPpBE9uLVKzgQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "which-typed-array": "^1.1.16"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
     "node_modules/is-typedarray": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz",
@@ -7137,52 +6281,6 @@
       "resolved": "https://registry.npmjs.org/is-utf8/-/is-utf8-0.2.1.tgz",
       "integrity": "sha512-rMYPYvCzsXywIsldgLaSoPlw5PfoB/ssr7hY4pLfcodrA5M/eArza1a9VmTiNIBNMjOGr1Ow9mTyU2o69U6U9Q==",
       "license": "MIT"
-    },
-    "node_modules/is-weakmap": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/is-weakmap/-/is-weakmap-2.0.2.tgz",
-      "integrity": "sha512-K5pXYOm9wqY1RgjpL3YTkF39tni1XajUIkawTLUo9EZEVUFga5gSQJF8nNS7ZwJQ02y+1YCNYcMh+HIf1ZqE+w==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/is-weakref": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/is-weakref/-/is-weakref-1.1.1.tgz",
-      "integrity": "sha512-6i9mGWSlqzNMEqpCp93KwRS1uUOodk2OJ6b+sq7ZPDSy2WuI5NFIxp/254TytR8ftefexkWn5xNiHUNpPOfSew==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "call-bound": "^1.0.3"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/is-weakset": {
-      "version": "2.0.4",
-      "resolved": "https://registry.npmjs.org/is-weakset/-/is-weakset-2.0.4.tgz",
-      "integrity": "sha512-mfcwb6IzQyOKTs84CQMrOwW4gQcaTOAWJ0zzJCl2WSPDrWk/OzDaImWFH3djXhb24g4eudZfLRozAvPGw4d9hQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "call-bound": "^1.0.3",
-        "get-intrinsic": "^1.2.6"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
     },
     "node_modules/is-yarn-global": {
       "version": "0.4.1",
@@ -7587,9 +6685,9 @@
       }
     },
     "node_modules/minimatch": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
-      "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.3.tgz",
+      "integrity": "sha512-M2GCs7Vk83NxkUyQV1bkABc4yxgz9kILhHImZiBPAZ9ybuvCb0/H7lEl5XvIg3g+9d4eNotkZA5IWwYl0tibaA==",
       "license": "ISC",
       "dependencies": {
         "brace-expansion": "^1.1.7"
@@ -7614,28 +6712,6 @@
       "license": "BlueOak-1.0.0",
       "engines": {
         "node": ">=16 || 14 >=14.17"
-      }
-    },
-    "node_modules/mock-property": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/mock-property/-/mock-property-1.1.0.tgz",
-      "integrity": "sha512-1/JjbLoGwv87xVsutkX0XJc0M0W4kb40cZl/K41xtTViBOD9JuFPKfyMNTrLJ/ivYAd0aPqu/vduamXO0emTFQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "define-data-property": "^1.1.4",
-        "functions-have-names": "^1.2.3",
-        "gopd": "^1.0.1",
-        "has-property-descriptors": "^1.0.2",
-        "hasown": "^2.0.2",
-        "isarray": "^2.0.5",
-        "object-inspect": "^1.13.2"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/ms": {
@@ -7716,23 +6792,6 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
-    "node_modules/object-is": {
-      "version": "1.1.6",
-      "resolved": "https://registry.npmjs.org/object-is/-/object-is-1.1.6.tgz",
-      "integrity": "sha512-F8cZ+KfGlSGi09lJT7/Nd6KJZ9ygtvYC0/UYYLI9nmQKLMnydpB9yvbv9K1uSkEu7FU9vYPmVwLg328tX+ot3Q==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "call-bind": "^1.0.7",
-        "define-properties": "^1.2.1"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
     "node_modules/object-keys": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-1.1.1.tgz",
@@ -7740,27 +6799,6 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
-      }
-    },
-    "node_modules/object.assign": {
-      "version": "4.1.7",
-      "resolved": "https://registry.npmjs.org/object.assign/-/object.assign-4.1.7.tgz",
-      "integrity": "sha512-nK28WOo+QIjBkDduTINE4JkF/UJJKyf2EJxvJKfblDpyg0Q+pkOHNTL0Qwy6NP6FhE/EnzV73BxxqcJaXY9anw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "call-bind": "^1.0.8",
-        "call-bound": "^1.0.3",
-        "define-properties": "^1.2.1",
-        "es-object-atoms": "^1.0.0",
-        "has-symbols": "^1.1.0",
-        "object-keys": "^1.1.1"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/on-finished": {
@@ -7799,24 +6837,6 @@
       },
       "engines": {
         "node": ">= 0.8.0"
-      }
-    },
-    "node_modules/own-keys": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/own-keys/-/own-keys-1.0.1.tgz",
-      "integrity": "sha512-qFOyK5PjiWZd+QQIh+1jhdb9LpxTF0qs7Pm8o5QHYZ0M3vKqSqzsZaEB6oWlxZ+q2sJBMI/Ktgd2N5ZwQoRHfg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "get-intrinsic": "^1.2.6",
-        "object-keys": "^1.1.1",
-        "safe-push-apply": "^1.0.0"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/p-cancelable": {
@@ -7936,16 +6956,6 @@
         "node": ">=8"
       }
     },
-    "node_modules/path-is-absolute": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
-      "integrity": "sha512-AVbw3UJ2e9bq64vSaS9Am0fje1Pa8pbGqTTsmXfaIiMpnr5DlDhfJOuLj9Sf95ZPVDAUerDfEk88MPmPe7UCQg==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
     "node_modules/path-key": {
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
@@ -8024,16 +7034,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/jonschlinkert"
-      }
-    },
-    "node_modules/possible-typed-array-names": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/possible-typed-array-names/-/possible-typed-array-names-1.1.0.tgz",
-      "integrity": "sha512-/+5VFTchJDoVj3bhoqi6UeymcD00DAwb1nJwamzPvHEszJ4FpF6SNNbUbOS8yI56qHzdV8eK0qEfOSiodkTdxg==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.4"
       }
     },
     "node_modules/prelude-ls": {
@@ -8154,12 +7154,6 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/quotemeta": {
-      "version": "0.0.0",
-      "resolved": "https://registry.npmjs.org/quotemeta/-/quotemeta-0.0.0.tgz",
-      "integrity": "sha512-1XGObUh7RN5b58vKuAsrlfqT+Rc4vmw8N4pP9gFCq1GFlTdV0Ex/D2Ro1Drvrqj++HPi3ig0Np17XPslELeMRA==",
-      "license": "MIT"
-    },
     "node_modules/range-parser": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.2.1.tgz",
@@ -8242,29 +7236,6 @@
         "node": ">=8.10.0"
       }
     },
-    "node_modules/reflect.getprototypeof": {
-      "version": "1.0.10",
-      "resolved": "https://registry.npmjs.org/reflect.getprototypeof/-/reflect.getprototypeof-1.0.10.tgz",
-      "integrity": "sha512-00o4I+DVrefhv+nX0ulyi3biSHCPDe+yLv5o/p6d/UVlirijB8E16FtfwSAi4g3tcqrQ4lRAqQSoFEZJehYEcw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "call-bind": "^1.0.8",
-        "define-properties": "^1.2.1",
-        "es-abstract": "^1.23.9",
-        "es-errors": "^1.3.0",
-        "es-object-atoms": "^1.0.0",
-        "get-intrinsic": "^1.2.7",
-        "get-proto": "^1.0.1",
-        "which-builtin-type": "^1.2.1"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
     "node_modules/regenerate": {
       "version": "1.4.2",
       "resolved": "https://registry.npmjs.org/regenerate/-/regenerate-1.4.2.tgz",
@@ -8288,27 +7259,6 @@
       "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.14.1.tgz",
       "integrity": "sha512-dYnhHh0nJoMfnkZs6GmmhFknAGRrLznOu5nc9ML+EJxGvrx6H7teuevqVqCuPcPK//3eDrrjQhehXVx9cnkGdw==",
       "license": "MIT"
-    },
-    "node_modules/regexp.prototype.flags": {
-      "version": "1.5.4",
-      "resolved": "https://registry.npmjs.org/regexp.prototype.flags/-/regexp.prototype.flags-1.5.4.tgz",
-      "integrity": "sha512-dYqgNSZbDwkaJ2ceRd9ojCGjBq+mOm9LmtXnAnEGyHhN/5R7iDW2TRw3h+o/jCFxus3P2LfWIIiwowAjANm7IA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "call-bind": "^1.0.8",
-        "define-properties": "^1.2.1",
-        "es-errors": "^1.3.0",
-        "get-proto": "^1.0.1",
-        "gopd": "^1.2.0",
-        "set-function-name": "^2.0.2"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
     },
     "node_modules/regexpu-core": {
       "version": "6.4.0",
@@ -8546,26 +7496,6 @@
         "tslib": "^2.1.0"
       }
     },
-    "node_modules/safe-array-concat": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/safe-array-concat/-/safe-array-concat-1.1.3.tgz",
-      "integrity": "sha512-AURm5f0jYEOydBj7VQlVvDrjeFgthDdEF5H1dP+6mNpoXOMo1quQqJ4wvJDyRZ9+pO3kGWoOdmV08cSv2aJV6Q==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "call-bind": "^1.0.8",
-        "call-bound": "^1.0.2",
-        "get-intrinsic": "^1.2.6",
-        "has-symbols": "^1.1.0",
-        "isarray": "^2.0.5"
-      },
-      "engines": {
-        "node": ">=0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
     "node_modules/safe-buffer": {
       "version": "5.2.1",
       "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
@@ -8585,41 +7515,6 @@
         }
       ],
       "license": "MIT"
-    },
-    "node_modules/safe-push-apply": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/safe-push-apply/-/safe-push-apply-1.0.0.tgz",
-      "integrity": "sha512-iKE9w/Z7xCzUMIZqdBsp6pEQvwuEebH4vdpjcDWnyzaI6yl6O9FHvVpmGelvEHNsoY6wGblkxR6Zty/h00WiSA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "es-errors": "^1.3.0",
-        "isarray": "^2.0.5"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/safe-regex-test": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/safe-regex-test/-/safe-regex-test-1.1.0.tgz",
-      "integrity": "sha512-x/+Cz4YrimQxQccJf5mKEbIa1NzeCRNI5Ecl/ekmlYaampdNLPalVyIcCZNNH3MvmqBugV5TMYZXv0ljslUlaw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "call-bound": "^1.0.2",
-        "es-errors": "^1.3.0",
-        "is-regex": "^1.2.1"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
     },
     "node_modules/safer-buffer": {
       "version": "2.1.2",
@@ -8745,37 +7640,6 @@
         "get-intrinsic": "^1.2.4",
         "gopd": "^1.0.1",
         "has-property-descriptors": "^1.0.2"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      }
-    },
-    "node_modules/set-function-name": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/set-function-name/-/set-function-name-2.0.2.tgz",
-      "integrity": "sha512-7PGFlmtwsEADb0WYyvCMa1t+yke6daIG4Wirafur5kcf+MhUnPms1UeR0CKQdTZD81yESwMHbtn+TR+dMviakQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "define-data-property": "^1.1.4",
-        "es-errors": "^1.3.0",
-        "functions-have-names": "^1.2.3",
-        "has-property-descriptors": "^1.0.2"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      }
-    },
-    "node_modules/set-proto": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/set-proto/-/set-proto-1.0.0.tgz",
-      "integrity": "sha512-RJRdvCo6IAnPdsvP/7m6bsQqNnn1FCBX5ZNtFL98MmFF/4xAIJTIg1YbHW5DC2W5SKZanrC6i4HsJqlajw/dZw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "dunder-proto": "^1.0.1",
-        "es-errors": "^1.3.0",
-        "es-object-atoms": "^1.0.0"
       },
       "engines": {
         "node": ">= 0.4"
@@ -9224,20 +8088,6 @@
         "node": ">= 0.8"
       }
     },
-    "node_modules/stop-iteration-iterator": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/stop-iteration-iterator/-/stop-iteration-iterator-1.1.0.tgz",
-      "integrity": "sha512-eLoXW/DHyl62zxY4SCaIgnRhuMr6ri4juEYARS8E6sCEqzKpOiE521Ucofdx+KnDZl5xmvGYaaKCk5FEOxJCoQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "es-errors": "^1.3.0",
-        "internal-slot": "^1.1.0"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      }
-    },
     "node_modules/stream-combiner": {
       "version": "0.0.4",
       "resolved": "https://registry.npmjs.org/stream-combiner/-/stream-combiner-0.0.4.tgz",
@@ -9259,65 +8109,6 @@
       },
       "engines": {
         "node": ">=8"
-      }
-    },
-    "node_modules/string.prototype.trim": {
-      "version": "1.2.10",
-      "resolved": "https://registry.npmjs.org/string.prototype.trim/-/string.prototype.trim-1.2.10.tgz",
-      "integrity": "sha512-Rs66F0P/1kedk5lyYyH9uBzuiI/kNRmwJAR9quK6VOtIpZ2G+hMZd+HQbbv25MgCA6gEffoMZYxlTod4WcdrKA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "call-bind": "^1.0.8",
-        "call-bound": "^1.0.2",
-        "define-data-property": "^1.1.4",
-        "define-properties": "^1.2.1",
-        "es-abstract": "^1.23.5",
-        "es-object-atoms": "^1.0.0",
-        "has-property-descriptors": "^1.0.2"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/string.prototype.trimend": {
-      "version": "1.0.9",
-      "resolved": "https://registry.npmjs.org/string.prototype.trimend/-/string.prototype.trimend-1.0.9.tgz",
-      "integrity": "sha512-G7Ok5C6E/j4SGfyLCloXTrngQIQU3PWtXGst3yM7Bea9FRURf1S42ZHlZZtsNque2FN2PoUhfZXYLNWwEr4dLQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "call-bind": "^1.0.8",
-        "call-bound": "^1.0.2",
-        "define-properties": "^1.2.1",
-        "es-object-atoms": "^1.0.0"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/string.prototype.trimstart": {
-      "version": "1.0.8",
-      "resolved": "https://registry.npmjs.org/string.prototype.trimstart/-/string.prototype.trimstart-1.0.8.tgz",
-      "integrity": "sha512-UXSH262CSZY1tfu3G3Secr6uGLCFVPMhIqHjlgCUtCCcgihYc/xKs9djMTMUOb2j1mVSeU8EU6NWc/iQKU6Gfg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "call-bind": "^1.0.7",
-        "define-properties": "^1.2.1",
-        "es-object-atoms": "^1.0.0"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/strip-ansi": {
@@ -9372,171 +8163,6 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/tap-colorize": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/tap-colorize/-/tap-colorize-1.2.0.tgz",
-      "integrity": "sha512-0w+QB/2xD5Lp+1aV7Tg8TU2CrIqZjH6oa0Ip+l0SesJQpAMmYvu9Z6SjERXTC/z/ckxDRFo6i+7jfjnrGJEAAg==",
-      "license": "MIT",
-      "dependencies": {
-        "colornames": "~0.0.2",
-        "minimist": "~0.2.0",
-        "quotemeta": "0.0.0",
-        "split": "~0.3.0",
-        "stream-combiner": "~0.2.1",
-        "through2": "~1.0.0",
-        "x256": "~0.0.2"
-      },
-      "bin": {
-        "tap-colorize": "bin/cmd.js"
-      }
-    },
-    "node_modules/tap-colorize/node_modules/isarray": {
-      "version": "0.0.1",
-      "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
-      "integrity": "sha512-D2S+3GLxWH+uhrNEcoh/fnmYeP8E8/zHl644d/jdA0g2uyXvy3sb0qxotE+ne0LtccHknQzWwZEzhak7oJ0COQ==",
-      "license": "MIT"
-    },
-    "node_modules/tap-colorize/node_modules/minimist": {
-      "version": "0.2.4",
-      "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.2.4.tgz",
-      "integrity": "sha512-Pkrrm8NjyQ8yVt8Am9M+yUt74zE3iokhzbG1bFVNjLB92vwM71hf40RkEsryg98BujhVOncKm/C1xROxZ030LQ==",
-      "license": "MIT",
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/tap-colorize/node_modules/object-keys": {
-      "version": "0.4.0",
-      "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-0.4.0.tgz",
-      "integrity": "sha512-ncrLw+X55z7bkl5PnUvHwFK9FcGuFYo9gtjws2XtSzL+aZ8tm830P60WJ0dSmFVaSalWieW5MD7kEdnXda9yJw==",
-      "license": "MIT"
-    },
-    "node_modules/tap-colorize/node_modules/readable-stream": {
-      "version": "1.1.14",
-      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.14.tgz",
-      "integrity": "sha512-+MeVjFf4L44XUkhM1eYbD8fyEsxcV81pqMSR5gblfcLCHfZvbrqy4/qYHE+/R5HoBUT11WV5O08Cr1n3YXkWVQ==",
-      "license": "MIT",
-      "dependencies": {
-        "core-util-is": "~1.0.0",
-        "inherits": "~2.0.1",
-        "isarray": "0.0.1",
-        "string_decoder": "~0.10.x"
-      }
-    },
-    "node_modules/tap-colorize/node_modules/stream-combiner": {
-      "version": "0.2.2",
-      "resolved": "https://registry.npmjs.org/stream-combiner/-/stream-combiner-0.2.2.tgz",
-      "integrity": "sha512-6yHMqgLYDzQDcAkL+tjJDC5nSNuNIx0vZtRZeiPh7Saef7VHX9H5Ijn9l2VIol2zaNYlYEX6KyuT/237A58qEQ==",
-      "license": "MIT",
-      "dependencies": {
-        "duplexer": "~0.1.1",
-        "through": "~2.3.4"
-      }
-    },
-    "node_modules/tap-colorize/node_modules/string_decoder": {
-      "version": "0.10.31",
-      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
-      "integrity": "sha512-ev2QzSzWPYmy9GuqfIVildA4OdcGLeFZQrq5ys6RtiuF+RQQiZWr8TZNyAcuVXyQRYfEO+MsoB/1BuQVhOJuoQ==",
-      "license": "MIT"
-    },
-    "node_modules/tap-colorize/node_modules/through2": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/through2/-/through2-1.0.0.tgz",
-      "integrity": "sha512-c0/VHHaVPY2007PCtr6AY7BIOx1yvLzO9rPlCuT2qFKYed0bQIJGixLA9xATHfRwXpd1IoorvwMinLJOAIzw9A==",
-      "license": "MIT",
-      "dependencies": {
-        "readable-stream": "~1.1.10",
-        "xtend": "~2.1.1"
-      }
-    },
-    "node_modules/tap-colorize/node_modules/xtend": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/xtend/-/xtend-2.1.2.tgz",
-      "integrity": "sha512-vMNKzr2rHP9Dp/e1NQFnLQlwlhp9L/LfvnsVdHxN1f+uggyVI3i08uD14GPvCToPkdsRfyPqIyYGmIk58V98ZQ==",
-      "dependencies": {
-        "object-keys": "~0.4.0"
-      },
-      "engines": {
-        "node": ">=0.4"
-      }
-    },
-    "node_modules/tape": {
-      "version": "5.9.0",
-      "resolved": "https://registry.npmjs.org/tape/-/tape-5.9.0.tgz",
-      "integrity": "sha512-czbGgxSVwRlbB3Ly/aqQrNwrDAzKHDW/kVXegp4hSFmR2c8qqm3hCgZbUy1+3QAQFGhPDG7J56UsV1uNilBFCA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@ljharb/resumer": "^0.1.3",
-        "@ljharb/through": "^2.3.13",
-        "array.prototype.every": "^1.1.6",
-        "call-bind": "^1.0.7",
-        "deep-equal": "^2.2.3",
-        "defined": "^1.0.1",
-        "dotignore": "^0.1.2",
-        "for-each": "^0.3.3",
-        "get-package-type": "^0.1.0",
-        "glob": "^7.2.3",
-        "has-dynamic-import": "^2.1.0",
-        "hasown": "^2.0.2",
-        "inherits": "^2.0.4",
-        "is-regex": "^1.1.4",
-        "minimist": "^1.2.8",
-        "mock-property": "^1.1.0",
-        "object-inspect": "^1.13.2",
-        "object-is": "^1.1.6",
-        "object-keys": "^1.1.1",
-        "object.assign": "^4.1.5",
-        "resolve": "^2.0.0-next.5",
-        "string.prototype.trim": "^1.2.9"
-      },
-      "bin": {
-        "tape": "bin/tape"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/tape/node_modules/glob": {
-      "version": "7.2.3",
-      "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
-      "integrity": "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==",
-      "deprecated": "Glob versions prior to v9 are no longer supported",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "fs.realpath": "^1.0.0",
-        "inflight": "^1.0.4",
-        "inherits": "2",
-        "minimatch": "^3.1.1",
-        "once": "^1.3.0",
-        "path-is-absolute": "^1.0.0"
-      },
-      "engines": {
-        "node": "*"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
-      }
-    },
-    "node_modules/tape/node_modules/resolve": {
-      "version": "2.0.0-next.5",
-      "resolved": "https://registry.npmjs.org/resolve/-/resolve-2.0.0-next.5.tgz",
-      "integrity": "sha512-U7WjGVG9sH8tvjW5SmGbQuui75FiyjAX72HX15DwBBwF9dNiQZRQAg9nnPhYy+TUnE0+VcrttuvNI8oSxZcocA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "is-core-module": "^2.13.0",
-        "path-parse": "^1.0.7",
-        "supports-preserve-symlinks-flag": "^1.0.0"
-      },
-      "bin": {
-        "resolve": "bin/resolve"
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
@@ -9650,84 +8276,6 @@
         "node": ">= 0.6"
       }
     },
-    "node_modules/typed-array-buffer": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/typed-array-buffer/-/typed-array-buffer-1.0.3.tgz",
-      "integrity": "sha512-nAYYwfY3qnzX30IkA6AQZjVbtK6duGontcQm1WSG1MD94YLqK0515GNApXkoxKOWMusVssAHWLh9SeaoefYFGw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "call-bound": "^1.0.3",
-        "es-errors": "^1.3.0",
-        "is-typed-array": "^1.1.14"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      }
-    },
-    "node_modules/typed-array-byte-length": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/typed-array-byte-length/-/typed-array-byte-length-1.0.3.tgz",
-      "integrity": "sha512-BaXgOuIxz8n8pIq3e7Atg/7s+DpiYrxn4vdot3w9KbnBhcRQq6o3xemQdIfynqSeXeDrF32x+WvfzmOjPiY9lg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "call-bind": "^1.0.8",
-        "for-each": "^0.3.3",
-        "gopd": "^1.2.0",
-        "has-proto": "^1.2.0",
-        "is-typed-array": "^1.1.14"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/typed-array-byte-offset": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/typed-array-byte-offset/-/typed-array-byte-offset-1.0.4.tgz",
-      "integrity": "sha512-bTlAFB/FBYMcuX81gbL4OcpH5PmlFHqlCCpAl8AlEzMz5k53oNDvN8p1PNOWLEmI2x4orp3raOFB51tv9X+MFQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "available-typed-arrays": "^1.0.7",
-        "call-bind": "^1.0.8",
-        "for-each": "^0.3.3",
-        "gopd": "^1.2.0",
-        "has-proto": "^1.2.0",
-        "is-typed-array": "^1.1.15",
-        "reflect.getprototypeof": "^1.0.9"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/typed-array-length": {
-      "version": "1.0.7",
-      "resolved": "https://registry.npmjs.org/typed-array-length/-/typed-array-length-1.0.7.tgz",
-      "integrity": "sha512-3KS2b+kL7fsuk/eJZ7EQdnEmQoaho/r6KUef7hxvltNA5DR8NAUM+8wJMbJyZ4G9/7i3v5zPBIMN5aybAh2/Jg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "call-bind": "^1.0.7",
-        "for-each": "^0.3.3",
-        "gopd": "^1.0.1",
-        "is-typed-array": "^1.1.13",
-        "possible-typed-array-names": "^1.0.0",
-        "reflect.getprototypeof": "^1.0.6"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
     "node_modules/typedarray-to-buffer": {
       "version": "3.1.5",
       "resolved": "https://registry.npmjs.org/typedarray-to-buffer/-/typedarray-to-buffer-3.1.5.tgz",
@@ -9735,25 +8283,6 @@
       "license": "MIT",
       "dependencies": {
         "is-typedarray": "^1.0.0"
-      }
-    },
-    "node_modules/unbox-primitive": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/unbox-primitive/-/unbox-primitive-1.1.0.tgz",
-      "integrity": "sha512-nWJ91DjeOkej/TA8pXQ3myruKpKEYgqvpw9lz4OPHj/NWFNluYrjbz9j01CJ8yKQd2g4jFoOkINCTW2I5LEEyw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "call-bound": "^1.0.3",
-        "has-bigints": "^1.0.2",
-        "has-symbols": "^1.1.0",
-        "which-boxed-primitive": "^1.1.1"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/unicode-canonical-property-names-ecmascript": {
@@ -10005,100 +8534,11 @@
         "node": ">= 8"
       }
     },
-    "node_modules/which-boxed-primitive": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/which-boxed-primitive/-/which-boxed-primitive-1.1.1.tgz",
-      "integrity": "sha512-TbX3mj8n0odCBFVlY8AxkqcHASw3L60jIuF8jFP78az3C2YhmGvqbHBpAjTRH2/xqYunrJ9g1jSyjCjpoWzIAA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "is-bigint": "^1.1.0",
-        "is-boolean-object": "^1.2.1",
-        "is-number-object": "^1.1.1",
-        "is-string": "^1.1.1",
-        "is-symbol": "^1.1.1"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/which-builtin-type": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/which-builtin-type/-/which-builtin-type-1.2.1.tgz",
-      "integrity": "sha512-6iBczoX+kDQ7a3+YJBnh3T+KZRxM/iYNPXicqk66/Qfm1b93iu+yOImkg0zHbj5LNOcNv1TEADiZ0xa34B4q6Q==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "call-bound": "^1.0.2",
-        "function.prototype.name": "^1.1.6",
-        "has-tostringtag": "^1.0.2",
-        "is-async-function": "^2.0.0",
-        "is-date-object": "^1.1.0",
-        "is-finalizationregistry": "^1.1.0",
-        "is-generator-function": "^1.0.10",
-        "is-regex": "^1.2.1",
-        "is-weakref": "^1.0.2",
-        "isarray": "^2.0.5",
-        "which-boxed-primitive": "^1.1.0",
-        "which-collection": "^1.0.2",
-        "which-typed-array": "^1.1.16"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/which-collection": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/which-collection/-/which-collection-1.0.2.tgz",
-      "integrity": "sha512-K4jVyjnBdgvc86Y6BkaLZEN933SwYOuBFkdmBu9ZfkcAbdVbpITnDmjvZ/aQjRXQrv5EPkTnD1s39GiiqbngCw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "is-map": "^2.0.3",
-        "is-set": "^2.0.3",
-        "is-weakmap": "^2.0.2",
-        "is-weakset": "^2.0.3"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
     "node_modules/which-module": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/which-module/-/which-module-2.0.1.tgz",
       "integrity": "sha512-iBdZ57RDvnOR9AGBhML2vFZf7h8vmBjhoaZqODJBFWHVtKkDmKuHai3cx5PgVMrX5YDNp27AofYbAwctSS+vhQ==",
       "license": "ISC"
-    },
-    "node_modules/which-typed-array": {
-      "version": "1.1.19",
-      "resolved": "https://registry.npmjs.org/which-typed-array/-/which-typed-array-1.1.19.tgz",
-      "integrity": "sha512-rEvr90Bck4WZt9HHFC4DJMsjvu7x+r6bImz0/BrbWb7A2djJ8hnZMrWnHo9F8ssv0OMErasDhftrfROTyqSDrw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "available-typed-arrays": "^1.0.7",
-        "call-bind": "^1.0.8",
-        "call-bound": "^1.0.4",
-        "for-each": "^0.3.5",
-        "get-proto": "^1.0.1",
-        "gopd": "^1.2.0",
-        "has-tostringtag": "^1.0.2"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
     },
     "node_modules/widest-line": {
       "version": "4.0.1",
@@ -10285,15 +8725,6 @@
       "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.7.tgz",
       "integrity": "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==",
       "license": "ISC"
-    },
-    "node_modules/x256": {
-      "version": "0.0.2",
-      "resolved": "https://registry.npmjs.org/x256/-/x256-0.0.2.tgz",
-      "integrity": "sha512-ZsIH+sheoF8YG9YG+QKEEIdtqpHRA9FYuD7MqhfyB1kayXU43RUNBFSxBEnF8ywSUxdg+8no4+bPr5qLbyxKgA==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.4.0"
-      }
     },
     "node_modules/xdg-basedir": {
       "version": "5.1.0",

--- a/package.json
+++ b/package.json
@@ -112,7 +112,6 @@
     "set-value": "^4.1.0",
     "showdown": "^1.9.1",
     "source-map-js": "^1.0.2",
-    "tap-colorize": "^1.2.0",
     "terser": "^5.22.0",
     "tmp": "^0.2.5",
     "unset-value": "^1.0.0",
@@ -125,7 +124,6 @@
     "baseline-browser-mapping": "^2.10.0",
     "dirsum": "^0.1.1",
     "source-map-support": "^0.5.21",
-    "tape": "^5.9.0",
     "tree-kill": "^1.2.2"
   },
   "engine": "node >= 20",

--- a/test/tool/compile.js
+++ b/test/tool/compile.js
@@ -20,7 +20,7 @@ qx.Class.define("qx.test.tool.compile.CompilerApi", {
         return;
       }
       function addTest(test) {
-        let args = [];
+        let args = ["--test-reporter=tap"];
         args.push(test + ".js");
         for (const arg of ["colorize", "verbose", "quiet", "fail-fast"]) {
           if (command.argv[arg]) {

--- a/test/tool/integrationtest/test-browserify.js
+++ b/test/tool/integrationtest/test-browserify.js
@@ -166,7 +166,7 @@ test("Recompile is incremental (doesn't rebuild bundle if not needed)", async ()
   }
 });
 
-test("Missing npm module is handled gracefully (ignoreMissing equivalent)", async assert => {
+test("Missing npm module is handled gracefully (ignoreMissing equivalent)", async () => {
   try {
     // Compile app that require()s a package that is intentionally not installed
     const result = await testUtils.runCompiler(testDirMissing);
@@ -195,8 +195,7 @@ test("Missing npm module is handled gracefully (ignoreMissing equivalent)", asyn
     );
 
     console.log(`✓ Missing module handled: bundle created (${stats.size} bytes), warning emitted`);
-    assert.end();
   } catch (ex) {
-    assert.end(ex);
+    throw ex;
   }
 });

--- a/test/tool/integrationtest/test-browserify.js
+++ b/test/tool/integrationtest/test-browserify.js
@@ -1,4 +1,5 @@
-const test = require("tape");
+const { test } = require("node:test");
+const assert = require("node:assert");
 const testUtils = require("../../../bin/tools/utils");
 const path = require("path");
 const fs = require("fs").promises;
@@ -34,17 +35,16 @@ async function fileExists(filePath) {
   }
 }
 
-test("Setup: Install dependencies", async assert => {
+test("Setup: Install dependencies", async () => {
   try {
     await installDependencies();
     assert.ok(true, "npm install successful");
-    assert.end();
   } catch (ex) {
-    assert.end(ex);
+    throw ex;
   }
 });
 
-test("Browserify bundles npm modules correctly", async assert => {
+test("Browserify bundles npm modules correctly", async () => {
   try {
     // 1. Compile the app
     let result = await testUtils.runCompiler(testDir);
@@ -86,13 +86,12 @@ test("Browserify bundles npm modules correctly", async assert => {
     console.log(`✓ Browserify bundle created: ${(stats.size / 1024).toFixed(1)} KB`);
     console.log(`✓ Detected require('uuid') at: ${appInfo.commonjsModules.uuid[0]}`);
 
-    assert.end();
   } catch (ex) {
-    assert.end(ex);
+    throw ex;
   }
 });
 
-test("Compiled app structure is correct", async assert => {
+test("Compiled app structure is correct", async () => {
   try {
     const compiledDir = path.join(testDir, "compiled/source/testbrowserify");
 
@@ -115,13 +114,12 @@ test("Compiled app structure is correct", async assert => {
 
     console.log("✓ All required files present");
 
-    assert.end();
   } catch (ex) {
-    assert.end(ex);
+    throw ex;
   }
 });
 
-test("Bundle contains expected npm modules", async assert => {
+test("Bundle contains expected npm modules", async () => {
   try {
     const browserifyFile = path.join(testDir, "compiled/source/testbrowserify/commonjs-browserify.js");
     const content = await fs.readFile(browserifyFile, 'utf-8');
@@ -133,13 +131,12 @@ test("Bundle contains expected npm modules", async assert => {
 
     console.log("✓ All expected modules bundled");
 
-    assert.end();
   } catch (ex) {
-    assert.end(ex);
+    throw ex;
   }
 });
 
-test("Recompile is incremental (doesn't rebuild bundle if not needed)", async assert => {
+test("Recompile is incremental (doesn't rebuild bundle if not needed)", async () => {
   try {
     // First compile already done, get browserify file mtime
     const browserifyFile = path.join(testDir, "compiled/source/testbrowserify/commonjs-browserify.js");
@@ -164,9 +161,8 @@ test("Recompile is incremental (doesn't rebuild bundle if not needed)", async as
     }
 
     assert.ok(true, "Recompile completed");
-    assert.end();
   } catch (ex) {
-    assert.end(ex);
+    throw ex;
   }
 });
 

--- a/test/tool/integrationtest/test-cli.js
+++ b/test/tool/integrationtest/test-cli.js
@@ -1,5 +1,5 @@
-const test = require("tape");
-const colorize = require('tap-colorize');
+const { test } = require("node:test");
+const assert = require("node:assert");
 const fs = require("fs");
 const fsp = require("fs").promises;
 const path = require("path");
@@ -10,7 +10,6 @@ const testDir = path.join(__dirname, "test-cli")
 const myAppDir = path.join(testDir, "myapp");
 
 //colorize output
-test.createStream().pipe(colorize()).pipe(process.stdout);
 
 
 async function assertPathExists(path){
@@ -21,18 +20,17 @@ async function assertPathExists(path){
   throw new Error(`Path does not exist: ${path}`);
 }
 
-test("test version", async assert => {
+test("test version", async () => {
   try {
     await testUtils.deleteRecursive(myAppDir);
     let result = await testUtils.runCommand(testDir, qxCmdPath, "--version");
     assert.ok(result.exitCode === 0, testUtils.reportError(result));
-    assert.end();
   } catch (ex) {
-    assert.end(ex);
+    throw ex;
   }
 });
 
-test("create app", async assert => {
+test("create app", async () => {
   try {
     await testUtils.deleteRecursive(myAppDir);
     let result;
@@ -45,14 +43,13 @@ test("create app", async assert => {
     result = await testUtils.runCommand(path.join(myAppDir, "compiled", "source", "myapp"), "node", "index.js");
     assert.ok(result.exitCode === 0, testUtils.reportError(result));
     assert.match(result.output, /Hello World!/);
-    assert.end();
   } catch (ex) {
-    assert.end(ex);
+    throw ex;
   }
 });
 
 
-test("qx package list", async assert => {
+test("qx package list", async () => {
   try {
     let result;
     result = await testUtils.runCommand(myAppDir, qxCmdPath, "package", "update", "-v");
@@ -65,14 +62,13 @@ test("qx package list", async assert => {
     assert.ok(result.exitCode === 0, testUtils.reportError(result));
     result = await testUtils.runCommand(myAppDir, qxCmdPath, "package", "list", "--uris-only");
     assert.ok(result.exitCode === 0, testUtils.reportError(result));
-    assert.end();
   } catch (ex) {
-    assert.end(ex);
+    throw ex;
   }
 });
 
 
-test("install packages", async assert => {
+test("install packages", async () => {
   try {
     let result;
     result = await testUtils.runCommand(myAppDir, qxCmdPath, "package", "list", "-v");
@@ -91,13 +87,12 @@ test("install packages", async assert => {
     result = await testUtils.runCommand(path.join(myAppDir, "compiled", "source", "myapp"), "node", "index.js");
     assert.ok(result.exitCode === 0, testUtils.reportError(result));
     assert.match(result.output, /Hello World!/);
-    assert.end();
   } catch (ex) {
-    assert.end(ex);
+    throw ex;
   }
 });
 
-test("reinstall package", async assert => {
+test("reinstall package", async () => {
   try {
     let result;
     result = await testUtils.runCommand(myAppDir, qxCmdPath, "clean", "-v");
@@ -112,13 +107,12 @@ test("reinstall package", async assert => {
     result = await testUtils.runCommand(myAppDir, qxCmdPath, "package", "list", "-isH");
     assert.ok(result.exitCode === 0, testUtils.reportError(result));
     // todo: check output
-    assert.end();
   } catch (ex) {
-    assert.end(ex);
+    throw ex;
   }
 });
 
-test("remove packages", async assert => {
+test("remove packages", async () => {
   try {
     let result;
     result = await testUtils.runCommand(myAppDir, qxCmdPath, "package", "remove", "oetiker/UploadWidget", "-v");
@@ -133,13 +127,12 @@ test("remove packages", async assert => {
     result = await testUtils.runCommand(myAppDir, qxCmdPath, "package", "list", "--installed", "--short", "--noheaders");
     assert.ok(result.exitCode === 0, testUtils.reportError(result));
     // todo check output: list should be empty
-    assert.end();
   } catch (ex) {
-    assert.end(ex);
+    throw ex;
   }
 });
 
-test("install without manifest", async assert => {
+test("install without manifest", async () => {
   try {
     result = await testUtils.runCommand(myAppDir, qxCmdPath, "clean", "-v");
     assert.ok(result.exitCode === 0, testUtils.reportError(result));
@@ -154,13 +147,12 @@ test("install without manifest", async assert => {
     result = await testUtils.runCommand(myAppDir, qxCmdPath, "package", "list", "--installed", "--short", "--noheaders");
     assert.ok(result.exitCode === 0, testUtils.reportError(result));
     // todo: check output
-    assert.end();
   } catch (ex) {
-    assert.end(ex);
+    throw ex;
   }
 });
 
-test("add class and add script", async assert => {
+test("add class and add script", async () => {
   try {
     result = await testUtils.runCommand(myAppDir, qxCmdPath, "add", "class", "myapp.Window", "--extend=qx.core.Object", "--force");
     assert.ok(result.exitCode === 0, testUtils.reportError(result));
@@ -172,22 +164,20 @@ test("add class and add script", async assert => {
     assert.ok(await assertPathExists(path.join(myAppDir, "compiled", "source", "myapp", "index.js")));
     result = await testUtils.runCommand(path.join(myAppDir, "compiled", "source", "myapp"), "node", "index.js");
     assert.ok(result.exitCode === 0, testUtils.reportError(result));
-    assert.end();
   } catch (ex) {
-    assert.end(ex);
+    throw ex;
   }
 });
 
-test("pkg command (package alias)", async assert => {
+test("pkg command (package alias)", async () => {
   try {
     // Test that qx pkg is an alias for qx package
     let result = await testUtils.runCommand(testDir, qxCmdPath, "pkg", "--help");
     assert.ok(result.exitCode === 0, testUtils.reportError(result));
     assert.ok(result.output.includes("package") || result.output.includes("pkg"), "pkg help should mention package functionality");
     
-    assert.end();
   } catch (ex) {
-    assert.end(ex);
+    throw ex;
   }
 });
 

--- a/test/tool/integrationtest/test-commands.js
+++ b/test/tool/integrationtest/test-commands.js
@@ -1,4 +1,5 @@
-const test = require("tape");
+const { test } = require("node:test");
+const assert = require("node:assert");
 const testUtils = require("../../../bin/tools/utils");
 const path = require("path");
 const fs = require("fs").promises;
@@ -9,7 +10,7 @@ const testDir = __dirname;
 const appNamespace = "testCmdApp" + Date.now();
 const appDir = path.join(testDir, "test-commands", appNamespace);
 
-test("test commands - UserError class", async assert => {
+test("test commands - UserError class", async () => {
   try {
     const qx = require("../qx");
     // Test that UserError works correctly
@@ -20,13 +21,12 @@ test("test commands - UserError class", async assert => {
       assert.ok(e.message === "test error message", "UserError should have correct message");
     }
     
-    assert.end();
   } catch (ex) {
-    assert.end(ex);
+    throw ex;
   }
 });
 
-test("test commands - CLI help works", async assert => {
+test("test commands - CLI help works", async () => {
   try {
     // Test that various CLI commands show help
     let result = await testUtils.runCommand(__dirname, qxCmdPath, "create", "--help");
@@ -42,13 +42,12 @@ test("test commands - CLI help works", async assert => {
     assert.ok(result.exitCode === 0, "Add help should work");
     assert.ok(result.output.includes("add"), "Help should mention add command");
    
-    assert.end();
   } catch (ex) {
-    assert.end(ex);
+    throw ex;
   }
 });
 
-test("test commands - create app and test rename", async assert => {
+test("test commands - create app and test rename", async () => {
   try {
     const workDir = path.join(testDir, "test-commands");
     
@@ -107,13 +106,12 @@ test("test commands - create app and test rename", async assert => {
     // Cleanup
     rimraf(appDir);
     
-    assert.end();
   } catch (ex) {
     // Cleanup on error
     if (await pathExists(appDir)) {
       rimraf(appDir);
     }
-    assert.end(ex);
+    throw ex;
   }
 });
 

--- a/test/tool/integrationtest/test-deps.js
+++ b/test/tool/integrationtest/test-deps.js
@@ -1,5 +1,6 @@
 const qx = require("../qx");
-const test = require("tape");
+const { test } = require("node:test");
+const assert = require("node:assert");
 const fs = require("fs");
 const async = require("async");
 const {promisify} = require("util");
@@ -339,8 +340,8 @@ test("Checks dependencies and environment settings", assert => {
         assert.ok(src.match(/url\(\"sub5\/image.png\"\)/), "Resource SCSS");
       })
 
-      .then(() => assert.end())
-      .catch(err => assert.end(err));
+      .then(() => {})
+      .catch(err => { throw err; });
 });
 
 async function deleteRecursive(name) {

--- a/test/tool/integrationtest/test-deps.js
+++ b/test/tool/integrationtest/test-deps.js
@@ -92,7 +92,7 @@ async function createMaker() {
   return maker;
 }
 
-test("Checks dependencies and environment settings", assert => {
+test("Checks dependencies and environment settings", async () => {
   function readJson(filename) {
     return readFile(filename, {encoding: "utf8"})
         .then(str => JSON.parse(str));
@@ -119,7 +119,7 @@ test("Checks dependencies and environment settings", assert => {
   var compileInfo;
   var db;
   var meta;
-  deleteRecursive("test-deps")
+  await deleteRecursive("test-deps")
       .then(() => createMaker())
       .then(_maker => {
         maker = _maker;

--- a/test/tool/integrationtest/test-externals.js
+++ b/test/tool/integrationtest/test-externals.js
@@ -1,9 +1,10 @@
-const test = require("tape");
+const { test } = require("node:test");
+const assert = require("node:assert");
 const testUtils = require("../../../bin/tools/utils");
 const fsPromises = testUtils.fsPromises;
 require("process").chdir(__dirname);
 
-test("test externals", async assert => {
+test("test externals", async () => {
   try {
 
     await testUtils.deleteRecursive("test-externals/myapp/compiled");
@@ -23,9 +24,8 @@ test("test externals", async assert => {
     assert.ok(!data.match(/THIS_IS_C_JS/));
     assert.ok(!data.match(/urisBefore: \[ "__external__:http:\/\/cdn.example.com\/my\/d.js" \]/));
 
-    assert.end();
   } catch(ex) {
-    assert.end(ex);
+    throw ex;
   }
 });
 

--- a/test/tool/integrationtest/test-issues.js
+++ b/test/tool/integrationtest/test-issues.js
@@ -1,4 +1,5 @@
-const test = require("tape");
+const { test } = require("node:test");
+const assert = require("node:assert");
 const fs = require("fs");
 const kill = require("tree-kill");
 const child_process = require("child_process");
@@ -7,32 +8,30 @@ const fsPromises = testUtils.fsPromises;
 process.chdir(__dirname);
 
 
-test("Issue553", async assert => {
+test("Issue553", async () => {
   try {
     await testUtils.deleteRecursive("test-issues/issue553/compiled");
     await testUtils.runCompiler("test-issues/issue553");
     assert.ok(fs.existsSync("test-issues/issue553/compiled/source/index.html"));
     let indexHtml = await fsPromises.readFile("test-issues/issue553/compiled/source/index.html", "utf8");
     assert.ok(!!indexHtml.match(/issue553one\/index.js/m));
-    assert.end();
   } catch(ex) {
-    assert.end(ex);
+    throw ex;
   }
 });
 
-test("Issue553 single app", async assert => {
+test("Issue553 single app", async () => {
   try {
     await testUtils.deleteRecursive("test-issues/issue553/compiled");
     await testUtils.runCompiler("test-issues/issue553", "--app-name=issue553two");
     assert.ok(!fs.existsSync("test-issues/issue553/compiled/source/index.html"));
     assert.ok(fs.existsSync("test-issues/issue553/compiled/source/issue553two/index.html"));
-    assert.end();
   }catch(ex) {
-    assert.end(ex);
+    throw ex;
   }
 });
 
-test("Issue553 Node", async assert => {
+test("Issue553 Node", async () => {
   try {
     await testUtils.deleteRecursive("test-issues/issue553_node/compiled");
     await testUtils.runCompiler("test-issues/issue553_node");
@@ -44,24 +43,22 @@ test("Issue553 Node", async assert => {
     assert.ok(!fs.existsSync("test-issues/issue553_node/compiled/source/issue553one/index.html"));
     assert.ok(fs.existsSync("test-issues/issue553_node/compiled/source/issue553two/index.js"));
     assert.ok(!fs.existsSync("test-issues/issue553_node/compiled/source/issue553two/index.html"));
-    assert.end();
   }catch(ex) {
-    assert.end(ex);
+    throw ex;
   }
 });
 
-test("Dynamic commands", async assert => {
+test("Dynamic commands", async () => {
   try {
     await testUtils.deleteRecursive("test-issues/testdynamic/compiled");
     let result = await testUtils.runCommand("test-issues/testdynamic", testUtils.getCompiler(), "testlib", "hello", "-t=4");
     assert.ok(result.output.match(/The commmand testlib; message=hello, type=4/));
-    assert.end();
   }catch(ex) {
-    assert.end(ex);
+    throw ex;
   }
 });
 
-test("Dynamic parameter", async assert => {
+test("Dynamic parameter", async () => {
   try {
     // Test a simple dynamic command with just one parameter
     let result = await testUtils.runCommand("test-issues/testdynamicparameter", testUtils.getCompiler(), "compile", "--help");
@@ -69,13 +66,12 @@ test("Dynamic parameter", async assert => {
     assert.ok(result.output.match(/A simple compiler flag/), "Should show correct output with parameter value");
     result = await testUtils.runCommand("test-issues/testdynamicparameter", testUtils.getCompiler(), "compile", "--simple", "--verbose");
     assert.ok(result.exitCode === 0, "Simple command should execute successfully");
-    assert.end();
   }catch(ex) {
-    assert.end(ex);
+    throw ex;
   }
 });
 
-test("Issue440", async assert => {
+test("Issue440", async () => {
   try {
     await testUtils.deleteRecursive("test-issues/issue440/compiled");
     let code = await fsPromises.readFile("test-issues/issue440/source/class/issue440/Application.js", "utf8");
@@ -105,13 +101,12 @@ test("Issue440", async assert => {
     await fsPromises.writeFile("test-issues/issue440/source/class/issue440/Application.js", code.join("\n"), "utf8");
     result = await testUtils.runCompiler("test-issues/issue440");
     assert.ok(result.exitCode === 0);
-    assert.end();
   }catch(ex) {
-    assert.end(ex);
+    throw ex;
   }
 });
 
-test("testLegalSCSS", async assert => {
+test("testLegalSCSS", async () => {
   try {
     let result;
     await testUtils.deleteRecursive("test-issues/testLegalSCSS/compiled");
@@ -128,13 +123,12 @@ test("testLegalSCSS", async assert => {
     assert.ok(test.indexOf("testLegalSCSS/css/test_css.css") > 0);
     assert.ok(test.indexOf("testLegalSCSS/css/test_scss.css") > 0);
     assert.ok(test.indexOf("testLegalSCSS/css/test_theme_scss.css") > 0);
-    assert.end();
   }catch(ex) {
-    assert.end(ex);
+    throw ex;
   }
 });
 
-test("Issue715", async assert => {
+test("Issue715", async () => {
   try {
     await testUtils.deleteRecursive("test-issues/issue715/compiled");
     await testUtils.runCompiler("test-issues/issue715", "--target=build", "--minify=off");
@@ -145,13 +139,12 @@ test("Issue715", async assert => {
     assert.ok(!str.match(/__applyMyProp\b/m));
     assert.ok(!str.match(/__privateStaticOne\b/m));
     assert.ok(!!str.match(/__privateStaticTwo/m));
-    assert.end();
   }catch(ex) {
-    assert.end(ex);
+    throw ex;
   }
 });
 
-test("Issue10407 - Compiler should warn about nonexistent classes", async assert => {
+test("Issue10407 - Compiler should warn about nonexistent classes", async () => {
   try {
     await testUtils.deleteRecursive("test-issues/issue10407/compiled");
 
@@ -177,13 +170,12 @@ test("Issue10407 - Compiler should warn about nonexistent classes", async assert
       "Should warn about nonexistent class qx.ddde.eee"
     );
 
-    assert.end();
   }catch(ex) {
-    assert.end(ex);
+    throw ex;
   }
 });
 
-test("Issue10407 - Compiler should fail with --warnAsError", async assert => {
+test("Issue10407 - Compiler should fail with --warnAsError", async () => {
   try {
     await testUtils.deleteRecursive("test-issues/issue10407/compiled");
 
@@ -191,13 +183,12 @@ test("Issue10407 - Compiler should fail with --warnAsError", async assert => {
     let result = await testUtils.runCompiler("test-issues/issue10407", "--warnAsError");
     assert.ok(result.exitCode !== 0, "Compilation with --warnAsError should fail when there are unresolved symbols");
 
-    assert.end();
   }catch(ex) {
-    assert.end(ex);
+    throw ex;
   }
 });
 
-test("Issue10407 - Watch mode should detect new unresolved classes in new files", async assert => {
+test("Issue10407 - Watch mode should detect new unresolved classes in new files", async () => {
   const newClassPath = "test-issues/issue10407-watch/source/class/issue10407watch/WatchTestClass.js";
 
   try {
@@ -251,7 +242,6 @@ test("Issue10407 - Watch mode should detect new unresolved classes in new files"
         await fsPromises.unlink(newClassPath);
       }
       assert.fail("Watch mode did not start within 40s");
-      assert.end();
       return;
     }
 
@@ -319,7 +309,6 @@ qx.Class.define("issue10407watch.WatchTestClass", {
       await fsPromises.unlink(newClassPath);
     }
 
-    assert.end();
   } catch(ex) {
     // Cleanup on error
     const appFilePath = "test-issues/issue10407-watch/source/class/issue10407watch/Application.js";
@@ -339,11 +328,11 @@ qx.Class.define("issue10407watch.WatchTestClass", {
         // Ignore cleanup errors
       }
     }
-    assert.end(ex);
+    throw ex;
   }
 });
 
-test("Issue10407 - Watch mode should detect unresolved classes in modified files", async assert => {
+test("Issue10407 - Watch mode should detect unresolved classes in modified files", async () => {
   const appFilePath = "test-issues/issue10407-watch/source/class/issue10407watch/Application.js";
   let originalContent = "";
 
@@ -399,7 +388,6 @@ test("Issue10407 - Watch mode should detect unresolved classes in modified files
       kill(watchProcess.pid, 'SIGKILL');
       await fsPromises.writeFile(appFilePath, originalContent, "utf8");
       assert.fail("Watch mode did not start within 40s");
-      assert.end();
       return;
     }
 
@@ -444,7 +432,6 @@ test("Issue10407 - Watch mode should detect unresolved classes in modified files
       "Watch mode should warn about unresolved class in modified file"
     );
 
-    assert.end();
   } catch(ex) {
     // Restore original file on error
     if (originalContent) {
@@ -454,11 +441,11 @@ test("Issue10407 - Watch mode should detect unresolved classes in modified files
         // Ignore cleanup errors
       }
     }
-    assert.end(ex);
+    throw ex;
   }
 });
 
-test("afterProcessFinished callback", async assert => {
+test("afterProcessFinished callback", async () => {
   try {
     const markerFile = "test-issues/test-afterProcessFinished/afterProcessFinished.marker";
 
@@ -483,9 +470,8 @@ test("afterProcessFinished callback", async assert => {
       await fsPromises.unlink(markerFile);
     }
 
-    assert.end();
   } catch(ex) {
-    assert.end(ex);
+    throw ex;
   }
 });
 

--- a/test/tool/integrationtest/test-lint.js
+++ b/test/tool/integrationtest/test-lint.js
@@ -1,5 +1,5 @@
-const test = require("tape");
-const colorize = require('tap-colorize');
+const { test } = require("node:test");
+const assert = require("node:assert");
 const fs = require("fs");
 const fsp = require("fs").promises;
 const path = require("path");
@@ -9,7 +9,6 @@ const testDir = path.join(__dirname, "test-lint");
 const myAppDir = path.join(testDir, "myapp");
 
 //colorize output
-test.createStream().pipe(colorize()).pipe(process.stdout);
 
 function reportError(result) {
   if (result.error) {
@@ -69,17 +68,16 @@ qx.Class.define("myapp.TestFile", {
   return testFilePath;
 }
 
-test("setup test app", async assert => {
+test("setup test app", async () => {
   try {
     await createTestApp();
     assert.ok(await assertPathExists(path.join(myAppDir, "compile.json")));
-    assert.end();
   } catch (ex) {
-    assert.end(ex);
+    throw ex;
   }
 });
 
-test("lint with legacy config format", async assert => {
+test("lint with legacy config format", async () => {
   try {
     // Create legacy format eslint config
     const legacyConfig = {
@@ -106,13 +104,12 @@ test("lint with legacy config format", async assert => {
     assert.ok(result.exitCode !== 0, "Lint should fail with errors");
     assert.ok(result.output.includes("curly") || result.error.includes("curly"), "Should report curly rule violation");
     
-    assert.end();
   } catch (ex) {
-    assert.end(ex);
+    throw ex;
   }
 });
 
-test("lint with flat config format", async assert => {
+test("lint with flat config format", async () => {
   try {
     // Create flat format eslint config - properly structured for flat config
     const flatConfig = [
@@ -142,13 +139,12 @@ test("lint with flat config format", async assert => {
     assert.ok(result.exitCode !== 0, "Lint should fail with errors");
     assert.ok(result.output.includes("curly") || result.error.includes("curly"), "Should report curly rule violation");
     
-    assert.end();
   } catch (ex) {
-    assert.end(ex);
+    throw ex;
   }
 });
 
-test("lint with --fix option (legacy config)", async assert => {
+test("lint with --fix option (legacy config)", async () => {
   try {
     // Create legacy config with fixable rules
     const legacyConfig = {
@@ -186,13 +182,12 @@ test("lint with --fix option (legacy config)", async assert => {
     assert.ok(fixedContent.includes('"myapp.FixableTest"'), "Should fix single quotes to double quotes");
     assert.ok(fixedContent.includes('var test = "single quotes";'), "Should add semicolons and fix quotes");
     
-    assert.end();
   } catch (ex) {
-    assert.end(ex);
+    throw ex;
   }
 });
 
-test("lint with --fix option (flat config)", async assert => {
+test("lint with --fix option (flat config)", async () => {
   try {
     // Create flat config with fixable rules
     const flatConfig = [
@@ -237,13 +232,12 @@ test("lint with --fix option (flat config)", async assert => {
     assert.ok(fixedContent.includes('"myapp.FixableTestFlat"'), "Should fix single quotes to double quotes");
     assert.ok(fixedContent.includes('var test = "single quotes";'), "Should add semicolons and fix quotes");
     
-    assert.end();
   } catch (ex) {
-    assert.end(ex);
+    throw ex;
   }
 });
 
-test("lint with --print-config option", async assert => {
+test("lint with --print-config option", async () => {
   try {
     const legacyConfig = {
       "extends": ["@qooxdoo/qx/browser"],
@@ -261,13 +255,12 @@ test("lint with --print-config option", async assert => {
     assert.ok(result.output.includes("curly"), "Should include curly rule in config output");
     assert.ok(result.output.includes("parser"), "Should include parser configuration");
     
-    assert.end();
   } catch (ex) {
-    assert.end(ex);
+    throw ex;
   }
 });
 
-test("lint with custom ignores in legacy config", async assert => {
+test("lint with custom ignores in legacy config", async () => {
   try {
     const legacyConfig = {
       "extends": ["@qooxdoo/qx/browser"],
@@ -296,13 +289,12 @@ test("lint with custom ignores in legacy config", async assert => {
     
     assert.ok(result.exitCode === 0, "Lint should succeed for ignored files");
     
-    assert.end();
   } catch (ex) {
-    assert.end(ex);
+    throw ex;
   }
 });
 
-test("lint with custom ignores in flat config", async assert => {
+test("lint with custom ignores in flat config", async () => {
   try {
     const flatConfig = [
       {
@@ -335,13 +327,12 @@ test("lint with custom ignores in flat config", async assert => {
     
     assert.ok(result.exitCode === 0, "Lint should succeed for ignored files");
     
-    assert.end();
   } catch (ex) {
-    assert.end(ex);
+    throw ex;
   }
 });
 
-test("lint entire project with both config formats", async assert => {
+test("lint entire project with both config formats", async () => {
   try {
     // Test with legacy config
     const legacyConfig = {
@@ -391,17 +382,15 @@ test("lint entire project with both config formats", async assert => {
     result = await testUtils.runCommand(myAppDir, qxCmdPath, "lint", "--quiet");
     assert.ok(result.exitCode === 0, "Project lint with flat config should succeed with rules turned off");
     
-    assert.end();
   } catch (ex) {
-    assert.end(ex);
+    throw ex;
   }
 });
 
-test("cleanup", async assert => {
+test("cleanup", async () => {
   try {
     await testUtils.deleteRecursive(testDir);
-    assert.end();
   } catch (ex) {
-    assert.end(ex);
+    throw ex;
   }
 });

--- a/test/tool/integrationtest/test-migrations.js
+++ b/test/tool/integrationtest/test-migrations.js
@@ -10,8 +10,6 @@ const debug = Boolean(process.env.DEBUG);
 const qxCmdPath = testUtils.getCompiler(debug ? "source":"build");
 let debugArg = "";
 if (debug) {
-  const colorize = require('tap-colorize');
-  test.createStream().pipe(colorize()).pipe(process.stdout);
   debugArg += "--debug --colorize";
 }
 

--- a/test/tool/integrationtest/test-qx-config.js
+++ b/test/tool/integrationtest/test-qx-config.js
@@ -1,4 +1,5 @@
-const test = require("tape");
+const { test } = require("node:test");
+const assert = require("node:assert");
 const fs = require("fs");
 const testUtils = require("../../../bin/tools/utils");
 const path = require("path");
@@ -15,37 +16,33 @@ const appDir = path.join(testDir, "configapp");
 
 let debugArg = "";
 if (debug) {
-  const colorize = require('tap-colorize');
-  test.createStream().pipe(colorize()).pipe(process.stdout);
   debugArg += "--debug --colorize";
 }
 
-test("Test qx config command without parameters", async assert => {
+test("Test qx config command without parameters", async () => {
   try {
     let result;
     result = await testUtils.runCommand(__dirname, qxCmdPath, "config");
     assert.ok(result.exitCode === 0, "qx config command should exit successfully");
     result.output = result.output.toLowerCase();
     assert.ok(result.output.includes("usage") || result.output.includes("commands"), "Output should contain usage information");
-    assert.end();
   } catch (ex) {
-    assert.end(ex);
+    throw ex;
   }
 });
 
-test("Test qx config help", async assert => {
+test("Test qx config help", async () => {
   try {
     let result;
     result = await testUtils.runCommand(__dirname, qxCmdPath, "config", "--help");
     assert.ok(result.exitCode === 0, "Config help should work");
     assert.ok(result.output.includes("config"), "Help should mention config command");
-    assert.end();
   } catch (ex) {
-    assert.end(ex);
+    throw ex;
   }
 });
 
-test("Test qx config subcommand help", async assert => {
+test("Test qx config subcommand help", async () => {
   try {
     let result;
     
@@ -58,26 +55,24 @@ test("Test qx config subcommand help", async assert => {
       assert.ok(result.output.includes(subcmd), `Help should mention ${subcmd} command`);
     }
     
-    assert.end();
   } catch (ex) {
-    assert.end(ex);
+    throw ex;
   }
 });
 
-test("Create test app for config commands", async assert => {
+test("Create test app for config commands", async () => {
   try {
     await testUtils.deleteRecursive(appDir);
     let result;
     result = await testUtils.runCommand(testDir, qxCmdPath, "create", "configapp", "-I");
     assert.ok(result.exitCode === 0, "Create app should succeed");
     assert.ok(fs.existsSync(path.join(appDir, "compile.json")), "compile.json should exist");
-    assert.end();
   } catch (ex) {
-    assert.end(ex);
+    throw ex;
   }
 });
 
-test("Test qx config set and get", async assert => {
+test("Test qx config set and get", async () => {
   try {
     let result;
     
@@ -90,38 +85,35 @@ test("Test qx config set and get", async assert => {
     assert.ok(result.exitCode === 0, "Config get should work");
     assert.ok(result.output.includes("test-value"), "Should return the set value");
     
-    assert.end();
   } catch (ex) {
-    assert.end(ex);
+    throw ex;
   }
 });
 
-test("Test qx config get non-existent key", async assert => {
+test("Test qx config get non-existent key", async () => {
   try {
     let result;
     result = await testUtils.runCommand(appDir, qxCmdPath, "config", "get", "non.existent.key");
     // This should either return empty or an error - let's accept both
     assert.ok(result.exitCode === 0 || result.exitCode === 1, "Config get for non-existent key should handle gracefully");
-    assert.end();
   } catch (ex) {
-    assert.end(ex);
+    throw ex;
   }
 });
 
-test("Test qx config list", async assert => {
+test("Test qx config list", async () => {
   try {
     let result;
     result = await testUtils.runCommand(appDir, qxCmdPath, "config", "list");
     assert.ok(result.exitCode === 0, "Config list should work");
     // Should list some default configuration values
     assert.ok(result.output.length > 0, "Config list should produce output");
-    assert.end();
   } catch (ex) {
-    assert.end(ex);
+    throw ex;
   }
 });
 
-test("Test qx config delete", async assert => {
+test("Test qx config delete", async () => {
   try {
     let result;
     
@@ -142,13 +134,12 @@ test("Test qx config delete", async assert => {
     result = await testUtils.runCommand(appDir, qxCmdPath, "config", "get", "delete.test.key");
     assert.ok(result.exitCode === 0 || result.exitCode === 1, "Config get for deleted key should handle gracefully");
     
-    assert.end();
   } catch (ex) {
-    assert.end(ex);
+    throw ex;
   }
 });
 
-test("Test qx config with JSON values", async assert => {
+test("Test qx config with JSON values", async () => {
   try {
     let result;
     
@@ -161,20 +152,18 @@ test("Test qx config with JSON values", async assert => {
     assert.ok(result.exitCode === 0, "Config get should work");
     assert.ok(result.output.includes("test") && result.output.includes("123"), "Should return the JSON value");
     
-    assert.end();
   } catch (ex) {
-    assert.end(ex);
+    throw ex;
   }
 });
 
 
 // Clean up test directory
-test("Clean up test directory", async assert => {
+test("Clean up test directory", async () => {
   try {
     await testUtils.deleteRecursive(testDir);
     assert.ok(!fs.existsSync(testDir), "Test directory should be cleaned up");
-    assert.end();
   } catch (ex) {
-    assert.end(ex);
+    throw ex;
   }
 });

--- a/test/tool/integrationtest/test-qx-deploy.js
+++ b/test/tool/integrationtest/test-qx-deploy.js
@@ -1,5 +1,5 @@
-const test = require("tape");
-const colorize = require('tap-colorize');
+const { test } = require("node:test");
+const assert = require("node:assert");
 const fs = require("fs");
 const fsp = require("fs").promises;
 const path = require("path");
@@ -10,7 +10,6 @@ const myAppDir = path.join(testDir, "myapp");
 const deployDir = path.join(testDir, "deploy");
 
 //colorize output
-test.createStream().pipe(colorize()).pipe(process.stdout);
 
 
 async function assertPathExists(path){
@@ -21,7 +20,7 @@ async function assertPathExists(path){
   throw new Error(`Path does not exist: ${path}`);
 }
 
-test("deploy help", async assert => {
+test("deploy help", async () => {
   try {
     let result = await testUtils.runCommand(__dirname, qxCmdPath, "deploy", "--help");
     assert.ok(result.exitCode === 0, testUtils.reportError(result));
@@ -39,13 +38,12 @@ test("deploy help", async assert => {
     assert.ok(!result.output.includes("--watch"), "Deploy should not have watch option");
     assert.ok(!result.output.includes("--save-unminified"), "Deploy should not have save-unminified option");
     
-    assert.end();
   } catch (ex) {
-    assert.end(ex);
+    throw ex;
   }
 });
 
-test("deploy basic functionality", async assert => {
+test("deploy basic functionality", async () => {
   try {
     // Setup test directory and create app
     await testUtils.deleteRecursive(testDir);
@@ -77,13 +75,12 @@ test("deploy basic functionality", async assert => {
     // Clean up
     await testUtils.deleteRecursive(testDir);
     
-    assert.end();
   } catch (ex) {
-    assert.end(ex);
+    throw ex;
   }
 });
 
-test("deploy with source maps", async assert => {
+test("deploy with source maps", async () => {
   try {
     // Setup test directory and create app
     await testUtils.deleteRecursive(testDir);
@@ -115,13 +112,12 @@ test("deploy with source maps", async assert => {
     // Clean up
     await testUtils.deleteRecursive(testDir);
     
-    assert.end();
   } catch (ex) {
-    assert.end(ex);
+    throw ex;
   }
 });
 
-test("deploy without source maps", async assert => {
+test("deploy without source maps", async () => {
   try {
     // Setup test directory and create app
     await testUtils.deleteRecursive(testDir);
@@ -147,13 +143,12 @@ test("deploy without source maps", async assert => {
     // Clean up
     await testUtils.deleteRecursive(testDir);
     
-    assert.end();
   } catch (ex) {
-    assert.end(ex);
+    throw ex;
   }
 });
 
-test("deploy specific application", async assert => {
+test("deploy specific application", async () => {
   try {
     // Setup test directory and create app
     await testUtils.deleteRecursive(testDir);
@@ -173,13 +168,12 @@ test("deploy specific application", async assert => {
     // Clean up
     await testUtils.deleteRecursive(testDir);
     
-    assert.end();
   } catch (ex) {
-    assert.end(ex);
+    throw ex;
   }
 });
 
-test("deploy without clean flag", async assert => {
+test("deploy without clean flag", async () => {
   try {
     // Setup test directory and create app
     await testUtils.deleteRecursive(testDir);
@@ -202,13 +196,12 @@ test("deploy without clean flag", async assert => {
     // Clean up
     await testUtils.deleteRecursive(testDir);
     
-    assert.end();
   } catch (ex) {
-    assert.end(ex);
+    throw ex;
   }
 });
 
-test("deploy error handling", async assert => {
+test("deploy error handling", async () => {
   try {
     // Setup test directory and create app
     await testUtils.deleteRecursive(testDir);
@@ -233,13 +226,12 @@ test("deploy error handling", async assert => {
     // Clean up
     await testUtils.deleteRecursive(testDir);
     
-    assert.end();
   } catch (ex) {
-    assert.end(ex);
+    throw ex;
   }
 });
 
-test("deploy file structure verification", async assert => {
+test("deploy file structure verification", async () => {
   try {
     // Setup test directory and create app
     await testUtils.deleteRecursive(testDir);
@@ -275,8 +267,7 @@ test("deploy file structure verification", async assert => {
     // Clean up
     await testUtils.deleteRecursive(testDir);
     
-    assert.end();
   } catch (ex) {
-    assert.end(ex);
+    throw ex;
   }
 });

--- a/test/tool/integrationtest/test-qx-es6ify.js
+++ b/test/tool/integrationtest/test-qx-es6ify.js
@@ -1,5 +1,5 @@
-const test = require("tape");
-const colorize = require('tap-colorize');
+const { test } = require("node:test");
+const assert = require("node:assert");
 const fs = require("fs");
 const fsp = require("fs").promises;
 const path = require("path");
@@ -9,7 +9,6 @@ const testDir = path.join(__dirname, "test-qx-es6ify");
 const myAppDir = path.join(testDir, "myapp");
 
 //colorize output
-test.createStream().pipe(colorize()).pipe(process.stdout);
 
 
 async function assertPathExists(path){
@@ -20,7 +19,7 @@ async function assertPathExists(path){
   throw new Error(`Path does not exist: ${path}`);
 }
 
-test("es6ify help", async assert => {
+test("es6ify help", async () => {
   try {
     let result = await testUtils.runCommand(__dirname, qxCmdPath, "es6ify", "--help");
     assert.ok(result.exitCode === 0, testUtils.reportError(result));
@@ -32,13 +31,12 @@ test("es6ify help", async assert => {
     assert.ok(result.output.includes("--arrow-functions"), "Help should mention arrowFunctions option");
     assert.ok(result.output.includes("--single-line-blocks"), "Help should mention singleLineBlocks option");
     assert.ok(result.output.includes("--git-pre-commit"), "Help should mention gitPreCommit option");
-    assert.end();
   } catch (ex) {
-    assert.end(ex);
+    throw ex;
   }
 });
 
-test("es6ify with sample file", async assert => {
+test("es6ify with sample file", async () => {
   try {
     // Setup test directory
     await testUtils.deleteRecursive(testDir);
@@ -103,13 +101,12 @@ qx.Class.define("MyTestClass", {
     // Clean up
     await testUtils.deleteRecursive(testDir);
     
-    assert.end();
   } catch (ex) {
-    assert.end(ex);
+    throw ex;
   }
 });
 
-test("es6ify with arrow function modes", async assert => {
+test("es6ify with arrow function modes", async () => {
   try {
     // Setup test directory
     await testUtils.deleteRecursive(testDir);
@@ -147,13 +144,12 @@ test("es6ify with arrow function modes", async assert => {
     // Clean up
     await testUtils.deleteRecursive(testDir);
     
-    assert.end();
   } catch (ex) {
-    assert.end(ex);
+    throw ex;
   }
 });
 
-test("es6ify with exclude option", async assert => {
+test("es6ify with exclude option", async () => {
   try {
     // Setup test directory
     await testUtils.deleteRecursive(testDir);
@@ -199,13 +195,12 @@ test("es6ify with exclude option", async assert => {
     // Clean up
     await testUtils.deleteRecursive(testDir);
     
-    assert.end();
   } catch (ex) {
-    assert.end(ex);
+    throw ex;
   }
 });
 
-test("es6ify with single line blocks option", async assert => {
+test("es6ify with single line blocks option", async () => {
   try {
     // Setup test directory
     await testUtils.deleteRecursive(testDir);
@@ -245,13 +240,12 @@ test("es6ify with single line blocks option", async assert => {
     // Clean up
     await testUtils.deleteRecursive(testDir);
     
-    assert.end();
   } catch (ex) {
-    assert.end(ex);
+    throw ex;
   }
 });
 
-test("es6ify with no overwrite option", async assert => {
+test("es6ify with no overwrite option", async () => {
   try {
     // Setup test directory
     await testUtils.deleteRecursive(testDir);
@@ -280,13 +274,12 @@ test("es6ify with no overwrite option", async assert => {
     // Clean up
     await testUtils.deleteRecursive(testDir);
     
-    assert.end();
   } catch (ex) {
-    assert.end(ex);
+    throw ex;
   }
 });
 
-test("es6ify default behavior", async assert => {
+test("es6ify default behavior", async () => {
   try {
     // Create a test app to verify default behavior
     await testUtils.deleteRecursive(myAppDir);
@@ -330,8 +323,7 @@ test("es6ify default behavior", async assert => {
     // Clean up
     await testUtils.deleteRecursive(testDir);
     
-    assert.end();
   } catch (ex) {
-    assert.end(ex);
+    throw ex;
   }
 });

--- a/test/tool/integrationtest/test-qx-export-glyphs.js
+++ b/test/tool/integrationtest/test-qx-export-glyphs.js
@@ -1,5 +1,5 @@
-const test = require("tape");
-const colorize = require('tap-colorize');
+const { test } = require("node:test");
+const assert = require("node:assert");
 const fs = require("fs");
 const fsp = require("fs").promises;
 const path = require("path");
@@ -8,7 +8,6 @@ const qxCmdPath = testUtils.getCompiler();
 const testDir = path.join(__dirname, "test-qx-export-glyphs");
 
 //colorize output
-test.createStream().pipe(colorize()).pipe(process.stdout);
 
 
 async function assertPathExists(path){
@@ -19,7 +18,7 @@ async function assertPathExists(path){
   throw new Error(`Path does not exist: ${path}`);
 }
 
-test("export-glyphs help", async assert => {
+test("export-glyphs help", async () => {
   try {
     let result = await testUtils.runCommand(__dirname, qxCmdPath, "export-glyphs", "--help");
     assert.ok(result.exitCode === 0, testUtils.reportError(result));
@@ -29,13 +28,12 @@ test("export-glyphs help", async assert => {
     assert.ok(result.output.includes("glyphFile"), "Help should mention glyphFile argument");
     assert.ok(result.output.includes("Font file to process"), "Help should describe fontFile");
     assert.ok(result.output.includes("Output glyph file"), "Help should describe glyphFile");
-    assert.end();
   } catch (ex) {
-    assert.end(ex);
+    throw ex;
   }
 });
 
-test("export-glyphs with MaterialIcons font", async assert => {
+test("export-glyphs with MaterialIcons font", async () => {
   try {
     // Setup test directory
     await testUtils.deleteRecursive(testDir);
@@ -68,13 +66,12 @@ test("export-glyphs with MaterialIcons font", async assert => {
     // Clean up
     await testUtils.deleteRecursive(testDir);
     
-    assert.end();
   } catch (ex) {
-    assert.end(ex);
+    throw ex;
   }
 });
 
-test("export-glyphs with FontAwesome font", async assert => {
+test("export-glyphs with FontAwesome font", async () => {
   try {
     // Setup test directory
     await testUtils.deleteRecursive(testDir);
@@ -102,13 +99,12 @@ test("export-glyphs with FontAwesome font", async assert => {
     // Clean up
     await testUtils.deleteRecursive(testDir);
     
-    assert.end();
   } catch (ex) {
-    assert.end(ex);
+    throw ex;
   }
 });
 
-test("export-glyphs with TTF font", async assert => {
+test("export-glyphs with TTF font", async () => {
   try {
     // Setup test directory
     await testUtils.deleteRecursive(testDir);
@@ -132,13 +128,12 @@ test("export-glyphs with TTF font", async assert => {
     // Clean up
     await testUtils.deleteRecursive(testDir);
     
-    assert.end();
   } catch (ex) {
-    assert.end(ex);
+    throw ex;
   }
 });
 
-test("export-glyphs with invalid font file", async assert => {
+test("export-glyphs with invalid font file", async () => {
   try {
     // Setup test directory
     await testUtils.deleteRecursive(testDir);
@@ -156,13 +151,12 @@ test("export-glyphs with invalid font file", async assert => {
     // Clean up
     await testUtils.deleteRecursive(testDir);
     
-    assert.end();
   } catch (ex) {
-    assert.end(ex);
+    throw ex;
   }
 });
 
-test("export-glyphs missing arguments", async assert => {
+test("export-glyphs missing arguments", async () => {
   try {
     // Test with missing arguments
     let result = await testUtils.runCommand(__dirname, qxCmdPath, "export-glyphs");
@@ -173,13 +167,12 @@ test("export-glyphs missing arguments", async assert => {
     result = await testUtils.runCommand(__dirname, qxCmdPath, "export-glyphs", "somefont.woff");
     assert.ok(result.exitCode !== 0, "Should fail when glyphFile argument is missing");
     
-    assert.end();
   } catch (ex) {
-    assert.end(ex);
+    throw ex;
   }
 });
 
-test("export-glyphs output verification", async assert => {
+test("export-glyphs output verification", async () => {
   try {
     // Setup test directory
     await testUtils.deleteRecursive(testDir);
@@ -218,8 +211,7 @@ test("export-glyphs output verification", async assert => {
     // Clean up
     await testUtils.deleteRecursive(testDir);
     
-    assert.end();
   } catch (ex) {
-    assert.end(ex);
+    throw ex;
   }
 });

--- a/test/tool/integrationtest/test-qx-lint.js
+++ b/test/tool/integrationtest/test-qx-lint.js
@@ -1,5 +1,5 @@
-const test = require("tape");
-const colorize = require('tap-colorize');
+const { test } = require("node:test");
+const assert = require("node:assert");
 const fs = require("fs");
 const fsp = require("fs").promises;
 const path = require("path");
@@ -9,7 +9,6 @@ const testDir = path.join(__dirname, "test-qx-lint");
 const myAppDir = path.join(testDir, "myapp");
 
 //colorize output
-test.createStream().pipe(colorize()).pipe(process.stdout);
 
 
 async function assertPathExists(path){
@@ -20,7 +19,7 @@ async function assertPathExists(path){
   throw new Error(`Path does not exist: ${path}`);
 }
 
-test("lint help", async assert => {
+test("lint help", async () => {
   try {
     let result = await testUtils.runCommand(__dirname, qxCmdPath, "lint", "--help");
     assert.ok(result.exitCode === 0, testUtils.reportError(result));
@@ -34,13 +33,12 @@ test("lint help", async assert => {
     assert.ok(result.output.includes("--use-eslintrc"), "Help should mention use-eslintrc option");
     assert.ok(result.output.includes("--warn-as-error"), "Help should mention warn-as-error option");
     assert.ok(result.output.includes("--fix-jsdoc-params"), "Help should mention fix-jsdoc-params option");
-    assert.end();
   } catch (ex) {
-    assert.end(ex);
+    throw ex;
   }
 });
 
-test("lint command with app", async assert => {
+test("lint command with app", async () => {
   try {
     // Create a test app for linting
     await testUtils.deleteRecursive(myAppDir);
@@ -92,13 +90,12 @@ test("lint command with app", async assert => {
     // Clean up
     await testUtils.deleteRecursive(testDir);
     
-    assert.end();
   } catch (ex) {
-    assert.end(ex);
+    throw ex;
   }
 });
 
-test("lint command with output file", async assert => {
+test("lint command with output file", async () => {
   try {
     // Create a test app for linting
     await testUtils.deleteRecursive(myAppDir);
@@ -119,13 +116,12 @@ test("lint command with output file", async assert => {
     // Clean up
     await testUtils.deleteRecursive(testDir);
     
-    assert.end();
   } catch (ex) {
-    assert.end(ex);
+    throw ex;
   }
 });
 
-test("lint command with fix option", async assert => {
+test("lint command with fix option", async () => {
   try {
     // Create a test app for linting
     await testUtils.deleteRecursive(myAppDir);
@@ -187,13 +183,12 @@ test("lint command with fix option", async assert => {
     // Clean up
     await testUtils.deleteRecursive(testDir);
     
-    assert.end();
   } catch (ex) {
-    assert.end(ex);
+    throw ex;
   }
 });
 
-test("lint command with jsdoc fixes", async assert => {
+test("lint command with jsdoc fixes", async () => {
   try {
     // Create a test app for linting
     await testUtils.deleteRecursive(myAppDir);
@@ -235,8 +230,7 @@ test("lint command with jsdoc fixes", async assert => {
     // Clean up
     await testUtils.deleteRecursive(testDir);
     
-    assert.end();
   } catch (ex) {
-    assert.end(ex);
+    throw ex;
   }
 });

--- a/test/tool/integrationtest/test-qx-migrate.js
+++ b/test/tool/integrationtest/test-qx-migrate.js
@@ -1,5 +1,5 @@
-const test = require("tape");
-const colorize = require('tap-colorize');
+const { test } = require("node:test");
+const assert = require("node:assert");
 const fs = require("fs");
 const fsp = require("fs").promises;
 const path = require("path");
@@ -7,23 +7,21 @@ const testUtils = require("../../../bin/tools/utils");
 const qxCmdPath = testUtils.getCompiler("source");
 
 // Colorize TAP output
-test.createStream().pipe(colorize()).pipe(process.stdout);
 
 // Test 1: Help command
-test("migrate --help", async assert => {
+test("migrate --help", async () => {
   try {
     let result = await testUtils.runCommand(__dirname, qxCmdPath, "migrate", "--help");
     assert.ok(result.exitCode === 0, testUtils.reportError(result));
     assert.ok(result.output.includes("migrate"), "Help should mention migrate command");
     assert.ok(result.output.includes("help"), "Help should mention help option");
-    assert.end();
   } catch (ex) {
-    assert.end(ex);
+    throw ex;
   }
 });
 
 // Test 2: Manifest.json dependency update
-test("M8_0_0: Manifest.json dependency update", async assert => {
+test("M8_0_0: Manifest.json dependency update", async () => {
   try {
     const baseDir = path.join(__dirname, "test-migrations", "v8.0.0");
     const unmigratedDir = path.join(baseDir, "unmigrated");
@@ -84,14 +82,13 @@ test("M8_0_0: Manifest.json dependency update", async assert => {
 
     // Cleanup
     await testUtils.deleteRecursive(migratedDir);
-    assert.end();
   } catch (ex) {
-    assert.end(ex);
+    throw ex;
   }
 });
 
 // Test 3: compile.js class name replacements
-test("M8_0_0: compile.js class name replacements", async assert => {
+test("M8_0_0: compile.js class name replacements", async () => {
   try {
     const baseDir = path.join(__dirname, "test-migrations", "v8.0.0");
     const unmigratedDir = path.join(baseDir, "unmigrated");
@@ -132,21 +129,20 @@ test("M8_0_0: compile.js class name replacements", async assert => {
       migratedContent.includes("qx.tool.compiler.cli.commands.Test"),
       "Migrated compile.js should have new Test class name"
     );
-    assert.notOk(
-      migratedContent.includes("qx.tool.cli.commands."),
+    assert.ok(!(
+      migratedContent.includes("qx.tool.cli.commands.")),
       "Migrated compile.js should NOT have old qx.tool.cli.commands references"
     );
 
     // Cleanup
     await testUtils.deleteRecursive(migratedDir);
-    assert.end();
   } catch (ex) {
-    assert.end(ex);
+    throw ex;
   }
 });
 
 // Test 4: form.add() uppercase name detection
-test("M8_0_0: form.add() uppercase name detection", async assert => {
+test("M8_0_0: form.add() uppercase name detection", async () => {
   try {
     const baseDir = path.join(__dirname, "test-migrations", "v8.0.0");
     const unmigratedDir = path.join(baseDir, "unmigrated");
@@ -195,14 +191,13 @@ test("M8_0_0: form.add() uppercase name detection", async assert => {
 
     // Cleanup
     await testUtils.deleteRecursive(migratedDir);
-    assert.end();
   } catch (ex) {
-    assert.end(ex);
+    throw ex;
   }
 });
 
 // Test 5: Breaking change announcements
-test("M8_0_0: Breaking change announcements", async assert => {
+test("M8_0_0: Breaking change announcements", async () => {
   try {
     const baseDir = path.join(__dirname, "test-migrations", "v8.0.0");
     const unmigratedDir = path.join(baseDir, "unmigrated");
@@ -254,14 +249,13 @@ test("M8_0_0: Breaking change announcements", async assert => {
 
     // Cleanup
     await testUtils.deleteRecursive(migratedDir);
-    assert.end();
   } catch (ex) {
-    assert.end(ex);
+    throw ex;
   }
 });
 
 // Test 6: Complete migration workflow
-test("M8_0_0: Complete migration workflow", async assert => {
+test("M8_0_0: Complete migration workflow", async () => {
   try {
     const baseDir = path.join(__dirname, "test-migrations", "v8.0.0");
     const unmigratedDir = path.join(baseDir, "unmigrated");
@@ -321,14 +315,13 @@ test("M8_0_0: Complete migration workflow", async assert => {
 
     // Cleanup
     await testUtils.deleteRecursive(migratedDir);
-    assert.end();
   } catch (ex) {
-    assert.end(ex);
+    throw ex;
   }
 });
 
 // Test 7: Property/Member conflict detection
-test("M8_0_0: Property/Member conflict detection", async assert => {
+test("M8_0_0: Property/Member conflict detection", async () => {
   try {
     const baseDir = path.join(__dirname, "test-migrations", "v8.0.0");
     const unmigratedDir = path.join(baseDir, "unmigrated");
@@ -450,14 +443,13 @@ test("M8_0_0: Property/Member conflict detection", async assert => {
 
     // Cleanup
     await testUtils.deleteRecursive(migratedDir);
-    assert.end();
   } catch (ex) {
-    assert.end(ex);
+    throw ex;
   }
 });
 
 // Test 8: instance.name usage detection
-test("M8_0_0: instance.name usage detection", async assert => {
+test("M8_0_0: instance.name usage detection", async () => {
   try {
     const baseDir = path.join(__dirname, "test-migrations", "v8.0.0");
     const unmigratedDir = path.join(baseDir, "unmigrated");
@@ -547,14 +539,13 @@ test("M8_0_0: instance.name usage detection", async assert => {
 
     // Cleanup
     await testUtils.deleteRecursive(migratedDir);
-    assert.end();
   } catch (ex) {
-    assert.end(ex);
+    throw ex;
   }
 });
 
 // Test 9: Constructor property setter order detection
-test("M8_0_0: Constructor property setter order detection", async assert => {
+test("M8_0_0: Constructor property setter order detection", async () => {
   try {
     const baseDir = path.join(__dirname, "test-migrations", "v8.0.0");
     const unmigratedDir = path.join(baseDir, "unmigrated");
@@ -651,14 +642,13 @@ test("M8_0_0: Constructor property setter order detection", async assert => {
 
     // Cleanup
     await testUtils.deleteRecursive(migratedDir);
-    assert.end();
   } catch (ex) {
-    assert.end(ex);
+    throw ex;
   }
 });
 
 // Test 10: migratePackages - no contrib.json (silent skip)
-test("M8_0_0: migratePackages - no contrib.json (silent skip)", async assert => {
+test("M8_0_0: migratePackages - no contrib.json (silent skip)", async () => {
   try {
     const baseDir = path.join(__dirname, "test-migrations", "v8.0.0");
     const unmigratedDir = path.join(baseDir, "unmigrated");
@@ -679,22 +669,21 @@ test("M8_0_0: migratePackages - no contrib.json (silent skip)", async assert => 
     assert.ok(result.exitCode === 0, testUtils.reportError(result));
 
     // Verify no package upgrade announcement
-    assert.notOk(
+    assert.ok(!(
       result.output.includes("Packages will be upgraded") ||
-      result.output.includes("package upgrade"),
+      result.output.includes("package upgrade")),
       "Should NOT announce package upgrade when contrib.json is missing"
     );
 
     // Cleanup
     await testUtils.deleteRecursive(migratedDir);
-    assert.end();
   } catch (ex) {
-    assert.end(ex);
+    throw ex;
   }
 });
 
 // Test 10: migratePackages - empty libraries array
-test("M8_0_0: migratePackages - empty libraries array", async assert => {
+test("M8_0_0: migratePackages - empty libraries array", async () => {
   try {
     const baseDir = path.join(__dirname, "test-migrations", "v8.0.0");
     const unmigratedDir = path.join(baseDir, "unmigrated");
@@ -717,22 +706,21 @@ test("M8_0_0: migratePackages - empty libraries array", async assert => {
     assert.ok(result.exitCode === 0, testUtils.reportError(result));
 
     // Verify no package upgrade announcement
-    assert.notOk(
+    assert.ok(!(
       result.output.includes("Packages will be upgraded") ||
-      result.output.includes("package upgrade"),
+      result.output.includes("package upgrade")),
       "Should NOT announce package upgrade when libraries array is empty"
     );
 
     // Cleanup
     await testUtils.deleteRecursive(migratedDir);
-    assert.end();
   } catch (ex) {
-    assert.end(ex);
+    throw ex;
   }
 });
 
 // Test 11: migratePackages - valid libraries with dry-run
-test("M8_0_0: migratePackages - valid libraries with dry-run", async assert => {
+test("M8_0_0: migratePackages - valid libraries with dry-run", async () => {
   try {
     const baseDir = path.join(__dirname, "test-migrations", "v8.0.0");
     const unmigratedDir = path.join(baseDir, "unmigrated");
@@ -784,14 +772,13 @@ test("M8_0_0: migratePackages - valid libraries with dry-run", async assert => {
 
     // Cleanup
     await testUtils.deleteRecursive(migratedDir);
-    assert.end();
   } catch (ex) {
-    assert.end(ex);
+    throw ex;
   }
 });
 
 // Test 12: migratePackages - valid libraries triggers upgrade
-test("M8_0_0: migratePackages - valid libraries triggers upgrade", async assert => {
+test("M8_0_0: migratePackages - valid libraries triggers upgrade", async () => {
   try {
     const baseDir = path.join(__dirname, "test-migrations", "v8.0.0");
     const unmigratedDir = path.join(baseDir, "unmigrated");
@@ -842,14 +829,13 @@ test("M8_0_0: migratePackages - valid libraries triggers upgrade", async assert 
 
     // Cleanup
     await testUtils.deleteRecursive(migratedDir);
-    assert.end();
   } catch (ex) {
-    assert.end(ex);
+    throw ex;
   }
 });
 
 // Test 13: migratePackages - malformed JSON (graceful skip)
-test("M8_0_0: migratePackages - malformed JSON (graceful skip)", async assert => {
+test("M8_0_0: migratePackages - malformed JSON (graceful skip)", async () => {
   try {
     const baseDir = path.join(__dirname, "test-migrations", "v8.0.0");
     const unmigratedDir = path.join(baseDir, "unmigrated");
@@ -870,9 +856,9 @@ test("M8_0_0: migratePackages - malformed JSON (graceful skip)", async assert =>
     assert.ok(result.exitCode === 0, testUtils.reportError(result));
 
     // Verify no package upgrade announcement (due to parse error)
-    assert.notOk(
+    assert.ok(!(
       result.output.includes("Packages will be upgraded") ||
-      result.output.includes("package upgrade"),
+      result.output.includes("package upgrade")),
       "Should NOT announce package upgrade when contrib.json is malformed"
     );
 
@@ -887,8 +873,7 @@ test("M8_0_0: migratePackages - malformed JSON (graceful skip)", async assert =>
 
     // Cleanup
     await testUtils.deleteRecursive(migratedDir);
-    assert.end();
   } catch (ex) {
-    assert.end(ex);
+    throw ex;
   }
 });

--- a/test/tool/integrationtest/test-qx-package.js
+++ b/test/tool/integrationtest/test-qx-package.js
@@ -1,4 +1,5 @@
-const test = require("tape");
+const { test } = require("node:test");
+const assert = require("node:assert");
 const fs = require("fs");
 const testUtils = require("../../../bin/tools/utils");
 const path = require("path");
@@ -14,12 +15,10 @@ const debug = Boolean(process.env.DEBUG);
 const qxCmdPath = testUtils.getCompiler("source");
 let debugArg = "";
 if (debug) {
-  const colorize = require('tap-colorize');
-  test.createStream().pipe(colorize()).pipe(process.stdout);
   debugArg += "--debug --colorize";
 }
 
-test("Test qx package command with help", async assert => {
+test("Test qx package command with help", async () => {
   try {
     let result;
     result = await testUtils.runCommand(testDir, qxCmdPath, "package", "--help");
@@ -27,13 +26,12 @@ test("Test qx package command with help", async assert => {
     result.output = result.output.toLowerCase();
     assert.ok(result.output.includes("usage:") || result.output.includes("commands:"), "Output should contain help information");
     assert.ok(result.output.includes("package"), "Output should mention package commands");
-    assert.end();
   } catch (ex) {
-    assert.end(ex);
+    throw ex;
   }
 });
 
-test("Create app", async assert => {
+test("Create app", async () => {
   try {
     await testUtils.deleteRecursive(appDir);
     let result;
@@ -42,14 +40,13 @@ test("Create app", async assert => {
     assert.ok(fs.existsSync(path.join(appDir, "compile.json")));
     result = await testUtils.runCommand(appDir, qxCmdPath, "package", "list", "--all", "--verbose");
     assert.ok(result.exitCode === 0);
-    assert.end();
   } catch (ex) {
-    assert.end(ex);
+    throw ex;
   }
 });
 
 
-test("Install qxl.test1, latest version", async assert => {
+test("Install qxl.test1, latest version", async () => {
   try {
     let result;
     result = await testUtils.runCommand(appDir, qxCmdPath, "package", "install", "qooxdoo/qxl.test1@latest");
@@ -61,13 +58,12 @@ test("Install qxl.test1, latest version", async assert => {
     assert.ok(result.exitCode === 0, testUtils.reportError(result));
     result = await testUtils.runCommand(appDir, qxCmdPath, "package", "remove", "qooxdoo/qxl.test1");
     assert.ok(result.exitCode === 0, testUtils.reportError(result));
-    assert.end();
   } catch (ex) {
-    assert.end(ex);
+    throw ex;
   }
 });
 
-test("Install qxl.test2/qxl.test2A, latest version", async assert => {
+test("Install qxl.test2/qxl.test2A, latest version", async () => {
   try {
     let result;
     result = await testUtils.runCommand(appDir, qxCmdPath, "package", "install", "qooxdoo/qxl.test2/qxl.test2A@2.0.2");
@@ -79,13 +75,12 @@ test("Install qxl.test2/qxl.test2A, latest version", async assert => {
     assert.ok(result.exitCode === 0, testUtils.reportError(result));
     result = await testUtils.runCommand(appDir, qxCmdPath, "package", "remove", "qooxdoo/qxl.test2/qxl.test2A");
     assert.ok(result.exitCode === 0, testUtils.reportError(result));
-    assert.end();
   } catch (ex) {
-    assert.end(ex);
+    throw ex;
   }
 });
 
-test("Install qxl.test1@release then migrate and upgrade", async assert => {
+test("Install qxl.test1@release then migrate and upgrade", async () => {
   try {
     let result;
     result = await testUtils.runCommand(appDir, qxCmdPath, "package", "install", "qooxdoo/qxl.test1@v1.2.1");
@@ -103,13 +98,12 @@ test("Install qxl.test1@release then migrate and upgrade", async assert => {
     assert.ok(result.exitCode === 0, testUtils.reportError(result));
     result = await testUtils.runCommand(appDir, qxCmdPath, "package", "remove", "qooxdoo/qxl.test1");
     assert.ok(result.exitCode === 0, testUtils.reportError(result));
-    assert.end();
   } catch (ex) {
-    assert.end(ex);
+    throw ex;
   }
 });
 
-test("Install qxl.test1@commit", async assert => {
+test("Install qxl.test1@commit", async () => {
   try {
     let result;
     result = await testUtils.runCommand(appDir, qxCmdPath, "package", "install", "qooxdoo/qxl.test1@b1125235c1002aadf84134c0fa52f5f037f466cd");
@@ -119,9 +113,8 @@ test("Install qxl.test1@commit", async assert => {
     assert.ok(result.output.split("\n").length === 4);
     result = await testUtils.runCompiler(appDir);
     assert.ok(result.exitCode === 0, testUtils.reportError(result));
-    assert.end();
   } catch (ex) {
-    assert.end(ex);
+    throw ex;
   }
 });
 
@@ -132,7 +125,7 @@ test("Install qxl.test1@commit", async assert => {
  * without requiring the --clean flag.
  */
 
-test("Issue #10194: Setup - Initial compile for baseline", async assert => {
+test("Issue #10194: Setup - Initial compile for baseline", async () => {
   try {
     // Clean up from previous tests
     let result = await testUtils.runCommand(appDir, qxCmdPath, "package", "remove", "qooxdoo/qxl.test1");
@@ -146,13 +139,12 @@ test("Issue #10194: Setup - Initial compile for baseline", async assert => {
     const dbPath = path.join(appDir, "compiled/source/db.json");
     assert.ok(fs.existsSync(dbPath), "db.json should exist after initial compile");
 
-    assert.end();
   } catch (ex) {
-    assert.end(ex);
+    throw ex;
   }
 });
 
-test("Issue #10194: Add package and compile WITHOUT --clean", async assert => {
+test("Issue #10194: Add package and compile WITHOUT --clean", async () => {
   try {
     let result;
 
@@ -172,13 +164,12 @@ test("Issue #10194: Add package and compile WITHOUT --clean", async assert => {
     assert.ok(dbContent.libraries, "Database should contain libraries");
     assert.ok(dbContent.libraries["qxl.test1"], "qxl.test1 should be in the libraries list (auto-detected without --clean)");
 
-    assert.end();
   } catch (ex) {
-    assert.end(ex);
+    throw ex;
   }
 });
 
-test("Issue #10194: Remove package and compile WITHOUT --clean", async assert => {
+test("Issue #10194: Remove package and compile WITHOUT --clean", async () => {
   try {
     let result;
 
@@ -194,15 +185,14 @@ test("Issue #10194: Remove package and compile WITHOUT --clean", async assert =>
     const dbPath = path.join(appDir, "compiled/source/db.json");
     const dbContent = JSON.parse(fs.readFileSync(dbPath, "utf8"));
 
-    assert.notOk(dbContent.libraries["qxl.test1"], "qxl.test1 should NOT be in the libraries list (removal auto-detected without --clean)");
+    assert.ok(!(dbContent.libraries["qxl.test1"]), "qxl.test1 should NOT be in the libraries list (removal auto-detected without --clean)");
 
-    assert.end();
   } catch (ex) {
-    assert.end(ex);
+    throw ex;
   }
 });
 
-test("Issue #10194: Re-add package at different version WITHOUT --clean", async assert => {
+test("Issue #10194: Re-add package at different version WITHOUT --clean", async () => {
   try {
     let result;
 
@@ -220,19 +210,17 @@ test("Issue #10194: Re-add package at different version WITHOUT --clean", async 
 
     assert.ok(dbContent.libraries["qxl.test1"], "qxl.test1 should be back in the libraries list (auto-detected without --clean)");
 
-    assert.end();
   } catch (ex) {
-    assert.end(ex);
+    throw ex;
   }
 });
 
-test("Issue #10194: Cleanup - Remove test package", async assert => {
+test("Issue #10194: Cleanup - Remove test package", async () => {
   try {
     let result = await testUtils.runCommand(appDir, qxCmdPath, "package", "remove", "qooxdoo/qxl.test1");
     assert.ok(result.exitCode === 0, testUtils.reportError(result));
-    assert.end();
   } catch (ex) {
-    assert.end(ex);
+    throw ex;
   }
 });
 

--- a/test/tool/integrationtest/test-qx-prettier.js
+++ b/test/tool/integrationtest/test-qx-prettier.js
@@ -1,5 +1,5 @@
-const test = require("tape");
-const colorize = require('tap-colorize');
+const { test } = require("node:test");
+const assert = require("node:assert");
 const fs = require("fs");
 const fsp = require("fs").promises;
 const path = require("path");
@@ -9,7 +9,6 @@ const testDir = path.join(__dirname, "test-qx-prettier");
 const myAppDir = path.join(testDir, "myapp");
 
 //colorize output
-test.createStream().pipe(colorize()).pipe(process.stdout);
 
 async function assertPathExists(path){
   let stat = await fsp.stat(path);
@@ -19,7 +18,7 @@ async function assertPathExists(path){
   throw new Error(`Path does not exist: ${path}`);
 }
 
-test("prettier help", async assert => {
+test("prettier help", async () => {
   try {
     let result = await testUtils.runCommand(__dirname, qxCmdPath, "prettier", "--help");
     assert.ok(result.exitCode === 0, testUtils.reportError(result));
@@ -29,13 +28,12 @@ test("prettier help", async assert => {
     assert.ok(result.output.includes("--check"), "Help should mention check option");
     assert.ok(result.output.includes("--write"), "Help should mention write option");
     assert.ok(result.output.includes("--git-pre-commit"), "Help should mention gitPreCommit option");
-    assert.end();
   } catch (ex) {
-    assert.end(ex);
+    throw ex;
   }
 });
 
-test("prettier format sample file", async assert => {
+test("prettier format sample file", async () => {
   try {
     // Setup test directory
     await testUtils.deleteRecursive(testDir);
@@ -87,13 +85,12 @@ return b;
     // Clean up
     await testUtils.deleteRecursive(testDir);
 
-    assert.end();
   } catch (ex) {
-    assert.end(ex);
+    throw ex;
   }
 });
 
-test("prettier check mode", async assert => {
+test("prettier check mode", async () => {
   try {
     // Setup test directory
     await testUtils.deleteRecursive(testDir);
@@ -131,13 +128,12 @@ return true;
     // Clean up
     await testUtils.deleteRecursive(testDir);
 
-    assert.end();
   } catch (ex) {
-    assert.end(ex);
+    throw ex;
   }
 });
 
-test("prettier already formatted file", async assert => {
+test("prettier already formatted file", async () => {
   try {
     // Setup test directory
     await testUtils.deleteRecursive(testDir);
@@ -176,13 +172,12 @@ test("prettier already formatted file", async assert => {
     // Clean up
     await testUtils.deleteRecursive(testDir);
 
-    assert.end();
   } catch (ex) {
-    assert.end(ex);
+    throw ex;
   }
 });
 
-test("prettier with multiple files", async assert => {
+test("prettier with multiple files", async () => {
   try {
     // Setup test directory
     await testUtils.deleteRecursive(testDir);
@@ -219,13 +214,12 @@ test("prettier with multiple files", async assert => {
     // Clean up
     await testUtils.deleteRecursive(testDir);
 
-    assert.end();
   } catch (ex) {
-    assert.end(ex);
+    throw ex;
   }
 });
 
-test("prettier with .prettierignore", async assert => {
+test("prettier with .prettierignore", async () => {
   try {
     // Setup test directory
     await testUtils.deleteRecursive(testDir);
@@ -265,13 +259,12 @@ test("prettier with .prettierignore", async assert => {
     // Clean up
     await testUtils.deleteRecursive(testDir);
 
-    assert.end();
   } catch (ex) {
-    assert.end(ex);
+    throw ex;
   }
 });
 
-test("prettier default behavior", async assert => {
+test("prettier default behavior", async () => {
   try {
     // Create a test app to verify default behavior
     await testUtils.deleteRecursive(myAppDir);
@@ -310,13 +303,12 @@ test("prettier default behavior", async assert => {
     // Clean up
     await testUtils.deleteRecursive(testDir);
 
-    assert.end();
   } catch (ex) {
-    assert.end(ex);
+    throw ex;
   }
 });
 
-test("prettier verbose mode", async assert => {
+test("prettier verbose mode", async () => {
   try {
     // Setup test directory
     await testUtils.deleteRecursive(testDir);
@@ -343,8 +335,7 @@ test("prettier verbose mode", async assert => {
     // Clean up
     await testUtils.deleteRecursive(testDir);
 
-    assert.end();
   } catch (ex) {
-    assert.end(ex);
+    throw ex;
   }
 });

--- a/test/tool/integrationtest/test-qx-publish.js
+++ b/test/tool/integrationtest/test-qx-publish.js
@@ -160,9 +160,8 @@ async function isGitAvailable() {
 // ============================================================================
 // Basic Command Tests
 // ============================================================================
-test('This test runs only on non-Linux systems', t => {
-  t.ok(true, 'Test executed');
-  t.end();
+test('This test runs only on non-Linux systems', async () => {
+  assert.ok(true, 'Test executed');
 });
 
 test("Test qx package publish help", async () => {

--- a/test/tool/integrationtest/test-qx-publish.js
+++ b/test/tool/integrationtest/test-qx-publish.js
@@ -1,6 +1,7 @@
 const os = require('os');
 
-const test = require("tape");
+const { test } = require("node:test");
+const assert = require("node:assert");
 const fs = require("fs");
 const testUtils = require("../../../bin/tools/utils");
 const path = require("path");
@@ -23,8 +24,6 @@ const packageDir = path.join(testDir, "testpackage");
 let temporaryTokenCreated = false;
 
 if (debug) {
-  const colorize = require('tap-colorize');
-  test.createStream().pipe(colorize()).pipe(process.stdout);
 }
 
 
@@ -166,7 +165,7 @@ test('This test runs only on non-Linux systems', t => {
   t.end();
 });
 
-test("Test qx package publish help", async assert => {
+test("Test qx package publish help", async () => {
   try {
     let result;
     result = await testUtils.runCommand(__dirname, qxCmdPath, "package", "publish", "--help");
@@ -175,13 +174,12 @@ test("Test qx package publish help", async assert => {
     assert.ok(result.output.includes("publish"), "Help should mention publish command");
     assert.ok(result.output.includes("github"), "Help should mention GitHub");
     assert.ok(result.output.includes("release"), "Help should mention release");
-    assert.end();
   } catch (ex) {
-    assert.end(ex);
+    throw ex;
   }
 });
 
-test("Test qx package publish without parameters shows usage", async assert => {
+test("Test qx package publish without parameters shows usage", async () => {
   try {
     let result;
     result = await testUtils.runCommand(__dirname, qxCmdPath, "package", "publish");
@@ -198,9 +196,8 @@ test("Test qx package publish without parameters shows usage", async assert => {
       result.error.toLowerCase().includes("error"),
       "Should show usage or error information"
     );
-    assert.end();
   } catch (ex) {
-    assert.end(ex);
+    throw ex;
   }
 });
 
@@ -208,7 +205,7 @@ test("Test qx package publish without parameters shows usage", async assert => {
 // Setup Test Package
 // ============================================================================
 
-test("Create test package structure", async assert => {
+test("Create test package structure", async () => {
   try {
     await testUtils.deleteRecursive(testDir);
     await createTestPackage("1.0.0");
@@ -220,18 +217,16 @@ test("Create test package structure", async assert => {
     const manifest = readManifest();
     assert.equal(manifest.info.version, "1.0.0", "Initial version should be 1.0.0");
 
-    assert.end();
   } catch (ex) {
-    assert.end(ex);
+    throw ex;
   }
 });
 
-test("Initialize git repository for test package", async assert => {
+test("Initialize git repository for test package", async () => {
   try {
     const gitAvailable = await isGitAvailable();
     if (!gitAvailable) {
-      assert.pass("Git not available, skipping git tests");
-      assert.end();
+      assert.ok(true, "Git not available, skipping git tests");
       return;
     }
 
@@ -239,9 +234,8 @@ test("Initialize git repository for test package", async assert => {
     assert.ok(success, "Git repository should be initialized");
     assert.ok(fs.existsSync(path.join(packageDir, ".git")), ".git directory should exist");
 
-    assert.end();
   } catch (ex) {
-    assert.end(ex);
+    throw ex;
   }
 });
 
@@ -249,7 +243,7 @@ test("Initialize git repository for test package", async assert => {
 // Setup GitHub Token (Required for Publish Tests)
 // ============================================================================
 
-test("Setup GitHub token for publish tests", async assert => {
+test("Setup GitHub token for publish tests", async () => {
   try {
     // Check if github.token already exists
     let result = await testUtils.runCommand(__dirname, qxCmdPath, "config", "get", "github.token");
@@ -277,12 +271,11 @@ test("Setup GitHub token for publish tests", async assert => {
       result = await testUtils.runCommand(__dirname, qxCmdPath, "config", "get", "github.token");
       assert.ok(result.output.includes("TEST_TOKEN"), "Temporary token should be set");
     } else {
-      assert.pass("GitHub token already exists, using existing token");
+      assert.ok(true, "GitHub token already exists, using existing token");
     }
 
-    assert.end();
   } catch (ex) {
-    assert.end(ex);
+    throw ex;
   }
 });
 
@@ -290,7 +283,7 @@ test("Setup GitHub token for publish tests", async assert => {
 // Validation Tests (Expected to Fail Gracefully)
 // ============================================================================
 
-test("Test publish without git repository", async assert => {
+test("Test publish without git repository", async () => {
   try {
     // Create a package without git
     const noGitDir = path.join(testDir, "nogit");
@@ -324,13 +317,12 @@ test("Test publish without git repository", async assert => {
     // Cleanup
     await testUtils.deleteRecursive(noGitDir);
 
-    assert.end();
   } catch (ex) {
-    assert.end(ex);
+    throw ex;
   }
 });
 
-test("Test publish without Manifest.json", async assert => {
+test("Test publish without Manifest.json", async () => {
   try {
     const noManifestDir = path.join(testDir, "nomanifest");
     if (!fs.existsSync(noManifestDir)) {
@@ -355,13 +347,12 @@ test("Test publish without Manifest.json", async assert => {
     // Cleanup
     await testUtils.deleteRecursive(noManifestDir);
 
-    assert.end();
   } catch (ex) {
-    assert.end(ex);
+    throw ex;
   }
 });
 
-test("Test publish with invalid version type", async assert => {
+test("Test publish with invalid version type", async () => {
   try {
     let result = await testUtils.runCommand(
       packageDir,
@@ -379,9 +370,8 @@ test("Test publish with invalid version type", async assert => {
       "Should fail with invalid version type"
     );
 
-    assert.end();
   } catch (ex) {
-    assert.end(ex);
+    throw ex;
   }
 });
 
@@ -389,12 +379,11 @@ test("Test publish with invalid version type", async assert => {
 // Dry-Run Mode Tests (Safe - No GitHub Interaction)
 // ============================================================================
 
-test("Test dry-run with default patch version increment", async assert => {
+test("Test dry-run with default patch version increment", async () => {
   try {
     const gitAvailable = await isGitAvailable();
     if (!gitAvailable) {
-      assert.pass("Git not available, skipping test");
-      assert.end();
+      assert.ok(true, "Git not available, skipping test");
       return;
     }
 
@@ -441,18 +430,16 @@ test("Test dry-run with default patch version increment", async assert => {
       "Manifest.json should NOT be modified in dry-run mode"
     );
 
-    assert.end();
   } catch (ex) {
-    assert.end(ex);
+    throw ex;
   }
 });
 
-test("Test dry-run with major version increment", async assert => {
+test("Test dry-run with major version increment", async () => {
   try {
     const gitAvailable = await isGitAvailable();
     if (!gitAvailable) {
-      assert.pass("Git not available, skipping test");
-      assert.end();
+      assert.ok(true, "Git not available, skipping test");
       return;
     }
 
@@ -485,18 +472,16 @@ test("Test dry-run with major version increment", async assert => {
       "Manifest.json should NOT be modified in dry-run mode"
     );
 
-    assert.end();
   } catch (ex) {
-    assert.end(ex);
+    throw ex;
   }
 });
 
-test("Test dry-run with minor version increment", async assert => {
+test("Test dry-run with minor version increment", async () => {
   try {
     const gitAvailable = await isGitAvailable();
     if (!gitAvailable) {
-      assert.pass("Git not available, skipping test");
-      assert.end();
+      assert.ok(true, "Git not available, skipping test");
       return;
     }
 
@@ -529,18 +514,16 @@ test("Test dry-run with minor version increment", async assert => {
       "Manifest.json should NOT be modified in dry-run mode"
     );
 
-    assert.end();
   } catch (ex) {
-    assert.end(ex);
+    throw ex;
   }
 });
 
-test("Test dry-run with patch version increment", async assert => {
+test("Test dry-run with patch version increment", async () => {
   try {
     const gitAvailable = await isGitAvailable();
     if (!gitAvailable) {
-      assert.pass("Git not available, skipping test");
-      assert.end();
+      assert.ok(true, "Git not available, skipping test");
       return;
     }
 
@@ -573,18 +556,16 @@ test("Test dry-run with patch version increment", async assert => {
       "Manifest.json should NOT be modified in dry-run mode"
     );
 
-    assert.end();
   } catch (ex) {
-    assert.end(ex);
+    throw ex;
   }
 });
 
-test("Test dry-run with explicit version number", async assert => {
+test("Test dry-run with explicit version number", async () => {
   try {
     const gitAvailable = await isGitAvailable();
     if (!gitAvailable) {
-      assert.pass("Git not available, skipping test");
-      assert.end();
+      assert.ok(true, "Git not available, skipping test");
       return;
     }
 
@@ -617,18 +598,16 @@ test("Test dry-run with explicit version number", async assert => {
       "Manifest.json should NOT be modified in dry-run mode"
     );
 
-    assert.end();
   } catch (ex) {
-    assert.end(ex);
+    throw ex;
   }
 });
 
-test("Test dry-run with prerelease type (e.g., 1.0.0 -> 1.0.1-0)", async assert => {
+test("Test dry-run with prerelease type (e.g., 1.0.0 -> 1.0.1-0)", async () => {
   try {
     const gitAvailable = await isGitAvailable();
     if (!gitAvailable) {
-      assert.pass("Git not available, skipping test");
-      assert.end();
+      assert.ok(true, "Git not available, skipping test");
       return;
     }
 
@@ -661,18 +640,16 @@ test("Test dry-run with prerelease type (e.g., 1.0.0 -> 1.0.1-0)", async assert 
       "Manifest.json should NOT be modified in dry-run mode"
     );
 
-    assert.end();
   } catch (ex) {
-    assert.end(ex);
+    throw ex;
   }
 });
 
-test("Test dry-run with custom commit message", async assert => {
+test("Test dry-run with custom commit message", async () => {
   try {
     const gitAvailable = await isGitAvailable();
     if (!gitAvailable) {
-      assert.pass("Git not available, skipping test");
-      assert.end();
+      assert.ok(true, "Git not available, skipping test");
       return;
     }
 
@@ -694,9 +671,8 @@ test("Test dry-run with custom commit message", async assert => {
       "Should mention custom/version or fail with expected error (GitHub API not available in tests)"
     );
 
-    assert.end();
   } catch (ex) {
-    assert.end(ex);
+    throw ex;
   }
 });
 
@@ -706,12 +682,11 @@ test("Test dry-run with custom commit message", async assert => {
 // Index File Tests
 // ============================================================================
 
-test("Test dry-run with create-index flag", async assert => {
+test("Test dry-run with create-index flag", async () => {
   try {
     const gitAvailable = await isGitAvailable();
     if (!gitAvailable) {
-      assert.pass("Git not available, skipping test");
-      assert.end();
+      assert.ok(true, "Git not available, skipping test");
       return;
     }
 
@@ -739,9 +714,8 @@ test("Test dry-run with create-index flag", async assert => {
       "qooxdoo.json should NOT be created in dry-run mode"
     );
 
-    assert.end();
   } catch (ex) {
-    assert.end(ex);
+    throw ex;
   }
 });
 
@@ -749,12 +723,11 @@ test("Test dry-run with create-index flag", async assert => {
 // Branch Detection Tests
 // ============================================================================
 
-test("Test dry-run on feature branch", async assert => {
+test("Test dry-run on feature branch", async () => {
   try {
     const gitAvailable = await isGitAvailable();
     if (!gitAvailable) {
-      assert.pass("Git not available, skipping test");
-      assert.end();
+      assert.ok(true, "Git not available, skipping test");
       return;
     }
 
@@ -816,18 +789,16 @@ test("Test dry-run on feature branch", async assert => {
       }
     }
 
-    assert.end();
   } catch (ex) {
-    assert.end(ex);
+    throw ex;
   }
 });
 
-test("Test dry-run on master branch", async assert => {
+test("Test dry-run on master branch", async () => {
   try {
     const gitAvailable = await isGitAvailable();
     if (!gitAvailable) {
-      assert.pass("Git not available, skipping test");
-      assert.end();
+      assert.ok(true, "Git not available, skipping test");
       return;
     }
 
@@ -884,18 +855,16 @@ test("Test dry-run on master branch", async assert => {
       "Should not show branch warning when on master/main"
     );
 
-    assert.end();
   } catch (ex) {
-    assert.end(ex);
+    throw ex;
   }
 });
 
-test("Test branch detection in detached HEAD state", async assert => {
+test("Test branch detection in detached HEAD state", async () => {
   try {
     const gitAvailable = await isGitAvailable();
     if (!gitAvailable) {
-      assert.pass("Git not available, skipping test");
-      assert.end();
+      assert.ok(true, "Git not available, skipping test");
       return;
     }
 
@@ -946,9 +915,8 @@ test("Test branch detection in detached HEAD state", async assert => {
       }
     }
 
-    assert.end();
   } catch (ex) {
-    assert.end(ex);
+    throw ex;
   }
 });
 
@@ -956,12 +924,11 @@ test("Test branch detection in detached HEAD state", async assert => {
 // Version Range Tests
 // ============================================================================
 
-test("Test dry-run with qx-version flag", async assert => {
+test("Test dry-run with qx-version flag", async () => {
   try {
     const gitAvailable = await isGitAvailable();
     if (!gitAvailable) {
-      assert.pass("Git not available, skipping test");
-      assert.end();
+      assert.ok(true, "Git not available, skipping test");
       return;
     }
 
@@ -983,18 +950,16 @@ test("Test dry-run with qx-version flag", async assert => {
       "Should mention 8.0/version or fail with expected error (GitHub API not available in tests)"
     );
 
-    assert.end();
   } catch (ex) {
-    assert.end(ex);
+    throw ex;
   }
 });
 
-test("Test dry-run with breaking changes flag", async assert => {
+test("Test dry-run with breaking changes flag", async () => {
   try {
     const gitAvailable = await isGitAvailable();
     if (!gitAvailable) {
-      assert.pass("Git not available, skipping test");
-      assert.end();
+      assert.ok(true, "Git not available, skipping test");
       return;
     }
 
@@ -1016,18 +981,16 @@ test("Test dry-run with breaking changes flag", async assert => {
       "Should mention breaking/version or fail with expected error (GitHub API not available in tests)"
     );
 
-    assert.end();
   } catch (ex) {
-    assert.end(ex);
+    throw ex;
   }
 });
 
-test("Test dry-run with qx-version-range override", async assert => {
+test("Test dry-run with qx-version-range override", async () => {
   try {
     const gitAvailable = await isGitAvailable();
     if (!gitAvailable) {
-      assert.pass("Git not available, skipping test");
-      assert.end();
+      assert.ok(true, "Git not available, skipping test");
       return;
     }
 
@@ -1049,9 +1012,8 @@ test("Test dry-run with qx-version-range override", async assert => {
       "Should mention range/version or fail with expected error (GitHub API not available in tests)"
     );
 
-    assert.end();
   } catch (ex) {
-    assert.end(ex);
+    throw ex;
   }
 });
 
@@ -1059,7 +1021,7 @@ test("Test dry-run with qx-version-range override", async assert => {
 // Cleanup
 // ============================================================================
 
-test("Clean up temporary GitHub token", async assert => {
+test("Clean up temporary GitHub token", async () => {
   try {
     if (temporaryTokenCreated) {
       let result = await testUtils.runCommand(__dirname, qxCmdPath, "config", "delete", "github.token");
@@ -1072,20 +1034,18 @@ test("Clean up temporary GitHub token", async assert => {
         "Temporary token should be deleted"
       );
     } else {
-      assert.pass("No temporary token to clean up");
+      assert.ok(true, "No temporary token to clean up");
     }
-    assert.end();
   } catch (ex) {
-    assert.end(ex);
+    throw ex;
   }
 });
 
-test("Clean up test directory", async assert => {
+test("Clean up test directory", async () => {
   try {
     await testUtils.deleteRecursive(testDir);
     assert.ok(!fs.existsSync(testDir), "Test directory should be cleaned up");
-    assert.end();
   } catch (ex) {
-    assert.end(ex);
+    throw ex;
   }
 });

--- a/test/tool/integrationtest/test-qx-typescript.js
+++ b/test/tool/integrationtest/test-qx-typescript.js
@@ -1,5 +1,5 @@
-const test = require("tape");
-const colorize = require('tap-colorize');
+const { test } = require("node:test");
+const assert = require("node:assert");
 const fs = require("fs");
 const fsp = require("fs").promises;
 const path = require("path");
@@ -9,7 +9,6 @@ const testDir = path.join(__dirname, "test-qx-typescript");
 const myAppDir = path.join(testDir, "myapp");
 
 //colorize output
-test.createStream().pipe(colorize()).pipe(process.stdout);
 
 
 async function assertPathExists(path){
@@ -20,7 +19,7 @@ async function assertPathExists(path){
   throw new Error(`Path does not exist: ${path}`);
 }
 
-test("typescript help", async assert => {
+test("typescript help", async () => {
   try {
     let result = await testUtils.runCommand(__dirname, qxCmdPath, "typescript", "--help");
     assert.ok(result.exitCode === 0, testUtils.reportError(result));
@@ -28,13 +27,12 @@ test("typescript help", async assert => {
     assert.ok(result.output.includes("generate typescript definitions"), "Help should mention typescript definitions");
     assert.ok(result.output.includes("output-filename"), "Help should mention output-filename option");
     assert.ok(result.output.includes("exclude"), "Help should mention exclude option");
-    assert.end();
   } catch (ex) {
-    assert.end(ex);
+    throw ex;
   }
 });
 
-test("typescript command with app", async assert => {
+test("typescript command with app", async () => {
   try {
     // Create a test app for typescript generation
     await testUtils.deleteRecursive(myAppDir);
@@ -61,13 +59,12 @@ test("typescript command with app", async assert => {
     // Clean up
     await testUtils.deleteRecursive(testDir);
     
-    assert.end();
   } catch (ex) {
-    assert.end(ex);
+    throw ex;
   }
 });
 
-test("typescript command with exclude", async assert => {
+test("typescript command with exclude", async () => {
   try {
     // Create a test app for typescript generation
     await testUtils.deleteRecursive(myAppDir);
@@ -106,13 +103,12 @@ test("typescript command with exclude", async assert => {
     // Clean up
     await testUtils.deleteRecursive(testDir);
 
-    assert.end();
   } catch (ex) {
-    assert.end(ex);
+    throw ex;
   }
 });
 
-test("typescript command with custom output filename", async assert => {
+test("typescript command with custom output filename", async () => {
   try {
     // Create a test app for typescript generation
     await testUtils.deleteRecursive(myAppDir);
@@ -144,13 +140,12 @@ test("typescript command with custom output filename", async assert => {
     // Clean up
     await testUtils.deleteRecursive(testDir);
 
-    assert.end();
   } catch (ex) {
-    assert.end(ex);
+    throw ex;
   }
 });
 
-test("typescript var type should map to unknown (issue #10555)", async assert => {
+test("typescript var type should map to unknown (issue #10555)", async () => {
   try {
     // Create a test app for typescript generation
     await testUtils.deleteRecursive(myAppDir);
@@ -227,8 +222,7 @@ qx.Class.define("myapp.TestVarType", {
     // Clean up
     await testUtils.deleteRecursive(testDir);
 
-    assert.end();
   } catch (ex) {
-    assert.end(ex);
+    throw ex;
   }
 });

--- a/test/tool/integrationtest/test-rotate-unique.js
+++ b/test/tool/integrationtest/test-rotate-unique.js
@@ -1,9 +1,10 @@
 const qx = require("../qx");
-const test = require("tape");
+const { test } = require("node:test");
+const assert = require("node:assert");
 const fs = require("fs");
 const testUtils = require("../../../bin/tools/utils");
 
-test("Checks rotateUnique", async assert => {
+test("Checks rotateUnique", async () => {
   await testUtils.deleteRecursive("test-rotate-unique");
   await testUtils.fsPromises.mkdir("test-rotate-unique");
 
@@ -23,6 +24,5 @@ test("Checks rotateUnique", async assert => {
   assert.ok(!await qx.tool.utils.files.Utils.safeStat("test-rotate-unique/log.txt.6"));
   assert.ok(!await qx.tool.utils.files.Utils.safeStat("test-rotate-unique/log.txt.7"));
   assert.ok(!await qx.tool.utils.files.Utils.safeStat("test-rotate-unique/log.txt.8"));
-  assert.end();
 });
 

--- a/test/tool/integrationtest/test-translation.js
+++ b/test/tool/integrationtest/test-translation.js
@@ -1,4 +1,5 @@
-const test = require("tape");
+const { test } = require("node:test");
+const assert = require("node:assert");
 const testUtils = require("../../../bin/tools/utils");
 const fsPromises = testUtils.fsPromises;
 
@@ -26,7 +27,7 @@ msgstr "lib-override-replaced-value"
 `, "utf8");
 }
 
-test("test translation file update", async assert => {
+test("test translation file update", async () => {
   try {
     let result;
     await prepare();
@@ -59,9 +60,8 @@ test("test translation file update", async assert => {
     let data = await fsPromises.readFile("test-translation/tranapp/compiled/source/tranapp/package-0.js", "utf8");
     assert.ok(!!data.match(/lib-override-replaced-value/));
 
-    assert.end();
   }catch(ex) {
-    assert.end(ex);
+    throw ex;
   }
 });
 

--- a/testLocal.cmd
+++ b/testLocal.cmd
@@ -1,2 +1,2 @@
-npm ci
-npm test -- --browsers=chromium,firefox --terse --headless --set-env qx.test.delay.scale=10
+call npm ci
+call npm test -- --browsers=chromium,firefox --terse --headless --set-env qx.test.delay.scale=10


### PR DESCRIPTION
## Summary

Replaces `tape` (+ `tap-colorize`) with the built-in `node:test` module available since Node.js 20 (already required by this project).

- Removes 2 dependencies: `tape` and `tap-colorize`
- Removes ~104 transitive packages
- All 20 integration test files in `test/tool/integrationtest/` migrated
- `test/tool/compile.js` updated to pass `--test-reporter=tap` (Node 22+ no longer defaults to TAP output)

## Migration per file

| Change | Count |
|--------|-------|
| `require("tape")` → `require("node:test")` + `require("node:assert")` | 20 files |
| `tap-colorize` setup lines removed | 12 files |
| `async assert =>` → `async () =>` | all test callbacks |
| `assert.end()` removed | ~300 occurrences |
| `assert.end(ex)` → `throw ex` | ~47 occurrences |
| `assert.notOk(x, msg)` → `assert.ok(!(x), msg)` | 5 occurrences |
| `assert.pass(msg)` → `assert.ok(true, msg)` | 17 occurrences |

🤖 Generated with [Claude Code](https://claude.com/claude-code)