### PR TITLE
fix(MPlacement): stop liveupdate placement loop when target is disposed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,13 @@
 now raise an error as this could have lead to an invalid edit. To prevent any errors, ensure
 that the table edits are completed or cancelled before refreshing table model data.
 
+## Bugfixes
+
+- `qx.ui.core.MPlacement#placeToWidget` with `liveupdate` no longer throws on every
+`qx.event.Idle` tick when the target widget is disposed before the placing widget
+disappears (e.g. a popup left open while its target's window is closed). The
+live-update loop now stops and releases its idle listener when the target is disposed.
+
 # v7.0.0
 
 ## Breaking changes

--- a/source/class/qx/test/ui/core/Placement.js
+++ b/source/class/qx/test/ui/core/Placement.js
@@ -173,6 +173,54 @@ qx.Class.define("qx.test.ui.core.Placement", {
       var w = new qx.ui.menu.Menu();
       this.__testAlwaysVisibleElementBelow(w);
       w.destroy();
+    },
+
+    testPlaceToDisposedWidgetReturnsFalse() {
+      var target = new qx.ui.core.Widget();
+      this.getRoot().add(target, { left: 10, top: 10 });
+      this.flush();
+
+      target.destroy();
+      this.flush();
+
+      // getContentLocation() on a disposed target would throw on its null
+      // content element; placeToWidget must bail and report failure instead.
+      var popup = new qx.ui.popup.Popup();
+      this.assertFalse(popup.placeToWidget(target));
+      popup.destroy();
+    },
+
+    testLiveUpdateStopsWhenTargetDisposed() {
+      var target = new qx.ui.core.Widget();
+      this.getRoot().add(target, { left: 10, top: 10 });
+      this.flush();
+
+      var idle = qx.event.Idle.getInstance();
+      var mgr = qx.event.Registration.getManager(idle);
+      var intervalListeners = function () {
+        return (mgr.getListeners(idle, "interval", false) || []).length;
+      };
+      var baseline = intervalListeners();
+
+      var popup = new qx.ui.popup.Popup();
+      popup.show();
+      popup.placeToWidget(target, true);
+      this.flush();
+
+      // The liveupdate placement subscribes to the global idle interval.
+      this.assertEquals(baseline + 1, intervalListeners());
+
+      // Closing the target's container disposes it while the popup lives on.
+      target.destroy();
+      this.flush();
+
+      // The leaked idle listener used to re-place against the disposed target
+      // every tick (throwing on its null content element); the next tick must
+      // now release that listener instead, dropping back to the baseline.
+      idle.fireEvent("interval");
+      this.assertEquals(baseline, intervalListeners());
+
+      popup.destroy();
     }
   }
 });

--- a/source/class/qx/ui/core/MPlacement.js
+++ b/source/class/qx/ui/core/MPlacement.js
@@ -347,6 +347,20 @@ qx.Mixin.define("qx.ui.core.MPlacement", {
      * @return {Boolean} true if the widget was successfully placed
      */
     placeToWidget(target, liveupdate) {
+      // A liveupdate placement keeps a global qx.event.Idle "interval" listener
+      // alive until the placing widget (this) disappears or is destructed. If
+      // the target is disposed first - e.g. its window/tab is closed while the
+      // popup is still open, and the popup is rooted elsewhere so it neither
+      // disappears nor is disposed with the target - the next idle tick calls
+      // target.getContentLocation() on a disposed widget, whose
+      // getContentElement() is null, throwing "Cannot read properties of null
+      // (reading 'getDomElement')" on every tick. Stop the loop and release the
+      // listener instead.
+      if (target.isDisposed()) {
+        this.__cleanupFromLastPlaceToWidgetLiveUpdate();
+        return false;
+      }
+
       // Use the idle event to make sure that the widget's position gets
       // updated automatically (e.g. the widget gets scrolled).
       if (liveupdate) {


### PR DESCRIPTION
### Problem

`qx.ui.core.MPlacement#placeToWidget(target, true)` (the `liveupdate` variant) registers a listener on the global `qx.event.Idle` `interval` event that re-places the widget against `target` on every tick. That listener is only released when the **placing** widget fires `disappear` or is destructed — never when the **target** is disposed.

Popups/menus attach to the application root rather than as children of the widget they point at. So if the target's containing window/tab/panel is closed while the popup is still open, the target gets disposed but the popup (and its idle listener) lives on. The next idle tick calls `target.getContentLocation()`, whose `getContentElement()` is now `null`, throwing:

```
TypeError: Cannot read properties of null (reading 'getDomElement')
    at getContentLocation (qx/ui/core/Widget.js)
    at placeToWidget (qx/ui/core/MPlacement.js)
    at <idle interval listener>
```

Because `qx.event.Idle` keeps firing, this repeats on every tick — we saw hundreds of identical errors logged from a single leaked popup.

### Fix

Bail out of `placeToWidget` and release the idle listener (`__cleanupFromLastPlaceToWidgetLiveUpdate`) when the target is disposed.

### Tests

Two regression tests added to `qx.test.ui.core.Placement`:

- `testPlaceToDisposedWidgetReturnsFalse` — `placeToWidget` on a disposed target returns `false` instead of throwing.
- `testLiveUpdateStopsWhenTargetDisposed` — after a live-update placement whose target is then disposed, firing the `qx.event.Idle` `interval` no longer throws.

Verified that both tests **fail without the fix** with the exact production error (`Cannot read properties of null (reading 'getDomElement')` at `MPlacement.js:350`) and pass with it; full framework suite green (`chromium: 3325 ok, 0 not ok`).