### PR TITLE
Fixed clicking on border of cell focus indicator in editing mode doen…

### DIFF
--- a/source/class/qx/ui/table/Table.js
+++ b/source/class/qx/ui/table/Table.js
@@ -1570,10 +1570,11 @@ qx.Class.define("qx.ui.table.Table", {
      *          visible.
      */
     setFocusedCell(col, row, scrollVisible) {
-      if (
-        !this.isEditing() &&
-        (col != this.__focusedCol || row != this.__focusedRow)
-      ) {
+      let cellChanged = col != this.__focusedCol || row != this.__focusedRow;
+      if (this.isEditing() && cellChanged) {
+        this.stopEditing();
+      }
+      if (!this.isEditing() && cellChanged) {
         if (col === null) {
           col = 0;
         }


### PR DESCRIPTION
Fixed #9281 

If a user clicks edge of border it causes now quitting from cell edit mode and new cell is focused. Please check it carefully.