### PR TITLE
Eliminate global registries for events and bindings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,15 @@
 # 8.0.0-beta.2
 
 ## Breaking changes
+- Bindings (made using class qx.data.SingleValueBinding) are now no longer stored in a global registry,
+because this prevented their source and target objects from being garbage-collected without manually disposing them first.
+- Removed `qx.data.SingleValueBinding.getAllBindings` as a consequence of the above,
+and also because there is no practical use case for it.
+- Event listener callbacks are now stored in their target objects themselves instead of a global registry,
+because this prevented objects with event listeners from being garbage collected unless they were manually disposed,
+and also prevented any objects in the closures of the listeners' callbacks from being garbage collected as well.
+- Removed method `qx.event.Mananger.getAllListeners` as a consequence of the above,
+and also because there is no practical use case for it.
 - Removed `async: true` key from property definition because now all properties have `setAsync` methods,
 which can be used to await the apply function's return value and the event handlers when a property is set. 
 The meaning of this setting wasn't very clear, also given that we now have async property storage.

--- a/docs/core/data_binding/data_binding.md
+++ b/docs/core/data_binding/data_binding.md
@@ -760,7 +760,6 @@ every object.
 > - **getAllBindingsForObject** is a function which is in the data binding class
 >   and returns all bindings for the given object. The object needs to be the
 >   source object.
-> - **getAllBindings** returns all bindings in a special map for all objects.
 
 Another way of managing is removing. There are three ways to remove bindings.
 

--- a/docs/core/data_binding/single_value_binding.md
+++ b/docs/core/data_binding/single_value_binding.md
@@ -151,7 +151,6 @@ every object.
 > - **getAllBindingsForObject** is a function which is in the data binding class
 >   and returns all bindings for the given object. The object needs to be the
 >   source object.
-> - **getAllBindings** returns all bindings in a special map for all objects.
 
 Another way of managing is removing. There are three ways to remove bindings.
 

--- a/docs/development/howto/memory_management.md
+++ b/docs/development/howto/memory_management.md
@@ -60,15 +60,6 @@ In many cases, the destructors are for classes which are typically used as
 singletons and need not be tracked - for example the various `qx.event.handler.*`
 and qx.event.dispatch.* classes.
 
-There is one remaining global list of objects which could benefit from
-refactoring - `qx.data.SingleValueBinding` keeps a global lookup of every bound
-object, so any listeners to or from an object property will prevent that object
-from being garbage collected. This could be modified so that the bindings are
-stored with the object, rather than in a global list indexed by hash code, but
-note that even when binding a single property, the target object also has links
-back to the source object; this means that unless both source and target are
-unbound, the binding will prevent garbage collection of both objects.
-
 The net effect of this patch is that automatic garbage collection is now
 possible, with the proviso that (a) if you must release any bindings manually,
 and (b) you must observe any “shutdown” requirements of classes.

