### PR TITLE
fix(table): tolerate null scrollerParent in _getPaneScrollerArr after dispose

### DIFF
--- a/source/class/qx/test/ui/table/Table.js
+++ b/source/class/qx/test/ui/table/Table.js
@@ -266,6 +266,34 @@ qx.Class.define("qx.test.ui.table.Table", {
       tableModel.dispose();
     },
 
+    testGetPaneScrollerArrEmptyAfterDispose() {
+      var model = this.createModel();
+      var table = new qx.ui.table.Table(model);
+
+      table.destroy();
+      this.flush();
+      model.dispose();
+
+      // __scrollerParent is gone; the accessor must yield no scrollers, not throw.
+      this.assertArrayEquals([], table._getPaneScrollerArr());
+    },
+
+    testColumnModelReinitAfterDisposeDoesNotThrow() {
+      var model = this.createModel();
+      var table = new qx.ui.table.Table(model);
+
+      table.destroy();
+      this.flush();
+
+      // Reproduces the async-after-dispose path: getTableColumnModel re-creates
+      // the disposed column model, whose init() fires visibilityChanged ->
+      // _onColVisibilityChanged -> _getPaneScrollerArr. Must not throw on the
+      // nulled scroller parent.
+      table.getTableColumnModel();
+
+      model.dispose();
+    },
+
     testFocusAfterRemove() {
       var tableModelSimple = new qx.ui.table.model.Simple();
       tableModelSimple.setColumns(["Location", "Team"]);

--- a/source/class/qx/ui/table/Table.js
+++ b/source/class/qx/ui/table/Table.js
@@ -1123,7 +1123,12 @@ qx.Class.define("qx.ui.table.Table", {
      * @return {qx.ui.table.pane.Scroller[]} all TablePaneScrollers in this table.
      */
     _getPaneScrollerArr() {
-      return this.__scrollerParent.getChildren();
+      // __scrollerParent is null once the table has been disposed. An async
+      // callback that touches the table after disposal (e.g. getTableColumnModel
+      // lazily re-creating a disposed column model, whose init() fires
+      // visibilityChanged) can still reach here, so return no scrollers rather
+      // than throwing on null.
+      return this.__scrollerParent ? this.__scrollerParent.getChildren() : [];
     },
 
     /**


### PR DESCRIPTION
## Summary

`qx.ui.table.Table._getPaneScrollerArr()` unconditionally dereferences `__scrollerParent`:

```js
_getPaneScrollerArr() {
  return this.__scrollerParent.getChildren();
}
```

`Table.destruct()` nulls `__scrollerParent` (via `_disposeObjects`). If any code reaches `_getPaneScrollerArr()` **after the table has been disposed**, it throws:

```
TypeError: Cannot read properties of null (reading 'getChildren')
```

## How it's reached

This is most easily triggered by deferred work that outlives the widget. A common path:

1. Application code awaits something (RPC, timer, animation frame) that holds a reference to a table.
2. The table is disposed in the meantime (e.g. its containing window/tab is closed).
3. The continuation calls `getTableColumnModel()`. Because `destruct()` also nulled `__columnModel`, the getter **lazily re-creates** the column model, whose `init()` synchronously fires `visibilityChanged` → `_onColVisibilityChanged()` → `_getPaneScrollerArr()` → `null.getChildren()`.

Because the throw happens during synchronous event dispatch, it escapes the caller's own `try/catch` as an unhandled error. `_getPaneScrollerArr()` is called from ~20 sites, so this is a general robustness gap rather than a single-call-site issue.

## Fix

Return an empty scroller array when `__scrollerParent` is null:

```js
_getPaneScrollerArr() {
  return this.__scrollerParent ? this.__scrollerParent.getChildren() : [];
}
```

Every caller either iterates the result (empty array → no-op) or indexes it (`getPaneScroller()` already returned `undefined` for an out-of-range index), and the visibility/scroll-update handlers (`_onColVisibilityChanged`, `_updateScrollerWidths`, `_updateScrollBarVisibility`) already tolerate an empty array — so returning `[]` is safe and simply makes a disposed table a no-op instead of a throw.

## Tests

Added to `qx.test.ui.table.Table`:

- `testGetPaneScrollerArrEmptyAfterDispose` — after `destroy()` + flush, `_getPaneScrollerArr()` returns `[]` instead of throwing.
- `testColumnModelReinitAfterDisposeDoesNotThrow` — reproduces the path above: after dispose, calling `getTableColumnModel()` (which re-inits and fires `visibilityChanged`) completes without throwing.

Both follow existing patterns in `Table.js` / `Dispose.js` (`LayoutTestCase`, `destroy()` + `this.flush()`, and calling the protected `_getPaneScrollerArr()` directly as `testSpecialListener` already does).