### PR TITLE
fix(Scroller): make cellEditorBlurAction reach the editor, and not steal focus

### DIFF
--- a/source/class/qx/test/ui/table/CellEditorLifecycle.js
+++ b/source/class/qx/test/ui/table/CellEditorLifecycle.js
@@ -1,0 +1,238 @@
+/* ************************************************************************
+
+   qooxdoo - the new era of web development
+
+   http://qooxdoo.org
+
+   Copyright:
+     2004-2026 1&1 Internet AG, Germany, http://www.1und1.de
+
+   License:
+     MIT: https://opensource.org/licenses/MIT
+     See the LICENSE file in the project's top-level directory for details.
+
+************************************************************************ */
+
+/**
+ * Drives every cell editor the framework ships through the real editing
+ * lifecycle on a mounted table: start the edit, change the value, then let the
+ * focus leave, under each {@link qx.ui.table.Table#cellEditorBlurAction} in
+ * turn.
+ *
+ * The per-editor tests under qx.test.ui.table.celleditor.* call the factories
+ * directly with a hand-built cellInfo, so they say nothing about how an editor
+ * behaves once qx.ui.table.pane.Scroller is driving it — which is where the
+ * focus handling lives, and where an editor that manages focus of its own (the
+ * CheckBox editor hands focus to its child) parts company with a plain field.
+ *
+ * The focus is moved as soon as the edit starts, deliberately: the blur action
+ * has to hold from the first moment, not once some deferred wiring has caught
+ * up.
+ */
+qx.Class.define("qx.test.ui.table.CellEditorLifecycle", {
+  extend: qx.test.ui.LayoutTestCase,
+
+  members: {
+    __fixtures: null,
+
+    /**
+     * One spec per cell editor the framework ships. `edit` makes a change the
+     * editor would report, and `edited` is what committing it must write.
+     *
+     * @return {Array} the specs.
+     */
+    editorSpecs() {
+      return [
+        {
+          name: "TextField",
+          create: () => new qx.ui.table.celleditor.TextField(),
+          value: "before",
+          edit: editor => editor.setValue("after"),
+          edited: "after"
+        },
+
+        {
+          name: "PasswordField",
+          create: () => new qx.ui.table.celleditor.PasswordField(),
+          value: "before",
+          edit: editor => editor.setValue("after"),
+          edited: "after"
+        },
+
+        {
+          name: "ComboBox",
+          create() {
+            var factory = new qx.ui.table.celleditor.ComboBox();
+            factory.setListData(["before", "after"]);
+            return factory;
+          },
+          value: "before",
+          edit: editor => editor.setValue("after"),
+          edited: "after"
+        },
+
+        {
+          name: "SelectBox",
+          create() {
+            var factory = new qx.ui.table.celleditor.SelectBox();
+            factory.setListData([
+              ["Before", null, "before"],
+              ["After", null, "after"]
+            ]);
+
+            return factory;
+          },
+          value: "before",
+          edit(editor) {
+            editor.setSelection([
+              editor.getChildrenContainer().findItem("After")
+            ]);
+          },
+          edited: "after"
+        },
+
+        {
+          // A focusable composite that hands the focus straight to its child
+          // checkbox, so the editor reports a focusout of its own the moment
+          // the edit starts, and the child — not the editor — is what reports
+          // one when the focus really leaves. Neither may be read at face value.
+          name: "CheckBox",
+          create: () => new qx.ui.table.celleditor.CheckBox(),
+          value: false,
+          edit: editor => editor.getChildren()[0].setValue(true),
+          edited: true
+        },
+
+        {
+          // Picks a factory per cell; whatever it hands back has to take part
+          // in the lifecycle like any other editor.
+          name: "Dynamic",
+          create() {
+            var delegate = new qx.ui.table.celleditor.TextField();
+            var factory = new qx.ui.table.celleditor.Dynamic(() => delegate);
+            factory.__delegate = delegate;
+            return factory;
+          },
+          value: "before",
+          edit: editor => editor.setValue("after"),
+          edited: "after"
+        }
+      ];
+    },
+
+    /**
+     * Mount a one-cell table wired to `spec`'s editor with the given blur
+     * action, start editing, make the change, then move the focus off it.
+     *
+     * @param spec {Map} an entry from {@link #editorSpecs}.
+     * @param blurAction {String} the cellEditorBlurAction to apply.
+     * @return {Map} the pane scroller that did the editing, and the table model.
+     */
+    blurAnEdit(spec, blurAction) {
+      var model = new qx.ui.table.model.Simple();
+      model.setColumns(["Editable"]);
+      model.setData([[spec.value]]);
+      model.setColumnEditable(0, true);
+
+      var factory = spec.create();
+      var table = new qx.ui.table.Table(model).set({
+        width: 300,
+        height: 100,
+        cellEditorBlurAction: blurAction
+      });
+
+      table.getTableColumnModel().setCellEditorFactory(0, factory);
+      var elsewhere = new qx.ui.form.TextField();
+      this.getRoot().add(table);
+      this.getRoot().add(elsewhere, { top: 200 });
+      this.__fixtures.push({ table: table, model: model, factory: factory });
+      this.flush();
+
+      table.setFocusedCell(0, 0, true);
+      var scroller = table._getPaneScrollerArr()[0];
+      this.assertTrue(scroller.startEditing(), spec.name + ": editing started");
+      this.flush();
+
+      spec.edit(scroller._cellEditor);
+      elsewhere.focus();
+      this.flush();
+
+      return { scroller: scroller, model: model };
+    },
+
+    setUp() {
+      super.setUp();
+      this.__fixtures = [];
+    },
+
+    tearDown() {
+      super.tearDown();
+      this.__fixtures.forEach(function (fixture) {
+        fixture.table.destroy();
+        fixture.model.dispose();
+        if (fixture.factory.__delegate) {
+          fixture.factory.__delegate.dispose();
+        }
+        fixture.factory.dispose();
+      });
+
+      this.__fixtures = null;
+      this.flush();
+    },
+
+    testSaveCommitsTheEdit() {
+      this.editorSpecs().forEach(function (spec) {
+        var run = this.blurAnEdit(spec, "save");
+
+        this.assertFalse(
+          run.scroller.isEditing(),
+          spec.name + ": the edit was ended"
+        );
+
+        this.assertEquals(
+          spec.edited,
+          run.model.getValue(0, 0),
+          spec.name + ": the edit was written"
+        );
+      }, this);
+    },
+
+    testCancelDiscardsTheEdit() {
+      this.editorSpecs().forEach(function (spec) {
+        var run = this.blurAnEdit(spec, "cancel");
+
+        this.assertFalse(
+          run.scroller.isEditing(),
+          spec.name + ": the edit was ended"
+        );
+
+        this.assertEquals(
+          spec.value,
+          run.model.getValue(0, 0),
+          spec.name + ": the edit was discarded"
+        );
+      }, this);
+    },
+
+    /**
+     * The default, and what every table that never sets the property gets: the
+     * focus leaving means nothing, and the edit stays open on the cell.
+     */
+    testNothingLeavesTheEditOpen() {
+      this.editorSpecs().forEach(function (spec) {
+        var run = this.blurAnEdit(spec, "nothing");
+
+        this.assertTrue(
+          run.scroller.isEditing(),
+          spec.name + ": the edit is still open"
+        );
+
+        this.assertEquals(
+          spec.value,
+          run.model.getValue(0, 0),
+          spec.name + ": nothing was written"
+        );
+      }, this);
+    }
+  }
+});