--- a/source/class/qx/data/SingleValueBinding.js
+++ b/source/class/qx/data/SingleValueBinding.js
@@ -617,14 +617,24 @@ qx.Class.define("qx.data.SingleValueBinding", {
     removeRelatedBindings(object, relatedObject) {
       const SingleValueBinding = qx.data.SingleValueBinding;
 
+      if (!object[SingleValueBinding.__SymbolBindingsInfo]) {
+        return;
+      }
+
       for (let binding of Object.values(object[SingleValueBinding.__SymbolBindingsInfo].source)) {
         if (binding.getTarget() === relatedObject) {
           binding.dispose();
         }
       }
+
+      //by this point, we may have removed all bindings,
+      //so we need to check again if the bindings property is still present
+      if (!object[SingleValueBinding.__SymbolBindingsInfo]) {
+        return;
+      }
       
-      for (let binding of Object.values(relatedObject[SingleValueBinding.__SymbolBindingsInfo].source)) {
-        if (binding.getTarget() === object) {
+      for (let binding of Object.values(object[SingleValueBinding.__SymbolBindingsInfo].target)) {
+        if (binding.getSource() === relatedObject) {
           binding.dispose();
         }
       }

--- a/source/class/qx/data/SingleValueBinding.js
+++ b/source/class/qx/data/SingleValueBinding.js
@@ -286,16 +286,16 @@ qx.Class.define("qx.data.SingleValueBinding", {
 
       if (oldValue) {
         //Delete old source's bindings if there was one
-        delete SingleValueBinding.__bindingsBySource[oldValue.toHashCode()][this.toHashCode()];
-        if (qx.lang.Object.isEmpty(SingleValueBinding.__bindingsBySource[oldValue.toHashCode()])) {
-          delete SingleValueBinding.__bindingsBySource[oldValue.toHashCode()];
+        delete oldValue[SingleValueBinding.__SymbolBindingsInfo].source[this.toHashCode()];
+        if (!SingleValueBinding.getAllBindingsForObject(oldValue).length) {
+          delete oldValue[SingleValueBinding.__SymbolBindingsInfo];
         }
       }
 
       if (value) {
         //Store the binding
-        SingleValueBinding.__bindingsBySource[value.toHashCode()] ??= {};
-        SingleValueBinding.__bindingsBySource[value.toHashCode()][this.toHashCode()] = this;
+        value[SingleValueBinding.__SymbolBindingsInfo] ??= { source: {}, target: {} };
+        value[SingleValueBinding.__SymbolBindingsInfo].source[this.toHashCode()] = this;
 
         //Set the input on the first segment of the source path
         let out = this.__sourceSegments[0].setInput(value);
@@ -358,16 +358,15 @@ qx.Class.define("qx.data.SingleValueBinding", {
       const SingleValueBinding = qx.data.SingleValueBinding;
 
       if (oldValue) {
-        delete SingleValueBinding.__bindingsByTarget[oldValue.toHashCode()][this.toHashCode()];
-        if (qx.lang.Object.isEmpty(SingleValueBinding.__bindingsByTarget[oldValue.toHashCode()])) {
-          delete SingleValueBinding.__bindingsByTarget[oldValue.toHashCode()];
+        delete oldValue[SingleValueBinding.__SymbolBindingsInfo].target[this.toHashCode()];
+        if (!SingleValueBinding.getAllBindingsForObject(oldValue).length) {
+          delete oldValue[SingleValueBinding.__SymbolBindingsInfo];
         }
       }
 
       if (value) {
-        const SingleValueBinding = qx.data.SingleValueBinding;
-        SingleValueBinding.__bindingsByTarget[value.toHashCode()] ??= {};
-        SingleValueBinding.__bindingsByTarget[value.toHashCode()][this.toHashCode()] = this;
+        value[SingleValueBinding.__SymbolBindingsInfo] ??= { source: {}, target: {} };
+        value[SingleValueBinding.__SymbolBindingsInfo].target[this.toHashCode()] = this;
 
         let out = this.__targetSegments[0].setInput(value);
         this.__initPromise = Promise.resolve(out);
@@ -460,11 +459,17 @@ qx.Class.define("qx.data.SingleValueBinding", {
   },
 
   statics: {
-    /** @type {Object<String,Object<String,Binding>>} map of maps, outer map is indexed by object hash, inner is indexed by binding hash */
-    __bindingsBySource: {},
-
-    /** @type {Object<String,Object<String,Binding>>} map of maps, outer map is indexed by object hash, inner is indexed by binding hash */
-    __bindingsByTarget: {},
+    /**
+     * This symbol is used to store information about bindings on the source/target objects,
+     * so that we don't need a global registry,
+     * which means objects can be garbage collected.
+     * 
+     * If an object is either a source or a target of a binding, its property with this symbol will have the following type:
+     * @typedef {Object} BindingsInfo
+     * @property {Object.<string, qx.data.SingleValueBinding>} source The bindings where the object is the source, indexed by the binding's hash code
+     * @property {Object.<string, qx.data.SingleValueBinding>} target The bindings where the object is the target, indexed by the binding's hash code
+     */
+    __SymbolBindingsInfo: Symbol("qx.data.SingleValueBinding.__SymbolBindingsInfo"),
 
     /**
      * @see {qx.data.SingleValueBinding#construct} for parameters
@@ -588,36 +593,13 @@ qx.Class.define("qx.data.SingleValueBinding", {
      */
     getAllBindingsForObject(object) {
       const SingleValueBinding = qx.data.SingleValueBinding;
-      let allBindings = {
-        ...(SingleValueBinding.__bindingsBySource[object.toHashCode()] ?? {}),
-        ...(SingleValueBinding.__bindingsByTarget[object.toHashCode()] ?? {})
-      };
-      return Object.values(allBindings).map(binding => binding.asRecord());
-    },
-
-    /**
-     * Returns a map containing for every bound object an array of data binding
-     * information. The key of the map is the hash code of the bound objects.
-     * Every binding is represented by an array containing id, sourceObject,
-     * sourceEvent, targetObject and targetProperty.
-     *
-     * @return {Object<string, BindingInfo>} Map containing all bindings.
-     *
-     * @typedef {[qx.data.SingleValueBinding, qx.core.Object, string, qx.core.Object, string]} BindingInfo
-     * Stores the binding ID, source object, source path, target object and target path respectively.
-     */
-    getAllBindings() {
-      let bindings = qx.data.SingleValueBinding.__bindingsBySource;
-
-      let result = {};
-      for (let [objectHash, objectBindings] of Object.entries(bindings)) {
-        let objectBindingsArray = [];
-        for (let [bindingHash, binding] of Object.entries(objectBindings)) {
-          objectBindingsArray.push([binding, binding.getSource(), binding.getSourcePath(), binding.getTarget(), binding.getTargetPath()]);
-        }
-        result[objectHash] = objectBindingsArray;
+      let bindingsInfo  = object[SingleValueBinding.__SymbolBindingsInfo];
+      if (!bindingsInfo) {
+        return [];
       }
-      return result;
+      
+      let bindings = Object.values({...bindingsInfo.source, ...bindingsInfo.target});
+      return bindings.map(binding => binding.asRecord());
     },
 
     /**
@@ -635,23 +617,16 @@ qx.Class.define("qx.data.SingleValueBinding", {
     removeRelatedBindings(object, relatedObject) {
       const SingleValueBinding = qx.data.SingleValueBinding;
 
-      let bySourceObject = SingleValueBinding.__bindingsBySource[object.toHashCode()];
-
-      if (bySourceObject) {
-        Object.values(bySourceObject).forEach(binding => {
-          if (binding.getTarget() === relatedObject) {
-            binding.dispose();
-          }
-        });
+      for (let binding of Object.values(object[SingleValueBinding.__SymbolBindingsInfo].source)) {
+        if (binding.getTarget() === relatedObject) {
+          binding.dispose();
+        }
       }
-
-      let byRelatedObject = SingleValueBinding.__bindingsBySource[relatedObject.toHashCode()];
-      if (byRelatedObject) {
-        Object.values(byRelatedObject).forEach(binding => {
-          if (binding.getTarget() === object) {
-            binding.dispose();
-          }
-        });
+      
+      for (let binding of Object.values(relatedObject[SingleValueBinding.__SymbolBindingsInfo].source)) {
+        if (binding.getTarget() === object) {
+          binding.dispose();
+        }
       }
     },
 

--- a/source/class/qx/event/Manager.js
+++ b/source/class/qx/event/Manager.js
@@ -65,9 +65,6 @@ qx.Class.define("qx.event.Manager", {
       }
     }
 
-    // Registry for event listeners
-    this.__listeners = new Map();
-
     // The handler and dispatcher instances
     this.__handlers = {};
     this.__dispatchers = {};
@@ -104,6 +101,12 @@ qx.Class.define("qx.event.Manager", {
      * @type {Array} private list of global event monitor functions
      */
     __globalEventMonitors: [],
+
+    /**
+     * Used to store the Map of listeners for each target.
+     * @type {Map}
+     */
+    __SymbolListeners: Symbol("qx.event.Manager.__SymbolListeners"),
 
     /**
      * Adds a global event monitor function which is called for each event fired
@@ -171,7 +174,6 @@ qx.Class.define("qx.event.Manager", {
 
   members: {
     __registration: null,
-    __listeners: null,
 
     __dispatchers: null,
     __disposeWrapper: null,
@@ -264,8 +266,8 @@ qx.Class.define("qx.event.Manager", {
      *       null when no listener were found.
      */
     getListeners(target, type, capture) {
-      var targetKey = target.$$hash || qx.core.ObjectRegistry.toHashCode(target);
-      var targetMap = this.__listeners.get(targetKey);
+      const Manager = qx.event.Manager;
+      var targetMap = target[Manager.__SymbolListeners];
 
       if (!targetMap) {
         return null;
@@ -306,48 +308,6 @@ qx.Class.define("qx.event.Manager", {
     },
 
     /**
-     * Returns all registered listeners.
-     *
-     * @internal
-     *
-     * @return {Object} All registered listeners. The key is the hash code for an object.
-     */
-    getAllListeners() {
-      return Object.fromEntries(
-        this.__listeners.entries().map(
-          ([targetKey, targetMap]) => [targetKey, Object.fromEntries(
-            targetMap.entries().map(
-              ([entryKey, entryMap]) => {
-                var listeners = [...entryMap.values()];
-                var proxy = new Proxy(listeners, {
-                  deleteProperty(target, property) {
-                    if (property !== "length") {
-                      var listener = target[property];
-                      entryMap.delete(listener.unique);
-                    }
-                    delete target[property];
-                    return true;
-                  },
-                  set(target, property, value, receiver) {
-                    if (property !== "length") {
-                      if (!value.unique) {
-                        throw new Error("Cannot store a listener without a unique id. Use addListener()");
-                      }
-                      entryMap[value.unique] = value;
-                    }
-                    target[property] = value;
-                    return true;
-                  }
-                })
-                return [entryKey, proxy];
-              }
-            )
-          )]
-        )
-      );
-    },
-
-    /**
      * Returns a serialized array of all events attached on the given target.
      *
      * @param target {Object} Any valid event target
@@ -355,8 +315,8 @@ qx.Class.define("qx.event.Manager", {
      *   <code>handler</code>, <code>self</code>, <code>type</code> and <code>capture</code>.
      */
     serializeListeners(target) {
-      var targetKey = target.$$hash || qx.core.ObjectRegistry.toHashCode(target);
-      var targetMap = this.__listeners.get(targetKey);
+      const Manager = qx.event.Manager;
+      var targetMap = target[Manager.__SymbolListeners];
       var result = [];
 
       if (targetMap) {
@@ -394,8 +354,8 @@ qx.Class.define("qx.event.Manager", {
      * @param enable {Boolean} Whether to enable or disable the events
      */
     toggleAttachedEvents(target, enable) {
-      var targetKey = target.$$hash || qx.core.ObjectRegistry.toHashCode(target);
-      var targetMap = this.__listeners.get(targetKey);
+      const Manager = qx.event.Manager;
+      var targetMap = target[Manager.__SymbolListeners];
 
       if (targetMap) {
         var indexOf, type, capture;
@@ -431,8 +391,8 @@ qx.Class.define("qx.event.Manager", {
         }
       }
 
-      var targetKey = target.$$hash || qx.core.ObjectRegistry.toHashCode(target);
-      var targetMap = this.__listeners.get(targetKey);
+      const Manager = qx.event.Manager;
+      var targetMap = target[Manager.__SymbolListeners];
 
       if (!targetMap) {
         return false;
@@ -467,12 +427,10 @@ qx.Class.define("qx.event.Manager", {
         }
       }
 
-      var targetKey = target.$$hash || qx.core.ObjectRegistry.toHashCode(target);
-      var targetMap = this.__listeners.get(targetKey);
+      var targetMap = target[qx.event.Manager.__SymbolListeners];
 
       if (!targetMap) {
-        targetMap = new Map();
-        this.__listeners.set(targetKey, targetMap);
+        targetMap = target[qx.event.Manager.__SymbolListeners] = new Map();
       }
 
       for (var listKey in list) {
@@ -525,6 +483,7 @@ qx.Class.define("qx.event.Manager", {
      * @throws {Error} if the parameters are wrong
      */
     addListener(target, type, listener, self, capture) {
+      const Manager = qx.event.Manager;
       if (qx.core.Environment.get("qx.debug")) {
         var msg =
           "Failed to add event listener for type '" +
@@ -546,12 +505,10 @@ qx.Class.define("qx.event.Manager", {
         }
       }
 
-      var targetKey = target.$$hash || qx.core.ObjectRegistry.toHashCode(target);
-      var targetMap = this.__listeners.get(targetKey);
+      var targetMap = target[Manager.__SymbolListeners];
 
       if (!targetMap) {
-        targetMap = new Map();
-        this.__listeners.set(targetKey, targetMap);
+        targetMap = target[Manager.__SymbolListeners] = new Map();
       }
 
       var entryKey = type + (capture ? "|capture" : "|bubble");
@@ -718,6 +675,7 @@ qx.Class.define("qx.event.Manager", {
      * @throws {Error} if the parameters are wrong
      */
     removeListener(target, type, listener, self, capture) {
+      const Manager = qx.event.Manager;
       if (qx.core.Environment.get("qx.debug")) {
         var msg =
           "Failed to remove event listener for type '" +
@@ -743,8 +701,7 @@ qx.Class.define("qx.event.Manager", {
         }
       }
 
-      var targetKey = target.$$hash || qx.core.ObjectRegistry.toHashCode(target);
-      var targetMap = this.__listeners.get(targetKey);
+      var targetMap = target[Manager.__SymbolListeners];
 
       if (!targetMap) {
         return false;
@@ -777,6 +734,7 @@ qx.Class.define("qx.event.Manager", {
      * @return {Boolean} <code>true</code> if the handler was removed
      */
     removeListenerById(target, id) {
+      const Manager = qx.event.Manager;
       if (qx.core.Environment.get("qx.debug")) {
         var msg =
           "Failed to remove event listener for id '" +
@@ -795,8 +753,7 @@ qx.Class.define("qx.event.Manager", {
       var capture = split[1].charCodeAt(0) === 99; // detect leading "c"
       var unique = split[2];
 
-      var targetKey = target.$$hash || qx.core.ObjectRegistry.toHashCode(target);
-      var targetMap = this.__listeners.get(targetKey);
+      var targetMap = target[Manager.__SymbolListeners];
 
       if (!targetMap) {
         return false;
@@ -828,8 +785,8 @@ qx.Class.define("qx.event.Manager", {
      * @return {Boolean} Whether the events were existant and were removed successfully.
      */
     removeAllListeners(target) {
-      var targetKey = target.$$hash || qx.core.ObjectRegistry.toHashCode(target);
-      var targetMap = this.__listeners.get(targetKey);
+      const Manager = qx.event.Manager;
+      var targetMap = target[Manager.__SymbolListeners];
       if (!targetMap) {
         return false;
       }
@@ -853,21 +810,20 @@ qx.Class.define("qx.event.Manager", {
         }
       }
 
-      this.__listeners.delete(targetKey);
+      delete target[Manager.__SymbolListeners];
       return true;
     },
 
     /**
      * Internal helper for deleting the internal listener  data structure for
-     * the given targetKey.
+     * the given target.
      *
-     * @param targetKey {String} Hash code for the object to delete its
-     *   listeners.
+     * @param target {Object} The object to delete its listeners.
      *
      * @internal
      */
-    deleteAllListeners(targetKey) {
-      this.__listeners.delete(targetKey);
+    deleteAllListeners(target) {
+      delete target[qx.event.Manager.__SymbolListeners];
     },
 
     /**
@@ -1038,7 +994,7 @@ qx.Class.define("qx.event.Manager", {
       qx.util.DisposeUtil.disposeMap(this, "__dispatchers");
 
       // Dispose data fields
-      this.__listeners = this.__window = this.__disposeWrapper = null;
+      this.__window = this.__disposeWrapper = null;
       this.__registration = this.__handlerCache = null;
     },
 

--- a/source/class/qx/event/Registration.js
+++ b/source/class/qx/event/Registration.js
@@ -36,11 +36,11 @@ qx.Class.define("qx.event.Registration", {
 
   statics: {
     /**
-     * Static list of all instantiated event managers. The key is the qooxdoo
-     * hash value of the corresponding window
+     * Symbol used to store the event manager on the target object.
+     * This allows us to not use a global registry, meaning that if the target is garbage collected,
+     * its manager can be garbage collected as well.
      */
-    __managers: {},
-
+    __SymbolManager: Symbol("qx.event.Registration.__SymbolManager"),
     /**
      * Get an instance of the event manager, which can handle events for the
      * given target.
@@ -65,15 +65,11 @@ qx.Class.define("qx.event.Registration", {
         target = window;
       }
 
-      var hash = target.$$hash || qx.core.ObjectRegistry.toHashCode(target);
-      var manager = this.__managers[hash];
-
-      if (!manager) {
-        manager = new qx.event.Manager(target, this);
-        this.__managers[hash] = manager;
+      if (!target[this.__SymbolManager]) {
+        target[this.__SymbolManager] = new qx.event.Manager(target, this);
       }
 
-      return manager;
+      return target[this.__SymbolManager];
     },
 
     /**
@@ -85,8 +81,7 @@ qx.Class.define("qx.event.Registration", {
      * @param mgr {qx.event.Manager} The manager to remove
      */
     removeManager(mgr) {
-      var id = mgr.getWindowId();
-      delete this.__managers[id];
+      delete mgr.getWindow()[this.__SymbolManager];
     },
 
     /**
@@ -176,10 +171,7 @@ qx.Class.define("qx.event.Registration", {
      * @internal
      */
     deleteAllListeners(target) {
-      var targetKey = target.$$hash;
-      if (targetKey) {
-        this.getManager(target).deleteAllListeners(targetKey);
-      }
+      this.getManager(target).deleteAllListeners(target);
     },
 
     /**

--- a/source/class/qx/test/data/singlevalue/Simple.js
+++ b/source/class/qx/test/data/singlevalue/Simple.js
@@ -257,30 +257,6 @@ qx.Class.define("qx.test.data.singlevalue.Simple", {
       }
     },
 
-    testGetAllBindings() {
-      // add three bindings
-      var id1 = qx.data.SingleValueBinding.bind(this.__a, "appearance", this.__b, "appearance");
-
-      var id2 = qx.data.SingleValueBinding.bind(this.__a, "zIndex", this.__b, "zIndex");
-
-      var id3 = qx.data.SingleValueBinding.bind(this.__b, "zIndex", this.__a, "zIndex");
-
-      // get all bindings
-      var allBindings = qx.data.SingleValueBinding.getAllBindings();
-
-      // check for the binding ids
-      this.assertEquals(id1, allBindings[this.__a.toHashCode()][0][0], "This id should be in!");
-
-      this.assertEquals(id2, allBindings[this.__a.toHashCode()][1][0], "This id should be in!");
-
-      this.assertEquals(id3, allBindings[this.__b.toHashCode()][0][0], "This id should be in!");
-
-      // check for the length
-      this.assertEquals(2, allBindings[this.__a.toHashCode()].length, "Not the right amount in the data!");
-
-      this.assertEquals(1, allBindings[this.__b.toHashCode()].length, "Not the right amount in the data!");
-    },
-
     testDebugStuff() {
       // just a test if the method runs threw without an exception
       var id1 = qx.data.SingleValueBinding.bind(this.__a, "appearance", this.__b, "appearance");

--- a/source/class/qx/test/ui/LayoutTestCase.js
+++ b/source/class/qx/test/ui/LayoutTestCase.js
@@ -96,17 +96,6 @@ qx.Class.define("qx.test.ui.LayoutTestCase", {
       // copy object registry
       var regCopy = qx.lang.Object.clone(qx.core.ObjectRegistry.getRegistry());
 
-      // copy event listener structure
-      var eventMgr = qx.event.Registration.getManager(window);
-      var listeners = eventMgr.getAllListeners();
-      var listenersCopy = {};
-      for (var hash in listeners) {
-        listenersCopy[hash] = {};
-        for (var key in listeners[hash]) {
-          listenersCopy[hash][key] = qx.lang.Array.clone(listeners[hash][key]);
-        }
-      }
-
       // call function
       fcn.call(context);
       this.flush();
@@ -129,38 +118,6 @@ qx.Class.define("qx.test.ui.LayoutTestCase", {
         );
       }
 
-      listeners = eventMgr.getAllListeners();
-
-      for (var hash in listeners) {
-        if (!listenersCopy[hash]) {
-          listenersCopy[hash] = {};
-        }
-
-        for (key in listeners[hash]) {
-          if (!listenersCopy[hash][key]) {
-            listenersCopy[hash][key] = [];
-          }
-
-          for (var i = 0; i < listeners[hash][key].length; i++) {
-            if (
-              listenersCopy[hash][key].indexOf(listeners[hash][key][i]) == -1
-            ) {
-              this.fail(
-                msg +
-                  ": The event listener '" +
-                  key +
-                  ":" +
-                  listeners[hash][key][i] +
-                  "'for the object '" +
-                  hash +
-                  ":" +
-                  qx.core.ObjectRegistry.fromHashCode(hash) +
-                  "' has not been removed."
-              );
-            }
-          }
-        }
-      }
 
       // check root children length
       this.assertIdentical(


### PR DESCRIPTION
This PR removes global registries used for storing event listeners and bindings, meaning that objects are no longer being prevented from being garbage collected without manually disposing them. Instead, the metadata is being stored in the objects themselves using properties with `Symbol` keys, which guarantees no naming collisions.

For bindings, the static properties `__bindingsBySource` and `__bindingsByTarget` which stored the bindings for source and target objects were removed from `qx.data.SingleValueBinding`. The source/target object now stores its bindings under `qx.data.SingleValueBinding.__SymbolBindingsInfo`.
This means that the following code would create a memory leak when the function returns (unless the objects are disposed), but it doesn't now:
```js
function foo() {
  let person1 = new app.Person();
  let person2 = new app.Person();
  person1.bind("name", person2, "name");
}
```

Similarly, for events, `qx.event.Manager` no longer uses a possibly-large `Map` to store listeners for targets but stores the info in the target object with key `qx.event.Manager.__SymbolListeners`. `qx.event.Registration` does something similar for its window objects. This solves the problem where if a listener callback has a dependent object in its closure then that dependent object is prevented from being garbage-collected.

The code below would create a memory leak before but doesn't anymore:
```js
function foo() {
  let person1 = new app.Person();
  let person2 = new app.Person();
  person1.addListener("changeName", (evt) => person2.setName(evt.getData()));
}
```

This PR introduces the breaking changes where the functions `qx.data.SingleValueBinding.getAllBindings` and `qx.event.Manager.getAllListeners` were removed, but I don't think those functions have any practical use cases and they can return enormous amounts of data.