### PR TITLE
fix(LayoutItem): leave the layout queue on dispose

### DIFF
--- a/source/class/qx/ui/core/LayoutItem.js
+++ b/source/class/qx/ui/core/LayoutItem.js
@@ -932,6 +932,19 @@ qx.Class.define("qx.ui.core.LayoutItem", {
   */
 
   destruct() {
+    // Leave the layout queue. Setting any dimension puts an item there via
+    // _applyDimension, and the queue holds it by hash in a static map, so a
+    // disposed item that is never taken out stays reachable for the life of the
+    // page. qx.ui.core.Widget.destruct does this for widgets; nothing did it for
+    // a plain LayoutItem such as qx.ui.core.ColumnData or qx.ui.core.Spacer.
+    //
+    // The queue cannot shed it on its own either: __getLevelGroupedWidgets only
+    // deletes an entry it can hand to a layout, which it decides with
+    // queue.Visibility.isVisible() -- false for anything the visibility queue
+    // has never seen, which a non-widget never is. So the entry is skipped
+    // rather than removed, and every later flush walks over it again.
+    qx.ui.core.queue.Layout.remove(this);
+
     // remove dynamic theme listener
     if (qx.core.Environment.get("qx.dyntheme") && this.__changeThemeLayoutItemListenerId) {
       qx.theme.manager.Meta.getInstance().removeListenerById(


### PR DESCRIPTION
A disposed `qx.ui.core.LayoutItem` that is not a `Widget` stays referenced by `qx.ui.core.queue.Layout` for the life of the page, and cannot be removed by anything.

## The chain

1. Setting any dimension calls `LayoutItem._applyDimension`, whose whole body is `qx.ui.core.queue.Layout.add(this)` (`LayoutItem.js:675`).
2. `Layout.add` keeps a strong reference in a **static** map: `this.__queue[widget.toHashCode()] = widget` (`queue/Layout.js:51`).
3. `qx.ui.core.Widget.destruct` removes itself from that queue (`Widget.js:3623`) — but `LayoutItem.destruct` does not, so a non-widget layout item never leaves.
4. **The queue cannot shed it either.** `__getLevelGroupedWidgets` only `delete`s an entry it can hand to a layout, and decides that with `queue.Visibility.isVisible(widget)` (`queue/Layout.js:167-179`). That is `this.__data[hash] || false` — false for anything the visibility queue has never seen, which a non-widget never is. So the entry is **skipped rather than removed**, and every later `flush()` walks over it again.

So the cost is not only retained memory: layout flush time grows with the number of disposed items, not with what is on screen.

## Where it bites

`qx.ui.core.ColumnData` is the case that surfaced it. It extends `LayoutItem`, and `setColumnWidth()` calls `setWidth()` for any numeric width (`ColumnData.js:71-76`) — which is what a table does as soon as a column has a pixel width, i.e. after any user drag-resize.

Measured in an application with ~750 widget classes: **2,283 `ColumnData` alive** at the end of a unit-test run.

`qx.ui.core.Spacer` is the framework's other non-widget `LayoutItem` and is covered by the same fix.

## The change

One line in `LayoutItem.destruct`, so every subclass is covered rather than patching `ColumnData` alone:

```js
qx.ui.core.queue.Layout.remove(this);
```

`Widget.destruct`'s existing call becomes redundant but harmless — removing an absent entry is a `delete` on a missing key.

Verified by building a large downstream application against it: full unit suite **4,025 tests, no failures**.

## Related

Same family as #10882 (`resizebehavior.Default` never disposing the `ColumnData` it creates) — that one stops them being created endlessly, this one stops the survivors being pinned. Both are "release what you registered", as in #9488 and #3295.

🤖 Generated with [Claude Code](https://claude.com/claude-code)