--- a/source/class/qx/test/ui/table/Table.js
+++ b/source/class/qx/test/ui/table/Table.js
@@ -266,6 +266,234 @@ qx.Class.define("qx.test.ui.table.Table", {
       tableModel.dispose();
     },
 
+    /**
+     * Build a mounted, editable one-cell table.
+     *
+     * @param blurAction {String} the cellEditorBlurAction to apply.
+     * @param editorFactory {qx.ui.table.ICellEditorFactory?} a factory to use
+     *   for the column, in place of the default text field.
+     * @param custom {Map?} the table's custom-config dict.
+     * @return {Map} the table, its model and its only pane scroller.
+     */
+    createEditableTable(blurAction, editorFactory, custom) {
+      var model = new qx.ui.table.model.Simple();
+      model.setColumns(["Editable"]);
+      model.setData([["before"]]);
+      model.setColumnEditable(0, true);
+
+      var table = new qx.ui.table.Table(model, custom).set({
+        width: 300,
+        height: 100,
+        cellEditorBlurAction: blurAction
+      });
+
+      if (editorFactory) {
+        table.getTableColumnModel().setCellEditorFactory(0, editorFactory);
+      }
+      this.getRoot().add(table);
+      this.flush();
+      table.setFocusedCell(0, 0, true);
+
+      return {
+        table: table,
+        model: model,
+        scroller: table._getPaneScrollerArr()[0]
+      };
+    },
+
+    /**
+     * A cell editor factory is entitled to return a widget that takes no focus
+     * of its own — one that manages its own popup, say. Starting an edit must
+     * not try to focus it, since qx.ui.core.Widget#focus throws on an
+     * unfocusable widget in a debug build.
+     */
+    testStartEditingAnUnfocusableCellEditor() {
+      var factory = new qx.ui.table.celleditor.TextField();
+      factory.createCellEditor = function (cellInfo) {
+        return new qx.ui.form.TextField("" + cellInfo.value).set({
+          focusable: false
+        });
+      };
+
+      var fixture = this.createEditableTable("save", factory);
+
+      this.assertTrue(fixture.scroller.startEditing(), "editing started");
+      this.assertTrue(fixture.scroller.isEditing());
+
+      fixture.table.destroy();
+      fixture.model.dispose();
+    },
+
+    /**
+     * A factory may decline a particular cell by answering null, which leaves
+     * the table not editing — and so with no editor to have wired a blur
+     * listener to.
+     */
+    testACellEditorFactoryCanDeclineTheCell() {
+      var factory = new qx.ui.table.celleditor.TextField();
+      factory.createCellEditor = function () {
+        return null;
+      };
+
+      var fixture = this.createEditableTable("save", factory);
+
+      this.assertFalse(
+        fixture.scroller.startEditing(),
+        "editing did not start"
+      );
+      this.assertFalse(fixture.scroller.isEditing());
+
+      fixture.table.destroy();
+      fixture.model.dispose();
+    },
+
+    /**
+     * Stopping an edit normally hands the focus back to the table, which is
+     * what the Enter key wants.
+     */
+    testStopEditingReturnsFocusToTheTable() {
+      var fixture = this.createEditableTable("nothing");
+      fixture.scroller.startEditing();
+      fixture.scroller._cellEditor.setValue("after");
+
+      var focused = 0;
+      fixture.table.focus = function () {
+        focused++;
+      };
+
+      fixture.scroller.stopEditing();
+
+      this.assertEquals(1, focused, "the table took the focus back");
+      this.assertEquals("after", fixture.model.getValue(0, 0));
+
+      fixture.table.destroy();
+      fixture.model.dispose();
+    },
+
+    /**
+     * The focus leaving the editor applies cellEditorBlurAction — and the save
+     * it does must not pull the focus back onto the table.
+     *
+     * qx.test.ui.table.CellEditorLifecycle covers which focus moves count as
+     * leaving, against the editors the framework ships.
+     */
+    testFocusLeavingTheCellEditorSaves() {
+      var fixture = this.createEditableTable("save");
+      fixture.scroller.startEditing();
+      fixture.scroller._cellEditor.setValue("after");
+
+      var focused = 0;
+      fixture.table.focus = function () {
+        focused++;
+      };
+      var editor = fixture.scroller._cellEditor;
+      var movedTo = new qx.ui.form.TextField();
+
+      fixture.scroller._onFocusoutCellEditorStopEditing({
+        getTarget() {
+          return editor;
+        },
+
+        getRelatedTarget() {
+          return movedTo;
+        }
+      });
+
+      movedTo.dispose();
+      this.assertFalse(fixture.scroller.isEditing(), "the edit was committed");
+      this.assertEquals("after", fixture.model.getValue(0, 0));
+      this.assertEquals(0, focused, "the focus was left where it went");
+
+      fixture.table.destroy();
+      fixture.model.dispose();
+    },
+
+    /**
+     * Not taking the focus back has to survive a subclass, which is why it is
+     * not an argument: `stopEditing` is widely overridden, and an override that
+     * declares no parameters of its own forwards none to its super — so an
+     * argument would be dropped before it reached `flushEditor`, and the blur
+     * save would go back to stealing the focus.
+     */
+    testFocusIsLeftAloneThroughAnOverriddenStopEditing() {
+      if (!qx.Class.isDefined("qx.test.ui.table.ForwardingScroller")) {
+        qx.Class.define("qx.test.ui.table.ForwardingScroller", {
+          extend: qx.ui.table.pane.Scroller,
+
+          members: {
+            stopEditing() {
+              super.stopEditing();
+            }
+          }
+        });
+      }
+
+      var fixture = this.createEditableTable("save", null, {
+        tablePaneScroller(obj) {
+          return new qx.test.ui.table.ForwardingScroller(obj);
+        }
+      });
+
+      fixture.scroller.startEditing();
+      fixture.scroller._cellEditor.setValue("after");
+
+      var focused = 0;
+      fixture.table.focus = function () {
+        focused++;
+      };
+      var editor = fixture.scroller._cellEditor;
+      var movedTo = new qx.ui.form.TextField();
+
+      fixture.scroller._onFocusoutCellEditorStopEditing({
+        getTarget() {
+          return editor;
+        },
+
+        getRelatedTarget() {
+          return movedTo;
+        }
+      });
+
+      movedTo.dispose();
+      this.assertEquals("after", fixture.model.getValue(0, 0));
+      this.assertEquals(0, focused, "the focus was left where it went");
+
+      fixture.table.destroy();
+      fixture.model.dispose();
+    },
+
+    /**
+     * An editor settling can report the focus as being nowhere for a moment —
+     * a ComboBox editor does it repeatedly as it opens. That is not the focus
+     * leaving the edit, and acting on it destroys the editor as it appears.
+     */
+    testFocusGoingNowhereDoesNotEndTheEdit() {
+      var fixture = this.createEditableTable("save");
+      fixture.scroller.startEditing();
+      fixture.scroller._cellEditor.setValue("after");
+      var editor = fixture.scroller._cellEditor;
+
+      fixture.scroller._onFocusoutCellEditorStopEditing({
+        getTarget() {
+          return editor;
+        },
+
+        getRelatedTarget() {
+          return null;
+        }
+      });
+
+      this.assertTrue(fixture.scroller.isEditing(), "the edit is still open");
+      this.assertEquals(
+        "before",
+        fixture.model.getValue(0, 0),
+        "nothing was written"
+      );
+
+      fixture.table.destroy();
+      fixture.model.dispose();
+    },
+
     testFocusAfterRemove() {
       var tableModelSimple = new qx.ui.table.model.Simple();
       tableModelSimple.setColumns(["Location", "Team"]);

--- a/source/class/qx/ui/table/pane/Scroller.js
+++ b/source/class/qx/ui/table/pane/Scroller.js
@@ -384,6 +384,8 @@ qx.Class.define("qx.ui.table.pane.Scroller", {
     __timer: null,
 
     __focusIndicatorPointerDownListener: null,
+    __cellEditorFocusoutListener: null,
+    __flushingOnFocusLoss: false,
 
     /**
      * The right inset of the pane. The right inset is the maximum of the
@@ -1873,8 +1875,18 @@ qx.Class.define("qx.ui.table.pane.Scroller", {
           // Make the focus indicator visible during editing
           this.__focusIndicator.setDecorator("table-scroller-focus-indicator");
 
-          this._cellEditor.addListenerOnce('focusin', this._onFocusinCellEditorAddBlurListener, this);
-          this._cellEditor.focus();
+          this.__cellEditorFocusoutListener = this._cellEditor.addListener(
+            "focusout",
+            this._onFocusoutCellEditorStopEditing,
+            this
+          );
+
+          // A cell editor factory may legitimately return a widget that takes
+          // no focus of its own (one that manages its own popup, say), and
+          // qx.ui.core.Widget#focus throws on those in a debug build.
+          if (this._cellEditor.isFocusable()) {
+            this._cellEditor.focus();
+          }
           this._cellEditor.activate();
         }
 
@@ -1916,7 +1928,12 @@ qx.Class.define("qx.ui.table.pane.Scroller", {
           .getTableModel()
           .setValue(this.__focusedCol, this.__focusedRow, value);
 
-        this.__table.focus();
+        // Returning the focus to the table is right for Enter, but wrong when
+        // the flush is itself the result of the focus leaving: it would take
+        // the focus back off whatever the user just moved to.
+        if (!this.__flushingOnFocusLoss) {
+          this.__table.focus();
+        }
 
         if (cancel) {
           this.cancelEditing();
@@ -1948,6 +1965,14 @@ qx.Class.define("qx.ui.table.pane.Scroller", {
 
             this.__focusIndicatorPointerDownListener = null;
           }
+
+          if (this.__cellEditorFocusoutListener !== null) {
+            this._cellEditor.removeListenerById(
+              this.__cellEditorFocusoutListener
+            );
+
+            this.__cellEditorFocusoutListener = null;
+          }
           this._updateFocusIndicator();
         }
         this._cellEditor.destroy();
@@ -1966,35 +1991,77 @@ qx.Class.define("qx.ui.table.pane.Scroller", {
     },
 
     /**
-     * Focusin event handler which attaches the blur event listener ot the cell editor
-     * and uses a timer event to allow the focusin event listener execution before
-     * the blur event listener execution
+     * Applies {@link qx.ui.table.Table#cellEditorBlurAction} when the focus
+     * leaves the cell editor.
+     *
+     * The listener is registered on the editor in {@link #startEditing}, so it
+     * only ever fires for an editor that takes the focus itself; an editor that
+     * is not focusable never sees it, because the widget layer resolves focus
+     * events to the nearest focusable ancestor. Such an editor is responsible
+     * for committing its own value.
+     *
+     * What counts is the focus leaving the editor's *subtree* for something
+     * else. `focusout` bubbles, so a composite editor reports whichever of its
+     * children held the focus as the target; and an editor is free to hand the
+     * focus to a child of its own — the CheckBox editor does, the moment the
+     * edit starts — which reports as the editor itself losing it. Reading
+     * either as the focus leaving the edit would end an edit that is still very
+     * much in progress.
+     *
+     * A focusout carrying no related target is not the focus leaving either: it
+     * is where the focus is momentarily nowhere, which an editor does to itself
+     * while it settles — a ComboBox editor churns focus out and back three
+     * times in the few milliseconds it takes to open, and acting on the first
+     * of those destroys the editor as it appears. Every real way out of an edit
+     * moves the focus onto something: another field, a toolbar button, a
+     * window's own close button.
+     *
+     * @param e {qx.event.type.Focus} the focusout event.
      */
-    _onFocusinCellEditorAddBlurListener(e) {
-      this.debug("executed FOCUSIN event listener for hash: " + e.getTarget().$$hash);
-      qx.event.Timer.once(function() {
-        this._cellEditor.addListener('focusout', this._onFocusoutCellEditorStopEditing, this);
-        this.debug('added FOCUSOUT listener to hash: ' + this._cellEditor.$$hash);
-      }, this, 1);
+    _onFocusoutCellEditorStopEditing(e) {
+      if (!this.__isWithinCellEditor(e.getTarget())) {
+        return;
+      }
+
+      var movedTo = e.getRelatedTarget();
+      if (!movedTo || this.__isWithinCellEditor(movedTo)) {
+        return;
+      }
+
+      switch (this.getTable().getCellEditorBlurAction()) {
+        case "save":
+          // Flagged rather than passed as an argument: stopEditing is widely
+          // overridden, and an override declaring no parameters compiles
+          // `this.base(arguments)` down to a call that forwards none, so an
+          // argument would be dropped before it ever reached flushEditor.
+          this.__flushingOnFocusLoss = true;
+          try {
+            this.stopEditing();
+          } finally {
+            this.__flushingOnFocusLoss = false;
+          }
+          break;
+        case "cancel":
+          this.cancelEditing();
+          break;
+        case "nothing":
+        default:
+        // do nothing
+      }
     },
 
-
-    _onFocusoutCellEditorStopEditing(e) {
-      this.debug("executed FOCUSOUT listener for hash " + e.getTarget().$$hash);
-      if (this._cellEditor === e.getTarget()) {
-        this.debug('hash: ' + this._cellEditor.$$hash);
-        switch (this.getTable().getCellEditorBlurAction()) {
-          case "save":
-            this.stopEditing();
-            break;
-          case "cancel":
-            this.cancelEditing();
-            break;
-          case "nothing":
-          default:
-            // do nothing
-        }
-      }
+    /**
+     * Whether a widget is the cell editor being used, or sits inside it.
+     *
+     * @param widget {qx.ui.core.Widget|null} the widget to test.
+     * @return {Boolean} true if the widget belongs to the open cell editor.
+     */
+    __isWithinCellEditor(widget) {
+      return (
+        !!widget &&
+        (widget === this._cellEditor ||
+          qx.ui.core.Widget.contains(this._cellEditor, widget))
+      );
     },
 
     /**


### PR DESCRIPTION
`Table#cellEditorBlurAction` is wired to the cell editor's own focus events, in
a way that is racy, silently inert for whole classes of editor, and that takes
the focus off whatever the user just moved to.

## What's wrong today

Measured on `master`, on a mounted one-cell table with
`cellEditorBlurAction: "save"`:

1. **A non-focusable cell editor throws.** `startEditing` calls
   `_cellEditor.focus()` unconditionally, and `Widget#focus` throws
   `"Widget is not focusable!"` in a debug build. A factory is entitled to
   return a widget that takes no focus of its own — one whose UI is a popup it
   manages itself, say — and `getFocusTarget()` exists precisely because such
   widgets are expected.

2. **…and never gets the blur action anyway.** `qx.ui.core.EventHandler`
   resolves focus-event targets through `Widget#getFocusTarget()`, the nearest
   *focusable* ancestor. For a non-focusable editor that is the `Table`, so the
   editor never fires `focusin`, the `focusout` listener is never attached, and
   the property silently does nothing.

3. **The wiring is a race.** The `focusout` listener is attached from a
   `focusin` handler via a 1 ms `qx.event.Timer`. An edit blurred inside that
   window is dropped, and if editing stops inside it the deferred callback
   dereferences a nulled `_cellEditor` and throws from a timer. (That crash is
   what #10876 guards; this supersedes it by removing the deferral.)

4. **The shipped CheckBox editor never commits, at any timing.**
   `celleditor.CheckBox` returns a focusable `Composite` that hands the focus to
   its child checkbox on `focus`. So the editor reports a `focusout` of its own
   the instant the edit starts, and the *child* — not the editor — is what
   reports one when the focus really leaves. `this._cellEditor === e.getTarget()`
   rejects both. Verified: edit, wait 100 ms, blur → `isEditing() === true`,
   model unchanged.

5. **A blur-save steals the focus back.** `flushEditor` calls `table.focus()`
   even when the flush was *caused by* the focus leaving, so clicking from a
   cell editor into another field lands the focus back on the table. Verified:
   after the blur, `FocusHandler.getActiveWidget()` is the `Table` and the
   clicked field does not have the `focused` state.

## The change

- focus the editor only when `isFocusable()`;
- register `focusout` in `startEditing` and drop it in `cancelEditing` — no
  timer, so no race and nothing to null-deref;
- decide on the editor's **subtree**, not the editor widget: the focus leaving
  is a `focusout` from inside the editor to somewhere outside it. Both ends are
  checked, which fixes CheckBox and any other editor that manages its own focus;
- the blur path marks the flush so it does not take the focus back. Enter is
  unchanged and still returns the focus to the table.

That last one is deliberately **not** an argument to `stopEditing`. That method
is widely overridden, and an override declaring no parameters of its own
compiles `this.base(arguments)` / `super.stopEditing()` down to a call that
forwards none — so the argument was dropped before it ever reached
`flushEditor`, and the save went on stealing the focus. I hit exactly that in
our own codebase before spotting it; there is a regression test for that shape
of subclass.

An editor that takes no focus does not participate in the blur action and must
commit its own value. That was already true by accident; it is now stated at the
handler.

## Tests

`qx.test.ui.table.CellEditorLifecycle` is new: it drives every editor the
framework ships — TextField, PasswordField, ComboBox, SelectBox, CheckBox,
Dynamic — through the real lifecycle on a mounted table, under each of the three
blur actions. There was no such coverage: the existing
`qx.test.ui.table.celleditor.*` tests call the factories directly with a
hand-built `cellInfo` and say nothing about behaviour once the `Scroller` is
driving. Against unmodified `master` the `"save"` and `"cancel"` sweeps both
fail; the `"nothing"` sweep passes on both and is a regression guard rather than
a demonstration.

`qx.test.ui.table.Table` gains the unfocusable editor, a factory declining the
cell by returning `null`, the focus outcome of `stopEditing`, the
overridden-`stopEditing` case above, and a focusout carrying no related target.

Not covered, and unchanged by this PR: modal-window cell editors
(`_cellEditor instanceof qx.ui.window.Window`) get no blur handling before or
after, and `qx.ui.treevirtual.celleditor.NodeEditor` is exercised downstream
rather than here.

## Compatibility

No public signature changes. Tables that set `"save"` or `"cancel"` will now see
the action fire in cases where it previously did not — CheckBox and other
composite editors, and blurs inside the first millisecond — and a blur-save no
longer returns the focus to the table. Tables on the default `"nothing"` are
unaffected.

A focusout carrying **no** related target still does not commit, deliberately.
An earlier revision of this PR treated it as the focus leaving, which destroyed
a ComboBox editor as it opened (see the comment below); every real way out of an
edit moves the focus onto something. The consequence is that a window losing
focus entirely — alt-tabbing away — does not commit, and cannot without
reintroducing that.

Supersedes #10876.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AZ7Ey5mhSN4ifkJPeuxeKm


