### PR TITLE
restore old inheritable properties behaviour + remove getSafe

### DIFF
--- a/source/class/qx/core/MProperty.js
+++ b/source/class/qx/core/MProperty.js
@@ -137,18 +137,10 @@ qx.Mixin.define("qx.core.MProperty", {
      * @return {var}
      *   The value of the value
      *
-     * @param safe {Boolean?false}
-     *
      * @throws {Error}
      *   if a property defined does not exist
      */
-    get(prop, safe) {
-      if (safe) {
-        let property = qx.Class.getByProperty(this.constructor, prop);
-        if (property) {
-          return property.getSafe(this);
-        }
-      }
+    get(prop) {
 
       // Otherwise, see if there's a hand-written getter method
       if (this["get" + qx.Bootstrap.firstUp(prop)] != undefined) {
@@ -161,20 +153,6 @@ qx.Mixin.define("qx.core.MProperty", {
       }
 
       throw new Error("No such property: " + prop);
-    },
-
-    /**
-     *
-     * Returns the value of the given property.
-     * If the property is not initialized, it will return undefined.
-     *
-     * @param prop {String}
-     *   Name of the property.
-     *
-     * @returns {*}
-     */
-    getSafe(prop) {
-      return this.get(prop, true);
     },
 
     /**

--- a/source/class/qx/core/property/Property.js
+++ b/source/class/qx/core/property/Property.js
@@ -36,11 +36,9 @@ qx.Bootstrap.define("qx.core.property.Property", {
 
   environment: {
     /**
-     * @deprecated Changing this setting is deprecated.
-     * If set to true, then getting a property that is inheritable but has nothing to inherit from
-     * will return null, instead of throwing an error.
+     * Show warning if getting inherited value for an inheritable property when there's no parent to inherit from.
      */
-    "qx.core.property.Property.inheritableDefaultIsNull": false,
+    "qx.core.property.Property.warnInheritFromNothing": false,
 
     /**
      * If set to true, then properties with init values will have their apply method called during construction.
@@ -778,24 +776,6 @@ qx.Bootstrap.define("qx.core.property.Property", {
     },
 
     /**
-     * Gets a property value; if not initialized, it will return undefined
-     * @param {qx.core.Object} thisObj
-     * @param {boolean?} async
-     * @returns {*}
-     */
-    getSafe(thisObj, async = false) {
-      if (qx.core.Environment.get("qx.debug")) {
-        if (this.__pseudoProperty) {
-          throw new Error(`${this}: Pseudo properties do not support getSafe`);
-        }
-      }      
-      if (async) {
-        return this.__getAsyncImpl(thisObj, true);
-      }
-      return this.__getImpl(thisObj, true);
-    },
-
-    /**
      * Gets the themed value, if there is one
      *
      * @param {qx.core.Object} thisObj
@@ -1245,8 +1225,14 @@ qx.Bootstrap.define("qx.core.property.Property", {
         return false;
       } else if (this.__definition?.nullable || this.__check?.isNullable()) {
         return null;
-      } else if (qx.core.Environment.get("qx.core.property.Property.inheritableDefaultIsNull") && this.isInheritable()) {
-        return null;
+      } else if (this.isInheritable()) {
+        //This behaviour is weird, but it's there to preserve BC.
+        let out = value == "inherit" ? "inherit" : null;
+
+        if (qx.core.Environment.get("qx.core.property.Property.warnInheritFromNothing")) {
+          this.warn(`Property ${this}: No parent widget to inherit from when getting inherited value. The value ${out} will be returned instead.`)
+        }
+        return out;
       } else if (safe) {
         return undefined;
       } else {

--- a/source/class/qx/test/core/Property.js
+++ b/source/class/qx/test/core/Property.js
@@ -589,10 +589,13 @@ qx.Class.define("qx.test.core.Property", {
       var chh3 = new qx.test.core.InheritanceDummy();
       let ch4 = new qx.test.core.InheritanceDummy();
 
+      //Ensure null is returned when there is nothing to inherit from
+      this.assertNull(ch4.getEnabled(), "ch4: initial value of enabled should be null");      
+
       ch4.setEnabled(true);
       this.assertEquals(0, ch2.applyCount, "ch2 initial apply count");
       this.assertEquals(1, ch4.applyCount, "ch4 initial apply count");
-      this.assertArrayEquals([true, undefined], ch4.lastApply, "ch4 initial apply args");
+      this.assertArrayEquals([true, null], ch4.lastApply, "ch4 initial apply args");
 
       pa.add(ch1);
       pa.add(ch2);
@@ -604,7 +607,7 @@ qx.Class.define("qx.test.core.Property", {
 
       // Simple: Only inheritance, no local values
       this.assertTrue(pa.setEnabled(true), "a1");
-      this.assertArrayEquals([true, undefined], ch2.lastApply, "ch2 initial apply args");
+      this.assertArrayEquals([true, null], ch2.lastApply, "ch2 initial apply args");
       this.assertEquals(1, ch2.applyCount, "ch2 initial apply count");
       this.assertEquals(1, ch2.eventCount, "ch2 initial event count");
       ch2.setEnabled("inherit");
@@ -656,26 +659,6 @@ qx.Class.define("qx.test.core.Property", {
       chh1.dispose();
       chh2.dispose();
       chh3.dispose();
-    },
-
-    testInheritanceInitValue() {
-      let pa = new qx.test.core.InheritanceDummy();
-      try {
-        pa.getEnabled();
-        this.fail("getEnabled should throw an error if no init value is set");
-      } catch (e) {}
-
-      pa.setEnabled(true);
-      this.assertTrue(pa.getEnabled(), "After setting enabled to true, it should return true");
-
-      pa.dispose();
-
-      //old, deprecated behaviour
-      qx.core.Environment.set("qx.core.property.Property.inheritableDefaultIsNull", true);
-      pa = new qx.test.core.InheritanceDummy();
-      this.assertNull(pa.getEnabled(), "Initial value of enabled should be null");
-      pa.dispose();
-      qx.core.Environment.set("qx.core.property.Property.inheritableDefaultIsNull", false);
     },
 
     testRefine() {
@@ -2361,7 +2344,6 @@ qx.Class.define("qx.test.core.Property", {
         let instance = new Clazz();
         let prop = qx.Class.getByProperty(Clazz, "foo");
         this.assertFalse(prop.hasLocalValue(instance), "Property foo should not be locally defined");
-        this.assertUndefined(instance.getSafe("foo"));
         try {
           instance.getFoo();
           this.assertTrue(false, "getFoo should throw an error when the property is not ready");

--- a/source/class/qx/ui/basic/Atom.js
+++ b/source/class/qx/ui/basic/Atom.js
@@ -199,7 +199,7 @@ qx.Class.define("qx.ui.basic.Atom", {
           control.setRich(this.getRich());
           control.setSelectable(this.getSelectable());
           this._add(control);
-          if (this.getLabel() == null || this.getSafe("showFeatures") === "icon") {
+          if (this.getLabel() == null || this.getShowFeatures() === "icon") {
             control.exclude();
           }
           break;
@@ -208,7 +208,7 @@ qx.Class.define("qx.ui.basic.Atom", {
           control = new qx.ui.basic.Image(this.getIcon());
           control.setAnonymous(true);
           this._addAt(control, 0);
-          if (this.getIcon() == null || this.getSafe("showFeatures") === "label") {
+          if (this.getIcon() == null || this.getShowFeatures() === "label") {
             control.exclude();
           }
           break;
@@ -230,7 +230,7 @@ qx.Class.define("qx.ui.basic.Atom", {
      * Updates the visibility of the label
      */
     _handleLabel() {
-      if (this.getLabel() == null || this.getSafe("showFeatures") === "icon") {
+      if (this.getLabel() == null || this.getShowFeatures() === "icon") {
         this._excludeChildControl("label");
       } else {
         this._showChildControl("label");
@@ -241,7 +241,7 @@ qx.Class.define("qx.ui.basic.Atom", {
      * Updates the visibility of the icon
      */
     _handleIcon() {
-      if (this.getIcon() == null || this.getSafe("showFeatures") === "label") {
+      if (this.getIcon() == null || this.getShowFeatures() === "label") {
         this._excludeChildControl("icon");
       } else {
         this._showChildControl("icon");


### PR DESCRIPTION
This PR reverts a change to property inheritance which I've introduced a while ago in Version 8, where if an object has an inheritable property (i.e. with `inheritable: true`) and has no own value (i.e. no init/set value OR value set to "inherit") AND has no parent widget to inherit the property from, an exception will be thrown that the property has not been initialized (i.e. is not ready). The old behaviour was that null was returned (although if set to "inherit", the string "inherit" would be returned which seems very illogical to me). 
For example, the output of this code would be (in Version 7):
```
null
inherit
```

```js
qx.Class.define("qx.test.core.InheritanceDummy", {
  extend: qx.core.Object,

  construct() {
    super();
    this.children = [];
  },

  properties: {  
    width_: {
      inheritable: true,
      themeable: true
    }
  },

  members: {
    add(child) {
      this.children.push(child);
      child.parent = this;
      child.$$refreshInheritables();
    },

    _getChildren() {
      return this.children;
    },

    getLayoutParent() {
      return this.parent;
    }
  }
});


let p = new qx.test.core.InheritanceDummy();
let c = new qx.test.core.InheritanceDummy();
p.add(c);

this.debug(c.getWidth_());
c.setWidth_("inherit");
this.debug(c.getWidth_());
```
This code would crash in V8 prior to this PR.

This reverts to the old behaviour but also now shows a warning (controlled via environment setting) if this happens, in which case the user should do something like provide an init value for the property as a fallback.

It also gets rid of the `getSafe` method for `Property` because it I've created it a long time ago in order to work around cases where properties have no parent in inherit from after changing the behaviour, but that wasn't very elegant. I now don't think there are valid use cases for calling `getSafe` outside of properties and it sounds like an abstraction leak.