### PR TITLE
allow use of qx.tool.utils.Json.loadJsonAsync without unnecessary dep

### DIFF
--- a/source/class/qx/tool/utils/Json.js
+++ b/source/class/qx/tool/utils/Json.js
@@ -22,8 +22,6 @@
  *
  * *********************************************************************** */
 
-const Ajv = require("ajv");
-const betterAjvErrors = require("better-ajv-errors").default;
 const fs = qx.tool.utils.Promisify.fs;
 
 qx.Class.define("qx.tool.utils.Json", {
@@ -55,6 +53,9 @@ qx.Class.define("qx.tool.utils.Json", {
      *    'warnOnly' parameter is true
      */
     validate(json, schema, warnOnly = false) {
+      const Ajv = require("ajv");
+      const betterAjvErrors = require("better-ajv-errors").default;
+
       let ajv = new Ajv({
         allErrors: true,
         strict: false


### PR DESCRIPTION
This PR make it possible to simply load a file by calling `qx.tool.utils.Json.loadJsonAsync` without having to bother to install the dependencies which are not required for it and are required by `validate` only (Ajv, betterAjvErrors).