### PR TITLE
fix(treevirtual): tolerate a row index the model no longer has

### DIFF
--- a/source/class/qx/test/ui/treevirtual/TreeVirtual.js
+++ b/source/class/qx/test/ui/treevirtual/TreeVirtual.js
@@ -1,0 +1,174 @@
+/* ************************************************************************
+
+   qooxdoo - the new era of web development
+
+   http://qooxdoo.org
+
+   Copyright:
+     2026 qooxdoo contributors
+
+   License:
+     MIT: https://opensource.org/licenses/MIT
+     See the LICENSE file in the project's top-level directory for details.
+
+************************************************************************ */
+
+/**
+ * Tests for the row lookups that have to tolerate a row index outliving the row
+ * it points at. Collapsing a branch rebuilds the row array shorter, and
+ * SimpleTreeDataModel.getNode() throws on an index past the end rather than
+ * returning nothing.
+ *
+ * The focused row is the case that is reachable by construction: the tree's
+ * dataChanged event carries no removeStart/removeCount, so Table's "remove
+ * focus if the focused row has been removed" branch never runs for a tree.
+ */
+qx.Class.define("qx.test.ui.treevirtual.TreeVirtual", {
+  extend: qx.dev.unit.TestCase,
+
+  members: {
+    __tree: null,
+    __root: null,
+
+    setUp() {
+      this.__tree = new qx.ui.treevirtual.TreeVirtual(["Tree"]);
+      var dataModel = this.__tree.getDataModel();
+      // Node 0 is the model's own hidden root, so the visible rows start here.
+      this.__root = dataModel.addBranch(null, "root", true);
+      dataModel.addLeaf(this.__root, "one");
+      dataModel.addLeaf(this.__root, "two");
+      dataModel.setData();
+    },
+
+    tearDown() {
+      this.__tree.destroy();
+      this.__tree = null;
+    },
+
+    testFocusedNodeIsNullOnceItsRowIsGone() {
+      this.__tree.setFocusedCell(0, 2, false);
+      this.assertNotNull(
+        this.__tree._getFocusedNode(),
+        "the leaf resolves while it exists"
+      );
+
+      this.__shrinkToRoot();
+
+      this.assertEquals(
+        2,
+        this.__tree.getFocusedRow(),
+        "a collapse leaves the focus where it was"
+      );
+      this.assertNull(
+        this.__tree._getFocusedNode(),
+        "so the focused row no longer resolves to a node"
+      );
+    },
+
+    testFocusedNodeIsNullWhenNothingIsFocused() {
+      // The focused row starts unset, and `null >= 0` is true, so a bounds
+      // check alone lets it through to a missing row-array entry.
+      this.assertNull(this.__tree.getFocusedRow(), "nothing is focused yet");
+
+      this.assertNull(this.__tree._getFocusedNode(), "and nothing resolves");
+    },
+
+    testKeyboardNavigationSurvivesAStaleFocus() {
+      this.__tree.setFocusedCell(0, 2, false);
+      this.__shrinkToRoot();
+
+      // Every key that reaches for the focused node: Enter toggles it, the Ctrl
+      // pair opens/closes it, the Shift pair walks to its parent / first child.
+      // Each used to throw here.
+      this.__staleFocusKeys().forEach(function (key) {
+        this.__tree.setFocusedCell(0, 2, false);
+        this.__tree._onKeyDown(this.__keyEvent(key[0], key[1]));
+      }, this);
+
+      // Not a requirement, just what the code does today: the guard stops the
+      // throw, it doesn't reconcile the focus onto a row that exists. If focus
+      // reconciliation lands later this assertion is what will go red.
+      this.assertEquals(
+        2,
+        this.__tree.getFocusedRow(),
+        "the focus is left where it was"
+      );
+    },
+
+    testTapSelectionSurvivesAStaleFocus() {
+      this.__tree.setFocusedCell(0, 2, false);
+      this.__shrinkToRoot();
+
+      // The selection manager resolves the focused node to decide whether the
+      // press hit the open/close button.
+      var handled = this.__tree
+        .getSelectionManager()
+        ._handleSelectEvent(0, this.__keyEvent("Space", 0));
+
+      this.assertUndefined(
+        handled,
+        "the press falls through to the normal selection"
+      );
+    },
+
+    testCalculatedSelectionSkipsRowsTheModelNoLongerHas() {
+      var dataModel = this.__tree.getDataModel();
+      this.assertEquals(3, dataModel.getRowCount(), "root plus its two leaves");
+
+      this.__shrinkToRoot();
+
+      // Selecting a row the model has dropped used to throw out of getNode()
+      // ("this._rowArr row (2) out of bounds"), by way of _onSelectionChanged.
+      this.__tree.getSelectionModel().setSelectionInterval(2, 2);
+
+      this.assertArrayEquals(
+        [],
+        this.__tree._calculateSelectedNodes(),
+        "a selection pointing past the end selects nothing"
+      );
+    },
+
+    // Guards against an over-eager bounds check rejecting a row that is there.
+    testCalculatedSelectionKeepsARowThatStillExists() {
+      this.__tree.getSelectionModel().setSelectionInterval(0, 0);
+
+      var selected = this.__tree._calculateSelectedNodes();
+
+      this.assertEquals(1, selected.length, "a live row still resolves");
+      this.assertEquals("root", selected[0].label);
+    },
+
+    /** Every key combination that resolves the focused node. */
+    __staleFocusKeys() {
+      var dom = qx.event.type.Dom;
+      return [
+        ["Enter", 0],
+        ["Left", dom.CTRL_MASK],
+        ["Right", dom.CTRL_MASK],
+        ["Left", dom.SHIFT_MASK],
+        ["Right", dom.SHIFT_MASK]
+      ];
+    },
+
+    /** A stand-in for the key sequence the handlers under test read. */
+    __keyEvent(identifier, modifiers) {
+      var dom = qx.event.type.Dom;
+      return {
+        getKeyIdentifier: () => identifier,
+        getModifiers: () => modifiers,
+        isShiftPressed: () => (modifiers & dom.SHIFT_MASK) !== 0,
+        isCtrlOrCommandPressed: () => (modifiers & dom.CTRL_MASK) !== 0,
+        preventDefault() {},
+        stopPropagation() {}
+      };
+    },
+
+    /** Drop the leaves, leaving the row array shorter than the selection. */
+    __shrinkToRoot() {
+      var dataModel = this.__tree.getDataModel();
+      dataModel.prune(this.__root, false);
+      dataModel.setData();
+      this.assertEquals(1, dataModel.getRowCount(), "only the root is left");
+    }
+  }
+});

