### PR TITLE
fix: pseudo-properties with getAsync method were considered as supportGetAsync

### DIFF
--- a/source/class/qx/core/property/Property.js
+++ b/source/class/qx/core/property/Property.js
@@ -639,12 +639,6 @@ qx.Bootstrap.define("qx.core.property.Property", {
           return self.resetAsync(this);
         });
       }
-
-      if (this.__pseudoProperty) {
-        this.__supportsGetAsync = this.__clazz.prototype["get" + qx.Bootstrap.firstUp(this.__propertyName) + "Async"] !== undefined;
-      } else {
-        this.__supportsGetAsync = this.__storage.supportsGetAsync();
-      }
     },
 
     /**
@@ -1233,7 +1227,7 @@ qx.Bootstrap.define("qx.core.property.Property", {
 
       if (value !== undefined) {
         return value;
-      } else if (this.__supportsGetAsync) {
+      } else if (this.supportsGetAsync()) {
         if (!safe) {
           throw new Error("Property " + this + " has not been initialized - try using getAsync() instead");
         } else {
@@ -1261,7 +1255,7 @@ qx.Bootstrap.define("qx.core.property.Property", {
      * @returns {Promise<*>}
      */
     async __getAsyncImpl(thisObj, safe) {
-      if (!this.__supportsGetAsync) {
+      if (!this.supportsGetAsync()) {
         if (qx.core.Environment.get("qx.debug")) {
           this.warn(`Called getAsync in property ${this} which does not support async getter. The value will be read synchronously.`);
         }
@@ -1550,7 +1544,7 @@ qx.Bootstrap.define("qx.core.property.Property", {
      * @return {Boolean}
      */
     supportsGetAsync() {
-      return this.__supportsGetAsync;      
+      return !!this.__storage?.supportsGetAsync();      
     },
 
     /**

--- a/source/class/qx/test/data/singlevalue/Simple.js
+++ b/source/class/qx/test/data/singlevalue/Simple.js
@@ -843,6 +843,43 @@ qx.Class.define("qx.test.data.singlevalue.Simple", {
       });
 
       new qx.test.data.singlevalue.simple.TestChangeEventSameInstance();
+    },
+
+    testPseudoProperty() {      
+      qx.Class.undefine("com.ieatsquirrels.Test");
+      const Test = qx.Class.define("qx.test.data.singlevalue.simple.TestPseudoProperty", {
+        extend: qx.core.Object,
+        properties: {
+          target: {
+            check: "String"
+          }
+        },
+        events: {
+          changeName: "qx.event.type.Data"
+        },
+        members: {
+          _name: "Patryk",
+          async getNameAsync() {
+            return "something completely different";
+          },
+          getName() {
+            return this._name;
+          },
+          setName(value) {
+            if (this._name !== value) {
+              let oldValue = this._value;
+              this._name = value;
+              this.fireDataEvent("changeName", value, oldValue);
+            }
+          }
+        }
+      });
+
+      let obj = new Test();
+      obj.bind("name", obj, "target");
+      this.assertEquals("Patryk", obj.getTarget(), "Initial set");
+      obj.setName("Marcin");
+      this.assertEquals("Marcin", obj.getTarget(), "After source change");
     }
   }
 });


### PR DESCRIPTION
This PR fixes problems where a class with a pseudo property (i.e. methods `getProperty`, `setProperty`, event `changeProperty`) also has a method `getPropertyAsync`. That method causes the property system to consider that property as supporting getAsync i.e. `property.supportsGetAsync` returns `true`. Pseudo-properties are deprecated in v8 because the property system is (or at least should be) customizable enough so that the user doesn't have to hand-code properties. Async pseudo property binding wasn't supported in Qooxdoo version 7 anyway, so this PR removes this behaviour.

An example problem is when you try to bind that pseudo-property. In `qx.data.binding.PropNameSegment.updateOutput`, we detect that the property supports `getAsync`, so we check if there is a local value first by calling `property.hasLocalValue(input)`, which causes a crash. 

The code below would crash before this PR but doesn't anymore:
```
const Test = qx.Class.define("qx.test.data.singlevalue.simple.TestPseudoProperty", {
        extend: qx.core.Object,
        properties: {
          target: {
            check: "String"
          }
        },
        events: {
          changeName: "qx.event.type.Data"
        },
        members: {
          _name: "Patryk",
          async getNameAsync() {
            return "something completely different";
          },
          getName() {
            return this._name;
          },
          setName(value) {
            if (this._name !== value) {
              let oldValue = this._value;
              this._name = value;
              this.fireDataEvent("changeName", value, oldValue);
            }
          }
        }
      });

      let obj = new Test();
      obj.bind("name", obj, "target");
```