### PR TITLE
feat(color): support CSS custom properties (var(--name)) as color values

### DIFF
--- a/source/class/qx/test/theme/manager/Color.js
+++ b/source/class/qx/test/theme/manager/Color.js
@@ -143,6 +143,30 @@ qx.Class.define("qx.test.theme.manager.Color", {
       this.assertException(function () {
         self.manager.setTheme(qx.test.Theme.themes.A);
       });
+    },
+
+    testResolveCssVariable() {
+      qx.Theme.define("qx.test.Theme.themes.CssVar", {
+        extend: qx.theme.indigo.Color,
+
+        colors: {
+          "vza-focus": "var(--vza-focus-color)",
+          "vza-banner": "var(--vza-banner-color, #8cadd5)"
+        }
+      });
+
+      this.manager.setTheme(qx.test.Theme.themes.CssVar);
+
+      this.assertEquals(
+        "var(--vza-focus-color)",
+        this.manager.resolve("vza-focus"),
+        "Einfache CSS-Variable muss unverändert durchgereicht werden"
+      );
+      this.assertEquals(
+        "var(--vza-banner-color, #8cadd5)",
+        this.manager.resolve("vza-banner"),
+        "CSS-Variable mit Fallback muss unverändert durchgereicht werden"
+      );
     }
   }
 });

--- a/source/class/qx/test/util/ColorUtil.js
+++ b/source/class/qx/test/util/ColorUtil.js
@@ -151,6 +151,28 @@ qx.Class.define("qx.test.util.ColorUtil", {
           alpha: 0.1
         })
       );
+    },
+
+    testIsCssVariable() {
+      this.assertTrue(qx.util.ColorUtil.isCssVariable("var(--foo)"), "einfache Variable");
+      this.assertTrue(qx.util.ColorUtil.isCssVariable("var(--vza-focus-color)"), "Bindestrich-Name");
+      this.assertTrue(qx.util.ColorUtil.isCssVariable("var(--foo, #8cadd5)"), "mit Fallback");
+      this.assertTrue(qx.util.ColorUtil.isCssVariable("var(--foo, var(--bar))"), "mit verschachteltem Fallback");
+
+      this.assertFalse(qx.util.ColorUtil.isCssVariable("#fff"), "Hex darf nicht erkannt werden");
+      this.assertFalse(qx.util.ColorUtil.isCssVariable("red"), "Named Color darf nicht erkannt werden");
+      this.assertFalse(qx.util.ColorUtil.isCssVariable("rgb(0,0,0)"), "RGB darf nicht erkannt werden");
+      this.assertFalse(qx.util.ColorUtil.isCssVariable("var(foo)"), "fehlendes -- muss fehlschlagen");
+      this.assertFalse(qx.util.ColorUtil.isCssVariable(""), "Leerstring muss fehlschlagen");
+      this.assertFalse(qx.util.ColorUtil.isCssVariable(null), "null muss fehlschlagen");
+    },
+
+    testIsCssStringWithCssVariable() {
+      this.assertTrue(qx.util.ColorUtil.isCssString("var(--vza-focus-color)"), "CSS-Variable muss als CSS-String gelten");
+      this.assertTrue(qx.util.ColorUtil.isCssString("var(--foo, #ccc)"), "CSS-Variable mit Fallback muss als CSS-String gelten");
+      this.assertTrue(qx.util.ColorUtil.isCssString("#fff"), "Hex bleibt gültig");
+      this.assertTrue(qx.util.ColorUtil.isCssString("red"), "Named Color bleibt gültig");
+      this.assertTrue(qx.util.ColorUtil.isCssString("rgb(0,0,0)"), "RGB bleibt gültig");
     }
   }
 });

--- a/source/class/qx/util/ColorUtil.js
+++ b/source/class/qx/util/ColorUtil.js
@@ -278,6 +278,16 @@ qx.Bootstrap.define("qx.util.ColorUtil", {
     },
 
     /**
+     * Detects if a string is a CSS custom property reference (e.g. var(--my-color))
+     *
+     * @param str {String} any string
+     * @return {Boolean} true when the incoming value is a CSS variable expression
+     */
+    isCssVariable(str) {
+      return typeof str === "string" && /^var\(--.+\)$/.test(str);
+    },
+
+    /**
      * Detects if a string is a valid CSS color string
      *
      * @param str {String} any string
@@ -285,6 +295,7 @@ qx.Bootstrap.define("qx.util.ColorUtil", {
      */
     isCssString(str) {
       return (
+        this.isCssVariable(str) ||
         this.isSystemColor(str) ||
         this.isNamedColor(str) ||
         this.ishexShortString(str) ||


### PR DESCRIPTION
## Summary

- Add `isCssVariable()` to `qx.util.ColorUtil` — detects `var(--name)` and `var(--name, fallback)` syntax
- Extend `isCssString()` to delegate to `isCssVariable()` first, so the theme color manager accepts CSS variables without throwing an error
- Tests added for `ColorUtil` and the theme color manager

## Motivation

CSS custom properties can now be used directly in Qooxdoo color themes:

```javascript
colors: {
  "vza-focus": "var(--vza-focus-color)"
}
```

This eliminates the need to maintain color values in both CSS (`--vza-focus-color`) and Qooxdoo theme files.

## Test plan

- [x] `qx.test.util.ColorUtil:testIsCssVariable` — verifies positive and negative cases
- [x] `qx.test.util.ColorUtil:testIsCssStringWithCssVariable` — verifies no regression for existing color formats
- [x] `qx.test.theme.manager.Color:testResolveCssVariable` — verifies CSS variables are passed through `resolve()` unchanged