--- a/source/class/qx/ui/treevirtual/SelectionManager.js
+++ b/source/class/qx/ui/treevirtual/SelectionManager.js
@@ -93,8 +93,10 @@ qx.Class.define("qx.ui.treevirtual.SelectionManager", {
           }
         }
 
-        // Get the node to which this event applies
-        var node = dataModel.getNode(tree.getFocusedRow());
+        // Get the node to which this event applies. The focused row outlives a
+        // collapse, and getNode() throws on a row that is gone rather than
+        // returning nothing, which is what left the check below unreachable.
+        var node = tree._getFocusedNode();
 
         if (!node) {
           return false;

--- a/source/class/qx/ui/treevirtual/TreeVirtual.js
+++ b/source/class/qx/ui/treevirtual/TreeVirtual.js
@@ -627,10 +627,10 @@ qx.Class.define("qx.ui.treevirtual.TreeVirtual", {
 
             if (focusedCol == treeCol) {
               // Get the focused node
-              var focusedRow = this.getFocusedRow();
-              var node = dm.getNode(focusedRow);
+              var node = this._getFocusedNode();
 
               if (
+                node &&
                 !node.bHideOpenClose &&
                 node.type != qx.ui.treevirtual.SimpleTreeDataModel.Type.LEAF
               ) {
@@ -658,10 +658,11 @@ qx.Class.define("qx.ui.treevirtual.TreeVirtual", {
             // Get the focused node
             var focusedRow = this.getFocusedRow();
             var treeCol = dm.getTreeColumn();
-            var node = dm.getNode(focusedRow);
+            var node = this._getFocusedNode();
 
             // If it's an open branch and open/close is allowed...
             if (
+              node &&
               node.type == qx.ui.treevirtual.SimpleTreeDataModel.Type.BRANCH &&
               !node.bHideOpenClose &&
               node.bOpened
@@ -683,10 +684,11 @@ qx.Class.define("qx.ui.treevirtual.TreeVirtual", {
             // Get the focused node
             focusedRow = this.getFocusedRow();
             treeCol = dm.getTreeColumn();
-            node = dm.getNode(focusedRow);
+            node = this._getFocusedNode();
 
             // If it's a closed branch and open/close is allowed...
             if (
+              node &&
               node.type == qx.ui.treevirtual.SimpleTreeDataModel.Type.BRANCH &&
               !node.bHideOpenClose &&
               !node.bOpened
@@ -708,12 +710,10 @@ qx.Class.define("qx.ui.treevirtual.TreeVirtual", {
             var dm = this.getDataModel();
 
             // Get the focused node
-            var focusedRow = this.getFocusedRow();
-            var treeCol = dm.getTreeColumn();
-            var node = dm.getNode(focusedRow);
+            var node = this._getFocusedNode();
 
             // If we're not at the top-level already...
-            if (node.parentNodeId) {
+            if (node && node.parentNodeId) {
               // Find out what rendered row our parent node is at
               var rowIndex = dm.getRowFromNodeId(node.parentNodeId);
 
@@ -729,12 +729,11 @@ qx.Class.define("qx.ui.treevirtual.TreeVirtual", {
             var dm = this.getDataModel();
 
             // Get the focused node
-            focusedRow = this.getFocusedRow();
-            treeCol = dm.getTreeColumn();
-            node = dm.getNode(focusedRow);
+            node = this._getFocusedNode();
 
             // If we're on a branch and open/close is allowed...
             if (
+              node &&
               node.type == qx.ui.treevirtual.SimpleTreeDataModel.Type.BRANCH &&
               !node.bHideOpenClose
             ) {
@@ -793,6 +792,35 @@ qx.Class.define("qx.ui.treevirtual.TreeVirtual", {
     },
 
     /**
+     * The node at the focused row, or null when there isn't one.
+     *
+     * Collapsing a branch rebuilds the row array shorter but leaves the focus
+     * where it was: the dataChanged event the tree fires carries no
+     * removeStart/removeCount, so qx.ui.table.Table's "remove focus if the
+     * focused row has been removed" branch (which protects a flat table)
+     * never runs for a tree. getNode() throws on the resulting index rather
+     * than returning nothing, so every consumer of the focused row has to
+     * bounds check first.
+     *
+     * The focused row can also be unset entirely (null, or undefined per
+     * BUG #4676), which getNode() reads straight off the row array as a
+     * missing entry.
+     *
+     * @return {Object|null}
+     *   The focused node, or null if there is no longer a row there.
+     */
+    _getFocusedNode() {
+      var dataModel = this.getDataModel();
+      var focusedRow = this.getFocusedRow();
+
+      return typeof focusedRow === "number" &&
+        focusedRow >= 0 &&
+        focusedRow < dataModel.getRowCount()
+        ? dataModel.getNode(focusedRow)
+        : null;
+    },
+
+    /**
      * Calculate and return the set of nodes which are currently selected by
      * the user, on the screen.  In the process of calculating which nodes
      * are selected, the nodes corresponding to the selected rows on the
@@ -817,6 +845,19 @@ qx.Class.define("qx.ui.treevirtual.TreeVirtual", {
           j <= selectedRanges[i].maxIndex;
           j++
         ) {
+          // A selected range can outlive the rows it covers: collapsing a
+          // branch rebuilds the row array shorter, and a selection that
+          // follows can still carry the pre-collapse index, on which
+          // getNode() throws rather than returning nothing. A selection
+          // pointing at a row that no longer exists selects nothing.
+          //
+          // Read the count per row rather than hoisting it: setState() below
+          // can re-enter through the selection model, and a changeSelection
+          // listener is free to reload the tree.
+          if (j < 0 || j >= stdcm.getRowCount()) {
+            continue;
+          }
+
           node = stdcm.getNode(j);
           stdcm.setState(node, { bSelected: true });
           selectedNodes.push(node);


### PR DESCRIPTION
Follow-up to #10874, at the row lookups that fix didn't cover.

`SimpleTreeDataModel.getNode(rowIndex)` throws on an out-of-range index **by design**:

```js
getNode(rowIndex) {
  if (rowIndex < 0 || rowIndex >= this._rowArr.length) {
    throw new Error("this._rowArr row (" + rowIndex + ") out of bounds: …");
  }
```

Three places hand it an index they never bounds check.

## The focused row, which is reachable by construction

Collapsing a branch rebuilds the row array shorter, but the focus doesn't move with it. `SimpleTreeDataModel.__render()` fires `dataChanged` with only `firstRow`/`lastRow` — no `removeStart`/`removeCount` — so `qx.ui.table.Table._updateTableData`'s

```js
// remove focus if the focused row has been removed
if (this.__focusedRow >= removeStart && this.__focusedRow < removeStart + removeCount) {
  this.setFocusedCell();
}
```

never runs for a tree, though it correctly protects a flat table (`qx.test.ui.table.Table#testFocusAfterRemove`). `setState()`'s `bOpened` handling resets the *selection model* but not the focused row. So after any collapse, `getFocusedRow()` can point past the end — and both consumers throw:

- **`SelectionManager.handleButtonClick()`** already meant to handle it. It bails on `if (!node) { return false; }`, which has never been reachable, because `getNode()` throws rather than returning nothing.
- **`TreeVirtual._onKeyDown()`** dereferences the node in five places (Enter, and the Shift/Ctrl arrow pairs), so any of those keys after a collapse throws out of the key handler.

Both now resolve through one `_getFocusedNode()` that answers null when the row is gone, and each site treats a missing node the way it already treats a node that doesn't qualify.

## `_calculateSelectedNodes()`

Same shape, for selected ranges. This is where it was first reported from production (a tap, on mobile Safari). The state is representable — the selection model isn't validated against the row count — but I want to be straight that **the exact route that report took is not established**: `qx.ui.table.pane.Scroller._getRowForPagePos` clamps against the live row count, so a merely stale row is not tappable, and the in-tap collapse-then-select path needs `openCloseClickSelectsRow`, which defaults false. It's guarded on the same principle as #10874's siblings — a selection pointing at a row that no longer exists selects nothing — rather than on a reproduction.

## Test

`qx.test.ui.treevirtual.TreeVirtual` covers the focused-row case end to end: it asserts the focus really is left behind by a collapse (the mechanism above), then that the lookup answers null instead of throwing, plus the selection helper's skip and a live row still resolving. Remove either guard and they fail with `this._rowArr row (2) out of bounds`.

The bound is `getRowCount()`, which is `this._rowArr.length` — exactly what `getNode()` checks against. It's read per iteration in `_calculateSelectedNodes` rather than hoisted, since `setState()` re-enters through the selection model and a `changeSelection` listener may reload the tree.