### PR TITLE
fix(SimpleTreeDataModel): tolerate stale selection ids in _clearSelections/getSelectedNodes

### DIFF
--- a/source/class/qx/ui/treevirtual/SimpleTreeDataModel.js
+++ b/source/class/qx/ui/treevirtual/SimpleTreeDataModel.js
@@ -1081,9 +1081,15 @@ qx.Class.define("qx.ui.treevirtual.SimpleTreeDataModel", {
      *
      */
     _clearSelections() {
-      // Clear selected state for any selected nodes.
+      // Clear selected state for any selected nodes.  A selection id can outlive
+      // its node when the node array is replaced or truncated (e.g. during a data
+      // reload) before the selection set is rebuilt, so guard against a missing
+      // node rather than dereferencing it.
       for (var selection in this._selections) {
-        this._nodeArr[selection].bSelected = false;
+        var node = this._nodeArr[selection];
+        if (node) {
+          node.bSelected = false;
+        }
       }
 
       // Reinitialize selections array.
@@ -1100,7 +1106,12 @@ qx.Class.define("qx.ui.treevirtual.SimpleTreeDataModel", {
       var nodes = [];
 
       for (var nodeId in this._selections) {
-        nodes.push(this._nodeArr[nodeId]);
+        // Skip any selection id whose node was removed before the selection set
+        // was rebuilt (see _clearSelections).
+        var node = this._nodeArr[nodeId];
+        if (node) {
+          nodes.push(node);
+        }
       }
 
       return nodes;


### PR DESCRIPTION
## Problem

`qx.ui.treevirtual.SimpleTreeDataModel` tracks selected nodes in `_selections` (a map of node id → `true`) and dereferences those ids against `_nodeArr` in two places:

- `_clearSelections()` → `this._nodeArr[selection].bSelected = false;`
- `getSelectedNodes()` → `nodes.push(this._nodeArr[nodeId]);`

Both assume every id in `_selections` still maps to a live node in `_nodeArr`. That invariant can break transiently: `_selections` is only rebuilt during `__render()`, but `_nodeArr` can be replaced or truncated *before* a re-render — most easily via `clearData(false)` / `setData(arr, false)`, which swap/empty the node array without re-rendering (the caller is expected to render later). If a selection change fires while a stale id is present and the node it referenced is already gone, `_clearSelections()` throws:

```
TypeError: Cannot set properties of undefined (setting 'bSelected')
    at SimpleTreeDataModel._clearSelections
    at TreeVirtual._onSelectionChanged
    ...
```

and `getSelectedNodes()` returns an array containing `undefined`, propagating the failure to any caller that reads node fields.

## How it happens

1. A row is selected in a `TreeVirtual`.
2. The model is reloaded so `_nodeArr` is replaced/shrunk (e.g. `clearData(false)` followed by an async rebuild) while the previously rendered rows are still on screen and `_rowArr` is still stale.
3. A selection change during that window writes a now-out-of-range node id into `_selections` (`_onSelectionChanged` → `_calculateSelectedNodes` → `setState({ bSelected: true })`, mapped through the stale `_rowArr` via `getNode()`).
4. The next selection change runs `_clearSelections()` over that dangling id → `_nodeArr[id]` is `undefined` → throw.

## Fix

Guard both helpers against a missing node. A selection id whose node no longer exists is, by definition, already cleared, so skipping it is the correct behaviour. The change is minimal and defensive, with no effect in the normal case where every id still resolves to a node.

🤖 Generated with [Claude Code](https://claude.com/claude-code)