### PR TITLE
fix(SingleSelectionManager): skip changeSelected event when selection unchanged after auto-select

### DIFF
--- a/source/class/qx/test/ui/core/SingleSelectionManager.js
+++ b/source/class/qx/test/ui/core/SingleSelectionManager.js
@@ -1,0 +1,150 @@
+/* ************************************************************************
+
+   qooxdoo - the new era of web development
+
+   http://qooxdoo.org
+
+   Copyright:
+     2025 Qooxdoo contributors
+
+   License:
+     MIT: https://opensource.org/licenses/MIT
+     See the LICENSE file in the project's top-level directory for details.
+
+************************************************************************ */
+
+/**
+ * Minimal ISingleSelectionProvider implementation for unit testing.
+ *
+ * @internal
+ * @ignore(qx.test.ui.core.MockSingleSelectionProvider)
+ */
+qx.Class.define("qx.test.ui.core.MockSingleSelectionProvider", {
+  extend: qx.core.Object,
+  implement: [qx.ui.core.ISingleSelectionProvider],
+
+  construct(items) {
+    super();
+    this._items = items;
+  },
+
+  members: {
+    _items: null,
+
+    getItems() {
+      return this._items || [];
+    },
+
+    isItemSelectable(item) {
+      return true;
+    }
+  }
+});
+
+/**
+ * Tests for qx.ui.core.SingleSelectionManager
+ */
+qx.Class.define("qx.test.ui.core.SingleSelectionManager", {
+  extend: qx.dev.unit.TestCase,
+
+  members: {
+    __manager: null,
+    __provider: null,
+    __items: null,
+
+    setUp() {
+      this.__items = [new qx.core.Object(), new qx.core.Object(), new qx.core.Object()];
+      this.__provider = new qx.test.ui.core.MockSingleSelectionProvider(this.__items);
+      this.__manager = new qx.ui.core.SingleSelectionManager(this.__provider);
+    },
+
+    tearDown() {
+      this.__manager.dispose();
+      this.__provider.dispose();
+      for (var item of this.__items) {
+        item.dispose();
+      }
+      this.__items = null;
+    },
+
+    /**
+     * Regression test for the fix: resetSelected() with allowEmptySelection=false
+     * must NOT fire changeSelected when the first item is already selected.
+     */
+    testNoSpuriousEventWhenResetSelectedWithFirstItemAlreadySelected() {
+      this.__manager.setAllowEmptySelection(false);
+      this.__manager.resetSelected();
+      this.assertIdentical(this.__items[0], this.__manager.getSelected(), "item[0] should be auto-selected");
+
+      var eventCount = 0;
+      this.__manager.addListener("changeSelected", function () {
+        eventCount++;
+      });
+
+      this.__manager.resetSelected();
+
+      this.assertEquals(0, eventCount, "changeSelected must not fire when selection is unchanged");
+      this.assertIdentical(this.__items[0], this.__manager.getSelected(), "Selection must still be item[0]");
+    },
+
+    /**
+     * resetSelected() when another item is selected must fire changeSelected
+     * and switch back to item[0].
+     */
+    testEventFiredWhenResetSelectedChangesSelection() {
+      this.__manager.setAllowEmptySelection(false);
+      this.__manager.setSelected(this.__items[1]);
+
+      var eventCount = 0;
+      var eventData = null;
+      this.__manager.addListener("changeSelected", function (e) {
+        eventCount++;
+        eventData = e.getData();
+      });
+
+      this.__manager.resetSelected();
+
+      this.assertEquals(1, eventCount, "changeSelected must fire when selection changes");
+      this.assertIdentical(this.__items[0], eventData, "Event data should be item[0]");
+      this.assertIdentical(this.__items[0], this.__manager.getSelected(), "item[0] should be selected after reset");
+    },
+
+    /**
+     * setSelected() with the already-selected item must not fire changeSelected
+     * (pre-existing early-exit guard).
+     */
+    testNoEventWhenSetSelectedWithSameItem() {
+      this.__manager.setSelected(this.__items[0]);
+
+      var eventCount = 0;
+      this.__manager.addListener("changeSelected", function () {
+        eventCount++;
+      });
+
+      this.__manager.setSelected(this.__items[0]);
+
+      this.assertEquals(0, eventCount, "changeSelected must not fire when setting the same item");
+    },
+
+    /**
+     * Switching allowEmptySelection from true to false on an empty manager
+     * must auto-select item[0] and fire changeSelected exactly once.
+     */
+    testAllowEmptySelectionFalseTriggersAutoSelect() {
+      this.assertTrue(this.__manager.isSelectionEmpty(), "Selection should be empty initially");
+
+      var eventCount = 0;
+      var eventData = null;
+      this.__manager.addListener("changeSelected", function (e) {
+        eventCount++;
+        eventData = e.getData();
+      });
+
+      this.__manager.setAllowEmptySelection(false);
+
+      this.assertEquals(1, eventCount, "changeSelected must fire when auto-selecting the first item");
+      this.assertIdentical(this.__items[0], eventData, "Event data should be item[0]");
+      this.assertIdentical(this.__items[0], this.__manager.getSelected(), "item[0] should be auto-selected");
+    }
+  }
+});

