### PR TITLE
fix(resizebehavior): dispose the ColumnData objects it created

### DIFF
--- a/source/class/qx/ui/table/columnmodel/resizebehavior/Default.js
+++ b/source/class/qx/ui/table/columnmodel/resizebehavior/Default.js
@@ -298,8 +298,11 @@ qx.Class.define("qx.ui.table.columnmodel.resizebehavior.Default", {
       // Are there now fewer (or the same number of) columns than there were
       // previously?
       if (numColumns <= colData.length) {
-        // Yup.  Delete the extras.
-        colData.splice(numColumns, colData.length);
+        // Yup.  Delete the extras, disposing them: this behavior instantiated
+        // them and is the only thing that holds them.
+        colData.splice(numColumns, colData.length).forEach(function (data) {
+          data.dispose();
+        });
         return;
       }
 
@@ -518,7 +521,10 @@ qx.Class.define("qx.ui.table.columnmodel.resizebehavior.Default", {
   */
 
   destruct() {
-    this.__resizeColumnData = this.__layoutChildren = null;
+    // __layoutChildren aliases entries of __resizeColumnData, so disposing the
+    // latter covers both.
+    this._disposeArray("__resizeColumnData");
+    this.__layoutChildren = null;
     this._disposeObjects("__layout", "__deferredComputeColumnsFlexWidth");
   }
 });


### PR DESCRIPTION
`qx.ui.table.columnmodel.resizebehavior.Default` creates a `qx.ui.core.ColumnData` per column through the `newResizeBehaviorColumnData` factory, and never disposes any of them.

Two places drop one without releasing it:

- **`destruct`** nulled `__resizeColumnData` rather than disposing its contents, so every `ColumnData` outlived the table that owned it.
- **`_setNumColumns`** spliced the surplus out when the column count shrank and dropped them on the floor.

## Why it is worth fixing beyond retained memory

`qx.ui.core.ColumnData` extends `qx.ui.core.LayoutItem`, whose constructor registers a `changeTheme` listener on the `qx.theme.manager.Meta` singleton and whose destructor removes it (guarded by `qx.core.Environment.get("qx.dyntheme")`).

So a leaked `ColumnData` stays on the list that `qx.theme.manager.Meta.setTheme()` walks. In an application with dynamic themes enabled, **live theme switching gets steadily slower the longer the application runs** — in proportion to every table column ever created, not to what is on screen.

That is how we found it. In a ~750-class application, two tests that perform live theme switches cost ~137 s each at the end of a unit-test run and ~0.3 s at the start, purely because of what had accumulated in between.

## Measurement

End of the same unit-test run, counting live objects via that `changeTheme` listener list:

| | before | after |
|---|---|---|
| `qx.ui.core.ColumnData` alive | 2,283 | **106** |
| total live objects | 6,276 | 4,099 |

The remaining 106 correspond exactly to the 106 `qx.ui.treevirtual.TreeVirtual` instances still alive at that point, which legitimately still hold their column models. Full suite: 3,975 tests, no failures, before and after.

## Why this is safe

Nothing outside the class holds these objects:

- `_getResizeColumnData()` is protected and has no callers anywhere else in the framework (`grep -rn "ResizeColumnData"` finds only this file).
- `__layoutChildren` holds *aliases* of entries in the same array — the visible subset — so disposing `__resizeColumnData` covers both, and it is nulled alongside.
- The objects are only ever created here, via the factory property.

## Related

#7613 fixed a different leak in this same class. This is the "dispose what you replaced/dropped" case, in the same spirit as #9488 (`qx.ui.form.List._applyOrientation` leaking the previous layout instance).
