### PR TITLE
async pseudo property fixes

### DIFF
--- a/docs/core/advanced_properties.md
+++ b/docs/core/advanced_properties.md
@@ -195,6 +195,9 @@ It will first attempt to get the property synchronously and then attempt asynchr
 NOTE: It is possible but discouraged to call `getAsync` on a property that doesn't support an async getter.
 Doing so will print out a warning.
 
+The property object (`qx.core.property.Property`) will support async getting,
+meaning that calling `supportsGetAsync` on it will return `true`.
+
 We can `get` the property value synchronously after the initial `getAsync`, like in the following example:
 ```js
 let myObject = myObjectFactory.getByUuid("asdfasdfk");
@@ -260,3 +263,50 @@ you can add `get`, `set`, and optionally `getAsync` functions to your definition
 
 This is known as inline or explicit property storage. This internally uses `qx.core.property.ExplicitPropertyStorage`,
 which simply defers to the `get`, `set`, `setAsync` functions in your definition.
+
+## Pseudo properties with async getter
+
+If a class contains a pseudo property (i.e. a hand-written property with at least get/event)
+and a `getPropertyAsync` method, the property object will treat the property as one supporting an async getter,
+meaning `property.supportsGetAsync` will return `true` and calling `property.getAsync(obj)` will straight defer to the `getPropertyAsync()` method.
+
+Example code:
+```js
+let Clazz = qx.Class.define("app.AsyncPseudoProperty", {
+  extend: qx.core.Object,
+
+  events: {
+    changePseudoProp: "qx.event.type.Data"
+  },
+
+  members: {
+    __pseudoProp: undefined,          
+
+    async getPseudoPropAsync() {
+      if (this.__pseudoProp !== undefined) {
+        return this.__pseudoProp;
+      }
+      return (this.__pseudoProp = 24);
+    },
+
+    getPseudoProp(safe) {            
+      if (!safe && !this.__pseudoProp) {
+        throw new Error("Property " + this.classname + ".pseudoProp is not yet ready!");
+      }
+      return this.__pseudoProp;
+    },
+
+    setPseudoProp(value) {
+      let oldValue = this.__pseudoProp;
+      this.__pseudoProp = value;
+      this.fireDataEvent("changePseudoProp", value, oldValue);
+    }
+  }
+});
+
+let obj = new app.AsyncPseudoProperty();
+let prop = qx.Class.getByProperty(obj.contructor, "pseudoProp");
+prop.supportsGetAsync() === true
+prop.getAsync(obj) === 24
+```
+

--- a/source/class/qx/core/MProperty.js
+++ b/source/class/qx/core/MProperty.js
@@ -146,13 +146,13 @@ qx.Mixin.define("qx.core.MProperty", {
       if (safe) {
         let property = qx.Class.getByProperty(this.constructor, prop);
         if (property) {
-          return property.getSafe(this);
+          return property.get(this, safe);
         }
       }
 
       // Otherwise, see if there's a hand-written getter method
       if (this["get" + qx.Bootstrap.firstUp(prop)] != undefined) {
-        return this["get" + qx.Bootstrap.firstUp(prop)]();
+        return this["get" + qx.Bootstrap.firstUp(prop)](safe);
       }
 
       // If the property exists as a member variable, get it directly
@@ -161,20 +161,6 @@ qx.Mixin.define("qx.core.MProperty", {
       }
 
       throw new Error("No such property: " + prop);
-    },
-
-    /**
-     *
-     * Returns the value of the given property.
-     * If the property is not initialized, it will return undefined.
-     *
-     * @param prop {String}
-     *   Name of the property.
-     *
-     * @returns {*}
-     */
-    getSafe(prop) {
-      return this.get(prop, true);
     },
 
     /**

--- a/source/class/qx/core/property/Property.js
+++ b/source/class/qx/core/property/Property.js
@@ -550,21 +550,21 @@ qx.Bootstrap.define("qx.core.property.Property", {
       Object.defineProperty(clazz.prototype, propertyName, propertyConfig);
 
       if (!this.__pseudoProperty) {
-        addMethod(methods.get, function () {
+        addMethod(methods.get, function (safe) {
           if (qx.core.Environment.get("qx.debug")) {
-            if (arguments.length) {
-              throw new Error(`Getter of property ${this} called with arguments, which is not allowed`);
+            if (arguments.length > 1) {
+              throw new Error(`Getter of property ${this} called with wrong number of arguments`);
             }
           }
-          return self.get(this);
+          return self.get(this, safe);
         });
-        addMethod(methods.getAsync, async function () {
+        addMethod(methods.getAsync, async function (safe) {
           if (qx.core.Environment.get("qx.debug")) {
-            if (arguments.length) {
-              throw new Error(`Getter of property ${this} called with arguments, which is not allowed`);
+            if (arguments.length > 1) {
+              throw new Error(`Getter of property ${this} called with wrong number of arguments`);
             }
           }
-          return await self.getAsync(this);
+          return await self.getAsync(this, safe);
         });
       }
 
@@ -753,13 +753,14 @@ qx.Bootstrap.define("qx.core.property.Property", {
      * Gets a property value; will raise an error if the property is not initialized
      *
      * @param {qx.core.Object} thisObj the object on which the property is defined
+     * @param {boolean} safe If true, and the property hasn't been initialized, `undefined` will be returned.
      * @return {*}
      */
-    get(thisObj) {
+    get(thisObj, safe = false) {
       if (this.__pseudoProperty) {
-        return this.__callFunction(thisObj, "get" + qx.Bootstrap.firstUp(this.__propertyName));
+        return this.__callFunction(thisObj, "get" + qx.Bootstrap.firstUp(this.__propertyName), safe);
       }
-      return this.__getImpl(thisObj, false);
+      return this.__getImpl(thisObj, safe);
     },
 
     /**
@@ -768,31 +769,14 @@ qx.Bootstrap.define("qx.core.property.Property", {
      * storage cannot provide a value which is not `undefined`
      *
      * @param {qx.core.Object} thisObj the object on which the property is defined
+     * @param {boolean} safe If true, and the property hasn't been initialized, `undefined` will be returned.
      * @return {*}
      */
-    async getAsync(thisObj) {
+    async getAsync(thisObj, safe = false) {
       if (this.__pseudoProperty) {
         return this.__callFunction(thisObj, "get" + qx.Bootstrap.firstUp(this.__propertyName) + "Async");
       }
-      return this.__getAsyncImpl(thisObj, false);
-    },
-
-    /**
-     * Gets a property value; if not initialized, it will return undefined
-     * @param {qx.core.Object} thisObj
-     * @param {boolean?} async
-     * @returns {*}
-     */
-    getSafe(thisObj, async = false) {
-      if (qx.core.Environment.get("qx.debug")) {
-        if (this.__pseudoProperty) {
-          throw new Error(`${this}: Pseudo properties do not support getSafe`);
-        }
-      }      
-      if (async) {
-        return this.__getAsyncImpl(thisObj, true);
-      }
-      return this.__getImpl(thisObj, true);
+      return this.__getAsyncImpl(thisObj, safe);
     },
 
     /**
@@ -1540,7 +1524,12 @@ qx.Bootstrap.define("qx.core.property.Property", {
      * @return {Boolean}
      */
     hasLocalValue(thisObj) {
-      let value = this.__getImpl(thisObj, true);
+      let value;
+      if (this.__pseudoProperty) {
+        value = thisObj["get" + qx.Bootstrap.firstUp(this.__propertyName)](true);
+      } else {
+        value = this.__getImpl(thisObj, true);
+      }
       return value !== undefined;
     },
 

--- a/source/class/qx/test/core/Property.js
+++ b/source/class/qx/test/core/Property.js
@@ -2361,7 +2361,7 @@ qx.Class.define("qx.test.core.Property", {
         let instance = new Clazz();
         let prop = qx.Class.getByProperty(Clazz, "foo");
         this.assertFalse(prop.hasLocalValue(instance), "Property foo should not be locally defined");
-        this.assertUndefined(instance.getSafe("foo"));
+        this.assertUndefined(instance.getFoo(true));
         try {
           instance.getFoo();
           this.assertTrue(false, "getFoo should throw an error when the property is not ready");
@@ -2431,6 +2431,56 @@ qx.Class.define("qx.test.core.Property", {
 
       let obj = new qx.test.core.property.TestPrivateProperties();
       await obj.test();
+    },
+
+    async testAsyncPseudoProperty() {
+      qx.Class.undefine("qx.test.core.property.TestAsyncPseudoProperty");
+      let Clazz = qx.Class.define("qx.test.core.property.TestAsyncPseudoProperty", {
+        extend: qx.core.Object,
+
+        events: {
+          changePseudoProp: "qx.event.type.Data"
+        },
+
+        members: {
+          __pseudoProp: undefined,          
+
+          async getPseudoPropAsync() {
+            if (this.__pseudoProp !== undefined) {
+              return this.__pseudoProp;
+            }
+            return (this.__pseudoProp = 24);
+          },
+
+          getPseudoProp(safe) {            
+            if (!safe && !this.__pseudoProp) {
+              throw new Error("Property " + this.classname + ".pseudoProp is not yet ready!");
+            }
+            return this.__pseudoProp;
+          },
+
+          setPseudoProp(value) {
+            let oldValue = this.__pseudoProp;
+            this.__pseudoProp = value;
+            this.fireDataEvent("changePseudoProp", value, oldValue);
+          }
+        }
+      });
+
+      let obj = new Clazz();
+      try {
+        obj.getPseudoProp();
+        this.assertTrue(false, "Initial get should fail");
+      } catch (e) {
+
+      }
+
+      this.assertUndefined(obj.getPseudoProp(true), "Initial get safe returns undefined£.");
+      let prop = qx.Class.getByProperty(Clazz, "pseudoProp");
+      this.assertFalse(prop.hasLocalValue(obj), "Unexpected result from hasLocalValue");
+      this.assertEquals(24, await obj.getPseudoPropAsync(), "Wrong value when getting async");
+      this.assertEquals(24, obj.getPseudoProp(), "Wrong value when getting async");        
+      this.assertTrue(prop.hasLocalValue(obj), "Unexpected result from hasLocalValue (2)");
     },
 
     /**

--- a/source/class/qx/ui/basic/Atom.js
+++ b/source/class/qx/ui/basic/Atom.js
@@ -199,7 +199,7 @@ qx.Class.define("qx.ui.basic.Atom", {
           control.setRich(this.getRich());
           control.setSelectable(this.getSelectable());
           this._add(control);
-          if (this.getLabel() == null || this.getSafe("showFeatures") === "icon") {
+          if (this.getLabel() == null || this.getShowFeatures(true) === "icon") {
             control.exclude();
           }
           break;
@@ -208,7 +208,7 @@ qx.Class.define("qx.ui.basic.Atom", {
           control = new qx.ui.basic.Image(this.getIcon());
           control.setAnonymous(true);
           this._addAt(control, 0);
-          if (this.getIcon() == null || this.getSafe("showFeatures") === "label") {
+          if (this.getIcon() == null || this.getShowFeatures(true) === "label") {
             control.exclude();
           }
           break;
@@ -230,7 +230,7 @@ qx.Class.define("qx.ui.basic.Atom", {
      * Updates the visibility of the label
      */
     _handleLabel() {
-      if (this.getLabel() == null || this.getSafe("showFeatures") === "icon") {
+      if (this.getLabel() == null || this.getShowFeatures(true) === "icon") {
         this._excludeChildControl("label");
       } else {
         this._showChildControl("label");
@@ -241,7 +241,7 @@ qx.Class.define("qx.ui.basic.Atom", {
      * Updates the visibility of the icon
      */
     _handleIcon() {
-      if (this.getIcon() == null || this.getSafe("showFeatures") === "label") {
+      if (this.getIcon() == null || this.getShowFeatures(true) === "label") {
         this._excludeChildControl("icon");
       } else {
         this._showChildControl("icon");


### PR DESCRIPTION
Problem: `qx.core.property.Property.hasLocalValue` fails on pseudo properties, which can cause errors in things like asynchronous bindings.

Solution: Introduce a way of getting a pseudo property safely. Do this by adding a boolean parameter called `safe` which when set to `true`, make the getter return `undefined` if the property is not ready.

To make things more consistent, getting a property safely now requires passing `true` as an argument into the injected getter, and methods `getSafe` from `qx.core.property.Property` and `MProperty` were removed, which is a minor breaking change for new v8 features only.

