### PR TITLE
fix(Scroller): guard cell-editor focusout timer against stopped editing

### DIFF
--- a/source/class/qx/ui/table/pane/Scroller.js
+++ b/source/class/qx/ui/table/pane/Scroller.js
@@ -1973,6 +1973,12 @@ qx.Class.define("qx.ui.table.pane.Scroller", {
     _onFocusinCellEditorAddBlurListener(e) {
       this.debug("executed FOCUSIN event listener for hash: " + e.getTarget().$$hash);
       qx.event.Timer.once(function() {
+        // Editing may have stopped (cell editor destroyed and nulled by
+        // cancelEditing/flushEditor) or the scroller been disposed during the
+        // 1ms delay; bail before dereferencing the now-null cell editor.
+        if (this.isDisposed() || this._cellEditor == null) {
+          return;
+        }
         this._cellEditor.addListener('focusout', this._onFocusoutCellEditorStopEditing, this);
         this.debug('added FOCUSOUT listener to hash: ' + this._cellEditor.$$hash);
       }, this, 1);


### PR DESCRIPTION
## Summary

`qx.ui.table.pane.Scroller._onFocusinCellEditorAddBlurListener` defers attaching the cell editor's `focusout` listener by 1 ms via `qx.event.Timer.once`, so the `focusin` handler completes before the blur listener is wired up. If editing stops within that 1 ms window — `cancelEditing()` / `flushEditor(true)` destroy the cell editor and set `this._cellEditor = null` — or the scroller is disposed, the deferred callback dereferences the now-null editor:

```js
this._cellEditor.addListener('focusout', this._onFocusoutCellEditorStopEditing, this);
```

and throws `TypeError: Cannot read properties of null (reading 'addListener')`.

## Reproduction

Happens with an inline (non-window) cell editor when focus leaves it in ~the same tick it gains focus: a fast click onto another widget, a dialog/menu stealing focus during editor activation, or the table/window being torn down right after editing starts. Because it fires from a timer during event dispatch, it escapes the caller's `try/catch` and surfaces as an unhandled error. We hit this in production.

## Fix

Bail out of the deferred callback when the scroller is disposed or the cell editor is already gone — there is nothing to attach the listener to in that case. No behaviour change on the normal path.