### PR TITLE
Static inheritance fixes

### DIFF
--- a/source/class/qx/Annotation.js
+++ b/source/class/qx/Annotation.js
@@ -116,7 +116,7 @@ qx.Bootstrap.define("qx.Annotation", {
     __getAnnos(clazz, name, group, annoClass) {
       var result = [];
       for (var tmp = clazz; tmp; tmp = tmp.superclass) {
-        if (tmp.$$annotations !== undefined) {
+        if (tmp.$$annotations != null) {
           var annos = group ? tmp.$$annotations[group] : tmp.$$annotations;
           var src = annos && annos.hasOwnProperty(name) ? annos[name] : null;
           if (src) {

--- a/source/class/qx/Class.js
+++ b/source/class/qx/Class.js
@@ -24,7 +24,12 @@ qx.Bootstrap.define("qx.Class", {
   type: "static",
 
   environment: {
-    "qx.Class.futureCheckJsDoc": false
+    "qx.Class.futureCheckJsDoc": false,
+    /**
+     * Whether to make classes inherit static members,
+     * such that methods/members can be accessed by subclasses of the class where they are defined.
+     */
+    "qx.Class.staticInheritance": true
   },
 
   statics: {
@@ -709,21 +714,23 @@ qx.Bootstrap.define("qx.Class", {
 
       qx.Bootstrap.extendClass(subclass, config.construct, superclass, classname);
 
-      if (superclass !== Object) {
-        Object.setPrototypeOf(subclass, superclass);
-
-        // Linking the constructors via the prototype chain (above) lets
-        // subclasses inherit static methods/properties, exactly like native
-        // `class Sub extends Base`. But it would also let the parent's
-        // internal `$$` metadata leak into the subclass. Give every subclass
-        // its own (empty) metadata slots so they shadow the parent's and the
-        // metadata stays strictly per-class.
-        subclass.$$events = null;
-        subclass.$$includes = null;
-        subclass.$$flatIncludes = null;
-        subclass.$$implements = null;
-        subclass.$$flatImplements = null;
-        subclass.$$annotations = null;
+      if (qx.core.Environment.get("qx.Class.staticInheritance")) {
+        if (superclass !== Object) {
+          Object.setPrototypeOf(subclass, superclass);
+          // Linking the constructors via the prototype chain (above) lets
+          // subclasses inherit static methods/properties, exactly like native
+          // `class Sub extends Base`. But it would also let the parent's
+          // internal `$$` metadata leak into the subclass. Give every subclass
+          // its own (empty) metadata slots so they shadow the parent's and the
+          // metadata stays strictly per-class.
+          subclass.$$objects = null;
+          subclass.$$events = null;
+          subclass.$$includes = null;
+          subclass.$$flatIncludes = null;
+          subclass.$$implements = null;
+          subclass.$$flatImplements = null;
+          subclass.$$annotations = null;
+        }
       }
 
       let superProperties = superclass.prototype.$$allProperties || {};


### PR DESCRIPTION
This PR fixes some bugs introduced by the recent PR (https://github.com/qooxdoo/qooxdoo/pull/10862) which introduced inheritance of statics in classes.

- Added environment setting "qx.Class.staticInheritance" which turns on/off this behaviour. This is useful for cases where the JavaScript engine does not support Object.setPrototypeOf, such as my Rhino, or when we simply don't want this breaking behaviour to occur.
- Fixed a bug with QxObjects by adding the `subclass.$$objects = null;`
- Fixed a bug with annotations by changing the line to `tmp.$$annotations != null`