### PR TITLE
fix(compiler): await asset loaders so combined-image meta is wired on first clean build

### DIFF
--- a/source/class/qx/tool/compiler/resources/Asset.js
+++ b/source/class/qx/tool/compiler/resources/Asset.js
@@ -167,7 +167,7 @@ qx.Class.define("qx.tool.compiler.resources.Asset", {
 
     async load() {
       if (this.__loaders) {
-        this.__loaders.forEach(loader => loader.load(this));
+        await Promise.all(this.__loaders.map(loader => loader.load(this)));
       }
     },
 


### PR DESCRIPTION
Fixes #10869.

### Problem

On a clean compile, members of a combined image (sprite) are emitted into the runtime resource map without their composite metadata — `[w, h, type, lib]` instead of `[w, h, type, lib, combinedFile, x, y]`. A second compile (without `--clean`) produces the correct entries, which is why projects using sprites have had to "compile twice".

### Cause

`qx.tool.compiler.resources.Asset#load()` fired its loaders but discarded the returned promises:

```js
this.__loaders.forEach(loader => loader.load(this));
```

`MetaLoader#load()` is `async` and sets `fileInfo.meta` via `await ...loadJsonAsync(...)`. Because the loaders weren't awaited, `await asset.load()` resolved before `fileInfo.meta` existed, so `Manager#findAllAssets()`'s `if (fileInfo.meta)` check failed on a clean build and `metaReferees` were never wired. `getAssetsForPaths()` then set no `composite/x/y`. It only "fixed itself" on the next compile because the first run had by then persisted `fileInfo.meta` into `resource-db.json`.

### Fix

Await the loaders:

```js
async load() {
  if (this.__loaders) {
    await Promise.all(this.__loaders.map(loader => loader.load(this)));
  }
}
```

### Verification

Patched the compiler with this change and ran a single `qx compile --target=build --clean` on a project containing a combined sprite. Member entries came out in the correct 7-element form on the **first** pass, matching what previously required two passes. Reverting the change restores the two-pass requirement.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