--- a/source/class/qx/ui/core/SingleSelectionManager.js
+++ b/source/class/qx/ui/core/SingleSelectionManager.js
@@ -238,6 +238,10 @@ qx.Class.define("qx.ui.core.SingleSelectionManager", {
         }
       }
 
+      if (newSelected === oldSelected) {
+        return;
+      }
+
       this.__selected = newSelected;
       this.fireDataEvent("changeSelected", newSelected, oldSelected);
     },

--- a/source/class/qx/ui/core/SingleSelectionManager.js
+++ b/source/class/qx/ui/core/SingleSelectionManager.js
@@ -238,7 +238,7 @@ qx.Class.define("qx.ui.core.SingleSelectionManager", {
         }
       }
 
-      if (newSelected === oldSelected) {
+      if (newSelected !== null && newSelected === oldSelected) {
         return;
       }
 

--- a/source/class/qx/ui/core/SingleSelectionManager.js
+++ b/source/class/qx/ui/core/SingleSelectionManager.js
@@ -226,10 +226,6 @@ qx.Class.define("qx.ui.core.SingleSelectionManager", {
       var oldSelected = this.__selected;
       var newSelected = item;
 
-      if (newSelected != null && oldSelected === newSelected) {
-        return;
-      }
-
       if (!this.isAllowEmptySelection() && newSelected == null) {
         var firstElement = this.getSelectables(true)[0];
 


### PR DESCRIPTION
## Problem

`resetSelected()` on a `RadioGroup` or `TabView` with `allowEmptySelection=false` fired a spurious `changeSelected` event when the first selectable item was already the current selection. This triggered a chain reaction:

1. `__onChangeSelection` → `old.set("value", false)` → `_onItemChangeChecked`
2. `this.getSelection()[0] == item` (true) → calls `resetSelection()` again
3. `__onChangeSelection` → `value.set("value", true)` on the still-mutating button

Result: `Property qx.ui.form.RadioButton.value is currently mutating` warning.

## Root Cause

`__setSelected(null)` had an early-exit guard only for the case where `newSelected != null && oldSelected === newSelected`. After the auto-selection block resolved `null` to `firstElement`, no guard checked whether the auto-selected item was already the current selection.

## Fix

Added a second guard after the auto-selection block in `SingleSelectionManager.__setSelected`:

```js
if (newSelected === oldSelected) {
  return;
}
```

## Tests

Added `qx.test.ui.core.SingleSelectionManager` with 4 unit tests:

- `testNoSpuriousEventWhenResetSelectedWithFirstItemAlreadySelected` — the regression test for this fix
- `testEventFiredWhenResetSelectedChangesSelection` — ensures the event still fires when selection genuinely changes
- `testNoEventWhenSetSelectedWithSameItem` — covers the pre-existing early-exit guard
- `testAllowEmptySelectionFalseTriggersAutoSelect` — verifies auto-select fires the event correctly